### PR TITLE
[Core] Remove unused CLI entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,10 +76,7 @@ test = "pytest"
 test-verbose = "pytest -v"
 test-coverage = "pytest --cov=src --cov-report=html --cov-report=term-missing"
 
-[tool.poetry.scripts]
-entity = "src.client.terminal:cli"
 
-# Pytest configuration in pyproject.toml format
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]


### PR DESCRIPTION
## Summary
- remove CLI script entry from poetry config

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/` *(fails: F401/E501 and other style errors)*
- `mypy src/` *(fails: 22 errors in 6 files)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: Unknown config option)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option)*
- `pytest -q` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_6860954fe1188322aa88dd3f695e5b61