### PR TITLE
[Core] Remove examples package from Poetry config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ package-mode = true
 
 packages = [
     { include = "src", from = "." },
-    { include = "examples", from = "." },
 ]
 
 


### PR DESCRIPTION
## Summary
- stop packaging the `examples` folder
- confirm editable install works

## Testing
- `pip install -e .`
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/`
- `mypy src/` *(fails: various typing issues)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: module not found)*
- `python -m src.registry.validator` *(fails: module not found)*
- `pytest tests/integration/ -v`
- `pytest tests/performance/ -m benchmark`

------
https://chatgpt.com/codex/tasks/task_e_6860955797ac83229cc16f8033fa5fd1