### PR TITLE
[Core] validate plugin dependencies

### DIFF
--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -111,6 +111,15 @@ class SystemInitializer:
                 registry.register_class(cls, cfg, name)
                 dep_graph[name] = getattr(cls, "dependencies", [])
 
+        # Validate dependencies declared by each plugin class
+        for plugin_class, _ in registry.all_plugin_classes():
+            result = plugin_class.validate_dependencies(registry)
+            if not result.success:
+                raise SystemError(
+                    f"Dependency validation failed for {plugin_class.__name__}: "
+                    f"{result.error_message}"
+                )
+
         # Phase 2: dependency validation
         self._validate_dependency_graph(registry, dep_graph)
         for plugin_class, cfg in registry.all_plugin_classes():


### PR DESCRIPTION
## Summary
- validate dependencies after plugin class registration
- test initializer errors when dependencies missing

## Testing
- `flake8 src/ tests/` *(fails: line length, unused imports, etc.)*
- `mypy src/` *(fails: numerous typing errors)*
- `bandit -r src/`
- `python -m src.registry.validator` *(fails: module not found)*
- `pytest tests/integration/ -v` *(fails: unknown config option)*
- `pytest tests/performance/ -m benchmark` *(fails: unknown config option)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68609ccc9ebc8322922e9fca69354e5f