### PR TITLE
[Core] Expand SimpleContext helpers

### DIFF
--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -171,11 +171,103 @@ class SimpleContext(PluginContext):
     def user(self) -> str:
         return self._state.metadata.get("user", "user")
 
+    @property
+    def location(self) -> Optional[str]:
+        return self._state.metadata.get("location")
+
     def say(self, message: str) -> None:
         self.set_response(message)
+
+    def think(self, thought: str) -> None:
+        self.add_conversation_entry(
+            content=thought,
+            role="system",
+            metadata={"type": "thought"},
+        )
 
     def recall(self, key: str, default: Any = None) -> Any:
         return self.get_metadata(key, default)
 
     def remember(self, key: str, value: Any) -> None:
         self.set_metadata(key, value)
+
+    async def use_tool(self, tool_name: str, **params: Any) -> Any:
+        result_key = self.execute_tool(tool_name, params)
+        return await self._wait_for_tool_result(result_key)
+
+    async def _wait_for_tool_result(self, result_key: str) -> Any:
+        if result_key not in self._state.stage_results:
+            call = next(
+                (
+                    c
+                    for c in self._state.pending_tool_calls
+                    if c.result_key == result_key
+                ),
+                None,
+            )
+            if call is None:
+                raise KeyError(result_key)
+            tool = self._registries.tools.get(call.name)
+            if not tool:
+                result = f"Error: tool {call.name} not found"
+                self.set_stage_result(call.result_key, result)
+                self._state.pending_tool_calls.remove(call)
+                return result
+            try:
+                if hasattr(tool, "execute_function_with_retry"):
+                    result = await tool.execute_function_with_retry(call.params)
+                elif hasattr(tool, "execute_function"):
+                    result = await tool.execute_function(call.params)
+                else:
+                    func = getattr(tool, "run", None)
+                    if asyncio.iscoroutinefunction(func):
+                        result = await func(call.params)
+                    else:
+                        result = func(call.params)
+                self.set_stage_result(call.result_key, result)
+                self._state.metrics.record_tool_execution(
+                    call.name,
+                    str(self.current_stage),
+                    self.pipeline_id,
+                    call.result_key,
+                    call.source,
+                )
+            except Exception as exc:
+                result = f"Error: {exc}"
+                self.set_stage_result(call.result_key, result)
+                self._state.metrics.record_tool_error(
+                    call.name,
+                    str(self.current_stage),
+                    self.pipeline_id,
+                    str(exc),
+                )
+            self._state.pending_tool_calls.remove(call)
+        return self.get_stage_result(result_key)
+
+    async def ask_llm(self, prompt: str) -> str:
+        llm = self.get_resource("ollama")
+        if llm is None:
+            raise RuntimeError("LLM resource 'ollama' not available")
+
+        if hasattr(llm, "generate"):
+            response = await llm.generate(prompt)
+        else:
+            func = getattr(llm, "__call__", None)
+            if asyncio.iscoroutinefunction(func):
+                response = await func(prompt)
+            else:
+                response = func(prompt)
+
+        if isinstance(response, LLMResponse):
+            return response.content
+        return str(response)
+
+    async def calculate(self, expression: str) -> Any:
+        return await self.use_tool("calculator", expression=expression)
+
+    def is_question(self) -> bool:
+        return self.message.strip().endswith("?")
+
+    def contains(self, *keywords: str) -> bool:
+        msg_lower = self.message.lower()
+        return any(keyword.lower() in msg_lower for keyword in keywords)

--- a/tests/test_simple_context.py
+++ b/tests/test_simple_context.py
@@ -1,0 +1,64 @@
+import asyncio
+from datetime import datetime
+
+from pipeline import (ConversationEntry, LLMResponse, PipelineState,
+                      PluginRegistry, ResourceRegistry, SimpleContext,
+                      SystemRegistries, ToolRegistry)
+
+
+class EchoLLM:
+    async def generate(self, prompt: str):
+        return LLMResponse(content=f"echo:{prompt}")
+
+
+class DoubleTool:
+    async def execute_function(self, params):
+        return params["n"] * 2
+
+
+def make_context(message: str = "hi", **metadata):
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(content=message, role="user", timestamp=datetime.now())
+        ],
+        metadata=metadata,
+        pipeline_id="1",
+    )
+    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), PluginRegistry())
+    return state, SimpleContext(state, registries)
+
+
+def test_think_adds_entry():
+    state, ctx = make_context()
+    ctx.think("processing")
+    assert state.conversation[-1].content == "processing"
+    assert state.conversation[-1].role == "system"
+
+
+def test_use_tool_executes_and_returns_result():
+    state, ctx = make_context()
+    ctx._registries.tools.add("double", DoubleTool())
+    result = asyncio.run(ctx.use_tool("double", n=3))
+    assert result == 6
+    assert state.stage_results
+
+
+def test_ask_llm_returns_content():
+    state, ctx = make_context()
+    ctx._registries.resources.add("ollama", EchoLLM())
+    result = asyncio.run(ctx.ask_llm("test"))
+    assert result == "echo:test"
+
+
+def test_calculate_uses_calculator():
+    state, ctx = make_context()
+    ctx._registries.tools.add("calculator", DoubleTool())
+    result = asyncio.run(ctx.calculate("unused"))
+    assert result is not None
+
+
+def test_is_question_and_contains_and_location():
+    state, ctx = make_context("Where are you?", location="Mars")
+    assert ctx.is_question()
+    assert ctx.contains("where")
+    assert ctx.location == "Mars"


### PR DESCRIPTION
## Summary
- extend `SimpleContext` with additional convenience helpers like `think`, `use_tool`, and `ask_llm`
- add `calculate`, `is_question`, `contains`, and `location` property
- implement `_wait_for_tool_result` for immediate tool execution
- cover helper methods with tests

## Testing
- `black src/pipeline/context.py tests/test_simple_context.py`
- `isort src/pipeline/context.py tests/test_simple_context.py`
- `flake8 src/ tests/` *(fails: E501, F401, etc.)*
- `mypy src/` *(fails: several missing stubs and type errors)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: module not found)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: module not found)*
- `python -m src.registry.validator` *(fails: module not found)*
- `pytest tests/integration/ -v` *(fails: directory not found)*
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68609ca93a1083229f9131a291a68d2a