### PR TITLE
[Tool] add parameter validation for ToolPlugin

### DIFF
--- a/tests/test_tool_plugin.py
+++ b/tests/test_tool_plugin.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import pytest
+
+from pipeline.plugins import ToolPlugin
+
+
+class EchoTool(ToolPlugin):
+    required_params = ["text"]
+
+    async def execute_function(self, params):
+        return params["text"]
+
+
+async def run_tool(tool, params):
+    return await tool.execute_function_with_retry(params)
+
+
+def test_tool_plugin_valid_params():
+    tool = EchoTool({})
+    result = asyncio.run(run_tool(tool, {"text": "hi"}))
+    assert result == "hi"
+
+
+def test_tool_plugin_missing_param():
+    tool = EchoTool({})
+    with pytest.raises(ValueError):
+        asyncio.run(run_tool(tool, {}))


### PR DESCRIPTION
## Summary
- add `_validate_required_params` and `validate_tool_params` to `ToolPlugin`
- validate parameters before retrying tool functions
- cover valid and invalid cases in unit tests

## Testing
- `isort src/ tests/`
- `black tests/test_tool_plugin.py src/pipeline/plugins.py`
- `flake8 src/ tests/` *(fails: various lint errors)*
- `mypy src/`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: file or directory not found)*
- `pytest tests/performance/ -m benchmark` *(fails: file or directory not found)*
- `pytest -q` *(fails: 1 failed, 19 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68613342769883228794b4b381e81a9b