### PR TITLE
[Maintenance] Expand variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1190,8 +1190,8 @@ class SystemInitializer:
     def _validate_dependency_graph(self, registry, dep_graph: Dict[str, List[str]]):
         """Validate dependency graph: check existence and detect circular dependencies"""
         # Check all dependencies exist
-        for plugin_name, deps in dep_graph.items():
-            for dep in deps:
+        for plugin_name, dependencies in dep_graph.items():
+            for dep in dependencies:
                 if not registry.has_plugin(dep):
                     available = registry.list_plugins()
                     raise SystemError(f"Plugin '{plugin_name}' requires '{dep}' but it's not registered. Available: {available}")

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -100,15 +100,15 @@ class SystemInitializer:
 
         # Phase 1: register all plugin classes
         resources = self.config.get("plugins", {}).get("resources", {})
-        for name, cfg in resources.items():
-            cls = import_plugin_class(cfg.get("type", name))
-            registry.register_class(cls, cfg, name)
+        for name, config in resources.items():
+            cls = import_plugin_class(config.get("type", name))
+            registry.register_class(cls, config, name)
             dep_graph[name] = getattr(cls, "dependencies", [])
 
         for section in ["tools", "adapters", "prompts"]:
-            for name, cfg in self.config.get("plugins", {}).get(section, {}).items():
-                cls = import_plugin_class(cfg.get("type", name))
-                registry.register_class(cls, cfg, name)
+            for name, config in self.config.get("plugins", {}).get(section, {}).items():
+                cls = import_plugin_class(config.get("type", name))
+                registry.register_class(cls, config, name)
                 dep_graph[name] = getattr(cls, "dependencies", [])
 
         # Validate dependencies declared by each plugin class
@@ -122,8 +122,8 @@ class SystemInitializer:
 
         # Phase 2: dependency validation
         self._validate_dependency_graph(registry, dep_graph)
-        for plugin_class, cfg in registry.all_plugin_classes():
-            result = plugin_class.validate_config(cfg)
+        for plugin_class, config in registry.all_plugin_classes():
+            result = plugin_class.validate_config(config)
             if not result.success:
                 raise SystemError(
                     f"Config validation failed for {plugin_class.__name__}: {result.error_message}"
@@ -131,8 +131,8 @@ class SystemInitializer:
 
         # Phase 3: initialize resources
         resource_registry = ResourceRegistry()
-        for cls, cfg in registry.resource_classes():
-            instance = cls(cfg)
+        for cls, config in registry.resource_classes():
+            instance = cls(config)
             if hasattr(instance, "initialize") and callable(
                 getattr(instance, "initialize")
             ):
@@ -141,14 +141,14 @@ class SystemInitializer:
 
         # Phase 3.5: register tools
         tool_registry = ToolRegistry()
-        for cls, cfg in registry.tool_classes():
-            instance = cls(cfg)
+        for cls, config in registry.tool_classes():
+            instance = cls(config)
             tool_registry.add(getattr(instance, "name", cls.__name__), instance)
 
         # Phase 4: instantiate prompt and adapter plugins
         plugin_registry = PluginRegistry()
-        for cls, cfg in registry.non_resource_non_tool_classes():
-            instance = cls(cfg)
+        for cls, config in registry.non_resource_non_tool_classes():
+            instance = cls(config)
             for stage in getattr(cls, "stages", []):
                 plugin_registry.register_plugin_for_stage(instance, stage)
 
@@ -157,8 +157,8 @@ class SystemInitializer:
     def _validate_dependency_graph(
         self, registry: ClassRegistry, dep_graph: Dict[str, List[str]]
     ):
-        for plugin_name, deps in dep_graph.items():
-            for dep in deps:
+        for plugin_name, dependencies in dep_graph.items():
+            for dep in dependencies:
                 if not registry.has_plugin(dep):
                     available = registry.list_plugins()
                     raise SystemError(

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -1,8 +1,15 @@
 import asyncio
 
-from pipeline import (FailurePlugin, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry, execute_pipeline)
+from pipeline import (
+    FailurePlugin,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 
 
 class FailPlugin(PromptPlugin):
@@ -35,12 +42,12 @@ def make_registries(error_plugin):
 
 
 def test_error_stage_execution():
-    regs = make_registries(ErrorPlugin)
-    result = asyncio.run(execute_pipeline("hi", regs))
+    registries = make_registries(ErrorPlugin)
+    result = asyncio.run(execute_pipeline("hi", registries))
     assert result == {"error": "boom"}
 
 
 def test_static_fallback_on_error_stage_failure():
-    regs = make_registries(BadErrorPlugin)
-    result = asyncio.run(execute_pipeline("hi", regs))
+    registries = make_registries(BadErrorPlugin)
+    result = asyncio.run(execute_pipeline("hi", registries))
     assert result["type"] == "static_fallback"

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -2,9 +2,16 @@ import asyncio
 
 from fastapi.testclient import TestClient
 
-from pipeline import (HTTPAdapter, PipelineManager, PipelineStage,
-                      PluginRegistry, PromptPlugin, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    HTTPAdapter,
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 
 
 class RespPlugin(PromptPlugin):
@@ -17,8 +24,8 @@ class RespPlugin(PromptPlugin):
 def make_adapter():
     plugins = PluginRegistry()
     plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO)
-    regs = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
-    manager = PipelineManager(regs)
+    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    manager = PipelineManager(registries)
     return HTTPAdapter(manager)
 
 

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -1,8 +1,14 @@
 import asyncio
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 
 
 class WaitPlugin(PromptPlugin):
@@ -16,8 +22,8 @@ class WaitPlugin(PromptPlugin):
 def make_manager():
     plugins = PluginRegistry()
     plugins.register_plugin_for_stage(WaitPlugin({}), PipelineStage.DO)
-    regs = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
-    return PipelineManager(regs)
+    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    return PipelineManager(registries)
 
 
 def test_pipeline_manager_active_flag():


### PR DESCRIPTION
## Summary
- rename `cfg`, `deps`, and `regs` variables to clear names
- keep docs and tests updated to match

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest -v`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: directory not found)*
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_686133449a608322b7cace3ff3a0a3ee