### PR TITLE
[Resource] Add simple memory resource

### DIFF
--- a/src/pipeline/plugins/resources/memory_resource.py
+++ b/src/pipeline/plugins/resources/memory_resource.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from pipeline.plugins import ResourcePlugin
+from pipeline.stages import PipelineStage
+
+
+class SimpleMemoryResource(ResourcePlugin):
+    """In-memory key/value store persisted across pipeline runs."""
+
+    stages = [PipelineStage.PARSE]
+    name = "memory"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._store: Dict[str, Any] = {}
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
+        return None
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        """Retrieve a value from memory."""
+        return self._store.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        """Store a value in memory."""
+        self._store[key] = value
+
+    def clear(self) -> None:
+        """Remove all stored values."""
+        self._store.clear()

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.plugins.resources.memory_resource import SimpleMemoryResource
+
+
+class IncrementPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+    dependencies = ["memory"]
+
+    async def _execute_impl(self, context):
+        memory = context.get_resource("memory")
+        count = memory.get("count", 0) + 1
+        memory.set("count", count)
+        context.set_response(count)
+
+
+def make_registries():
+    plugins = PluginRegistry()
+    plugins.register_plugin_for_stage(IncrementPlugin({}), PipelineStage.DO)
+    resources = ResourceRegistry()
+    resources.add("memory", SimpleMemoryResource())
+    return SystemRegistries(resources, ToolRegistry(), plugins)
+
+
+def test_memory_persists_between_runs():
+    registries = make_registries()
+    first = asyncio.run(execute_pipeline("hi", registries))
+    second = asyncio.run(execute_pipeline("again", registries))
+    assert first == 1
+    assert second == 2


### PR DESCRIPTION
## Summary
- implement SimpleMemoryResource for simple key/value storage
- cover memory persistence with unit test

## Testing
- `flake8 src tests`
- `mypy src`
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: directory not found)*
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6861666c137883229c173727e3ffe625