### PR TITLE
[Adapter] Add CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ python examples/http_server.py
 python examples/pipeline_example.py
 ```
 
+### Command Line Usage
+Launch an agent from a YAML configuration file:
+
+```bash
+python src/cli.py --config path/to/config.yml
+```
+
 ### One-Liner Context Operations
 ```python
 @agent.plugin

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -3,3 +3,10 @@
 :start-after: <!-- start quick_start -->
 :end-before: <!-- end quick_start -->
 ```
+
+### CLI Usage
+Run an agent from a YAML configuration file:
+
+```bash
+python src/cli.py --config config.yml
+```

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,34 @@
+import argparse
+
+from agent import Agent
+
+
+class CLI:
+    """Command line interface for running an Entity agent."""
+
+    def __init__(self) -> None:
+        self.args = self._parse_args()
+
+    def _parse_args(self) -> argparse.Namespace:
+        parser = argparse.ArgumentParser(
+            description="Run an Entity agent using a YAML configuration.",
+        )
+        parser.add_argument(
+            "--config",
+            "-c",
+            required=True,
+            help="Path to a YAML configuration file.",
+        )
+        return parser.parse_args()
+
+    def run(self) -> None:
+        agent = Agent(self.args.config)
+        agent.run()
+
+
+def main() -> None:
+    CLI().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+
+import yaml
+
+
+def test_cli_entrypoint(tmp_path):
+    config = {"server": {"host": "127.0.0.1", "port": 8123}}
+    path = tmp_path / "config.yml"
+    path.write_text(yaml.dump(config))
+
+    result = subprocess.run(
+        [sys.executable, "src/cli.py", "--config", str(path), "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "usage" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- add argparse-based CLI entrypoint
- show CLI usage in docs and README
- test CLI entrypoint with temporary config

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686166717d548322822f04fabcf7767f