### PR TITLE
[Core] add metrics collection

### DIFF
--- a/src/pipeline/agent.py
+++ b/src/pipeline/agent.py
@@ -212,4 +212,4 @@ class Agent:
             tools=self.tool_registry,
             plugins=self.plugin_registry,
         )
-        return await execute_pipeline(message, registries)
+        return cast(Dict[str, Any], await execute_pipeline(message, registries))

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -181,6 +181,10 @@ class SimpleContext(PluginContext):
         if llm is None:
             raise RuntimeError("LLM resource 'ollama' not available")
 
+        self._state.metrics.record_llm_call(
+            "SimpleContext", str(self.current_stage), "ask_llm"
+        )
+
         if hasattr(llm, "generate"):
             response = await llm.generate(prompt)
         else:

--- a/src/pipeline/manager.py
+++ b/src/pipeline/manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Dict, Optional, Set
+from typing import Any, Dict, Optional, Set, cast
 
 from .registries import SystemRegistries
 
@@ -33,14 +33,17 @@ class PipelineManager:
         async with self._lock:
             self._active.discard(pipeline_id)
 
-    async def _run_pipeline(self, message: str) -> Dict:
+    async def _run_pipeline(self, message: str) -> Dict[str, Any]:
         if self._registries is None:
             raise ValueError("PipelineManager requires registries to run pipelines")
         from .pipeline import execute_pipeline
 
-        return await execute_pipeline(message, self._registries, pipeline_manager=self)
+        result = await execute_pipeline(
+            message, self._registries, pipeline_manager=self
+        )
+        return cast(Dict[str, Any], result)
 
-    async def run_pipeline(self, message: str) -> Dict:
+    async def run_pipeline(self, message: str) -> Dict[str, Any]:
         return await self._run_pipeline(message)
 
     async def has_active_pipelines_async(self) -> bool:

--- a/src/pipeline/state.py
+++ b/src/pipeline/state.py
@@ -21,7 +21,7 @@ class ConversationEntry:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
-@dataclass
+@dataclass(eq=False)
 class ToolCall:
     name: str
     params: Dict[str, Any]
@@ -42,23 +42,45 @@ class FailureInfo:
 
 @dataclass
 class MetricsCollector:
-    """Placeholder metrics collector."""
+    """Collect simple pipeline metrics."""
+
+    pipeline_durations: list[float] = field(default_factory=list)
+    plugin_durations: dict[str, list[float]] = field(default_factory=dict)
+    tool_execution_count: dict[str, int] = field(default_factory=dict)
+    tool_error_count: dict[str, int] = field(default_factory=dict)
+    llm_call_count: dict[str, int] = field(default_factory=dict)
+
+    def record_pipeline_duration(self, duration: float) -> None:
+        self.pipeline_durations.append(duration)
 
     def record_plugin_duration(self, plugin: str, stage: str, duration: float) -> None:
-        pass
+        key = f"{stage}:{plugin}"
+        self.plugin_durations.setdefault(key, []).append(duration)
 
     def record_tool_execution(
         self, tool_name: str, stage: str, pipeline_id: str, result_key: str, source: str
     ) -> None:
-        pass
+        key = f"{stage}:{tool_name}"
+        self.tool_execution_count[key] = self.tool_execution_count.get(key, 0) + 1
 
     def record_tool_error(
         self, tool_name: str, stage: str, pipeline_id: str, error: str
     ) -> None:
-        pass
+        key = f"{stage}:{tool_name}"
+        self.tool_error_count[key] = self.tool_error_count.get(key, 0) + 1
 
     def record_llm_call(self, plugin: str, stage: str, purpose: str) -> None:
-        pass
+        key = f"{stage}:{plugin}:{purpose}"
+        self.llm_call_count[key] = self.llm_call_count.get(key, 0) + 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pipeline_durations": self.pipeline_durations,
+            "plugin_durations": self.plugin_durations,
+            "tool_execution_count": self.tool_execution_count,
+            "tool_error_count": self.tool_error_count,
+            "llm_call_count": self.llm_call_count,
+        }
 
 
 @dataclass

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,61 @@
+import asyncio
+
+from pipeline import (
+    LLMResponse,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
+
+
+class EchoLLM:
+    async def generate(self, prompt: str):
+        return LLMResponse(content=prompt)
+
+
+class EchoTool(ToolPlugin):
+    required_params = ["text"]
+
+    async def execute_function(self, params):
+        return params["text"]
+
+
+class MetricsPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        context.execute_tool("echo", {"text": "hello"})
+        await self.call_llm(context, "hi", "test")
+        context.set_response("ok")
+
+
+def make_registries():
+    plugins = PluginRegistry()
+    plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DO)
+    resources = ResourceRegistry()
+    resources.add("ollama", EchoLLM())
+    tools = ToolRegistry()
+    tools.add("echo", EchoTool({}))
+    return SystemRegistries(resources, tools, plugins)
+
+
+def test_metrics_collected():
+    registries = make_registries()
+
+    response, metrics = asyncio.run(
+        execute_pipeline("start", registries, return_metrics=True)
+    )
+    assert response == "ok"
+
+    data = metrics.to_dict()
+    stage = str(PipelineStage.DO)
+    plugin_key = f"{stage}:{MetricsPlugin.__name__}"
+    assert plugin_key in data["plugin_durations"]
+    assert data["tool_execution_count"][f"{stage}:echo"] == 1
+    assert data["llm_call_count"][f"{stage}:{MetricsPlugin.__name__}:test"] == 1
+    assert data["pipeline_durations"] and data["pipeline_durations"][0] > 0


### PR DESCRIPTION
## Summary
- collect metrics during pipeline execution
- extend context helpers to track LLM calls
- expose metrics via `to_dict`
- add regression tests for metrics

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: file or directory not found)*
- `pytest tests/performance/ -m benchmark` *(fails: file or directory not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861666db1048322a4e23eeee8c039f8