### PR TITLE
[Tool] Add DuckDuckGo SearchTool

### DIFF
--- a/src/pipeline/plugins/tools/__init__.py
+++ b/src/pipeline/plugins/tools/__init__.py
@@ -1,0 +1,7 @@
+from .calculator_tool import CalculatorTool
+from .search_tool import SearchTool
+
+__all__ = [
+    "CalculatorTool",
+    "SearchTool",
+]

--- a/src/pipeline/plugins/tools/search_tool.py
+++ b/src/pipeline/plugins/tools/search_tool.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+
+from pipeline.plugins import ToolPlugin
+from pipeline.stages import PipelineStage
+
+
+class SearchTool(ToolPlugin):
+    """Simple search tool using DuckDuckGo's public API."""
+
+    stages = [PipelineStage.DO]
+    required_params = ["query"]
+
+    async def execute_function(self, params: Dict[str, Any]) -> str:
+        query = params.get("query")
+        if not query:
+            raise ValueError("'query' parameter is required")
+
+        url = "https://api.duckduckgo.com/"
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                response = await client.get(
+                    url,
+                    params={
+                        "q": query,
+                        "format": "json",
+                        "no_redirect": 1,
+                        "no_html": 1,
+                    },
+                )
+                response.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network error path
+            raise RuntimeError(f"Search request failed: {exc}") from exc
+
+        data = response.json()
+        topics = data.get("RelatedTopics")
+        if topics and isinstance(topics, list):
+            first = topics[0]
+            if isinstance(first, dict) and first.get("Text"):
+                return str(first["Text"])
+        return "No results found."

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -1,0 +1,37 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
+                      PluginContext, PluginRegistry, ResourceRegistry,
+                      SystemRegistries, ToolRegistry)
+from pipeline.plugins.tools.search_tool import SearchTool
+
+
+class FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self):
+        return {"RelatedTopics": [{"Text": "Example Result"}]}
+
+
+async def run_search():
+    state = PipelineState(
+        conversation=[ConversationEntry(content="hi", role="user")],
+        pipeline_id="1",
+        metrics=MetricsCollector(),
+    )
+    tools = ToolRegistry()
+    tools.add("search", SearchTool())
+    registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
+    ctx = PluginContext(state, registries)
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=FakeResponse())):
+        result = await ctx.use_tool("search", query="test")
+    return result
+
+
+def test_search_tool_registered_and_returns_result():
+    result = asyncio.run(run_search())
+    assert result == "Example Result"


### PR DESCRIPTION
## Summary
- implement `SearchTool` for quick web lookup
- export `SearchTool` from tools package
- test basic registration and execution

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: Unknown config option)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option)*
- `pytest -q` *(fails: ImportError: cannot import name 'LLMResponse' from partially initialized module 'pipeline.context')*


------
https://chatgpt.com/codex/tasks/task_e_68616a60c4ec83229196291478a65f52