### PR TITLE
[Resource] Implement structured logging resource

### DIFF
--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -1,0 +1,9 @@
+from .echo_llm import EchoLLMResource
+from .memory_resource import SimpleMemoryResource
+from .structured_logging import StructuredLogging
+
+__all__ = [
+    "EchoLLMResource",
+    "SimpleMemoryResource",
+    "StructuredLogging",
+]

--- a/src/pipeline/plugins/resources/structured_logging.py
+++ b/src/pipeline/plugins/resources/structured_logging.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from typing import Any, Dict
+
+from pipeline.plugins import ResourcePlugin, ValidationResult
+from pipeline.stages import PipelineStage
+
+
+class StructuredLogging(ResourcePlugin):
+    """Configure Python's logging module based on YAML configuration."""
+
+    stages = [PipelineStage.PARSE]
+    name = "logging"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self._configured = False
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        level = config.get("level")
+        if level is not None and str(level).upper() not in logging._nameToLevel:
+            return ValidationResult.error_result(f"Invalid log level: {level}")
+
+        if config.get("file_enabled") and not config.get("file_path"):
+            return ValidationResult.error_result(
+                "'file_path' is required when file_enabled is True"
+            )
+
+        return ValidationResult.success_result()
+
+    def _configure_logging(self) -> None:
+        if self._configured:
+            return
+
+        level_name = str(self.config.get("level", "INFO")).upper()
+        level = logging._nameToLevel.get(level_name, logging.INFO)
+        fmt = self.config.get(
+            "format", "%(asctime)s [%(levelname)8s] %(name)s: %(message)s"
+        )
+
+        handlers: list[logging.Handler] = [logging.StreamHandler()]
+        if self.config.get("file_enabled"):
+            file_path = str(self.config.get("file_path", "entity.log"))
+            max_size = int(self.config.get("max_file_size", 10_485_760))
+            backup_count = int(self.config.get("backup_count", 5))
+            handlers.append(
+                RotatingFileHandler(
+                    file_path, maxBytes=max_size, backupCount=backup_count
+                )
+            )
+
+        logging.basicConfig(level=level, format=fmt, handlers=handlers, force=True)
+        self._configured = True
+
+    async def initialize(self) -> None:
+        self._configure_logging()
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    async def _execute_impl(
+        self, context
+    ) -> Any:  # pragma: no cover - no runtime action
+        return None

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -1,0 +1,27 @@
+import asyncio
+import logging
+from logging.handlers import RotatingFileHandler
+
+from pipeline.plugins.resources.structured_logging import StructuredLogging
+
+
+async def init_logging(cfg):
+    plugin = StructuredLogging(cfg)
+    await plugin.initialize()
+
+
+def test_structured_logging_initializes(tmp_path):
+    config = {
+        "level": "WARNING",
+        "format": "%(levelname)s:%(message)s",
+        "file_enabled": True,
+        "file_path": str(tmp_path / "entity.log"),
+        "max_file_size": 1024,
+        "backup_count": 1,
+    }
+    asyncio.run(init_logging(config))
+
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.WARNING
+    assert any(isinstance(h, RotatingFileHandler) for h in root_logger.handlers)
+    assert any(isinstance(h, logging.StreamHandler) for h in root_logger.handlers)


### PR DESCRIPTION
## Summary
- add structured logging resource plugin
- export StructuredLogging in resources package
- test logging initialization

## Testing
- `PYENV_VERSION=3.12.10 black src/pipeline/plugins/resources/structured_logging.py tests/test_structured_logging.py src/pipeline/plugins/resources/__init__.py`
- `PYENV_VERSION=3.12.10 isort src/pipeline/plugins/resources/structured_logging.py tests/test_structured_logging.py src/pipeline/plugins/resources/__init__.py --check`
- `PYENV_VERSION=3.12.10 flake8 src/pipeline/plugins/resources/structured_logging.py tests/test_structured_logging.py src/pipeline/plugins/resources/__init__.py`
- `PYENV_VERSION=3.12.10 mypy src/pipeline/plugins/resources/structured_logging.py` *(fails: missing stubs)*
- `PYENV_VERSION=3.12.10 bandit -r src/pipeline/plugins/resources/structured_logging.py`
- `PYENV_VERSION=3.12.10 python -m src.config.validator --config config/dev.yaml` *(fails: module not found)*
- `PYENV_VERSION=3.12.10 python -m src.config.validator --config config/prod.yaml` *(fails: module not found)*
- `PYENV_VERSION=3.12.10 python -m src.registry.validator` *(fails: module not found)*
- `PYENV_VERSION=3.12.10 pytest tests/integration/ -v` *(fails: unknown config option)*
- `PYENV_VERSION=3.12.10 pytest tests/performance/ -m benchmark` *(fails: unknown config option)*
- `pytest tests/test_structured_logging.py -k test_structured_logging_initializes -vv`

------
https://chatgpt.com/codex/tasks/task_e_68616e8d57d08322a848a3d39d70017f