### PR TITLE
[Core] track llm call durations

### DIFF
--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -113,6 +113,8 @@ class BasePlugin(ABC):
             self.__class__.__name__, str(context.current_stage), purpose
         )
 
+        start = time.time()
+
         if hasattr(llm, "generate"):
             response = await llm.generate(prompt)
         else:
@@ -123,6 +125,10 @@ class BasePlugin(ABC):
                 response = await func(prompt)
             else:
                 response = func(prompt)
+
+        context._state.metrics.record_llm_duration(
+            self.__class__.__name__, str(context.current_stage), time.time() - start
+        )
 
         return LLMResponse(content=str(response))
 

--- a/src/pipeline/state.py
+++ b/src/pipeline/state.py
@@ -49,6 +49,7 @@ class MetricsCollector:
     tool_execution_count: dict[str, int] = field(default_factory=dict)
     tool_error_count: dict[str, int] = field(default_factory=dict)
     llm_call_count: dict[str, int] = field(default_factory=dict)
+    llm_durations: dict[str, list[float]] = field(default_factory=dict)
 
     def record_pipeline_duration(self, duration: float) -> None:
         self.pipeline_durations.append(duration)
@@ -73,6 +74,10 @@ class MetricsCollector:
         key = f"{stage}:{plugin}:{purpose}"
         self.llm_call_count[key] = self.llm_call_count.get(key, 0) + 1
 
+    def record_llm_duration(self, plugin: str, stage: str, duration: float) -> None:
+        key = f"{stage}:{plugin}"
+        self.llm_durations.setdefault(key, []).append(duration)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "pipeline_durations": self.pipeline_durations,
@@ -80,6 +85,7 @@ class MetricsCollector:
             "tool_execution_count": self.tool_execution_count,
             "tool_error_count": self.tool_error_count,
             "llm_call_count": self.llm_call_count,
+            "llm_durations": self.llm_durations,
         }
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -56,6 +56,7 @@ def test_metrics_collected():
     stage = str(PipelineStage.DO)
     plugin_key = f"{stage}:{MetricsPlugin.__name__}"
     assert plugin_key in data["plugin_durations"]
+    assert plugin_key in data["llm_durations"]
     assert data["tool_execution_count"][f"{stage}:echo"] == 1
     assert data["llm_call_count"][f"{stage}:{MetricsPlugin.__name__}:test"] == 1
     assert data["pipeline_durations"] and data["pipeline_durations"][0] > 0

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -1,9 +1,17 @@
 import asyncio
+from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginRegistry,
+    ResourceRegistry,
+    SimpleContext,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.plugins.tools.search_tool import SearchTool
 
 
@@ -19,14 +27,16 @@ class FakeResponse:
 
 async def run_search():
     state = PipelineState(
-        conversation=[ConversationEntry(content="hi", role="user")],
+        conversation=[
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        ],
         pipeline_id="1",
         metrics=MetricsCollector(),
     )
     tools = ToolRegistry()
     tools.add("search", SearchTool())
     registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
-    ctx = PluginContext(state, registries)
+    ctx = SimpleContext(state, registries)
     with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=FakeResponse())):
         result = await ctx.use_tool("search", query="test")
     return result


### PR DESCRIPTION
## Summary
- capture LLM call durations in metrics
- time calls inside BasePlugin.call_llm
- validate timing info in metrics tests
- fix search tool test

## Testing
- `mypy src/pipeline/base_plugins.py src/pipeline/state.py tests/test_metrics.py tests/test_search_tool.py`
- `bandit -r src/pipeline/base_plugins.py src/pipeline/state.py tests/test_metrics.py tests/test_search_tool.py`
- `pytest -q`
- `PYTHONPATH=src python -m pipeline.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `PYTHONPATH=src python -m pipeline.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `PYTHONPATH=src python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: directory not found)*
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616e981e388322a19ae44de34653b1