### PR TITLE
[Tool] Add WeatherApiTool

### DIFF
--- a/src/pipeline/plugins/tools/__init__.py
+++ b/src/pipeline/plugins/tools/__init__.py
@@ -1,7 +1,9 @@
 from .calculator_tool import CalculatorTool
 from .search_tool import SearchTool
+from .weather_api_tool import WeatherApiTool
 
 __all__ = [
     "CalculatorTool",
     "SearchTool",
+    "WeatherApiTool",
 ]

--- a/src/pipeline/plugins/tools/weather_api_tool.py
+++ b/src/pipeline/plugins/tools/weather_api_tool.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+
+from pipeline.plugins import ToolPlugin
+from pipeline.stages import PipelineStage
+
+
+class WeatherApiTool(ToolPlugin):
+    """Fetch weather information from an external API."""
+
+    stages = [PipelineStage.DO]
+    required_params = ["location"]
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self.base_url: str = self.config.get("base_url", "https://api.weather.com")
+        self.api_key: str | None = self.config.get("api_key")
+        self.timeout: int = int(self.config.get("timeout", 10))
+
+    async def execute_function(self, params: Dict[str, Any]) -> Any:
+        location = params.get("location")
+        if not location:
+            raise ValueError("'location' parameter is required")
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(
+                    self.base_url,
+                    params={"location": location, "api_key": self.api_key},
+                )
+                response.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network error path
+            raise RuntimeError(f"Weather request failed: {exc}") from exc
+
+        return response.json()

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -1,9 +1,16 @@
 import asyncio
 from unittest.mock import AsyncMock, patch
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.plugins.tools.search_tool import SearchTool
 
 

--- a/tests/test_weather_api_tool.py
+++ b/tests/test_weather_api_tool.py
@@ -1,0 +1,54 @@
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginRegistry,
+    ResourceRegistry,
+    SimpleContext,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.plugins.tools.weather_api_tool import WeatherApiTool
+
+
+class FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:  # pragma: no cover - test stub
+        pass
+
+    def json(self):
+        return {"temp": "72F"}
+
+
+async def run_weather():
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id="1",
+        metrics=MetricsCollector(),
+    )
+    tools = ToolRegistry()
+    tool = WeatherApiTool({"base_url": "http://test/weather", "api_key": "key"})
+    tools.add("weather", tool)
+    registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
+    ctx = SimpleContext(state, registries)
+    with patch(
+        "httpx.AsyncClient.get", new=AsyncMock(return_value=FakeResponse())
+    ) as mock_get:
+        result = await ctx.use_tool("weather", location="Berlin")
+        mock_get.assert_called_with(
+            "http://test/weather",
+            params={"location": "Berlin", "api_key": "key"},
+        )
+    return result
+
+
+def test_weather_api_tool_returns_json():
+    result = asyncio.run(run_weather())
+    assert result == {"temp": "72F"}


### PR DESCRIPTION
## Summary
- implement `WeatherApiTool` plugin for fetching weather data
- expose tool from the tools package
- test HTTPX interaction for the new tool
- reformat imports in `test_search_tool.py`

## Testing
- `black src/ tests/`
- `isort --check-only src/ tests/` *(fails: imports not sorted)*
- `flake8 src/ tests/`
- `mypy src/` *(fails: missing yaml stubs)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: module not found)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: module not found)*
- `python -m src.registry.validator` *(fails: module not found)*
- `pytest tests/integration/ -v` *(fails: directory not found)*
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*
- `pytest tests/test_weather_api_tool.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68616e8931308322a6d6c4226e0d2610