### PR TITLE
[Prompt] Resolve merge markers in react prompt

### DIFF
--- a/src/pipeline/plugins/prompts/react_prompt.py
+++ b/src/pipeline/plugins/prompts/react_prompt.py
@@ -41,17 +41,11 @@ class ReActPrompt(PromptPlugin):
             )
 
             action_prompt = (
-                f'Based on my thought: "{thought.content}"\n\n'
+                f'Based on my thought: "{thought.content}"\n'
                 "Should I:\n1. Take an action (specify: search, calculate, etc.)\n"
                 "2. Give a final answer\n\n"
-<<<<<< codex/add-subcommand-to-reload-config
-                "Respond with either "
-                '"Action: <action_name> <parameters>" '
+                'Respond with either "Action: <action_name> <parameters>" '
                 'or "Final Answer: <answer>"'
-======
-                'Respond with either "Action: <action_name> <parameters>" or '
-                '"Final Answer: <answer>"'
->>>>>> main
             )
             action_decision = await self.call_llm(
                 context, action_prompt, purpose=f"react_action_step_{step}"


### PR DESCRIPTION
## Summary
- fix merge conflict markers in the ReAct prompt template

## Testing
- `black src/ tests/`
- `isort --profile black src/ tests/`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v`
- `pytest tests/performance/ -m benchmark`

------
https://chatgpt.com/codex/tasks/task_e_6861749820c88322a53546f328c0f817