### PR TITLE
[Core] Filter plugin registration by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ def smart_assistant(context):
 ### Instant Plugin Discovery
 ```python
 # Framework auto-discovers plugins by naming convention
+# functions must end with `_plugin`
 # weather_plugin.py
 def weather_plugin(context):
     return get_weather_data()

--- a/src/pipeline/agent.py
+++ b/src/pipeline/agent.py
@@ -158,7 +158,7 @@ class Agent:
                     and obj is not BasePlugin
                 ):
                     self.add_plugin(obj({}))
-                elif callable(obj):
+                elif callable(obj) and name.endswith("_plugin"):
                     self.plugin(obj)
             except Exception as exc:  # noqa: BLE001
                 logger.error(

--- a/tests/test_agent_from_directory.py
+++ b/tests/test_agent_from_directory.py
@@ -19,3 +19,38 @@ def hi_plugin(ctx):\n    return 'hi'\n"""
     assert any(p.name == "hi_plugin" for p in plugins)
     assert not any(p.name == "bad" for p in plugins)
     assert any("Failed to import plugin module" in r.message for r in caplog.records)
+
+
+def test_directory_plugin_naming(tmp_path):
+    mixed = tmp_path / "mixed.py"
+    mixed.write_text(
+        """
+from pipeline import BasePlugin, PipelineStage
+
+def good_plugin(ctx):
+    return 'ok'
+
+def bad(ctx):
+    return 'no'
+
+class GoodClass(BasePlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        return 'class'
+
+class BadClass:
+    pass
+"""
+    )
+
+    agent = Agent.from_directory(str(tmp_path))
+    plugins = agent.plugins.get_for_stage(PipelineStage.DO)
+
+    names = {getattr(p, "name", p.__class__.__name__) for p in plugins}
+    classes = {p.__class__.__name__ for p in plugins}
+
+    assert "good_plugin" in names
+    assert "bad" not in names
+    assert "GoodClass" in classes
+    assert "BadClass" not in classes


### PR DESCRIPTION
## Summary
- register only functions ending with `_plugin`
- clarify plugin naming convention in README
- test directory loader ignores invalid names

## Testing
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `pytest tests/test_agent_from_directory.py::test_directory_plugin_naming -q`
- `pytest -q` *(fails: SyntaxError in react_prompt.py)*

------
https://chatgpt.com/codex/tasks/task_e_686174c005188322b98126de045b5021