### PR TITLE
[Resource] Add PostgreSQL resource plugin

### DIFF
--- a/src/pipeline/plugins/prompts/react_prompt.py
+++ b/src/pipeline/plugins/prompts/react_prompt.py
@@ -44,28 +44,8 @@ class ReActPrompt(PromptPlugin):
                 f'Based on my thought: "{thought.content}"\n'
                 "Should I:\n1. Take an action (specify: search, calculate, etc.)\n"
                 "2. Give a final answer\n\n"
-<<<<<< codex/create-failure-plugin-with-tests-and-documentation
-                'Respond with either "Action: <action_name> <parameters>" or '
-                '"Final Answer: <answer>"'
-======
-<<<<< xb4ohw-codex/create-config-directory-and-example-configs
-                'Respond with either "Action: <action_name> <parameters>" or '
-                '"Final Answer: <answer>"'
-=====
-<<<<< codex/create-config-directory-and-example-configs
-                'Respond with either "Action: <action_name> <parameters>" or '
-                '"Final Answer: <answer>"'
-=====
-<<<< dhvmir-codex/remove-or-refactor-old-plugin-directories
-                'Respond with either "Action: <action_name> <parameters>" or '
-                '"Final Answer: <answer>"'
-====
                 'Respond with either "Action: <action_name> <parameters>" '
                 'or "Final Answer: <answer>"'
->>>> main
->>>>> main
->>>>> main
->>>>>> main
             )
             action_decision = await self.call_llm(
                 context, action_prompt, purpose=f"react_action_step_{step}"

--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -1,9 +1,11 @@
 from .echo_llm import EchoLLMResource
 from .memory_resource import SimpleMemoryResource
+from .postgres import PostgresResource
 from .structured_logging import StructuredLogging
 
 __all__ = [
     "EchoLLMResource",
     "SimpleMemoryResource",
     "StructuredLogging",
+    "PostgresResource",
 ]

--- a/src/pipeline/plugins/resources/postgres.py
+++ b/src/pipeline/plugins/resources/postgres.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import asyncpg
+
+from pipeline.plugins import ResourcePlugin
+from pipeline.stages import PipelineStage
+
+
+class PostgresResource(ResourcePlugin):
+    """Asynchronous PostgreSQL connection resource."""
+
+    stages = [PipelineStage.PARSE]
+    name = "database"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self._connection: Optional[asyncpg.Connection] = None
+
+    async def initialize(self) -> None:
+        self._connection = await asyncpg.connect(
+            database=str(self.config.get("name")),
+            host=str(self.config.get("host", "localhost")),
+            port=int(self.config.get("port", 5432)),
+            user=str(self.config.get("username")),
+            password=str(self.config.get("password")),
+        )
+
+    async def _execute_impl(self, context) -> Any:  # pragma: no cover - no op
+        return None
+
+    async def health_check(self) -> bool:
+        if self._connection is None:
+            return False
+        try:
+            await self._connection.fetchval("SELECT 1")
+            return True
+        except Exception:
+            return False

--- a/tests/test_postgres_resource.py
+++ b/tests/test_postgres_resource.py
@@ -1,0 +1,45 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from pipeline.plugins.resources.postgres import PostgresResource
+
+
+async def init_resource():
+    cfg = {
+        "host": "localhost",
+        "port": 5432,
+        "name": "db",
+        "username": "user",
+        "password": "pass",
+    }
+    conn = AsyncMock()
+    with patch("asyncpg.connect", new=AsyncMock(return_value=conn)) as mock_connect:
+        plugin = PostgresResource(cfg)
+        await plugin.initialize()
+        mock_connect.assert_awaited_with(
+            database="db",
+            host="localhost",
+            port=5432,
+            user="user",
+            password="pass",
+        )
+    return plugin, conn
+
+
+def test_initialize_opens_connection():
+    plugin, _ = asyncio.run(init_resource())
+    assert plugin._connection is not None
+
+
+async def run_health_check():
+    plugin = PostgresResource({})
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=1)
+    plugin._connection = conn
+    result = await plugin.health_check()
+    conn.fetchval.assert_awaited_with("SELECT 1")
+    return result
+
+
+def test_health_check_runs_query():
+    assert asyncio.run(run_health_check())


### PR DESCRIPTION
## Summary
- add a Postgres resource implementation using asyncpg
- export PostgresResource
- fix merge artifact in `react_prompt.py`
- test Postgres initialization and health check

## Testing
- `black src/pipeline/plugins/resources/postgres.py src/pipeline/plugins/resources/__init__.py src/pipeline/plugins/prompts/react_prompt.py tests/test_postgres_resource.py`
- `isort --check src/pipeline/plugins/resources/postgres.py src/pipeline/plugins/resources/__init__.py src/pipeline/plugins/prompts/react_prompt.py tests/test_postgres_resource.py`
- `flake8 src/ tests/`
- `mypy -p pipeline`
- `mypy -p entity`
- `bandit -r src/`
- `pytest tests/integration/ -v` *(fails: file or directory not found)*
- `pytest tests/performance/ -m benchmark` *(fails: file or directory not found)*
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6861d8f556dc8322ab3016e9b79cf337