### PR TITLE
[Registry] Add validator script and tests

### DIFF
--- a/src/registry/__init__.py
+++ b/src/registry/__init__.py
@@ -1,0 +1,5 @@
+"""Registry utilities and validators."""
+
+from .validator import RegistryValidator
+
+__all__ = ["RegistryValidator"]

--- a/src/registry/validator.py
+++ b/src/registry/validator.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+from typing import Dict, List
+
+SRC_PATH = pathlib.Path(__file__).resolve().parents[1]
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from pipeline.initializer import ClassRegistry, SystemInitializer, import_plugin_class
+from pipeline.plugins import ValidationResult
+from pipeline.stages import PipelineStage
+
+"""Helpers for validating plugin dependencies and stage assignments."""
+
+
+class RegistryValidator:
+    """Validate plugin registry configuration without initializing resources."""
+
+    def __init__(self, config_path: str) -> None:
+        self.initializer = SystemInitializer.from_yaml(config_path)
+        self.registry = ClassRegistry()
+        self.dep_graph: Dict[str, List[str]] = {}
+
+    def _register_classes(self) -> None:
+        plugins_cfg = self.initializer.config.get("plugins", {})
+        for section in ["resources", "tools", "adapters", "prompts"]:
+            for name, cfg in plugins_cfg.get(section, {}).items():
+                cls = import_plugin_class(cfg.get("type", name))
+                self.registry.register_class(cls, cfg, name)
+                self.dep_graph[name] = list(getattr(cls, "dependencies", []))
+                self._validate_stage_assignment(name, cls)
+
+    @staticmethod
+    def _validate_stage_assignment(name: str, cls: type) -> None:
+        stages = getattr(cls, "stages", None)
+        if not stages:
+            raise SystemError(f"Plugin '{name}' does not specify any stages")
+        invalid = [s for s in stages if not isinstance(s, PipelineStage)]
+        if invalid:
+            raise SystemError(f"Plugin '{name}' has invalid stage values: {invalid}")
+
+    def _validate_dependencies(self) -> None:
+        for cls, _ in self.registry.all_plugin_classes():
+            result: ValidationResult = cls.validate_dependencies(self.registry)
+            if not result.success:
+                raise SystemError(
+                    f"Dependency validation failed for {cls.__name__}: {result.error_message}"
+                )
+
+        for plugin_name, deps in self.dep_graph.items():
+            for dep in deps:
+                if not self.registry.has_plugin(dep):
+                    available = self.registry.list_plugins()
+                    raise SystemError(
+                        (
+                            f"Plugin '{plugin_name}' requires '{dep}' but it's not registered. "
+                            f"Available: {available}"
+                        )
+                    )
+
+        in_degree = {node: 0 for node in self.dep_graph}
+        for node, neighbors in self.dep_graph.items():
+            for neigh in neighbors:
+                if neigh in in_degree:
+                    in_degree[neigh] += 1
+
+        queue = [n for n, d in in_degree.items() if d == 0]
+        processed: List[str] = []
+        while queue:
+            current = queue.pop(0)
+            processed.append(current)
+            for neigh in self.dep_graph[current]:
+                if neigh in in_degree:
+                    in_degree[neigh] -= 1
+                    if in_degree[neigh] == 0:
+                        queue.append(neigh)
+
+        if len(processed) != len(in_degree):
+            cycle_nodes = [n for n in in_degree if n not in processed]
+            raise SystemError(f"Circular dependency detected involving: {cycle_nodes}")
+
+    def run(self) -> None:
+        self._register_classes()
+        self._validate_dependencies()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate plugin dependencies and stage assignments"
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to the YAML configuration file",
+    )
+    args = parser.parse_args()
+
+    try:
+        RegistryValidator(args.config).run()
+    except SystemError as exc:  # pragma: no cover - CLI only
+        print(f"Validation failed: {exc}")
+        raise SystemExit(1)
+    print("Validation succeeded")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -1,0 +1,79 @@
+import pytest
+import yaml
+
+from pipeline.plugins import PromptPlugin, ResourcePlugin
+from pipeline.stages import PipelineStage
+from registry.validator import RegistryValidator
+
+
+class A(ResourcePlugin):
+    stages = [PipelineStage.PARSE]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class B(PromptPlugin):
+    stages = [PipelineStage.THINK]
+    dependencies = ["a"]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class C(PromptPlugin):
+    stages = [PipelineStage.DO]
+    dependencies = ["missing"]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class D(PromptPlugin):
+    stages = [PipelineStage.PARSE]
+    dependencies = ["e"]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class E(PromptPlugin):
+    stages = [PipelineStage.DO]
+    dependencies = ["d"]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+def _write_config(tmp_path, plugins):
+    path = tmp_path / "config.yml"
+    path.write_text(yaml.dump({"plugins": plugins}))
+    return path
+
+
+def test_validator_success(tmp_path):
+    plugins = {
+        "resources": {"a": {"type": "tests.test_registry_validator:A"}},
+        "prompts": {"b": {"type": "tests.test_registry_validator:B"}},
+    }
+    path = _write_config(tmp_path, plugins)
+    RegistryValidator(str(path)).run()
+
+
+def test_validator_missing_dependency(tmp_path):
+    plugins = {"prompts": {"c": {"type": "tests.test_registry_validator:C"}}}
+    path = _write_config(tmp_path, plugins)
+    with pytest.raises(SystemError, match="requires 'missing'"):
+        RegistryValidator(str(path)).run()
+
+
+def test_validator_cycle_detection(tmp_path):
+    plugins = {
+        "prompts": {
+            "d": {"type": "tests.test_registry_validator:D"},
+            "e": {"type": "tests.test_registry_validator:E"},
+        }
+    }
+    path = _write_config(tmp_path, plugins)
+    with pytest.raises(SystemError, match="Circular dependency detected"):
+        RegistryValidator(str(path)).run()


### PR DESCRIPTION
## Summary
- add registry validation utility
- validate configs without initializing resources
- detect missing and circular dependencies
- unit tests for validator

## Testing
- `black src/ tests/`
- `isort src/registry/validator.py tests/test_registry_validator.py --profile black`
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/` *(fails: no .py files)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: Invalid plugin path)*
- `pytest tests/integration/ -v` *(fails: directory not found)*
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*
- `pytest -q tests/test_registry_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_6861ddf0cb0483228e44c8995cb6879a