### PR TITLE
[Config] add validator CLI and tests

### DIFF
--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -1,0 +1,51 @@
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, os.path.join(os.getcwd(), "src"))
+
+from pipeline import SystemInitializer  # noqa: E402
+
+
+class ConfigValidator:
+    """CLI for validating Entity configuration files."""
+
+    def __init__(self) -> None:
+        self.args = self._parse_args()
+
+    def _parse_args(self) -> argparse.Namespace:
+        parser = argparse.ArgumentParser(
+            description="Validate an Entity YAML configuration file."
+        )
+        parser.add_argument(
+            "--config",
+            "-c",
+            required=True,
+            help="Path to configuration file",
+        )
+        return parser.parse_args()
+
+    def run(self) -> int:
+        try:
+            with Path(self.args.config).open("r") as fh:
+                config = yaml.safe_load(fh) or {}
+            config = SystemInitializer._interpolate_env_vars(config)
+            initializer = SystemInitializer(config)
+            asyncio.run(initializer.initialize())
+        except Exception as exc:  # pragma: no cover - error path
+            print(f"Configuration invalid: {exc}")
+            return 1
+        print("Configuration valid.")
+        return 0
+
+
+def main() -> None:
+    raise SystemExit(ConfigValidator().run())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -1,0 +1,32 @@
+import subprocess
+import sys
+
+import yaml
+
+
+def test_config_validator_success(tmp_path):
+    config = {"plugins": {"resources": {"a": {"type": "tests.test_initializer:A"}}}}
+    path = tmp_path / "valid.yml"
+    path.write_text(yaml.dump(config))
+
+    result = subprocess.run(
+        [sys.executable, "-m", "src.config.validator", "--config", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "Configuration valid" in result.stdout
+
+
+def test_config_validator_failure(tmp_path):
+    config = {"plugins": {"prompts": {"d": {"type": "tests.test_initializer:D"}}}}
+    path = tmp_path / "bad.yml"
+    path.write_text(yaml.dump(config))
+
+    result = subprocess.run(
+        [sys.executable, "-m", "src.config.validator", "--config", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "missing dependency" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- implement `src.config.validator` CLI for validating YAML configuration
- add tests covering valid and invalid configs

## Testing
- `flake8 src/config/validator.py tests/test_config_validator.py`
- `mypy src/config/validator.py tests/test_config_validator.py src/pipeline/initializer.py`
- `bandit -r src/config/validator.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: Required environment variable DB_USERNAME not found)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: Required environment variable DB_HOST not found)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: Unknown config option asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option asyncio_mode)*
- `pytest tests/test_config_validator.py -q` *(fails: Unknown config option asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_6861ddf61c5c832283a656467981907a