### PR TITLE
[Prompt] Add intent classifier prompt

### DIFF
--- a/src/pipeline/plugins/prompts/__init__.py
+++ b/src/pipeline/plugins/prompts/__init__.py
@@ -1,7 +1,9 @@
+from .intent_classifier import IntentClassifierPrompt
 from .memory_retrieval import MemoryRetrievalPrompt
 from .react_prompt import ReActPrompt
 
 __all__ = [
+    "IntentClassifierPrompt",
     "MemoryRetrievalPrompt",
     "ReActPrompt",
 ]

--- a/src/pipeline/plugins/prompts/intent_classifier.py
+++ b/src/pipeline/plugins/prompts/intent_classifier.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pipeline.context import PluginContext
+from pipeline.plugins import PromptPlugin, ValidationResult
+from pipeline.stages import PipelineStage
+
+
+class IntentClassifierPrompt(PromptPlugin):
+    """Classify user intent using an LLM."""
+
+    dependencies = ["ollama"]
+    stages = [PipelineStage.THINK]
+
+    @classmethod
+    def validate_config(cls, config: dict) -> ValidationResult:
+        if "confidence_threshold" not in config:
+            return ValidationResult.error_result("missing confidence_threshold")
+        try:
+            value = float(config["confidence_threshold"])
+        except (TypeError, ValueError):
+            return ValidationResult.error_result(
+                "confidence_threshold must be a number"
+            )
+        if not 0.0 <= value <= 1.0:
+            return ValidationResult.error_result(
+                "confidence_threshold must be between 0 and 1"
+            )
+        return ValidationResult.success_result()
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        last_message = context.get_conversation_history()[-1].content
+        prompt = "Classify the user's intent in one word.\n" f"Message: {last_message}"
+        response = await self.call_llm(context, prompt, purpose="intent_classification")
+        context.set_stage_result("intent", response.content)

--- a/tests/test_intent_classifier_prompt.py
+++ b/tests/test_intent_classifier_prompt.py
@@ -1,0 +1,47 @@
+import asyncio
+from datetime import datetime
+
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.plugins.prompts.intent_classifier import IntentClassifierPrompt
+
+
+class FakeLLM:
+    async def generate(self, prompt: str):
+        return "greeting"
+
+
+def make_context(llm: FakeLLM):
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id="1",
+        metrics=MetricsCollector(),
+    )
+    resources = ResourceRegistry()
+    resources.add("ollama", llm)
+    registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
+    return state, PluginContext(state, registries)
+
+
+def test_intent_classifier_success():
+    state, ctx = make_context(FakeLLM())
+    plugin = IntentClassifierPrompt({"confidence_threshold": 0.5})
+
+    asyncio.run(plugin.execute(ctx))
+
+    assert state.stage_results["intent"] == "greeting"
+
+
+def test_intent_classifier_validate_error():
+    result = IntentClassifierPrompt.validate_config({"confidence_threshold": 2})
+    assert not result.success


### PR DESCRIPTION
## Summary
- add IntentClassifierPrompt for classifying intent with an LLM
- export IntentClassifierPrompt in prompts package
- test intent classification success and config validation

## Testing
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src` *(fails: no files found)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: module not found)*
- `python -m src.registry.validator` *(fails: module not found)*
- `pytest tests/integration/ -v` *(fails: unknown config option)*
- `pytest tests/performance/ -m benchmark` *(fails: unknown config option)*
- `pytest -q` *(fails: unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_6861ddfc2e388322abf9d4cb3c273aa4