### PR TITLE
[Resource] Add Ollama LLM resource

### DIFF
--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -1,10 +1,12 @@
 from .echo_llm import EchoLLMResource
 from .memory_resource import SimpleMemoryResource
+from .ollama_llm import OllamaLLMResource
 from .postgres import PostgresResource
 from .structured_logging import StructuredLogging
 
 __all__ = [
     "EchoLLMResource",
+    "OllamaLLMResource",
     "SimpleMemoryResource",
     "StructuredLogging",
     "PostgresResource",

--- a/src/pipeline/plugins/resources/ollama_llm.py
+++ b/src/pipeline/plugins/resources/ollama_llm.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+
+from pipeline.plugins import ResourcePlugin, ValidationResult
+from pipeline.stages import PipelineStage
+
+
+class OllamaLLMResource(ResourcePlugin):
+    """LLM resource backed by a running Ollama server."""
+
+    stages = [PipelineStage.PARSE]
+    name = "ollama"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self.base_url: str | None = self.config.get("base_url")
+        self.model: str | None = self.config.get("model")
+        self.params: Dict[str, Any] = {
+            k: v for k, v in self.config.items() if k not in {"base_url", "model"}
+        }
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        if not config.get("base_url"):
+            return ValidationResult.error_result("'base_url' is required")
+        if not config.get("model"):
+            return ValidationResult.error_result("'model' is required")
+        return ValidationResult.success_result()
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
+        return None
+
+    async def generate(self, prompt: str) -> str:
+        if not self.base_url or not self.model:
+            raise RuntimeError("Ollama resource not properly configured")
+
+        url = f"{self.base_url.rstrip('/')}/api/generate"
+        payload = {"model": self.model, "prompt": prompt, **self.params}
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.post(url, json=payload)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"Ollama request failed: {exc}") from exc
+
+        data = response.json()
+        text = data.get("response", "")
+        return str(text)
+
+    __call__ = generate


### PR DESCRIPTION
## Summary
- implement `OllamaLLMResource` for calling a local Ollama server
- export the new resource from the resources package

## Testing
- `flake8 src tests` *(fails: E402 module level import not at top of file)*
- `mypy src` *(fails: no files found)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: Required environment variable DB_USERNAME not found)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: Required environment variable DB_HOST not found)*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: Required environment variable DB_USERNAME not found)*
- `pytest tests/integration/ -v` *(errors: ModuleNotFoundError: asyncpg)*
- `pytest tests/performance/ -m benchmark`

------
https://chatgpt.com/codex/tasks/task_e_6861e3c5c7dc8322acea25d60082c40a