### PR TITLE
[Resource] Add OllamaLLMResource test

### DIFF
--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -1,10 +1,12 @@
 from .echo_llm import EchoLLMResource
 from .memory_resource import SimpleMemoryResource
+from .ollama_llm import OllamaLLMResource
 from .postgres import PostgresResource
 from .structured_logging import StructuredLogging
 
 __all__ = [
     "EchoLLMResource",
+    "OllamaLLMResource",
     "SimpleMemoryResource",
     "StructuredLogging",
     "PostgresResource",

--- a/src/pipeline/plugins/resources/ollama_llm.py
+++ b/src/pipeline/plugins/resources/ollama_llm.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+
+from pipeline.plugins import ResourcePlugin, ValidationResult
+from pipeline.stages import PipelineStage
+
+
+class OllamaLLMResource(ResourcePlugin):
+    """LLM resource that sends prompts to an Ollama server."""
+
+    stages = [PipelineStage.PARSE]
+    name = "ollama"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self.base_url: str = self.config.get("base_url", "http://localhost:11434")
+        self.model: str = self.config.get("model", "llama3")
+        self.timeout: int = int(self.config.get("timeout", 30))
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        if not config.get("base_url"):
+            return ValidationResult.error_result("'base_url' is required")
+        if not config.get("model"):
+            return ValidationResult.error_result("'model' is required")
+        return ValidationResult.success_result()
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
+        return None
+
+    async def generate(self, prompt: str) -> str:
+        url = f"{self.base_url}/api/generate"
+        payload = {"model": self.model, "prompt": prompt}
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+        data = response.json()
+        return str(data.get("response", ""))
+
+    __call__ = generate

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -1,9 +1,16 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.plugins.prompts.chain_of_thought import ChainOfThoughtPrompt
 
 

--- a/tests/test_ollama_resource.py
+++ b/tests/test_ollama_resource.py
@@ -1,0 +1,34 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from pipeline.plugins.resources.ollama_llm import OllamaLLMResource
+
+
+class FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+    def json(self):
+        return {"response": "hi"}
+
+
+async def run_generate():
+    resource = OllamaLLMResource(
+        {"base_url": "http://ollama:11434", "model": "tinyllama"}
+    )
+    with patch(
+        "httpx.AsyncClient.post", new=AsyncMock(return_value=FakeResponse())
+    ) as mock_post:
+        result = await resource.generate("hello")
+        mock_post.assert_called_with(
+            "http://ollama:11434/api/generate",
+            json={"model": "tinyllama", "prompt": "hello"},
+        )
+    return result
+
+
+def test_generate_sends_prompt_and_returns_text():
+    result = asyncio.run(run_generate())
+    assert result == "hi"


### PR DESCRIPTION
## Summary
- implement `OllamaLLMResource` for talking to an Ollama server
- expose the new resource in the resources package
- test Ollama resource generation flow with patched `httpx`

## Testing
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: Required environment variable DB_USERNAME not found)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: Required environment variable DB_HOST not found)*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: Required environment variable DB_USERNAME not found)*
- `pytest tests/integration/ -v`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861e3c62a8c8322adfc2ee89ad57b0d