### PR TITLE
[Core] load default plugins for Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Entity Pipeline Framework Architecture Summary
+
+When instantiated without a configuration file, ``Agent`` loads a basic set of
+plugins so the pipeline can run out of the box:
+
+- ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
+- ``SimpleMemoryResource`` – in-memory storage available across pipeline runs.
+- ``SearchTool`` – wrapper around DuckDuckGo's search API.
+- ``CalculatorTool`` – safe evaluator for arithmetic expressions.
+- ``HTTPAdapter`` – FastAPI adapter exposing a ``POST /`` endpoint.
+
+These defaults allow ``Agent()`` to process messages without any external
+configuration.

--- a/src/agent.py
+++ b/src/agent.py
@@ -17,7 +17,7 @@ class Agent:
             with open(config, "r") as fh:
                 self.config = yaml.safe_load(fh)
         else:
-            self.config = config or {}
+            self.config = config
         self.initializer = SystemInitializer(self.config)
         self._registries: SystemRegistries | None = None
 
@@ -36,7 +36,7 @@ class Agent:
             await self._ensure_initialized()
             if self._registries is None:
                 raise RuntimeError("System not initialized")
-            server_cfg = self.config.get("server", {})
+            server_cfg = (self.config or {}).get("server", {})
             adapter = HTTPAdapter(server_cfg)
             await adapter.serve(self._registries)
 

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -69,8 +69,30 @@ def initialization_cleanup_context():
 
 
 class SystemInitializer:
-    def __init__(self, config: Dict) -> None:
-        self.config = config
+    """Initialize and validate all plugins for the pipeline."""
+
+    DEFAULT_CONFIG: Dict[str, Any] = {
+        "plugins": {
+            "resources": {
+                "ollama": {
+                    "type": "pipeline.plugins.resources.echo_llm:EchoLLMResource"
+                },
+                "memory": {
+                    "type": "pipeline.plugins.resources.memory_resource:SimpleMemoryResource"
+                },
+            },
+            "tools": {
+                "search": {"type": "pipeline.plugins.tools.search_tool:SearchTool"},
+                "calculator": {
+                    "type": "pipeline.plugins.tools.calculator_tool:CalculatorTool"
+                },
+            },
+            "adapters": {"http": {"type": "pipeline.adapters.http:HTTPAdapter"}},
+        }
+    }
+
+    def __init__(self, config: Dict | None = None) -> None:
+        self.config = config or self.DEFAULT_CONFIG
 
     @classmethod
     def from_yaml(cls, yaml_path: str) -> "SystemInitializer":

--- a/tests/test_agent_default_config.py
+++ b/tests/test_agent_default_config.py
@@ -1,0 +1,10 @@
+import asyncio
+
+from agent import Agent
+
+
+def test_agent_no_config_runs_pipeline():
+    agent = Agent()
+    result = asyncio.run(agent.handle("hello"))
+    assert isinstance(result, dict)
+    assert result.get("message")


### PR DESCRIPTION
## Summary
- add built-in default plugin config to `SystemInitializer`
- handle optional config in `Agent`
- explain defaults in README
- test Agent default configuration

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src` *(fails: no files detected)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: module not found)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: module not found)*
- `python -m src.registry.validator` *(fails: module not found)*
- `pytest tests/integration/ -v` *(fails: unknown config option)*
- `pytest tests/performance/ -m benchmark` *(fails: unknown config option)*
- `pytest -q` *(fails: missing dependency pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_6861ddeecdb48322a9f86d7310338538