### PR TITLE
[Docs] Add Ollama resource setup

### DIFF
--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -23,3 +23,17 @@ agent.tool_registry.add("search", SearchTool())
 async def lookup(context):
     return await context.use_tool("search", query="Entity Pipeline")
 ```
+
+### Enabling the Ollama Resource
+Add the Ollama LLM resource to your configuration so plugins can use it:
+
+```yaml
+plugins:
+  resources:
+    ollama:
+      type: ollama_llm
+      base_url: "http://localhost:11434"
+      model: "tinyllama"
+```
+
+The development environment does not require authentication.


### PR DESCRIPTION
## Summary
- outline how to enable the Ollama resource in quick start

## Testing
- `black --check src tests`
- `isort src tests`
- `flake8 src tests`
- `mypy src/**/*.py --config-file mypy.ini`
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: Invalid plugin path: postgres)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: Invalid plugin path: postgres)*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: Invalid plugin path: postgres)*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: asyncpg)*
- `pytest tests/performance/ -m benchmark`

------
https://chatgpt.com/codex/tasks/task_e_6861e3c7c6188322987d98efc13ccb90