### PR TITLE
[Core] Fix agent initialization and optional postgres test

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -23,7 +23,16 @@ class Agent:
 
     async def _ensure_initialized(self) -> None:
         if self._registries is None:
-            self._registries = await self.initializer.initialize()
+            initialized = await self.initializer.initialize()
+            if isinstance(initialized, tuple):
+                plugin_reg, resource_reg, tool_reg = initialized
+                self._registries = SystemRegistries(
+                    resources=resource_reg,
+                    tools=tool_reg,
+                    plugins=plugin_reg,
+                )
+            else:
+                self._registries = initialized
 
     async def handle(self, message: str) -> Any:
         await self._ensure_initialized()

--- a/tests/integration/test_postgres_history.py
+++ b/tests/integration/test_postgres_history.py
@@ -19,7 +19,10 @@ CONN = {
 def test_save_and_load_history():
     async def run():
         resource = PostgresResource(CONN)
-        await resource.initialize()
+        try:
+            await resource.initialize()
+        except OSError as exc:
+            pytest.skip(f"PostgreSQL not available: {exc}")
         await resource._connection.execute("DROP TABLE IF EXISTS test_history")
         await resource._connection.execute(
             "CREATE TABLE test_history ("


### PR DESCRIPTION
## Summary
- ensure Agent converts initializer's tuple into SystemRegistries
- skip Postgres integration test when server isn't running

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src` *(fails: There are no .py[i] files in directory 'src')*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/performance/ -m benchmark` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6861ee4aa5648322bf9b507d5f75bdc6