### PR TITLE
[Config] Load env variables from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_USERNAME=agent
+DB_PASSWORD=
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=llama3:8b-instruct-q6_K
+WEATHER_API_KEY=changeme

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -8,15 +8,15 @@ plugins:
   resources:
     database:
       type: pipeline.plugins.resources.postgres:PostgresResource
-      host: "localhost"
+      host: "${DB_HOST}"
       port: 5432
       name: "dev_db"
       username: "${DB_USERNAME}"
       password: "${DB_PASSWORD}"
     ollama:
       type: pipeline.plugins.resources.ollama_llm:OllamaLLMResource
-      base_url: "http://localhost:11434"
-      model: "llama3:8b-instruct-q6_K"
+      base_url: "${OLLAMA_BASE_URL}"
+      model: "${OLLAMA_MODEL}"
     logging:
       type: pipeline.plugins.resources.structured_logging:StructuredLogging
       level: "DEBUG"

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -17,8 +17,8 @@ plugins:
       history_table: "chat_history"
     ollama:
       type: pipeline.plugins.resources.ollama_llm:OllamaLLMResource
-      base_url: "http://ollama:11434"
-      model: "llama3:8b-instruct-q6_K"
+      base_url: "${OLLAMA_BASE_URL}"
+      model: "${OLLAMA_MODEL}"
       temperature: 0.7
     logging:
       type: pipeline.plugins.resources.structured_logging:StructuredLogging

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ extensions = [
 
 
 templates_path = ["_templates"]
-exclude_patterns = []
+exclude_patterns: list[str] = []
 
 source_suffix = {
     ".rst": "restructuredtext",

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -37,3 +37,6 @@ plugins:
 ```
 
 The development environment does not require authentication.
+Copy `.env.example` to `.env` and update the variables to quickly
+configure database and LLM credentials. These values will be automatically
+loaded when running the agent or tests.

--- a/examples/http_server.py
+++ b/examples/http_server.py
@@ -11,7 +11,7 @@ from entity import Agent
 
 
 def main() -> None:
-    agent = Agent({"server": {"host": "127.0.0.1", "port": 8000}})
+    agent = Agent({"server": {"host": "127.0.0.1", "port": 8000}})  # type: ignore[arg-type]
     agent.run()
 
 

--- a/examples/pipeline_example.py
+++ b/examples/pipeline_example.py
@@ -32,7 +32,7 @@ class CalculatorTool(ToolPlugin):
         expression = params.get("expression")
         if expression is None:
             raise ValueError("'expression' parameter is required")
-        allowed_names = {"__builtins__": {}}
+        allowed_names: dict[str, dict[str, object]] = {"__builtins__": {}}
         try:
             return eval(str(expression), allowed_names, {})
         except Exception as exc:  # noqa: BLE001

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,3 +15,6 @@ ignore_missing_imports = True
 [mypy-httpx.*]
 ignore_missing_imports = True
 
+[mypy-dotenv.*]
+ignore_missing_imports = True
+

--- a/src/cli.py
+++ b/src/cli.py
@@ -54,7 +54,9 @@ class CLI:
             registries: Any | None = agent._registries
             if registries is None:
                 raise RuntimeError("System not initialized")
-            plugin_registry = getattr(registries, "plugins", registries[0])
+            plugin_registry = getattr(registries, "plugins", None)
+            if plugin_registry is None:
+                plugin_registry = registries[0]
             with open(file_path, "r") as fh:
                 cfg = yaml.safe_load(fh) or {}
             success = True

--- a/src/config/environment.py
+++ b/src/config/environment.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+def load_env(env_file: str | Path = ".env") -> None:
+    """Load environment variables from a .env file if it exists."""
+    env_path = Path(env_file)
+    if env_path.exists():
+        load_dotenv(env_path)

--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -9,6 +9,7 @@ import yaml
 sys.path.insert(0, os.path.join(os.getcwd(), "src"))
 
 from pipeline import SystemInitializer  # noqa: E402
+from config.environment import load_env
 
 
 class ConfigValidator:
@@ -33,6 +34,7 @@ class ConfigValidator:
         try:
             with Path(self.args.config).open("r") as fh:
                 config = yaml.safe_load(fh) or {}
+            load_env()
             config = SystemInitializer._interpolate_env_vars(config)
             initializer = SystemInitializer(config)
             asyncio.run(initializer.initialize())

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -5,6 +5,8 @@ from contextlib import contextmanager
 from importlib import import_module
 from typing import Any, Dict, Iterable, List, Tuple
 
+from config.environment import load_env
+
 from .base_plugins import BasePlugin, ResourcePlugin, ToolPlugin
 from .registries import PluginRegistry, ResourceRegistry, ToolRegistry
 
@@ -91,18 +93,20 @@ class SystemInitializer:
         }
     }
 
-    def __init__(self, config: Dict | None = None) -> None:
+    def __init__(self, config: Dict | None = None, env_file: str = ".env") -> None:
+        load_env(env_file)
         self.config = config or self.DEFAULT_CONFIG
 
     @classmethod
-    def from_yaml(cls, yaml_path: str) -> "SystemInitializer":
+    def from_yaml(cls, yaml_path: str, env_file: str = ".env") -> "SystemInitializer":
         import yaml
 
         with open(yaml_path, "r") as fh:
             content = fh.read()
         config = yaml.safe_load(content)
+        load_env(env_file)
         config = cls._interpolate_env_vars(config)
-        return cls(config)
+        return cls(config, env_file)
 
     def get_resource_config(self, name: str) -> Dict:
         return self.config["plugins"]["resources"][name]

--- a/src/pipeline/plugins/failure/basic_logger.py
+++ b/src/pipeline/plugins/failure/basic_logger.py
@@ -16,11 +16,14 @@ class BasicLogger(FailurePlugin):
     async def _execute_impl(self, context: PluginContext) -> Any:
         info = context._state.failure_info
         logger = logging.getLogger(self.__class__.__name__)
-        logger.error(
-            "Pipeline failure encountered",
-            extra={
-                "stage": info.stage,
-                "plugin": info.plugin_name,
-                "error": info.error_message,
-            },
-        )
+        if info is not None:
+            logger.error(
+                "Pipeline failure encountered",
+                extra={
+                    "stage": info.stage,
+                    "plugin": info.plugin_name,
+                    "error": info.error_message,
+                },
+            )
+        else:
+            logger.error("Pipeline failure encountered with no context")


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- add `.env.example` with credentials
- interpolate database and LLM credentials in configs
- mention `.env` file in quick start docs
- improve CLI and logging stability

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/`
- `mypy $(git ls-files '*.py')`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml`
- `python -m src.config.validator --config config/prod.yaml`
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v`
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f27efcbc8322ab25fe1f8afcb134