### PR TITLE
[Testing] Use .env variables in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from config.environment import load_env
+
+
+@pytest.fixture(autouse=True)
+def _load_test_env(monkeypatch):
+    """Load environment variables for tests from the example file."""
+    env_path = Path(__file__).resolve().parents[1] / ".env.example"
+    load_env(env_path)
+    yield

--- a/tests/integration/test_postgres_history.py
+++ b/tests/integration/test_postgres_history.py
@@ -1,16 +1,22 @@
 import asyncio
+import os
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
+from config.environment import load_env
 from pipeline.plugins.resources.postgres import PostgresResource
 from pipeline.state import ConversationEntry
 
+load_env(Path(__file__).resolve().parents[2] / ".env.example")
+
 CONN = {
-    "host": "localhost",
+    "host": os.environ["DB_HOST"],
     "port": 5432,
     "name": "dev_db",
-    "username": "agent",
+    "username": os.environ["DB_USERNAME"],
+    "password": os.environ.get("DB_PASSWORD", ""),
     "history_table": "test_history",
 }
 

--- a/tests/test_ollama_resource.py
+++ b/tests/test_ollama_resource.py
@@ -1,7 +1,12 @@
 import asyncio
+import os
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+from config.environment import load_env
 from pipeline.plugins.resources.ollama_llm import OllamaLLMResource
+
+load_env(Path(__file__).resolve().parents[1] / ".env.example")
 
 
 class FakeResponse:
@@ -16,15 +21,18 @@ class FakeResponse:
 
 async def run_generate():
     resource = OllamaLLMResource(
-        {"base_url": "http://ollama:11434", "model": "tinyllama"}
+        {
+            "base_url": os.environ["OLLAMA_BASE_URL"],
+            "model": os.environ["OLLAMA_MODEL"],
+        }
     )
     with patch(
         "httpx.AsyncClient.post", new=AsyncMock(return_value=FakeResponse())
     ) as mock_post:
         result = await resource.generate("hello")
         mock_post.assert_called_with(
-            "http://ollama:11434/api/generate",
-            json={"model": "tinyllama", "prompt": "hello"},
+            f"{os.environ['OLLAMA_BASE_URL']}/api/generate",
+            json={"model": os.environ["OLLAMA_MODEL"], "prompt": "hello"},
         )
     return result
 

--- a/tests/test_postgres_resource.py
+++ b/tests/test_postgres_resource.py
@@ -1,16 +1,21 @@
 import asyncio
+import os
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+from config.environment import load_env
 from pipeline.plugins.resources.postgres import PostgresResource
+
+load_env(Path(__file__).resolve().parents[1] / ".env.example")
 
 
 async def init_resource():
     cfg = {
-        "host": "localhost",
+        "host": os.environ["DB_HOST"],
         "port": 5432,
         "name": "db",
-        "username": "user",
-        "password": "pass",
+        "username": os.environ["DB_USERNAME"],
+        "password": os.environ.get("DB_PASSWORD", ""),
     }
     conn = AsyncMock()
     with patch("asyncpg.connect", new=AsyncMock(return_value=conn)) as mock_connect:
@@ -18,10 +23,10 @@ async def init_resource():
         await plugin.initialize()
         mock_connect.assert_awaited_with(
             database="db",
-            host="localhost",
+            host=os.environ["DB_HOST"],
             port=5432,
-            user="user",
-            password="pass",
+            user=os.environ["DB_USERNAME"],
+            password=os.environ.get("DB_PASSWORD", ""),
         )
     return plugin, conn
 


### PR DESCRIPTION
## Summary
- load `.env.example` for tests
- use env variables in Postgres, Ollama and Weather tests

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/`
- `mypy src/pipeline/agent.py src/pipeline/execution.py src/pipeline/base_plugins.py`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml`
- `python -m src.config.validator --config config/prod.yaml`
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: KeyError 'DB_HOST' before env fix)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f788aeb48322b9b531ee0d6a7075