### PR TITLE
[Testing] Load env variables in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from config.environment import load_env
 
 @pytest.fixture(autouse=True)
 def _load_test_env(monkeypatch):
-    """Load environment variables for tests from the example file."""
-    env_path = Path(__file__).resolve().parents[1] / ".env.example"
+    """Load environment variables for tests from the .env file."""
+    env_path = Path(__file__).resolve().parents[1] / ".env"
     load_env(env_path)
     yield

--- a/tests/integration/test_postgres_history.py
+++ b/tests/integration/test_postgres_history.py
@@ -9,7 +9,7 @@ from config.environment import load_env
 from pipeline.plugins.resources.postgres import PostgresResource
 from pipeline.state import ConversationEntry
 
-load_env(Path(__file__).resolve().parents[2] / ".env.example")
+load_env(Path(__file__).resolve().parents[2] / ".env")
 
 CONN = {
     "host": os.environ["DB_HOST"],

--- a/tests/test_ollama_resource.py
+++ b/tests/test_ollama_resource.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 from config.environment import load_env
 from pipeline.plugins.resources.ollama_llm import OllamaLLMResource
 
-load_env(Path(__file__).resolve().parents[1] / ".env.example")
+load_env(Path(__file__).resolve().parents[1] / ".env")
 
 
 class FakeResponse:

--- a/tests/test_postgres_resource.py
+++ b/tests/test_postgres_resource.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 from config.environment import load_env
 from pipeline.plugins.resources.postgres import PostgresResource
 
-load_env(Path(__file__).resolve().parents[1] / ".env.example")
+load_env(Path(__file__).resolve().parents[1] / ".env")
 
 
 async def init_resource():

--- a/tests/test_weather_api_tool.py
+++ b/tests/test_weather_api_tool.py
@@ -17,7 +17,7 @@ from pipeline import (
 )
 from pipeline.plugins.tools.weather_api_tool import WeatherApiTool
 
-load_env(Path(__file__).resolve().parents[1] / ".env.example")
+load_env(Path(__file__).resolve().parents[1] / ".env")
 
 
 class FakeResponse:


### PR DESCRIPTION
## Summary
- load .env variables for pytest

## Testing
- `black src/ tests/`
- `isort tests/conftest.py tests/integration/test_postgres_history.py tests/test_ollama_resource.py tests/test_postgres_resource.py tests/test_weather_api_tool.py`
- `flake8 src/ tests/`
- `python -m mypy src/` *(fails: There are no .py[i] files in directory 'src')*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml`
- `python -m src.config.validator --config config/prod.yaml`
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v`
- `pytest tests/performance/ -m benchmark` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861fd1c234c832290c61a3d1d930692