### PR TITLE
[Core] Preserve plugin registration order

### DIFF
--- a/src/pipeline/registries.py
+++ b/src/pipeline/registries.py
@@ -55,12 +55,11 @@ class PluginRegistry:
         """Register ``plugin`` to execute during ``stage``."""
 
         self._stage_plugins[stage].append(plugin)
-        self._stage_plugins[stage].sort(key=lambda p: getattr(p, "priority", 50))
         plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
         self._names.setdefault(plugin, str(plugin_name))
 
     def get_for_stage(self, stage: PipelineStage) -> List[BasePlugin]:
-        """Return plugins registered for ``stage`` in priority order."""
+        """Return plugins registered for ``stage`` in registration order."""
 
         return list(self._stage_plugins.get(stage, []))
 

--- a/tests/test_plugin_registry_order.py
+++ b/tests/test_plugin_registry_order.py
@@ -1,0 +1,69 @@
+import asyncio
+
+import yaml
+
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemInitializer,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+
+
+class First(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        context.set_metadata("order", ["first"])
+
+
+class Second(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        order = context.get_metadata("order")
+        order.append("second")
+        context.set_metadata("order", order)
+
+
+class Third(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        order = context.get_metadata("order")
+        order.append("third")
+        context.set_metadata("order", order)
+        context.set_response(order)
+
+
+def test_plugin_registration_order_matches_execution():
+    registry = PluginRegistry()
+    registry.register_plugin_for_stage(First({}), PipelineStage.DO)
+    registry.register_plugin_for_stage(Second({}), PipelineStage.DO)
+    registry.register_plugin_for_stage(Third({}), PipelineStage.DO)
+    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), registry)
+    result = asyncio.run(execute_pipeline("hi", registries))
+    assert result == ["first", "second", "third"]
+
+
+def test_initializer_preserves_yaml_order(tmp_path):
+    config = {
+        "plugins": {
+            "prompts": {
+                "first": {"type": "tests.test_plugin_registry_order:First"},
+                "second": {"type": "tests.test_plugin_registry_order:Second"},
+                "third": {"type": "tests.test_plugin_registry_order:Third"},
+            }
+        }
+    }
+    path = tmp_path / "config.yml"
+    path.write_text(yaml.dump(config))
+
+    initializer = SystemInitializer.from_yaml(str(path))
+    plugin_reg, _, _ = asyncio.run(initializer.initialize())
+    plugins = plugin_reg.get_for_stage(PipelineStage.DO)
+    assert [p.__class__ for p in plugins] == [First, Second, Third]


### PR DESCRIPTION
## Summary
- ensure plugin order of execution matches registration
- verify that initialization also respects YAML order
- add regression tests for plugin order

## Testing
- `flake8 src/ tests/` *(fails: module level import not at top of file, unused import)*
- `mypy src` *(fails: "There are no .py[i] files in directory 'src'")*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'dotenv')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: 'dotenv')*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'dotenv')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: 'dotenv')*
- `pytest -k plugin_registry_order -v` *(fails: ModuleNotFoundError: 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6862062a079083228c50bfb6d4b84a08