### PR TITLE
[Docs] Add vector memory pipeline example

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -5,6 +5,10 @@
 :end-before: <!-- end quick_start -->
 ```
 
+## Examples
+
+- [`vector_memory_pipeline.py`](../../examples/vector_memory_pipeline.py)
+  demonstrates using Postgres, an Ollama LLM, and simple vector memory.
 
 ```{toctree}
 :hidden:


### PR DESCRIPTION
## Summary
- add a vector memory example demonstrating Postgres/Ollama integration
- reference the example in the documentation index

## Testing
- `black src/ tests/ examples/vector_memory_pipeline.py`
- `isort src/ tests/ examples/vector_memory_pipeline.py`
- `flake8 src/ tests/ examples/vector_memory_pipeline.py`
- `mypy src/pipeline/__init__.py`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(no tests ran)*
- `pytest tests/performance/ -m benchmark` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6862095443a08322a4ed2672c575ea9f