### PR TITLE
[Config] validate vector memory and enforce dependency

### DIFF
--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -36,6 +36,7 @@ class ConfigValidator:
                 config = yaml.safe_load(fh) or {}
             load_env()
             config = SystemInitializer._interpolate_env_vars(config)
+            self._validate_vector_memory(config)
             initializer = SystemInitializer(config)
             asyncio.run(initializer.initialize())
         except Exception as exc:  # pragma: no cover - error path
@@ -43,6 +44,32 @@ class ConfigValidator:
             return 1
         print("Configuration valid.")
         return 0
+
+    def _validate_vector_memory(self, config: dict) -> None:
+        """Ensure vector memory configuration contains required fields."""
+
+        vm_cfg = config.get("plugins", {}).get("resources", {}).get("vector_memory")
+        if not vm_cfg:
+            return
+
+        table = vm_cfg.get("table")
+        if not isinstance(table, str) or not table:
+            raise ValueError("vector_memory: 'table' is required")
+
+        embedding = vm_cfg.get("embedding_model")
+        if not isinstance(embedding, dict):
+            raise ValueError("vector_memory: 'embedding_model' must be a mapping")
+
+        if not embedding.get("name"):
+            raise ValueError("vector_memory: 'embedding_model.name' is required")
+
+        if "dimensions" in embedding:
+            try:
+                int(embedding["dimensions"])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "vector_memory: 'embedding_model.dimensions' must be an integer"
+                ) from exc
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- validate optional vector memory configuration
- ensure `vector_memory` is registered when `ComplexPrompt` is used
- test new registry rule

## Testing
- `black src/registry/validator.py src/config/validator.py tests/test_registry_validator.py`
- `isort src/config/validator.py src/registry/validator.py tests/test_registry_validator.py`
- `flake8 src/ tests/`
- `mypy $(git ls-files '*.py')` *(fails: Source file found twice)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml`
- `python -m src.config.validator --config config/prod.yaml`
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: Unknown config option asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_6862095815d08322aa284c3ebbcecc9e