### PR TITLE
[Prompt] Add ComplexPrompt plugin

### DIFF
--- a/src/pipeline/plugins/prompts/__init__.py
+++ b/src/pipeline/plugins/prompts/__init__.py
@@ -1,4 +1,5 @@
 from .chain_of_thought import ChainOfThoughtPrompt
+from .complex_prompt import ComplexPrompt
 from .intent_classifier import IntentClassifierPrompt
 from .memory_retrieval import MemoryRetrievalPrompt
 from .react_prompt import ReActPrompt
@@ -7,5 +8,6 @@ __all__ = [
     "IntentClassifierPrompt",
     "MemoryRetrievalPrompt",
     "ReActPrompt",
+    "ComplexPrompt",
     "ChainOfThoughtPrompt",
 ]

--- a/src/pipeline/plugins/prompts/complex_prompt.py
+++ b/src/pipeline/plugins/prompts/complex_prompt.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import List
+
+from pipeline.context import ConversationEntry, PluginContext
+from pipeline.plugins import PromptPlugin
+from pipeline.stages import PipelineStage
+
+
+class ComplexPrompt(PromptPlugin):
+    """Generate responses using DB history and vector memory."""
+
+    dependencies = ["ollama", "database", "vector_memory"]
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        """Compose a context-aware reply.
+
+        Steps:
+        1. Load recent history from the database.
+        2. Embed the latest user message and find similar entries.
+        3. Call the LLM to create a reply.
+        4. Record the reply in the conversation and set the pipeline response.
+        """
+
+        db = context.get_resource("database")
+        vector_memory = context.get_resource("vector_memory")
+
+        history: List[ConversationEntry] = []
+        if db and hasattr(db, "load_history"):
+            history = await db.load_history(context.pipeline_id)
+        history_text = "\n".join(f"{h.role}: {h.content}" for h in history)
+
+        last_message = ""
+        for entry in reversed(context.get_conversation_history()):
+            if entry.role == "user":
+                last_message = entry.content
+                break
+
+        similar: List[str] = []
+        if vector_memory:
+            await vector_memory.add_embedding(last_message)
+            k = int(self.config.get("k", 3))
+            similar = await vector_memory.query_similar(last_message, k)
+        similar_text = "; ".join(similar)
+
+        prompt = (
+            "Conversation history:\n"
+            + history_text
+            + "\nSimilar topics: "
+            + similar_text
+            + f"\nUser: {last_message}\nAssistant:"
+        )
+
+        response = await self.call_llm(context, prompt, purpose="complex_prompt")
+
+        context.add_conversation_entry(
+            content=response.content,
+            role="assistant",
+            metadata={"source": "complex_prompt"},
+        )
+        context.set_response(response.content)

--- a/tests/test_complex_prompt.py
+++ b/tests/test_complex_prompt.py
@@ -1,0 +1,73 @@
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.plugins.prompts.complex_prompt import ComplexPrompt
+
+
+class FakeLLM:
+    name = "ollama"
+
+    def __init__(self):
+        self.generate = AsyncMock(return_value="done")
+
+
+class FakeDB:
+    name = "database"
+
+    def __init__(self, history):
+        self.load_history = AsyncMock(return_value=history)
+
+
+class FakeVectorMemory:
+    name = "vector_memory"
+
+    def __init__(self):
+        self.add_embedding = AsyncMock()
+        self.query_similar = AsyncMock(return_value=["similar"])
+
+
+def make_context(llm, db, memory):
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(content="hello", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id="1",
+        metrics=MetricsCollector(),
+    )
+    resources = ResourceRegistry()
+    resources.add("ollama", llm)
+    resources.add("database", db)
+    resources.add("vector_memory", memory)
+    registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
+    return state, PluginContext(state, registries)
+
+
+def test_complex_prompt_uses_resources():
+    llm = FakeLLM()
+    history = [ConversationEntry(content="old", role="user", timestamp=datetime.now())]
+    db = FakeDB(history)
+    memory = FakeVectorMemory()
+    state, ctx = make_context(llm, db, memory)
+    plugin = ComplexPrompt({"k": 1})
+
+    asyncio.run(plugin.execute(ctx))
+
+    db.load_history.assert_awaited_with("1")
+    memory.add_embedding.assert_awaited_with("hello")
+    memory.query_similar.assert_awaited_with("hello", 1)
+    llm.generate.assert_awaited()
+    assert state.response == "done"
+    assert any(
+        e.role == "assistant" and e.content == "done" for e in state.conversation
+    )


### PR DESCRIPTION
## Summary
- implement `ComplexPrompt` that combines Postgres history and vector memory
- register plugin in prompts package
- test that database, vector memory and LLM are used

## Testing
- `flake8 src/ tests/`
- `mypy -p pipeline -p config -p registry -p entity --config-file mypy.ini`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option: asyncio_mode)*
- `pytest -q` *(fails: asyncpg.exceptions.InvalidCatalogNameError: database "agent_sandbox" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68620951e5548322a176d1f0ac945816