### PR TITLE
[Prompt] Add vector memory integration test

### DIFF
--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -1,0 +1,88 @@
+import asyncio
+import os
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from config.environment import load_env
+from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
+                      PluginContext, PluginRegistry, ResourceRegistry,
+                      SystemRegistries, ToolRegistry)
+from pipeline.plugins.prompts.complex_prompt import ComplexPrompt
+from pipeline.plugins.resources.echo_llm import EchoLLMResource
+from pipeline.plugins.resources.postgres import PostgresResource
+from pipeline.plugins.resources.vector_memory import VectorMemoryResource
+
+load_env(Path(__file__).resolve().parents[2] / ".env")
+
+
+@pytest.mark.integration
+def test_vector_memory_integration():
+    async def run():
+        db_cfg = {
+            "host": os.environ.get("DB_HOST", "localhost"),
+            "port": 5432,
+            "name": os.environ.get("DB_NAME", os.environ.get("DB_USER", "dev_db")),
+            "username": os.environ.get(
+                "DB_USER", os.environ.get("DB_USERNAME", "agent")
+            ),
+            "password": os.environ.get("DB_PASSWORD", ""),
+            "history_table": "test_history_int",
+        }
+        vm_cfg = {
+            "host": db_cfg["host"],
+            "port": db_cfg["port"],
+            "name": db_cfg["name"],
+            "username": db_cfg["username"],
+            "password": db_cfg["password"],
+            "table": "test_vectors_int",
+            "dimensions": 3,
+        }
+        db = PostgresResource(db_cfg)
+        vm = VectorMemoryResource(vm_cfg)
+        llm = EchoLLMResource()
+        try:
+            await db.initialize()
+            await vm.initialize()
+        except OSError as exc:
+            pytest.skip(f"PostgreSQL not available: {exc}")
+        await db._connection.execute(f"DROP TABLE IF EXISTS {db_cfg['history_table']}")
+        await db._connection.execute(
+            f"CREATE TABLE {db_cfg['history_table']} ("
+            "conversation_id text, role text, content text, "
+            "metadata jsonb, timestamp timestamptz)"
+        )
+        await vm._connection.execute(f"DROP TABLE IF EXISTS {vm_cfg['table']}")
+        await vm._connection.execute(
+            f"CREATE TABLE {vm_cfg['table']} (text text, embedding vector({vm_cfg['dimensions']}))"
+        )
+        history_entry = ConversationEntry(
+            content="previous", role="user", timestamp=datetime.now()
+        )
+        await db.save_history("conv1", [history_entry])
+        await vm.add_embedding("previous")
+        resources = ResourceRegistry()
+        resources.add("database", db)
+        resources.add("vector_memory", vm)
+        resources.add("ollama", llm)
+        registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
+        state = PipelineState(
+            conversation=[
+                ConversationEntry(
+                    content="previous", role="user", timestamp=datetime.now()
+                )
+            ],
+            pipeline_id="conv1",
+            metrics=MetricsCollector(),
+        )
+        ctx = PluginContext(state, registries)
+        plugin = ComplexPrompt({"k": 1})
+        await plugin.execute(ctx)
+        response = state.response
+        await db._connection.close()
+        await vm._connection.close()
+        return response
+
+    result = asyncio.run(run())
+    assert "Similar topics: previous" in result


### PR DESCRIPTION
## Summary
- add integration test for VectorMemoryResource with ComplexPrompt
- refine configuration to connect to default Postgres port

## Testing
- `black src/ tests/`
- `isort tests/integration/test_vector_memory_integration.py`
- `flake8 src/ tests/`
- `mypy -p pipeline -p config -p registry -p entity -m agent`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml`
- `python -m src.config.validator --config config/prod.yaml`
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v`
- `pytest tests/performance/ -m benchmark` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620dccb7b48322b5a9bea01849cdb4