### PR TITLE
[Pipeline] Add conversation manager and example

### DIFF
--- a/examples/http_server.py
+++ b/examples/http_server.py
@@ -7,13 +7,31 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
+import asyncio
+from typing import Any
+
 from entity import Agent
+from pipeline import ConversationManager, PipelineManager
+from pipeline.adapters.http import HTTPAdapter, MessageRequest
 
 
-def main() -> None:
+async def main() -> None:
     agent = Agent({"server": {"host": "127.0.0.1", "port": 8000}})  # type: ignore[arg-type]
-    agent.run()
+    await agent._ensure_initialized()
+    registries = agent._registries
+    if registries is None:
+        raise RuntimeError("System not initialized")
+
+    pipeline_manager = PipelineManager(registries)
+    conversation_manager = ConversationManager(registries, pipeline_manager)
+    adapter = HTTPAdapter(pipeline_manager, agent.config.get("server", {}))
+
+    @adapter.app.post("/conversation")
+    async def conversation(req: MessageRequest) -> dict[str, Any]:
+        return await conversation_manager.process_request(req.message)
+
+    await adapter.serve(registries)
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -7,6 +7,7 @@ from .context import (
     SimpleContext,
     ToolCall,
 )
+from .conversation_manager import ConversationManager
 from .initializer import (
     ClassRegistry,
     SystemInitializer,
@@ -79,5 +80,6 @@ __all__ = [
     "update_plugin_configuration",
     "Agent",
     "PipelineManager",
+    "ConversationManager",
     "HTTPAdapter",
 ]

--- a/src/pipeline/conversation_manager.py
+++ b/src/pipeline/conversation_manager.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, Dict, cast
+
+from .manager import PipelineManager
+from .pipeline import execute_pipeline
+from .registries import SystemRegistries
+
+
+class ConversationManager:
+    """Coordinate multi-turn processing through repeated pipeline execution."""
+
+    def __init__(
+        self,
+        registries: SystemRegistries,
+        pipeline_manager: PipelineManager | None = None,
+    ) -> None:
+        self._registries = registries
+        self._pipeline_manager = pipeline_manager or PipelineManager(registries)
+
+    async def process_request(self, user_message: str) -> Dict[str, Any]:
+        """Process a user message, delegating back to the pipeline when needed."""
+        response = cast(
+            Dict[str, Any],
+            await execute_pipeline(
+                user_message,
+                self._registries,
+                pipeline_manager=self._pipeline_manager,
+            ),
+        )
+        while (
+            isinstance(response, dict) and response.get("type") == "continue_processing"
+        ):
+            follow_up = str(response.get("message", ""))
+            response = cast(
+                Dict[str, Any],
+                await execute_pipeline(
+                    follow_up,
+                    self._registries,
+                    pipeline_manager=self._pipeline_manager,
+                ),
+            )
+        return response

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from pipeline import (
+    ConversationManager,
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+
+
+class ContinuePlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        if context.message == "start":
+            context.set_response({"type": "continue_processing", "message": "next"})
+
+
+class RespondPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        if context.message == "next":
+            context.set_response("done")
+
+
+def make_manager():
+    plugins = PluginRegistry()
+    plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DO)
+    plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO)
+    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    manager = PipelineManager(registries)
+    conv = ConversationManager(registries, manager)
+    return conv, manager
+
+
+def test_conversation_manager_delegation():
+    conv, manager = make_manager()
+
+    async def run():
+        result = await conv.process_request("start")
+        return result
+
+    result = asyncio.run(run())
+    assert result == "done"
+    assert not manager.has_active_pipelines()


### PR DESCRIPTION
## Summary
- introduce a simple `ConversationManager` that re-runs the pipeline until requests no longer delegate using `{"type": "continue_processing"}`
- update the HTTP server example to showcase `ConversationManager`
- add unit tests for the new manager

## Testing
- `flake8 src/ tests/ examples/http_server.py` *(fails: command not found)*
- `mypy src/pipeline/conversation_manager.py` *(fails: found 1 error)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest -k conversation_manager -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6862123092348322a5d23ee41690d1ab