### PR TITLE
[Adapter] add http adapter helpers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ def calculator(context):
         return f"The answer is {result}"
 
 # Run the agent
-agent.run()  # Automatically starts server on localhost:8000
+agent.run_http()  # Automatically starts server on localhost:8000
 ```
 
 The default setup registers a simple `CalculatorTool`, a `SearchTool`, and an
@@ -117,7 +117,7 @@ class MyCustomPrompt(PromptPlugin):
 
 agent = Agent.from_package("pipeline.plugins")
 >>>>>> main
-agent.run()
+agent.run_http()
 ```
 
 ### Multi-Turn and Complex Reasoning Patterns
@@ -1789,7 +1789,7 @@ class SimpleContext:
 ```python
 # Just works
 agent = Agent()
-agent.run()
+agent.run_http()
 ```
 
 ### Simple Configuration (Layer 2)  
@@ -1865,7 +1865,7 @@ def weather(context):
     if "weather" in context.message:
         return "It's sunny and 75°F today!"
 
-agent.run()  # http://localhost:8000 - ready to use!
+agent.run_http()  # http://localhost:8000 - ready to use!
 ```
 
 ### Intermediate (Growing sophistication)
@@ -1884,7 +1884,7 @@ class SmartWeatherPlugin(Plugin):
             context.say(f"The weather in {location} is {weather}")
 
 agent.add_plugin(SmartWeatherPlugin())
-agent.run()
+agent.run_http()
 ```
 
 ### Advanced (Full power)

--- a/examples/plugin_loader.py
+++ b/examples/plugin_loader.py
@@ -12,7 +12,7 @@ from pipeline import Agent  # noqa: E402
 
 def main() -> None:
     agent = Agent.from_directory("../plugins")
-    agent.run()
+    agent.run_http()
 
 
 if __name__ == "__main__":

--- a/src/cli.py
+++ b/src/cli.py
@@ -45,7 +45,7 @@ class CLI:
         agent = Agent(self.args.config)
         if self.args.command == "reload-config":
             return self._reload_config(agent, self.args.file)
-        agent.run()
+        agent.run_http()
         return 0
 
     def _reload_config(self, agent: Agent, file_path: str) -> int:

--- a/src/pipeline/agent.py
+++ b/src/pipeline/agent.py
@@ -4,15 +4,14 @@ import asyncio
 import importlib
 import importlib.util
 import inspect
-import json
 import logging
 import pkgutil
 from dataclasses import dataclass, field
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable, Dict, Optional, cast
 
+from .adapters.http import HTTPAdapter
 from .pipeline import execute_pipeline
 from .plugins import (
     AdapterPlugin,
@@ -200,43 +199,29 @@ class Agent:
                     exc,
                 )
 
-    def _create_server(self, host: str, port: int) -> HTTPServer:
+    def create_http_adapter(
+        self, host: str = "127.0.0.1", port: int = 8000
+    ) -> HTTPAdapter:
+        """Return an :class:`HTTPAdapter` for this agent's registries."""
+
+        config: dict[str, Any] = {"host": host, "port": port}
+        return HTTPAdapter(config=config)
+
+    async def serve_http(self, host: str = "127.0.0.1", port: int = 8000) -> None:
+        """Serve requests using the :class:`HTTPAdapter`."""
+
+        adapter = self.create_http_adapter(host, port)
         registries = SystemRegistries(
             resources=self.resource_registry,
             tools=self.tool_registry,
             plugins=self.plugin_registry,
         )
+        await adapter.serve(registries)
 
-        class Handler(BaseHTTPRequestHandler):
-            def do_POST(self) -> None:  # noqa: N802 - http server naming
-                length = int(self.headers.get("Content-Length", "0"))
-                body = self.rfile.read(length).decode("utf-8")
-                try:
-                    data = json.loads(body)
-                except json.JSONDecodeError:
-                    self.send_response(400)
-                    self.end_headers()
-                    self.wfile.write(b"Invalid JSON")
-                    return
-                message = data.get("message", "")
-                response = asyncio.run(execute_pipeline(message, registries))
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps(response).encode("utf-8"))
+    def run_http(self, host: str = "127.0.0.1", port: int = 8000) -> None:
+        """Convenience wrapper to start the HTTP adapter."""
 
-        return HTTPServer((host, port), Handler)
-
-    def run(self, host: str = "localhost", port: int = 8000) -> None:
-        """Launch a minimal HTTP adapter for the agent."""
-        server = self._create_server(host, port)
-        print(f"Serving on http://{host}:{port}")
-        try:
-            server.serve_forever()
-        except KeyboardInterrupt:
-            pass
-        finally:
-            server.server_close()
+        asyncio.run(self.serve_http(host, port))
 
     async def run_message(self, message: str) -> Dict[str, Any]:
         registries = SystemRegistries(

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -6,9 +6,16 @@ from pathlib import Path
 import pytest
 
 from config.environment import load_env
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.plugins.prompts.complex_prompt import ComplexPrompt
 from pipeline.plugins.resources.echo_llm import EchoLLMResource
 from pipeline.plugins.resources.postgres import PostgresResource

--- a/tests/test_cli_adapter.py
+++ b/tests/test_cli_adapter.py
@@ -1,9 +1,15 @@
 import asyncio
 from typing import Any
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.adapters.cli import CLIAdapter
 
 


### PR DESCRIPTION
## Summary
- remove deprecated run() logic
- add create_http_adapter, serve_http, and run_http
- update CLI, docs and plugin example to use run_http

## Testing
- `black src examples tests`
- `isort --profile black src examples tests`
- `flake8 src tests` *(fails: command not found)*
- `mypy src` *(fails: there are no .py[i] files)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68621bdf5c6483229ab1a30fdf3caed5