### PR TITLE
[Adapter] document adapters

### DIFF
--- a/src/pipeline/adapters/__init__.py
+++ b/src/pipeline/adapters/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Adapter implementations used to expose the pipeline externally."""
+
 from .cli import CLIAdapter
 from .http import HTTPAdapter
 from .websocket import WebSocketAdapter

--- a/src/pipeline/adapters/cli.py
+++ b/src/pipeline/adapters/cli.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+"""Command-line adapter for interactive pipeline usage.
+
+This module defines :class:`CLIAdapter`, an adapter that exposes the
+pipeline through an interactive REPL style prompt. Users can type a
+message, the pipeline processes it, and the resulting response is
+printed to standard output.
+"""
+
 import asyncio
 from typing import Any, cast
 
@@ -25,7 +33,13 @@ class CLIAdapter(AdapterPlugin):
         self._registries: SystemRegistries | None = None
 
     async def serve(self, registries: SystemRegistries) -> None:
-        """Start interactive prompt loop."""
+        """Run the interactive command-line loop.
+
+        Parameters
+        ----------
+        registries:
+            System registries containing all initialized plugins and resources.
+        """
         self._registries = registries
         print("Enter message (Ctrl-D to quit)")
         while True:

--- a/src/pipeline/adapters/http.py
+++ b/src/pipeline/adapters/http.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+"""HTTP adapter exposing the pipeline through a FastAPI endpoint.
+
+The :class:`HTTPAdapter` defined here spins up a small FastAPI
+application with a single POST route. Incoming messages are forwarded
+to the pipeline and the JSON response is returned to the caller.
+"""
+
 from typing import Any, cast
 
 import uvicorn
@@ -43,6 +50,13 @@ class HTTPAdapter(AdapterPlugin):
             )
 
     async def serve(self, registries: SystemRegistries) -> None:
+        """Start the FastAPI HTTP server.
+
+        Parameters
+        ----------
+        registries:
+            System registries containing all initialized plugins and resources.
+        """
         self._registries = registries
         host = self.config.get("host", "127.0.0.1")
         port = int(self.config.get("port", 8000))

--- a/src/pipeline/adapters/websocket.py
+++ b/src/pipeline/adapters/websocket.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+"""WebSocket adapter providing real-time interaction with the pipeline.
+
+This module exposes :class:`WebSocketAdapter`, a FastAPI based adapter
+that handles bi-directional communication over a WebSocket connection.
+Each connected client can send messages to the pipeline and receive
+JSON responses in return.
+"""
+
 from typing import Any, cast
 
 import uvicorn
@@ -34,6 +42,13 @@ class WebSocketAdapter(AdapterPlugin):
         return cast(dict[str, Any], await execute_pipeline(message, self._registries))
 
     async def _connection_handler(self, websocket: WebSocket) -> None:
+        """Handle a single client WebSocket connection.
+
+        Parameters
+        ----------
+        websocket:
+            The accepted WebSocket connection from FastAPI.
+        """
         await websocket.accept()
         try:
             while True:
@@ -50,6 +65,13 @@ class WebSocketAdapter(AdapterPlugin):
         self.app.add_api_websocket_route("/", self._connection_handler)
 
     async def serve(self, registries: SystemRegistries) -> None:
+        """Start the FastAPI WebSocket server.
+
+        Parameters
+        ----------
+        registries:
+            System registries containing all initialized plugins and resources.
+        """
         self._registries = registries
         host = self.config.get("host", "127.0.0.1")
         port = int(self.config.get("port", 8001))


### PR DESCRIPTION
## Summary
- document adapter modules
- add docstrings for serve and connection handler methods

## Testing
- `flake8 src/pipeline/adapters/__init__.py src/pipeline/adapters/cli.py src/pipeline/adapters/http.py src/pipeline/adapters/websocket.py`
- `mypy src/pipeline/adapters/cli.py src/pipeline/adapters/http.py src/pipeline/adapters/websocket.py src/pipeline/adapters/__init__.py`
- `bandit -r src/pipeline/adapters`
- `python -m src.config.validator --config config/dev.yaml`
- `python -m src.config.validator --config config/prod.yaml`
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: InvalidAuthorizationSpecificationError)*
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*


------
https://chatgpt.com/codex/tasks/task_e_68621be694e4832283b928ffab235a72