### PR TITLE
[Resource] refine LLM handling

### DIFF
--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -15,6 +15,7 @@ from .initializer import (
     initialization_cleanup_context,
 )
 from .manager import PipelineManager
+from .observability import log_metrics, metrics_as_json
 from .pipeline import (
     create_default_response,
     create_static_error_response,
@@ -35,6 +36,7 @@ from .plugins import (
     ValidationResult,
 )
 from .registries import PluginRegistry, ResourceRegistry, SystemRegistries, ToolRegistry
+from .resources import LLM
 from .stages import PipelineStage
 from .state import FailureInfo, MetricsCollector, PipelineState
 
@@ -51,6 +53,7 @@ __all__ = [
     "ConversationEntry",
     "ToolCall",
     "LLMResponse",
+    "LLM",
     "FailureInfo",
     "MetricsCollector",
     "BasePlugin",
@@ -84,4 +87,6 @@ __all__ = [
     "HTTPAdapter",
     "WebSocketAdapter",
     "CLIAdapter",
+    "log_metrics",
+    "metrics_as_json",
 ]

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -193,19 +193,17 @@ class SimpleContext(PluginContext):
         )
 
         if hasattr(llm, "generate"):
-            response = await llm.generate(prompt)
+            result = await llm.generate(prompt)
         else:
             func = getattr(llm, "__call__", None)
             if func is None:
                 raise RuntimeError("LLM resource is not callable")
             if asyncio.iscoroutinefunction(func):
-                response = await func(prompt)
+                result = await func(prompt)
             else:
-                response = func(prompt)
+                result = func(prompt)
 
-        if isinstance(response, LLMResponse):
-            return response.content
-        return str(response)
+        return result.content if isinstance(result, LLMResponse) else str(result)
 
     async def calculate(self, expression: str) -> Any:
         return await self.use_tool("calculator", expression=expression)

--- a/src/pipeline/observability.py
+++ b/src/pipeline/observability.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from .state import MetricsCollector
+
+logger = logging.getLogger(__name__)
+
+
+def log_metrics(metrics: MetricsCollector) -> None:
+    """Log collected metrics using the standard logger."""
+
+    data = metrics.to_dict()
+    logger.info("Pipeline metrics", extra={"metrics": data})
+
+
+def metrics_as_json(metrics: MetricsCollector) -> str:
+    """Return metrics as a formatted JSON string."""
+
+    return json.dumps(metrics.to_dict(), indent=2)

--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,0 +1,3 @@
+from .llm import LLM
+
+__all__ = ["LLM"]

--- a/src/pipeline/resources/llm.py
+++ b/src/pipeline/resources/llm.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class LLM(ABC):
+    """Interface for language model resources."""
+
+    @abstractmethod
+    async def generate(self, prompt: str) -> str:
+        """Generate text in response to ``prompt``."""
+
+    async def __call__(self, prompt: str) -> str:
+        return await self.generate(prompt)


### PR DESCRIPTION
## Summary
- keep LLM as a resource plugin without special context helper
- log and record metrics directly in `BasePlugin.call_llm`
- revert `SimpleContext.ask_llm` to call the LLM resource

## Testing
- `black src/ tests/`
- `isort src/pipeline/base_plugins.py src/pipeline/context.py src/pipeline/__init__.py src/pipeline/resources/__init__.py src/pipeline/resources/llm.py src/pipeline/observability.py`
- `flake8 src/ tests/` *(fails: F401 unused imports)*
- `mypy src/` *(no Python files detected)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: DB_HOST not found)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: DB_HOST not found)*
- `python -m src.registry.validator` *(fails: missing --config)*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: httpx)*
- `pytest tests/performance/ -m benchmark`


------
https://chatgpt.com/codex/tasks/task_e_68628c7b33808322a5c9c017d79595e6