### PR TITLE
Add additional unit tests

### DIFF
--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -1,0 +1,47 @@
+import asyncio
+import time
+
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.base_plugins import PluginAutoClassifier
+from pipeline.context import SimpleContext
+
+
+class SleepTool(ToolPlugin):
+    async def execute_function(self, params):
+        await asyncio.sleep(0.05)
+        return params.get("text", "done")
+
+
+async def use_tool_plugin(ctx: SimpleContext) -> None:
+    result = await ctx.use_tool("sleep", text="hello")
+    ctx.set_response(result)
+
+
+def make_registries() -> SystemRegistries:
+    resources = ResourceRegistry()
+    tools = ToolRegistry()
+    tools.add("sleep", SleepTool({}))
+    plugins = PluginRegistry()
+    plugin = PluginAutoClassifier.classify(
+        use_tool_plugin,
+        {"stage": PipelineStage.DO, "name": "UseToolPlugin"},
+    )
+    plugins.register_plugin_for_stage(plugin, PipelineStage.DO)
+    return SystemRegistries(resources, tools, plugins)
+
+
+def test_async_tool_execution():
+    registries = make_registries()
+    start = time.time()
+    result = asyncio.run(execute_pipeline("hi", registries))
+    duration = time.time() - start
+    assert result == "hello"
+    assert duration >= 0.05

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from pipeline import (
+    FailurePlugin,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.pipeline import create_static_error_response
+from pipeline.plugins.failure.basic_logger import BasicLogger
+
+
+class BoomPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        raise RuntimeError("boom")
+
+
+class FallbackPlugin(FailurePlugin):
+    stages = [PipelineStage.ERROR]
+
+    async def _execute_impl(self, context):
+        info = context._state.failure_info
+        context.set_response({"error": info.error_message})
+
+
+def make_registries(error_plugin):
+    plugins = PluginRegistry()
+    plugins.register_plugin_for_stage(BoomPlugin({}), PipelineStage.DO)
+    plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR)
+    plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
+    return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+
+
+def test_error_plugin_runs():
+    registries = make_registries(FallbackPlugin)
+    result = asyncio.run(execute_pipeline("hi", registries))
+    assert result == {"error": "boom"}
+
+
+def test_static_error_response():
+    pipeline_id = "123"
+    resp = create_static_error_response(pipeline_id)
+    assert resp["error_id"] == pipeline_id
+    assert resp["type"] == "static_fallback"

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,41 @@
+import asyncio
+import time
+
+from pipeline import (
+    MetricsCollector,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+
+
+class TimedPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        await asyncio.sleep(0.05)
+        context.set_response("ok")
+
+
+def make_registries():
+    plugins = PluginRegistry()
+    plugins.register_plugin_for_stage(TimedPlugin({}), PipelineStage.DO)
+    return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+
+
+def test_metrics_overhead():
+    registries = make_registries()
+    start = time.time()
+    result, metrics = asyncio.run(
+        execute_pipeline("hi", registries, return_metrics=True)
+    )
+    duration = time.time() - start
+    plugin_key = f"{PipelineStage.DO}:TimedPlugin"
+    recorded = metrics.plugin_durations[plugin_key][0]
+    assert result == "ok"
+    assert recorded >= 0.05
+    assert duration - recorded < 0.05

--- a/tests/test_plugin_layers.py
+++ b/tests/test_plugin_layers.py
@@ -1,0 +1,53 @@
+import asyncio
+
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    ResourcePlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.base_plugins import PluginAutoClassifier
+from pipeline.context import SimpleContext
+
+
+class MyResource(ResourcePlugin):
+    stages = [PipelineStage.PARSE]
+
+    async def _execute_impl(self, context):
+        context._state.metadata["init"] = True
+
+
+class MyTool(ToolPlugin):
+    required_params = ["value"]
+
+    async def execute_function(self, params):
+        return params["value"]
+
+
+async def my_prompt(ctx: SimpleContext) -> None:
+    val = await ctx.use_tool("tool", value="ok")
+    ctx.set_response(val)
+
+
+def make_registries() -> SystemRegistries:
+    resources = ResourceRegistry()
+    resources.add("resource", MyResource({}))
+    tools = ToolRegistry()
+    tools.add("tool", MyTool({}))
+    plugins = PluginRegistry()
+    plugin = PluginAutoClassifier.classify(
+        my_prompt,
+        {"stage": PipelineStage.DO, "name": "MyPrompt"},
+    )
+    plugins.register_plugin_for_stage(plugin, PipelineStage.DO)
+    return SystemRegistries(resources, tools, plugins)
+
+
+def test_plugin_layers_cooperate():
+    registries = make_registries()
+    result = asyncio.run(execute_pipeline("hi", registries))
+    assert result == "ok"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import pytest
+
+from pipeline.plugins import ToolPlugin
+
+
+class FailOnceTool(ToolPlugin):
+    required_params = ["text"]
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.calls = 0
+
+    async def execute_function(self, params):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("fail")
+        return params["text"]
+
+
+def test_tool_retry_success():
+    tool = FailOnceTool({"max_retries": 1, "retry_delay": 0})
+    result = asyncio.run(tool.execute_function_with_retry({"text": "hi"}))
+    assert result == "hi"
+    assert tool.calls == 2
+
+
+def test_tool_retry_exceeds():
+    tool = FailOnceTool({"max_retries": 0, "retry_delay": 0})
+    with pytest.raises(RuntimeError):
+        asyncio.run(tool.execute_function_with_retry({"text": "hi"}))
+    assert tool.calls == 1

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,66 @@
+import asyncio
+
+import pytest
+import yaml
+
+from pipeline import (
+    PipelineStage,
+    PromptPlugin,
+    ResourcePlugin,
+    SystemInitializer,
+    ValidationResult,
+)
+
+
+class ValidatingPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    @classmethod
+    def validate_config(cls, config):
+        if "required" not in config:
+            return ValidationResult.error_result("missing 'required'")
+        return ValidationResult.success_result()
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class DepPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+    dependencies = ["resource"]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class Res(ResourcePlugin):
+    stages = [PipelineStage.PARSE]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+def test_from_dict_validation():
+    with pytest.raises(Exception):
+        ValidatingPlugin.from_dict({})
+    plugin = ValidatingPlugin.from_dict({"required": True})
+    assert isinstance(plugin, ValidatingPlugin)
+
+
+def test_dependency_validation(tmp_path):
+    cfg = {
+        "plugins": {
+            "prompts": {"dep": {"type": "tests.test_validation:DepPlugin"}},
+        }
+    }
+    path = tmp_path / "cfg.yml"
+    path.write_text(yaml.dump(cfg))
+    initializer = SystemInitializer.from_yaml(str(path))
+    with pytest.raises(SystemError):
+        asyncio.run(initializer.initialize())
+
+    cfg["plugins"]["resources"] = {"resource": {"type": "tests.test_validation:Res"}}
+    path.write_text(yaml.dump(cfg))
+    initializer = SystemInitializer.from_yaml(str(path))
+    registries = asyncio.run(initializer.initialize())
+    assert registries[2] is not None


### PR DESCRIPTION
## Summary
- test async tool usage
- verify plugin layers cooperation
- validate config and dependencies
- test tool retry logic
- ensure error fallback works
- measure observability overhead

## Testing
- `pytest tests/test_async_patterns.py tests/test_plugin_layers.py tests/test_validation.py tests/test_tools.py tests/test_error_handling.py tests/test_observability.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68628c8139748322b74f3f20b434eb74