### PR TITLE
Add python-dotenv dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ pyyaml = "^6.0.2"
 fastapi = "^0.110.0"
 uvicorn = {extras = ["standard"], version = "^0.30.0"}
 asyncpg = "^0.30.0"
+python-dotenv = "^1.1.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"


### PR DESCRIPTION
## Summary
- install `python-dotenv` as a primary dependency so tests can load environment files

## Testing
- `black src tests` *(fails: 3 files would fail to parse)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6862d9f766f88322a9526a45fb3a432f