### PR TITLE
Switch prints to structured logging

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -6,6 +6,9 @@ import yaml
 
 from entity import Agent
 from pipeline import update_plugin_configuration
+from pipeline.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class CLI:
@@ -62,9 +65,11 @@ class CLI:
                         plugin_registry, name, conf
                     )
                     if result.success:
-                        print(f"Updated {name}")
+                        logger.info("Updated %s", name)
                     else:
-                        print(f"Failed to update {name}: {result.error_message}")
+                        logger.error(
+                            "Failed to update %s: %s", name, result.error_message
+                        )
                         success = False
             return 0 if success else 1
 

--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -4,9 +4,12 @@ from pathlib import Path
 
 import yaml
 
+from pipeline.logging import get_logger
 from src.config.environment import load_env  # noqa: E402
 from src.pipeline import SystemInitializer  # noqa: E402
 from src.pipeline.config import ConfigLoader
+
+logger = get_logger(__name__)
 
 
 class ConfigValidator:
@@ -37,9 +40,9 @@ class ConfigValidator:
             initializer = SystemInitializer(config)
             asyncio.run(initializer.initialize())
         except Exception as exc:  # pragma: no cover - error path
-            print(f"Configuration invalid: {exc}")
+            logger.error("Configuration invalid: %s", exc)
             return 1
-        print("Configuration valid.")
+        logger.info("Configuration valid.")
         return 0
 
     def _validate_vector_memory(self, config: dict) -> None:

--- a/src/pipeline/adapters/cli.py
+++ b/src/pipeline/adapters/cli.py
@@ -41,12 +41,12 @@ class CLIAdapter(AdapterPlugin):
             System registries containing all initialized plugins and resources.
         """
         self._registries = registries
-        print("Enter message (Ctrl-D to quit)")
+        self.logger.info("Enter message (Ctrl-D to quit)")
         while True:
             try:
                 message = await asyncio.to_thread(input, "> ")
             except EOFError:
-                print()
+                self.logger.info("Exiting CLI")
                 break
             message = message.strip()
             if not message:
@@ -60,7 +60,7 @@ class CLIAdapter(AdapterPlugin):
                     dict[str, Any],
                     await execute_pipeline(message, self._registries),
                 )
-            print(response)
+            self.logger.info("%s", response)
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - adapter
         pass

--- a/src/pipeline/plugins/resources/postgres.py
+++ b/src/pipeline/plugins/resources/postgres.py
@@ -23,8 +23,7 @@ class PostgresResource(ResourcePlugin):
         self._history_table = self.config.get("history_table")
 
     async def initialize(self) -> None:
-        print("🔍 Connecting to Postgres with:")
-        print(self.config)
+        self.logger.info("Connecting to Postgres", extra={"config": self.config})
         self._connection = await asyncpg.connect(
             database=str(self.config.get("name")),
             host=str(self.config.get("host", "localhost")),

--- a/src/registry/validator.py
+++ b/src/registry/validator.py
@@ -13,8 +13,11 @@ if str(SRC_PATH) not in sys.path:
 
 from pipeline.initializer import ClassRegistry  # noqa: E402
 from pipeline.initializer import SystemInitializer, import_plugin_class  # noqa: E402
+from pipeline.logging import get_logger
 from pipeline.plugins import ValidationResult  # noqa: E402
 from pipeline.stages import PipelineStage  # noqa: E402
+
+logger = get_logger(__name__)
 
 
 class RegistryValidator:
@@ -113,9 +116,9 @@ def main() -> None:
     try:
         RegistryValidator(args.config).run()
     except SystemError as exc:  # pragma: no cover - CLI only
-        print(f"Validation failed: {exc}")
+        logger.error("Validation failed: %s", exc)
         raise SystemExit(1)
-    print("Validation succeeded")
+    logger.info("Validation succeeded")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entrypoint


### PR DESCRIPTION
## Summary
- update modules to use project's structured logger

## Testing
- `black src/ tests/` *(fails: cannot parse base_plugins.py)*
- `isort src/ tests/`
- `flake8 src/ tests/` *(fails: F811 redefinition, E999 syntax errors)*
- `mypy src/` *(fails: no .py files detected)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: pipeline)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: pipeline)*
- `python -m src.registry.validator` *(fails: SyntaxError in base_plugins.py)*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6862d9f4cf948322a2fe24c4a546eaeb