### PR TITLE
Add ErrorFormatter failure plugin

### DIFF
--- a/src/pipeline/plugins/failure/__init__.py
+++ b/src/pipeline/plugins/failure/__init__.py
@@ -1,3 +1,4 @@
 from .basic_logger import BasicLogger
+from .error_formatter import ErrorFormatter
 
-__all__ = ["BasicLogger"]
+__all__ = ["BasicLogger", "ErrorFormatter"]

--- a/src/pipeline/plugins/failure/error_formatter.py
+++ b/src/pipeline/plugins/failure/error_formatter.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pipeline.context import PluginContext
+from pipeline.plugins import FailurePlugin
+from pipeline.stages import PipelineStage
+
+
+class ErrorFormatter(FailurePlugin):
+    """Generate a simple user message from captured failure information."""
+
+    stages = [PipelineStage.ERROR]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        info = context.get_failure_info()
+        if info is None:
+            context.set_response({"error": "Unknown error"})
+            return
+        message = f"{info.plugin_name} failed: {info.error_message}"
+        context.set_response({"error": message})

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -13,6 +13,7 @@ from pipeline import (
     execute_pipeline,
 )
 from pipeline.plugins.failure.basic_logger import BasicLogger
+from pipeline.plugins.failure.error_formatter import ErrorFormatter
 
 # isort: on
 
@@ -65,3 +66,10 @@ def test_static_fallback_on_error_stage_failure():
     registries = make_registries(BadErrorPlugin)
     result = asyncio.run(execute_pipeline("hi", registries))
     assert result["type"] == "static_fallback"
+
+
+def test_error_formatter_produces_message():
+    """Ensure ErrorFormatter creates a user-facing error message."""
+    registries = make_registries(ErrorFormatter)
+    result = asyncio.run(execute_pipeline("hi", registries))
+    assert result == {"error": "FailPlugin failed: boom"}


### PR DESCRIPTION
## Summary
- add `ErrorFormatter` failure plugin
- re-export new plugin
- cover the plugin in error stage tests

## Testing
- `flake8 src/pipeline/plugins/failure/error_formatter.py tests/test_error_stage.py src/pipeline/plugins/failure/__init__.py` *(fails: command not found)*
- `mypy src/pipeline/plugins/failure/error_formatter.py`
- `bandit -r src/pipeline/plugins/failure/error_formatter.py` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_686301de19e083229aa198a0fdbcea85