### PR TITLE
Add runtime config reload docs

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -31,3 +31,15 @@ For a working example, see
 [`vector_memory_pipeline.py`](../../examples/vector_memory_pipeline.py).
 These advanced capabilities highlight **Preserve All Power (7)** by allowing
 low-level database features without sacrificing the simple default setup.
+
+### Runtime Configuration Reload
+
+Update plugin settings without restarting the agent:
+
+```bash
+python -m src.cli reload-config updated.yaml
+```
+
+The command waits for active pipelines to finish, then applies the new YAML
+configuration. This demonstrates **Dynamic Configuration Updates**, letting you
+tweak resources or tools at runtime while keeping the system responsive.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -10,6 +10,17 @@
 - [`vector_memory_pipeline.py`](../../examples/vector_memory_pipeline.py)
   demonstrates using Postgres, an Ollama LLM, and simple vector memory.
 
+## Runtime Configuration Reload
+
+Reload plugin configuration on the fly:
+
+```bash
+python -m src.cli reload-config updated.yaml
+```
+
+This feature highlights **Dynamic Configuration Updates** and keeps
+long-running agents responsive.
+
 ```{toctree}
 :hidden:
 


### PR DESCRIPTION
## Summary
- document runtime configuration reload in the advanced usage guide
- mention dynamic config updates in the docs index

## Testing
- `make -C docs html`
- `black --check src tests`
- `isort --check src tests` *(fails: imports not sorted)*
- `flake8 src tests` *(fails: F401 and other issues)*
- `mypy src/**/*.py` *(fails: module path errors)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'asyncpg')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'asyncpg')*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: No module named 'asyncpg')*
- `pytest tests/integration/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_686301d6e5f88322a28131b9d8df0e86