### PR TITLE
[Core] Add JSON and dict initialization

### DIFF
--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
+import copy
+import json
 import os
 from contextlib import contextmanager
 from importlib import import_module
 from typing import Any, Dict, Iterable, List, Tuple
-import copy
 
 from src.config.environment import load_env
-from .defaults import DEFAULT_CONFIG
 
 from .base_plugins import BasePlugin, ResourcePlugin, ToolPlugin
+from .defaults import DEFAULT_CONFIG
 from .registries import PluginRegistry, ResourceRegistry, ToolRegistry
 
 
@@ -92,6 +93,23 @@ class SystemInitializer:
         config = yaml.safe_load(content)
         load_env(env_file)
         config = cls._interpolate_env_vars(config)
+        return cls(config, env_file)
+
+    @classmethod
+    def from_json(cls, json_path: str, env_file: str = ".env") -> "SystemInitializer":
+        with open(json_path, "r") as fh:
+            content = fh.read()
+        config = json.loads(content or "{}")
+        load_env(env_file)
+        config = cls._interpolate_env_vars(config)
+        return cls(config, env_file)
+
+    @classmethod
+    def from_dict(
+        cls, cfg: Dict[str, Any], env_file: str = ".env"
+    ) -> "SystemInitializer":
+        load_env(env_file)
+        config = cls._interpolate_env_vars(dict(cfg))
         return cls(config, env_file)
 
     def get_resource_config(self, name: str) -> Dict:


### PR DESCRIPTION
## Summary
- support JSON and dict config with `SystemInitializer.from_json()` and `from_dict()`
- test initializer against JSON and dict inputs

## Testing
- `black src/pipeline/initializer.py tests/test_initializer.py`
- `isort src/pipeline/initializer.py tests/test_initializer.py`
- `flake8 src/pipeline/initializer.py tests/test_initializer.py`
- `mypy src/pipeline/initializer.py`
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option: asyncio_mode)*
- `pytest` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686301c145e883228f336b368faaa2df