### PR TITLE
Update HTTPAdapter stages

### DIFF
--- a/src/pipeline/adapters/http.py
+++ b/src/pipeline/adapters/http.py
@@ -25,9 +25,12 @@ class MessageRequest(BaseModel):
 
 
 class HTTPAdapter(AdapterPlugin):
-    """HTTP adapter using FastAPI."""
+    """HTTP adapter using FastAPI for input and output."""
 
-    stages = [PipelineStage.DELIVER]
+    # Adapter serves both as the request entry point and response delivery
+    # mechanism. It therefore participates in the PARSE and DELIVER stages to
+    # mirror the input/output boundary of the pipeline.
+    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
 
     def __init__(
         self, manager: PipelineManager | None = None, config: dict | None = None

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -33,6 +33,9 @@ def make_adapter():
 def test_http_adapter_basic():
     adapter = make_adapter()
 
+    # ensure the adapter participates in both input and output stages
+    assert HTTPAdapter.stages == [PipelineStage.PARSE, PipelineStage.DELIVER]
+
     async def _make_request():
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=adapter.app),


### PR DESCRIPTION
## Summary
- align HTTPAdapter with architecture docs by registering for both PARSE and DELIVER stages
- assert stage registration in HTTP adapter test

## Testing
- `poetry run pytest tests/test_http_adapter.py -q`
- `poetry run pytest -q` *(fails: Agent.__init__() got an unexpected keyword argument 'llm', CLI and error handling tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6863052c4d68832290bfdecbca14ff11