### PR TITLE
Enhance HTTPAdapter server

### DIFF
--- a/src/pipeline/adapters/http.py
+++ b/src/pipeline/adapters/http.py
@@ -25,32 +25,34 @@ class MessageRequest(BaseModel):
 
 
 class HTTPAdapter(AdapterPlugin):
-    """HTTP adapter using FastAPI for input and output."""
+    """FastAPI based HTTP adapter for request/response handling."""
 
-    # Adapter serves both as the request entry point and response delivery
-    # mechanism. It therefore participates in the PARSE and DELIVER stages to
-    # mirror the input/output boundary of the pipeline.
     stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
 
     def __init__(
-        self, manager: PipelineManager | None = None, config: dict | None = None
+        self,
+        manager: PipelineManager | None = None,
+        config: dict | None = None,
     ) -> None:
         super().__init__(config)
         self.manager = manager
         self.app = FastAPI()
+        self._server: uvicorn.Server | None = None
         self._registries: SystemRegistries | None = None
         self._setup_routes()
 
     def _setup_routes(self) -> None:
         @self.app.post("/")
         async def handle(req: MessageRequest) -> dict[str, Any]:
-            if self.manager is not None:
-                return await self.manager.run_pipeline(req.message)
-            if self._registries is None:
-                raise RuntimeError("Adapter not initialized")
-            return cast(
-                dict[str, Any], await execute_pipeline(req.message, self._registries)
-            )
+            return await self._handle_message(req.message)
+
+    async def _handle_message(self, message: str) -> dict[str, Any]:
+        """Send a message through the pipeline and return the response."""
+        if self.manager is not None:
+            return await self.manager.run_pipeline(message)
+        if self._registries is None:
+            raise RuntimeError("Adapter not initialized")
+        return cast(dict[str, Any], await execute_pipeline(message, self._registries))
 
     async def serve(self, registries: SystemRegistries) -> None:
         """Start the FastAPI HTTP server.
@@ -64,8 +66,13 @@ class HTTPAdapter(AdapterPlugin):
         host = self.config.get("host", "127.0.0.1")
         port = int(self.config.get("port", 8000))
         config = uvicorn.Config(self.app, host=host, port=port, log_level="info")
-        server = uvicorn.Server(config)
-        await server.serve()
+        self._server = uvicorn.Server(config)
+        await self._server.serve()
+
+    async def shutdown(self) -> None:
+        """Gracefully stop the running server, if any."""
+        if self._server is not None:
+            await self._server.shutdown()
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - adapter
         pass


### PR DESCRIPTION
## Summary
- use a dedicated `_handle_message` method
- keep reference to the running uvicorn server
- provide graceful shutdown for HTTPAdapter

## Testing
- `pytest tests/test_http_adapter.py::test_http_adapter_basic -q`
- `pytest -q` *(fails: asyncpg.exceptions.InvalidCatalogNameError, TypeError, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68630739d54c83229cbfe260c7b6907b