### PR TITLE
[Adapter] Print CLI responses

### DIFF
--- a/src/pipeline/adapters/cli.py
+++ b/src/pipeline/adapters/cli.py
@@ -61,6 +61,7 @@ class CLIAdapter(AdapterPlugin):
                     await execute_pipeline(message, self._registries),
                 )
             self.logger.info("%s", response)
+            print(response)
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - adapter
         pass


### PR DESCRIPTION
## Summary
- print CLI adapter responses in addition to logging
- refactor CLI adapter test to use caplog instead of patching `print`

## Testing
- `flake8 src/pipeline/adapters/cli.py tests/test_cli_adapter.py`
- `python -m mypy src/pipeline/adapters/cli.py`
- `bandit -r src/pipeline/adapters/cli.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: database "agent_sandbox" does not exist)*
- `pytest tests/performance/ -m benchmark` *(fails: file or directory not found)*
- `pytest tests/test_cli_adapter.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68630e24a1108322aa290373d11eb955