### PR TITLE
[Failure] Update failure info retrieval in tests

### DIFF
--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -25,7 +25,7 @@ class FallbackPlugin(FailurePlugin):
     stages = [PipelineStage.ERROR]
 
     async def _execute_impl(self, context):
-        info = context._state.failure_info
+        info = context.get_failure_info()
         context.set_response({"error": info.error_message})
 
 


### PR DESCRIPTION
## Summary
- update fallback test plugin to use `context.get_failure_info()`

## Testing
- `isort src/ tests/ --check --diff` *(fails: imports unsorted)*
- `flake8 src/ tests/` *(fails: F401, F811, E402, etc.)*
- `mypy src/pipeline/*.py` *(fails: attribute errors)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: Unknown config option asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_68630d67e274832281f139b715f8bfb9