### PR TITLE
[Resource] Implement OpenAI resource

### DIFF
--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -1,6 +1,7 @@
 from .echo_llm import EchoLLMResource
 from .memory_resource import SimpleMemoryResource
 from .ollama_llm import OllamaLLMResource
+from .openai import OpenAIResource
 from .postgres import PostgresResource
 from .structured_logging import StructuredLogging
 from .vector_memory import VectorMemoryResource
@@ -12,4 +13,5 @@ __all__ = [
     "StructuredLogging",
     "PostgresResource",
     "VectorMemoryResource",
+    "OpenAIResource",
 ]

--- a/src/pipeline/plugins/resources/openai.py
+++ b/src/pipeline/plugins/resources/openai.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+
+from pipeline.plugins import ResourcePlugin, ValidationResult
+from pipeline.stages import PipelineStage
+
+
+class OpenAIResource(ResourcePlugin):
+    """LLM resource for OpenAI's chat completion API."""
+
+    stages = [PipelineStage.PARSE]
+    name = "openai"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self.api_key: str | None = self.config.get("api_key")
+        self.model: str | None = self.config.get("model")
+        self.base_url: str | None = self.config.get("base_url")
+        self.params: Dict[str, Any] = {
+            k: v
+            for k, v in self.config.items()
+            if k not in {"api_key", "model", "base_url"}
+        }
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        if not config.get("api_key"):
+            return ValidationResult.error_result("'api_key' is required")
+        if not config.get("model"):
+            return ValidationResult.error_result("'model' is required")
+        if not config.get("base_url"):
+            return ValidationResult.error_result("'base_url' is required")
+        return ValidationResult.success_result()
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
+        return None
+
+    async def generate(self, prompt: str) -> str:
+        if not self.api_key or not self.model or not self.base_url:
+            raise RuntimeError("OpenAI resource not properly configured")
+
+        url = f"{self.base_url.rstrip('/')}/v1/chat/completions"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            **self.params,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.post(url, headers=headers, json=payload)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"OpenAI request failed: {exc}") from exc
+
+        data = response.json()
+        text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+        return str(text)
+
+    __call__ = generate

--- a/tests/test_openai_resource.py
+++ b/tests/test_openai_resource.py
@@ -1,0 +1,38 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from pipeline.plugins.resources.openai import OpenAIResource
+
+
+class FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def json(self):
+        return {"choices": [{"message": {"content": "hi"}}]}
+
+
+async def run_generate():
+    resource = OpenAIResource(
+        {
+            "api_key": "key",
+            "model": "gpt-4",
+            "base_url": "https://api.openai.com",
+        }
+    )
+    with patch(
+        "httpx.AsyncClient.post", new=AsyncMock(return_value=FakeResponse())
+    ) as mock_post:
+        result = await resource.generate("hello")
+        mock_post.assert_awaited_with(
+            "https://api.openai.com/v1/chat/completions",
+            headers={"Authorization": "Bearer key"},
+            json={"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]},
+        )
+    return result
+
+
+def test_generate_sends_prompt_and_returns_text():
+    assert asyncio.run(run_generate()) == "hi"


### PR DESCRIPTION
## Summary
- add OpenAIResource using ResourcePlugin
- expose it in resource package
- test OpenAIResource generate() with mocked httpx

## Testing
- `mypy src/pipeline/plugins/resources/openai.py tests/test_openai_resource.py --ignore-missing-imports`
- `bandit -r src/pipeline/plugins/resources/openai.py -q`
- `pytest tests/test_openai_resource.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6863133984008322aa988e72734a147b