### PR TITLE
[Prompt] Add PII scrubber plugin

### DIFF
--- a/src/pipeline/plugins/prompts/__init__.py
+++ b/src/pipeline/plugins/prompts/__init__.py
@@ -2,6 +2,7 @@ from .chain_of_thought import ChainOfThoughtPrompt
 from .complex_prompt import ComplexPrompt
 from .intent_classifier import IntentClassifierPrompt
 from .memory_retrieval import MemoryRetrievalPrompt
+from .pii_scrubber import PIIScrubberPrompt
 from .react_prompt import ReActPrompt
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "ReActPrompt",
     "ComplexPrompt",
     "ChainOfThoughtPrompt",
+    "PIIScrubberPrompt",
 ]

--- a/src/pipeline/plugins/prompts/pii_scrubber.py
+++ b/src/pipeline/plugins/prompts/pii_scrubber.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pipeline.context import PluginContext
+from pipeline.plugins import PromptPlugin
+from pipeline.stages import PipelineStage
+from pipeline.state import ConversationEntry
+
+
+class PIIScrubberPrompt(PromptPlugin):
+    """Scrub email addresses and phone numbers from text."""
+
+    stages = [PipelineStage.REVIEW]
+
+    EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+    PHONE_PATTERN = re.compile(
+        r"(?:\+?\d{1,3}[-. ]?)?(?:\(?\d{3}\)?[-. ]?)?\d{3}[-. ]?\d{4}"
+    )
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        state = context._get_state()
+        state.conversation = [self._scrub_entry(entry) for entry in state.conversation]
+        if state.response is not None:
+            state.response = self._scrub_value(state.response)
+
+    def _scrub_entry(self, entry: ConversationEntry) -> ConversationEntry:
+        """Return ``entry`` with its content sanitized."""
+
+        entry.content = self._scrub_text(entry.content)
+        return entry
+
+    def _scrub_text(self, text: str) -> str:
+        """Replace email addresses and phone numbers in ``text``."""
+
+        text = self.EMAIL_PATTERN.sub("[email]", text)
+        text = self.PHONE_PATTERN.sub("[phone]", text)
+        return text
+
+    def _scrub_value(self, value: Any) -> Any:
+        """Recursively sanitize ``value`` if it contains text."""
+
+        if isinstance(value, str):
+            return self._scrub_text(value)
+        if isinstance(value, dict):
+            return {k: self._scrub_value(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._scrub_value(v) for v in value]
+        return value

--- a/tests/test_pii_scrubber_plugin.py
+++ b/tests/test_pii_scrubber_plugin.py
@@ -1,0 +1,40 @@
+import asyncio
+from datetime import datetime
+
+from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
+                      PluginContext, PluginRegistry, ResourceRegistry,
+                      SystemRegistries, ToolRegistry)
+from pipeline.plugins.prompts.pii_scrubber import PIIScrubberPrompt
+
+
+def make_context():
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(
+                content="Email me at user@example.com or call 555-111-2222",
+                role="user",
+                timestamp=datetime.now(),
+            )
+        ],
+        pipeline_id="1",
+        metrics=MetricsCollector(),
+    )
+    state.response = "Contact admin@example.com at (123) 456-7890"
+    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), PluginRegistry())
+    return state, PluginContext(state, registries)
+
+
+def test_pii_is_scrubbed_from_history_and_response():
+    state, ctx = make_context()
+    plugin = PIIScrubberPrompt({})
+
+    asyncio.run(plugin.execute(ctx))
+
+    assert "user@example.com" not in state.conversation[0].content
+    assert "555-111-2222" not in state.conversation[0].content
+    assert "admin@example.com" not in state.response
+    assert "123" not in state.response
+    assert "[email]" in state.conversation[0].content
+    assert "[phone]" in state.conversation[0].content
+    assert "[email]" in state.response
+    assert "[phone]" in state.response


### PR DESCRIPTION
## Summary
- sanitize phone numbers and email addresses during review
- export `PIIScrubberPrompt`
- test PII scrubber plugin

## Testing
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src` *(fails: There are no .py[i] files)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest -k pii_scrubber -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_686313466c8c83229ec31f53c56f94f4