### PR TITLE
Add conversation history saver plugin

### DIFF
--- a/src/pipeline/plugins/prompts/__init__.py
+++ b/src/pipeline/plugins/prompts/__init__.py
@@ -2,6 +2,7 @@ from .chain_of_thought import ChainOfThoughtPrompt
 from .complex_prompt import ComplexPrompt
 from .intent_classifier import IntentClassifierPrompt
 from .memory_retrieval import MemoryRetrievalPrompt
+from .conversation_history_saver import ConversationHistorySaver
 from .react_prompt import ReActPrompt
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "ReActPrompt",
     "ComplexPrompt",
     "ChainOfThoughtPrompt",
+    "ConversationHistorySaver",
 ]

--- a/src/pipeline/plugins/prompts/conversation_history_saver.py
+++ b/src/pipeline/plugins/prompts/conversation_history_saver.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pipeline.context import PluginContext
+from pipeline.plugins import PromptPlugin
+from pipeline.stages import PipelineStage
+
+
+class ConversationHistorySaver(PromptPlugin):
+    """Persist conversation history to the configured database."""
+
+    dependencies = ["database"]
+    stages = [PipelineStage.DELIVER]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        """Save the entire conversation using the database resource."""
+        db = context.get_resource("database")
+        if db and hasattr(db, "save_history"):
+            await db.save_history(
+                context.pipeline_id, context.get_conversation_history()
+            )

--- a/tests/test_history_saver.py
+++ b/tests/test_history_saver.py
@@ -1,0 +1,47 @@
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.plugins.prompts.conversation_history_saver import ConversationHistorySaver
+
+
+class FakeDB:
+    name = "database"
+
+    def __init__(self) -> None:
+        self.save_history = AsyncMock()
+
+
+def make_context(db: FakeDB):
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id="1",
+        metrics=MetricsCollector(),
+    )
+    resources = ResourceRegistry()
+    resources.add("database", db)
+    registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
+    return state, PluginContext(state, registries)
+
+
+def test_history_saver_invokes_db():
+    db = FakeDB()
+    state, ctx = make_context(db)
+    plugin = ConversationHistorySaver({})
+
+    expected_history = ctx.get_conversation_history()
+    asyncio.run(plugin.execute(ctx))
+
+    db.save_history.assert_awaited_with("1", expected_history)


### PR DESCRIPTION
## Summary
- save conversation history to database during deliver stage
- export the new ConversationHistorySaver prompt plugin
- test that history is persisted via database resource

## Testing
- `pytest tests/test_history_saver.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6863134e02c88322a593c5c467bfdf4f