### PR TITLE
[Adapter] Add websocket command

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -32,6 +32,7 @@ class CLI:
         parser.set_defaults(command="run")
 
         subparsers.add_parser("run", help="Start the agent")
+        subparsers.add_parser("serve-websocket", help="Start the agent via WebSocket")
         reload_parser = subparsers.add_parser(
             "reload-config",
             help="Reload plugin configuration from a YAML file",
@@ -42,6 +43,9 @@ class CLI:
 
     def run(self) -> int:
         agent = Agent(self.args.config)
+        if self.args.command == "serve-websocket":
+            agent.run_websocket()
+            return 0
         if self.args.command == "reload-config":
             return self._reload_config(agent, self.args.file)
         agent.run_http()

--- a/src/pipeline/agent.py
+++ b/src/pipeline/agent.py
@@ -12,6 +12,7 @@ from types import ModuleType
 from typing import Any, Callable, Dict, Optional, cast
 
 from .adapters.http import HTTPAdapter
+from .adapters.websocket import WebSocketAdapter
 from .pipeline import execute_pipeline
 from .plugins import BasePlugin
 from .plugins.classifier import PluginAutoClassifier
@@ -160,6 +161,14 @@ class Agent:
         config: dict[str, Any] = {"host": host, "port": port}
         return HTTPAdapter(config=config)
 
+    def create_websocket_adapter(
+        self, host: str = "127.0.0.1", port: int = 8001
+    ) -> WebSocketAdapter:
+        """Return a :class:`WebSocketAdapter` for this agent's registries."""
+
+        config: dict[str, Any] = {"host": host, "port": port}
+        return WebSocketAdapter(config=config)
+
     async def serve_http(self, host: str = "127.0.0.1", port: int = 8000) -> None:
         """Serve requests using the :class:`HTTPAdapter`."""
 
@@ -171,10 +180,26 @@ class Agent:
         )
         await adapter.serve(registries)
 
+    async def serve_websocket(self, host: str = "127.0.0.1", port: int = 8001) -> None:
+        """Serve requests using the :class:`WebSocketAdapter`."""
+
+        adapter = self.create_websocket_adapter(host, port)
+        registries = SystemRegistries(
+            resources=self.resource_registry,
+            tools=self.tool_registry,
+            plugins=self.plugin_registry,
+        )
+        await adapter.serve(registries)
+
     def run_http(self, host: str = "127.0.0.1", port: int = 8000) -> None:
         """Convenience wrapper to start the HTTP adapter."""
 
         asyncio.run(self.serve_http(host, port))
+
+    def run_websocket(self, host: str = "127.0.0.1", port: int = 8001) -> None:
+        """Convenience wrapper to start the WebSocket adapter."""
+
+        asyncio.run(self.serve_websocket(host, port))
 
     async def run_message(self, message: str) -> Dict[str, Any]:
         registries = SystemRegistries(

--- a/tests/test_cli_websocket.py
+++ b/tests/test_cli_websocket.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+from cli import CLI
+from pipeline.adapters.websocket import WebSocketAdapter
+
+
+def test_cli_websocket(monkeypatch, tmp_path):
+    config = tmp_path / "cfg.yml"
+    config.write_text("")
+    called = False
+
+    async def fake_serve(self, registries):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(WebSocketAdapter, "serve", fake_serve)
+    monkeypatch.setattr(
+        sys, "argv", ["prog", "--config", str(config), "serve-websocket"]
+    )
+
+    CLI().run()
+
+    assert called


### PR DESCRIPTION
## Summary
- add websocket adapter helpers to `Agent`
- expose `serve-websocket` CLI command
- test that CLI starts the websocket adapter

## Testing
- `black src/ tests/`
- `isort src/ tests/ --check` *(fails: imports not sorted)*
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/` *(fails: no files found)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'yaml')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: 'dotenv')*
- `pytest -v` *(fails: ModuleNotFoundError: 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68631361c7dc8322a81c45cf6a4ba1c6