### PR TITLE
Sort plugins by priority

### DIFF
--- a/src/pipeline/registries.py
+++ b/src/pipeline/registries.py
@@ -61,11 +61,12 @@ class PluginRegistry:
             ) from exc
 
         self._stage_plugins[stage_enum].append(plugin)
+        self._stage_plugins[stage_enum].sort(key=lambda p: getattr(p, "priority", 50))
         plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
         self._names.setdefault(plugin, str(plugin_name))
 
     def get_for_stage(self, stage: PipelineStage) -> List[BasePlugin]:
-        """Return plugins registered for ``stage`` in registration order."""
+        """Return plugins for ``stage`` sorted by ascending priority."""
 
         return list(self._stage_plugins.get(stage, []))
 


### PR DESCRIPTION
## Summary
- order plugins by priority when registering
- add priorities to test plugins
- test priority ordering during registration and initialization

## Testing
- `pytest tests/test_plugin_registry_order.py -q`
- `pytest -q` *(fails: InvalidCatalogNameError, unexpected kwargs)*

------
https://chatgpt.com/codex/tasks/task_e_6863136798d08322bd16bb57a533c5f2