### PR TITLE
[Docs] Update example scripts

### DIFF
--- a/examples/http_server.py
+++ b/examples/http_server.py
@@ -11,20 +11,20 @@ import asyncio
 from typing import Any
 
 from entity import Agent
-from pipeline import ConversationManager, PipelineManager
+from pipeline import ConversationManager, PipelineManager, SystemRegistries
 from pipeline.adapters.http import HTTPAdapter, MessageRequest
 
 
 async def main() -> None:
-    agent = Agent({"server": {"host": "127.0.0.1", "port": 8000}})  # type: ignore[arg-type]
-    await agent._ensure_initialized()
-    registries = agent._registries
-    if registries is None:
-        raise RuntimeError("System not initialized")
-
+    agent = Agent()
+    registries = SystemRegistries(
+        resources=agent.resource_registry,
+        tools=agent.tool_registry,
+        plugins=agent.plugin_registry,
+    )
     pipeline_manager = PipelineManager(registries)
     conversation_manager = ConversationManager(registries, pipeline_manager)
-    adapter = HTTPAdapter(pipeline_manager, agent.config.get("server", {}))
+    adapter = HTTPAdapter(pipeline_manager, {"host": "127.0.0.1", "port": 8000})
 
     @adapter.app.post("/conversation")
     async def conversation(req: MessageRequest) -> dict[str, Any]:

--- a/examples/pipeline_example.py
+++ b/examples/pipeline_example.py
@@ -39,7 +39,7 @@ class CalculatorTool(ToolPlugin):
             raise ValueError(f"Invalid expression: {exc}") from exc
 
 
-def hello_plugin(ctx):  # pragma: no cover - example code
+async def hello_plugin(ctx):  # pragma: no cover - example code
     if "hello" in ctx.message.lower():
         return "Hello there!"
     return None


### PR DESCRIPTION
## Summary
- fix pipeline example's hello plugin to be async
- update HTTP server example to new API
- simplify vector memory example with echo LLM

## Testing
- `pytest -q` *(fails: asyncpg.exceptions.InvalidCatalogNameError)*
- `flake8 src tests` *(fails: F401, E402, F811)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: Configuration invalid: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: Configuration invalid: database "agent" does not exist)*
- `python examples/pipeline_example.py`
- `python examples/vector_memory_pipeline.py`
- `python examples/http_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68631631349c8322bec86e01f2f3b1bb