### PR TITLE
[Core] log llm call details

### DIFF
--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -109,9 +109,24 @@ class BasePlugin(ABC):
             else:
                 response = func(prompt)
 
-        context.record_llm_duration(self.__class__.__name__, time.time() - start)
+        duration = time.time() - start
+        context.record_llm_duration(self.__class__.__name__, duration)
 
-        return LLMResponse(content=str(response))
+        llm_response = LLMResponse(content=str(response))
+        self.logger.info(
+            "LLM call completed",
+            extra={
+                "plugin": self.__class__.__name__,
+                "stage": str(context.current_stage),
+                "purpose": purpose,
+                "prompt_length": len(prompt),
+                "response_length": len(llm_response.content),
+                "duration": duration,
+                "pipeline_id": context.pipeline_id,
+            },
+        )
+
+        return llm_response
 
     # --- Validation & Reconfiguration ---
     @classmethod

--- a/tests/test_call_llm_logging.py
+++ b/tests/test_call_llm_logging.py
@@ -1,0 +1,71 @@
+import asyncio
+from datetime import datetime
+
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+
+
+class FakeLLM:
+    async def generate(self, prompt: str) -> str:
+        return "pong"
+
+
+class DummyPlugin(PromptPlugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(
+        self, context: PluginContext
+    ) -> None:  # pragma: no cover - not used
+        pass
+
+
+def make_context(llm: FakeLLM) -> PluginContext:
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id="123",
+        metrics=MetricsCollector(),
+        current_stage=PipelineStage.THINK,
+    )
+    resources = ResourceRegistry()
+    resources.add("ollama", llm)
+    registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
+    return PluginContext(state, registries)
+
+
+def test_call_llm_logs_info(monkeypatch):
+    llm = FakeLLM()
+    ctx = make_context(llm)
+    plugin = DummyPlugin({})
+
+    recorded = {}
+
+    def fake_info(message: str, *, extra=None, **kwargs):
+        recorded["message"] = message
+        if extra:
+            recorded.update(extra)
+
+    monkeypatch.setattr(plugin.logger, "info", fake_info)
+
+    result = asyncio.run(plugin.call_llm(ctx, "hello", "test"))
+
+    assert result.content == "pong"
+    assert recorded["message"] == "LLM call completed"
+    assert recorded["plugin"] == "DummyPlugin"
+    assert recorded["stage"] == str(PipelineStage.THINK)
+    assert recorded["purpose"] == "test"
+    assert recorded["prompt_length"] == len("hello")
+    assert recorded["response_length"] == len("pong")
+    assert recorded["pipeline_id"] == "123"
+    assert isinstance(recorded["duration"], float)


### PR DESCRIPTION
## Summary
- log LLM call details in `BasePlugin.call_llm`
- test that logging details are captured

## Testing
- `black src/pipeline/base_plugins.py tests/test_call_llm_logging.py`
- `isort src/pipeline/base_plugins.py tests/test_call_llm_logging.py`
- `flake8 src/pipeline/base_plugins.py tests/test_call_llm_logging.py` *(fails: command not found)*
- `mypy src/pipeline/base_plugins.py tests/test_call_llm_logging.py`
- `bandit -r src/pipeline/base_plugins.py tests/test_call_llm_logging.py` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: database does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database does not exist)*
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: database does not exist)*
- `pytest tests/performance/ -m benchmark` *(no tests found)*
- `pytest` *(fails: multiple errors as above)*

------
https://chatgpt.com/codex/tasks/task_e_6863233a34808322be8172f8d3eaffeb