### PR TITLE
[Core] add llm alias helper and update tests

### DIFF
--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -90,9 +90,9 @@ class BasePlugin(ABC):
     ) -> "LLMResponse":
         from .context import LLMResponse
 
-        llm = context.get_resource("ollama")
+        llm = context.get_llm()
         if llm is None:
-            raise RuntimeError("LLM resource 'ollama' not available")
+            raise RuntimeError("LLM resource not available")
 
         context.record_llm_call(self.__class__.__name__, purpose)
 

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -84,6 +84,15 @@ class PluginContext:
         """Return a shared resource plugin registered as ``name``."""
         return self._registries.resources.get(name)
 
+    def get_llm(self) -> Any | None:
+        """Return the configured LLM resource.
+
+        Looks for a resource registered as ``"llm"`` first and falls back to
+        ``"ollama"`` for backward compatibility.
+        """
+        llm = self.get_resource("llm")
+        return llm if llm is not None else self.get_resource("ollama")
+
     @property
     def message(self) -> str:
         """Return the latest user message."""
@@ -264,9 +273,9 @@ class SimpleContext(PluginContext):
 
     async def ask_llm(self, prompt: str) -> str:
         """Send ``prompt`` to the configured LLM and return its reply."""
-        llm = self.get_resource("ollama")
+        llm = self.get_llm()
         if llm is None:
-            raise RuntimeError("LLM resource 'ollama' not available")
+            raise RuntimeError("LLM resource not available")
 
         self.record_llm_call("SimpleContext", "ask_llm")
         start = asyncio.get_event_loop().time()

--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -16,6 +16,7 @@ DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
 
 DEFAULT_RESOURCES: Dict[str, Dict[str, Any]] = {
     "ollama": {"type": "pipeline.plugins.resources.echo_llm:EchoLLMResource"},
+    "llm": {"type": "pipeline.plugins.resources.echo_llm:EchoLLMResource"},
     "memory": {
         "type": "pipeline.plugins.resources.memory_resource:SimpleMemoryResource"
     },

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -73,6 +73,7 @@ def test_vector_memory_integration():
         resources.add("database", db)
         resources.add("vector_memory", vm)
         resources.add("ollama", llm)
+        resources.add("llm", llm)
         registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
         state = PipelineState(
             conversation=[

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -43,6 +43,7 @@ def make_context(llm: FakeLLM):
     tools = ToolRegistry()
     plugins = PluginRegistry()
     resources.add("ollama", llm)
+    resources.add("llm", llm)
     tools.add("analysis_tool", DummyTool())
     registries = SystemRegistries(resources, tools, plugins)
     return state, PluginContext(state, registries)

--- a/tests/test_complex_prompt.py
+++ b/tests/test_complex_prompt.py
@@ -47,6 +47,7 @@ def make_context(llm, db, memory):
     )
     resources = ResourceRegistry()
     resources.add("ollama", llm)
+    resources.add("llm", llm)
     resources.add("database", db)
     resources.add("vector_memory", memory)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())

--- a/tests/test_intent_classifier_prompt.py
+++ b/tests/test_intent_classifier_prompt.py
@@ -29,6 +29,7 @@ def make_context(llm: FakeLLM):
     )
     resources = ResourceRegistry()
     resources.add("ollama", llm)
+    resources.add("llm", llm)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return state, PluginContext(state, registries)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -39,6 +39,7 @@ def make_registries():
     plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DO)
     resources = ResourceRegistry()
     resources.add("ollama", EchoLLM())
+    resources.add("llm", EchoLLM())
     tools = ToolRegistry()
     tools.add("echo", EchoTool({}))
     return SystemRegistries(resources, tools, plugins)

--- a/tests/test_react_prompt.py
+++ b/tests/test_react_prompt.py
@@ -39,6 +39,7 @@ def make_context(llm: FakeLLM):
     tools = ToolRegistry()
     plugins = PluginRegistry()
     resources.add("ollama", llm)
+    resources.add("llm", llm)
 
     calculator = CalculatorTool()
     tools.add("calculator_tool", calculator)


### PR DESCRIPTION
## Summary
- add `get_llm` helper to context
- update LLM calls to use `get_llm`
- register LLM resources under `"llm"` alias
- adapt tests for the new alias

## Testing
- `isort src/ tests/ --check --diff`
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src` *(fails: no .py files found)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6863233bebc4832282d959a394147f8a