### PR TITLE
[Docs] Document runtime config reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,24 @@ agent = Agent()
 def hello(context):
     return "hello"
 ```
+
+## Runtime Configuration Reload
+Update plugin settings without restarting the agent.
+
+```bash
+python src/cli.py reload-config updated.yaml
+```
+
+See [ARCHITECTURE.md](ARCHITECTURE.md#%F0%9F%94%84-reconfigurable-agent-infrastructure) for details on dynamic reconfiguration.
+
+### Using the "llm" Resource Key
+Define your LLM once and share it across plugins:
+
+```yaml
+plugins:
+  resources:
+    llm:
+      type: openai_llm
+      model: gpt-4
+      api_key: ${OPENAI_API_KEY}
+```

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -45,3 +45,24 @@ configure database and LLM credentials. These values will be automatically
 loaded when running the agent or tests.
 This fast path aligns with the **15-Minute Rule (2)**, giving new
 contributors a working agent almost immediately.
+
+### Runtime Configuration Reload
+Reload plugin definitions while the agent is running:
+
+```bash
+python src/cli.py reload-config updated.yaml
+```
+
+For more on dynamic configuration, see [ARCHITECTURE.md](../../ARCHITECTURE.md#%F0%9F%94%84-reconfigurable-agent-infrastructure).
+
+### Using the "llm" Resource Key
+Configure a shared LLM resource in YAML:
+
+```yaml
+plugins:
+  resources:
+    llm:
+      type: openai_llm
+      model: gpt-4
+      api_key: ${OPENAI_API_KEY}
+```


### PR DESCRIPTION
## Summary
- document reloading configuration via `src/cli.py reload-config`
- describe new `llm` resource key
- add cross link to `ARCHITECTURE.md`

## Testing
- `black src/ tests/`
- `flake8 src/ tests/`
- `mypy src` *(fails: Duplicate module named "pipeline.observability")*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'asyncpg')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'asyncpg')*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: No module named 'asyncpg')*
- `pytest tests/integration/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_6863233e68e483228e9ea0dc70ebd7c1