### PR TITLE
[Resource] add LLMResource base class

### DIFF
--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -1,3 +1,5 @@
+from pipeline.resources import LLMResource
+
 from .echo_llm import EchoLLMResource
 from .memory_resource import SimpleMemoryResource
 from .ollama_llm import OllamaLLMResource
@@ -13,5 +15,6 @@ __all__ = [
     "StructuredLogging",
     "PostgresResource",
     "VectorMemoryResource",
+    "LLMResource",
     "OpenAIResource",
 ]

--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,3 +1,3 @@
-from .llm import LLM
+from .llm import LLM, LLMResource
 
-__all__ = ["LLM"]
+__all__ = ["LLM", "LLMResource"]

--- a/src/pipeline/resources/llm.py
+++ b/src/pipeline/resources/llm.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
+
+from pipeline.plugins import ResourcePlugin
+from pipeline.stages import PipelineStage
 
 
 class LLM(ABC):
@@ -12,3 +16,17 @@ class LLM(ABC):
 
     async def __call__(self, prompt: str) -> str:
         return await self.generate(prompt)
+
+
+class LLMResource(ResourcePlugin, LLM):
+    """Base class for LLM-backed resources."""
+
+    stages = [PipelineStage.PARSE]
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - no op
+        return None
+
+    async def generate(self, prompt: str) -> str:
+        raise NotImplementedError
+
+    __call__ = generate


### PR DESCRIPTION
## Summary
- add `LLMResource` base class
- export `LLMResource` from resources package
- re-export base class from resource plugin package

## Testing
- `flake8 src/ tests/`
- `mypy -p pipeline`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'asyncpg')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'asyncpg')*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: No module named 'asyncpg')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pgvector')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'asyncpg')*
- `pytest tests/performance/ -m benchmark` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863277507148322a3b5b68817567c52