### PR TITLE
[Resource] add LLMResource base and alias registration

### DIFF
--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -167,7 +167,11 @@ class SystemInitializer:
                 getattr(instance, "initialize")
             ):
                 await instance.initialize()
-            resource_registry.add(getattr(instance, "name", cls.__name__), instance)
+            primary_name = getattr(instance, "name", cls.__name__)
+            resource_registry.add(primary_name, instance)
+            for alias in getattr(instance, "aliases", []):
+                if alias != primary_name:
+                    resource_registry.add(alias, instance)
 
         # Phase 3.5: register tools
         tool_registry = ToolRegistry()

--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -1,4 +1,5 @@
 from .echo_llm import EchoLLMResource
+from .llm_resource import LLMResource
 from .memory_resource import SimpleMemoryResource
 from .ollama_llm import OllamaLLMResource
 from .openai import OpenAIResource
@@ -8,6 +9,7 @@ from .vector_memory import VectorMemoryResource
 
 __all__ = [
     "EchoLLMResource",
+    "LLMResource",
     "OllamaLLMResource",
     "SimpleMemoryResource",
     "StructuredLogging",

--- a/src/pipeline/plugins/resources/echo_llm.py
+++ b/src/pipeline/plugins/resources/echo_llm.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from pipeline.plugins import ResourcePlugin
-from pipeline.stages import PipelineStage
+from pipeline.plugins.resources.llm_resource import LLMResource
 
 
-class EchoLLMResource(ResourcePlugin):
+class EchoLLMResource(LLMResource):
     """Simple LLM resource that echoes the prompt back."""
 
-    stages = [PipelineStage.PARSE]
-    name = "ollama"
+    name = "echo"
+    aliases = ["llm"]
 
     async def _execute_impl(self, context):
         return None

--- a/src/pipeline/plugins/resources/llm_resource.py
+++ b/src/pipeline/plugins/resources/llm_resource.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from pipeline.plugins import ResourcePlugin
+from pipeline.resources import LLM
+from pipeline.stages import PipelineStage
+
+
+class LLMResource(ResourcePlugin, LLM):
+    """Base class for language model resources."""
+
+    stages = [PipelineStage.PARSE]
+    name = "llm"
+    aliases: List[str] = ["llm"]
+
+    async def _execute_impl(self, context) -> None:
+        return None

--- a/src/pipeline/plugins/resources/ollama_llm.py
+++ b/src/pipeline/plugins/resources/ollama_llm.py
@@ -4,19 +4,19 @@ from typing import Any, Dict
 
 import httpx
 
-from pipeline.plugins import ResourcePlugin, ValidationResult
-from pipeline.stages import PipelineStage
+from pipeline.plugins import ValidationResult
+from pipeline.plugins.resources.llm_resource import LLMResource
 
 
-class OllamaLLMResource(ResourcePlugin):
+class OllamaLLMResource(LLMResource):
     """LLM resource backed by a running Ollama server.
 
     Uses **Structured LLM Access (22)** so any stage can generate text while the
     framework automatically tracks token usage.
     """
 
-    stages = [PipelineStage.PARSE]
     name = "ollama"
+    aliases = ["llm"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/src/pipeline/plugins/resources/openai.py
+++ b/src/pipeline/plugins/resources/openai.py
@@ -4,15 +4,15 @@ from typing import Any, Dict
 
 import httpx
 
-from pipeline.plugins import ResourcePlugin, ValidationResult
-from pipeline.stages import PipelineStage
+from pipeline.plugins import ValidationResult
+from pipeline.plugins.resources.llm_resource import LLMResource
 
 
-class OpenAIResource(ResourcePlugin):
+class OpenAIResource(LLMResource):
     """LLM resource for OpenAI's chat completion API."""
 
-    stages = [PipelineStage.PARSE]
     name = "openai"
+    aliases = ["llm"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -124,3 +124,25 @@ def test_initializer_from_json_and_dict(tmp_path):
         == len(pd.get_for_stage(PipelineStage.THINK))
     )
     assert ry.get("A") and rj.get("A") and rd.get("A")
+
+
+def test_llm_alias_registration(tmp_path):
+    config = {
+        "plugins": {
+            "resources": {
+                "ollama": {
+                    "type": "pipeline.plugins.resources.ollama_llm:OllamaLLMResource",
+                    "base_url": "http://localhost:11434",
+                    "model": "tiny",
+                }
+            }
+        }
+    }
+
+    path = tmp_path / "cfg.yml"
+    path.write_text(yaml.dump(config))
+
+    initializer = SystemInitializer.from_yaml(str(path))
+    _, resources, _ = asyncio.run(initializer.initialize())
+
+    assert resources.get("llm") is resources.get("ollama")


### PR DESCRIPTION
## Summary
- add a shared `LLMResource` base class
- register resource aliases so LLMs are available via `llm`
- update Ollama, OpenAI, and Echo resources to use the new base class
- expose `LLMResource` in resource exports
- test resource aliasing via `SystemInitializer`

## Testing
- `flake8` *(fails: Command not found)*
- `mypy -p pipeline`
- `bandit -r src` *(fails: Command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68632776206483229db428754d69b9f1