### PR TITLE
[Resource] Add Gemini and Claude resources

### DIFF
--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -2,6 +2,8 @@ from .echo_llm import EchoLLMResource
 from .memory_resource import SimpleMemoryResource
 from .ollama_llm import OllamaLLMResource
 from .openai import OpenAIResource
+from .gemini import GeminiResource
+from .claude import ClaudeResource
 from .postgres import PostgresResource
 from .structured_logging import StructuredLogging
 from .vector_memory import VectorMemoryResource
@@ -14,4 +16,6 @@ __all__ = [
     "PostgresResource",
     "VectorMemoryResource",
     "OpenAIResource",
+    "GeminiResource",
+    "ClaudeResource",
 ]

--- a/src/pipeline/plugins/resources/claude.py
+++ b/src/pipeline/plugins/resources/claude.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+
+from pipeline.plugins import ResourcePlugin, ValidationResult
+from pipeline.stages import PipelineStage
+
+
+class ClaudeResource(ResourcePlugin):
+    """LLM resource for Anthropic's Claude API."""
+
+    stages = [PipelineStage.PARSE]
+    name = "claude"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self.api_key: str | None = self.config.get("api_key")
+        self.model: str | None = self.config.get("model")
+        self.base_url: str | None = self.config.get("base_url")
+        self.params: Dict[str, Any] = {
+            k: v
+            for k, v in self.config.items()
+            if k not in {"api_key", "model", "base_url"}
+        }
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        if not config.get("api_key"):
+            return ValidationResult.error_result("'api_key' is required")
+        if not config.get("model"):
+            return ValidationResult.error_result("'model' is required")
+        if not config.get("base_url"):
+            return ValidationResult.error_result("'base_url' is required")
+        return ValidationResult.success_result()
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
+        return None
+
+    async def generate(self, prompt: str) -> str:
+        if not self.api_key or not self.model or not self.base_url:
+            raise RuntimeError("Claude resource not properly configured")
+
+        url = f"{self.base_url.rstrip('/')}/v1/messages"
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": "2023-06-01",
+        }
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            **self.params,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.post(url, headers=headers, json=payload)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"Claude request failed: {exc}") from exc
+
+        data = response.json()
+        text = data.get("content", [{}])[0].get("text", "")
+        return str(text)
+
+    __call__ = generate

--- a/src/pipeline/plugins/resources/gemini.py
+++ b/src/pipeline/plugins/resources/gemini.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+
+from pipeline.plugins import ResourcePlugin, ValidationResult
+from pipeline.stages import PipelineStage
+
+
+class GeminiResource(ResourcePlugin):
+    """LLM resource for Google's Gemini API."""
+
+    stages = [PipelineStage.PARSE]
+    name = "gemini"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self.api_key: str | None = self.config.get("api_key")
+        self.model: str | None = self.config.get("model")
+        self.base_url: str | None = self.config.get("base_url")
+        self.params: Dict[str, Any] = {
+            k: v
+            for k, v in self.config.items()
+            if k not in {"api_key", "model", "base_url"}
+        }
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        if not config.get("api_key"):
+            return ValidationResult.error_result("'api_key' is required")
+        if not config.get("model"):
+            return ValidationResult.error_result("'model' is required")
+        if not config.get("base_url"):
+            return ValidationResult.error_result("'base_url' is required")
+        return ValidationResult.success_result()
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
+        return None
+
+    async def generate(self, prompt: str) -> str:
+        if not self.api_key or not self.model or not self.base_url:
+            raise RuntimeError("Gemini resource not properly configured")
+
+        url = f"{self.base_url.rstrip('/')}/v1beta/models/{self.model}:generateContent"
+        headers = {"Content-Type": "application/json"}
+        params = {"key": self.api_key}
+        payload = {"contents": [{"parts": [{"text": prompt}]}], **self.params}
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                response = await client.post(
+                    url, headers=headers, params=params, json=payload
+                )
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RuntimeError(f"Gemini request failed: {exc}") from exc
+
+        data = response.json()
+        text = (
+            data.get("candidates", [{}])[0]
+            .get("content", {})
+            .get("parts", [{}])[0]
+            .get("text", "")
+        )
+        return str(text)
+
+    __call__ = generate

--- a/tests/test_claude_resource.py
+++ b/tests/test_claude_resource.py
@@ -1,0 +1,41 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from pipeline.plugins.resources.claude import ClaudeResource
+
+
+class FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def json(self):
+        return {"content": [{"text": "hi"}]}
+
+
+async def run_generate():
+    resource = ClaudeResource(
+        {
+            "api_key": "key",
+            "model": "claude-3",
+            "base_url": "https://api.anthropic.com",
+        }
+    )
+    with patch(
+        "httpx.AsyncClient.post", new=AsyncMock(return_value=FakeResponse())
+    ) as mock_post:
+        result = await resource.generate("hello")
+        mock_post.assert_awaited_with(
+            "https://api.anthropic.com/v1/messages",
+            headers={"x-api-key": "key", "anthropic-version": "2023-06-01"},
+            json={
+                "model": "claude-3",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+    return result
+
+
+def test_generate_sends_prompt_and_returns_text():
+    assert asyncio.run(run_generate()) == "hi"

--- a/tests/test_gemini_resource.py
+++ b/tests/test_gemini_resource.py
@@ -1,0 +1,39 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from pipeline.plugins.resources.gemini import GeminiResource
+
+
+class FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def json(self):
+        return {"candidates": [{"content": {"parts": [{"text": "hi"}]}}]}
+
+
+async def run_generate():
+    resource = GeminiResource(
+        {
+            "api_key": "key",
+            "model": "gemini-pro",
+            "base_url": "https://generativelanguage.googleapis.com",
+        }
+    )
+    with patch(
+        "httpx.AsyncClient.post", new=AsyncMock(return_value=FakeResponse())
+    ) as mock_post:
+        result = await resource.generate("hello")
+        mock_post.assert_awaited_with(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+            headers={"Content-Type": "application/json"},
+            params={"key": "key"},
+            json={"contents": [{"parts": [{"text": "hello"}]}]},
+        )
+    return result
+
+
+def test_generate_sends_prompt_and_returns_text():
+    assert asyncio.run(run_generate()) == "hi"


### PR DESCRIPTION
## Summary
- implement GeminiResource and ClaudeResource
- export them in resources package
- test both resources with simple unit tests

## Testing
- `pytest tests/test_gemini_resource.py tests/test_claude_resource.py -q`
- `isort src/ tests/ --check-only` *(fails: imports incorrectly sorted)*
- `flake8 src/ tests/` *(fails: F401 and F811 errors)*
- `mypy src/` *(fails: no .py files detected)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: database "agent_sandbox" does not exist)*
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863277954448322959c558be27381e9