### PR TITLE
[Tests] remove ollama key from test registrations

### DIFF
--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -72,7 +72,7 @@ def test_vector_memory_integration():
         resources = ResourceRegistry()
         resources.add("database", db)
         resources.add("vector_memory", vm)
-        resources.add("ollama", llm)
+        resources.add("llm", llm)
         registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
         state = PipelineState(
             conversation=[

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -15,7 +15,7 @@ from pipeline.plugins.prompts.chain_of_thought import ChainOfThoughtPrompt
 
 
 class FakeLLM:
-    name = "ollama"
+    name = "llm"
 
     def __init__(self, responses):
         self._responses = list(responses)
@@ -42,7 +42,7 @@ def make_context(llm: FakeLLM):
     resources = ResourceRegistry()
     tools = ToolRegistry()
     plugins = PluginRegistry()
-    resources.add("ollama", llm)
+    resources.add("llm", llm)
     tools.add("analysis_tool", DummyTool())
     registries = SystemRegistries(resources, tools, plugins)
     return state, PluginContext(state, registries)

--- a/tests/test_complex_prompt.py
+++ b/tests/test_complex_prompt.py
@@ -16,7 +16,7 @@ from pipeline.plugins.prompts.complex_prompt import ComplexPrompt
 
 
 class FakeLLM:
-    name = "ollama"
+    name = "llm"
 
     def __init__(self):
         self.generate = AsyncMock(return_value="done")
@@ -46,7 +46,7 @@ def make_context(llm, db, memory):
         metrics=MetricsCollector(),
     )
     resources = ResourceRegistry()
-    resources.add("ollama", llm)
+    resources.add("llm", llm)
     resources.add("database", db)
     resources.add("vector_memory", memory)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())

--- a/tests/test_intent_classifier_prompt.py
+++ b/tests/test_intent_classifier_prompt.py
@@ -28,7 +28,7 @@ def make_context(llm: FakeLLM):
         metrics=MetricsCollector(),
     )
     resources = ResourceRegistry()
-    resources.add("ollama", llm)
+    resources.add("llm", llm)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return state, PluginContext(state, registries)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -38,7 +38,7 @@ def make_registries():
     plugins = PluginRegistry()
     plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DO)
     resources = ResourceRegistry()
-    resources.add("ollama", EchoLLM())
+    resources.add("llm", EchoLLM())
     tools = ToolRegistry()
     tools.add("echo", EchoTool({}))
     return SystemRegistries(resources, tools, plugins)

--- a/tests/test_react_prompt.py
+++ b/tests/test_react_prompt.py
@@ -16,7 +16,7 @@ from pipeline.plugins.tools.calculator_tool import CalculatorTool
 
 
 class FakeLLM:
-    name = "ollama"
+    name = "llm"
 
     def __init__(self, responses):
         self._responses = list(responses)
@@ -38,7 +38,7 @@ def make_context(llm: FakeLLM):
     resources = ResourceRegistry()
     tools = ToolRegistry()
     plugins = PluginRegistry()
-    resources.add("ollama", llm)
+    resources.add("llm", llm)
 
     calculator = CalculatorTool()
     tools.add("calculator_tool", calculator)


### PR DESCRIPTION
## Summary
- register test LLMs only with `"llm"` key
- drop leftover `"ollama"` key usage in tests

## Testing
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/ --config-file mypy.ini` *(fails: source files not found)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: missing dependency)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: missing dependency)*
- `python -m src.registry.validator` *(fails: missing dependency)*
- `pytest tests/integration/ -v` *(fails: missing dependency)*
- `pytest tests/performance/ -m benchmark` *(fails: missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68632784a5388322953a303e527c6443