### PR TITLE
Update docs for new llm config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,30 @@ plugins so the pipeline can run out of the box:
 These defaults allow ``Agent()`` to process messages without any external
 configuration.
 
+<!-- start quick_start -->
+Get started quickly by installing the package and running an agent with a YAML
+file:
+
+```bash
+pip install entity-pipeline
+python src/cli.py --config config.yaml
+```
+<!-- end quick_start -->
+
+<!-- start config -->
+The ``llm`` resource now accepts a ``provider`` key. Choose from ``openai``,
+``ollama``, ``gemini``, or ``claude``:
+
+```yaml
+plugins:
+  resources:
+    llm:
+      provider: ollama  # openai, ollama, gemini, claude
+      model: tinyllama
+      base_url: "http://localhost:11434"
+```
+<!-- end config -->
+
 Every plugin executes with a ``PluginContext`` which grants controlled
 access to resources, conversation history, and helper methods for calling
 tools or LLMs. This context keeps plugin logic focused while the framework

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,7 +8,8 @@
 ## Examples
 
 - [`vector_memory_pipeline.py`](../../examples/vector_memory_pipeline.py)
-  demonstrates using Postgres, an Ollama LLM, and simple vector memory.
+  demonstrates using Postgres, an LLM with the Ollama provider, and simple
+  vector memory.
 
 ## Runtime Configuration Reload
 

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -27,14 +27,15 @@ async def lookup(context):
 The `context` argument is an instance of `PluginContext`. See
 [the context guide](context.md) for an overview of its helper methods.
 
-### Enabling the Ollama Resource
-Add the Ollama LLM resource to your configuration so plugins can use it:
+### Configuring the LLM Resource
+Select an LLM provider in your configuration. The following example uses
+Ollama, but you can set `provider` to `openai`, `gemini`, or `claude`:
 
 ```yaml
 plugins:
   resources:
-    ollama:
-      type: ollama_llm
+    llm:
+      provider: ollama  # openai, ollama, gemini, claude
       base_url: "http://localhost:11434"
       model: "tinyllama"
 ```


### PR DESCRIPTION
## Summary
- document the generic `llm` resource in README
- mention LLM provider selection in the quick-start guide
- tweak example description on the docs index

## Testing
- `flake8 src/ tests/`
- `mypy src/**/*.py`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest` *(fails: 6 failed, 68 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68632785e6388322941c18c505cafe78