### PR TITLE
[Pipeline] Resolve LLM conflict markers

### DIFF
--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -90,21 +90,9 @@ class BasePlugin(ABC):
     ) -> "LLMResponse":
         from .context import LLMResponse
 
-<<<<<< codex/rename-ollama-to-llm-and-update-configs
-        llm = context.get_resource("llm")
-        if llm is None:
-            raise RuntimeError("LLM resource 'llm' not available")
-======
-<<<<< codex/replace--ollama--with--llm--in-code
-        llm = context.get_resource("llm")
-        if llm is None:
-            raise RuntimeError("LLM resource 'llm' not available")
-======
         llm = context.get_llm()
         if llm is None:
             raise RuntimeError("LLM resource not available")
->>>>>> main
->>>>>> main
 
         context.record_llm_call(self.__class__.__name__, purpose)
 
@@ -341,5 +329,4 @@ __all__ = [
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .plugins.classifier import PluginAutoClassifier
 else:  # pragma: no cover - runtime import for compatibility
-    from .plugins.classifier import \
-        PluginAutoClassifier  # type: ignore  # noqa: E402
+    from .plugins.classifier import PluginAutoClassifier  # type: ignore  # noqa: E402

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -9,8 +9,7 @@ from typing import Any, Dict, List, Optional, cast
 
 from .registries import SystemRegistries
 from .stages import PipelineStage
-from .state import (ConversationEntry, FailureInfo, LLMResponse, PipelineState,
-                    ToolCall)
+from .state import ConversationEntry, FailureInfo, LLMResponse, PipelineState, ToolCall
 
 
 class PluginContext:
@@ -274,21 +273,9 @@ class SimpleContext(PluginContext):
 
     async def ask_llm(self, prompt: str) -> str:
         """Send ``prompt`` to the configured LLM and return its reply."""
-<<<<<< codex/rename-ollama-to-llm-and-update-configs
-        llm = self.get_resource("llm")
-        if llm is None:
-            raise RuntimeError("LLM resource 'llm' not available")
-=======
-<<<<<< codex/replace--ollama--with--llm--in-code
-        llm = self.get_resource("llm")
-        if llm is None:
-            raise RuntimeError("LLM resource 'llm' not available")
-=======
         llm = self.get_llm()
         if llm is None:
             raise RuntimeError("LLM resource not available")
->>>>>> main
->>>>>> main
 
         self.record_llm_call("SimpleContext", "ask_llm")
         start = asyncio.get_event_loop().time()


### PR DESCRIPTION
## Summary
- clean merge conflict markers in base_plugins.py and context.py
- ensure LLM access uses `context.get_llm()` and raise `RuntimeError` if none

## Testing
- `flake8 src/ tests/` *(fails: F401, F811, E402, etc.)*
- `python -m mypy src` *(fails: no .py files in directory)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: database "agent_sandbox" does not exist)*
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863323d4d948322bcd1a69efedac44f