### PR TITLE
Fix LLM reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ Plugins interact through a controlled context interface:
 
 ```python
 # Resource access
-llm = context.get_resource("ollama")
+llm = context.get_llm()
 db = context.get_resource("database")
 
 # Tool execution (immediate)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -837,7 +837,7 @@ class BasePlugin:
     
     async def call_llm(self, context, prompt: str, purpose: str) -> LLMResponse:
         """Structured LLM access with automatic logging and metrics"""
-        llm = context.get_resource("ollama")  # or configured LLM resource
+        llm = context.get_llm()  # previously context.get_resource("ollama")
         
         # Enhanced observability
         if hasattr(context, '_state'):

--- a/examples/vector_memory_pipeline.py
+++ b/examples/vector_memory_pipeline.py
@@ -50,7 +50,7 @@ class ComplexPrompt(PromptPlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         memory: VectorMemoryResource = context.get_resource("vector_memory")
         memory.add("greeting", [1.0, 0.0, 0.0])
-        llm = context.get_resource("ollama")
+        llm = context.get_llm()
         response = await llm.generate("Respond to the user using stored context.")
         context.add_conversation_entry(response, role="assistant")
 

--- a/old.md
+++ b/old.md
@@ -982,7 +982,7 @@ class BasePlugin:
     
     async def call_llm(self, context, prompt: str, purpose: str) -> LLMResponse:
         """Structured LLM access with automatic logging and metrics"""
-        llm = context.get_resource("ollama")  # or configured LLM resource
+        llm = context.get_llm()  # previously context.get_resource("ollama")
         
         # Enhanced observability
         if hasattr(context, '_state'):


### PR DESCRIPTION
## Summary
- document the new `context.get_llm()` helper
- update example pipeline to use `get_llm()`

## Testing
- `black examples/vector_memory_pipeline.py`
- `poetry run poe docs`
- `black src/ tests/` *(fails: cannot parse base_plugins.py)*
- `isort src/ tests/`
- `flake8 src/ tests/`
- `mypy src/` *(no .py files message)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: syntax error)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: syntax error)*
- `python -m src.registry.validator` *(fails: syntax error)*
- `pytest tests/integration/ -v` *(fails: syntax error during collection)*
- `pytest tests/performance/ -m benchmark` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863323ea65483229b87256fe3b7f8cf