### PR TITLE
Add llm helper tests

### DIFF
--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,6 +1,6 @@
 from .agent import Agent
 from .config_update import ConfigUpdateResult, update_plugin_configuration
-from .context import ConversationEntry, PluginContext, ToolCall
+from .context import ConversationEntry, PluginContext, SimpleContext, ToolCall
 from .conversation_manager import ConversationManager
 from .decorators import plugin
 from .errors import create_static_error_response
@@ -54,6 +54,7 @@ __all__ = [
     "PipelineStage",
     "PipelineState",
     "PluginContext",
+    "SimpleContext",
     "ConversationEntry",
     "ToolCall",
     "LLMResponse",

--- a/tests/test_llm_helpers.py
+++ b/tests/test_llm_helpers.py
@@ -1,0 +1,65 @@
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SimpleContext,
+    SystemRegistries,
+    ToolRegistry,
+)
+
+
+class StubLLM:
+    async def generate(self, prompt: str) -> str:
+        return prompt
+
+
+def make_context(llm=None) -> SimpleContext:
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id="1",
+        metrics=MetricsCollector(),
+    )
+    resources = ResourceRegistry()
+    if llm is not None:
+        resources.add("llm", llm)
+    registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
+    return SimpleContext(state, registries)
+
+
+def test_ask_llm_returns_text():
+    ctx = make_context(StubLLM())
+    result = asyncio.run(ctx.ask_llm("hello"))
+    assert result == "hello"
+
+
+def test_ask_llm_without_llm_resource_raises():
+    ctx = make_context()
+    with pytest.raises(RuntimeError):
+        asyncio.run(ctx.ask_llm("hi"))
+
+
+class DummyPlugin(PromptPlugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(
+        self, context: SimpleContext
+    ) -> None:  # pragma: no cover - not used
+        pass
+
+
+def test_base_plugin_call_llm():
+    ctx = make_context(StubLLM())
+    plugin = DummyPlugin({})
+    response = asyncio.run(plugin.call_llm(ctx, "test", "testing"))
+    assert response.content == "test"


### PR DESCRIPTION
## Summary
- export `SimpleContext` in package init
- test `SimpleContext.ask_llm` success and failure cases
- test `BasePlugin.call_llm` through a dummy plugin

## Testing
- `isort src/pipeline/__init__.py tests/test_llm_helpers.py`
- `black src/pipeline/__init__.py tests/test_llm_helpers.py`
- `flake8 src/pipeline/__init__.py tests/test_llm_helpers.py` *(fails: command not found)*
- `mypy src/pipeline/__init__.py tests/test_llm_helpers.py` *(fails: invalid syntax)*
- `bandit -r src/pipeline/__init__.py tests/test_llm_helpers.py` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: invalid syntax)*
- `pytest -k test_llm_helpers.py -vv` *(fails: invalid syntax)*

------
https://chatgpt.com/codex/tasks/task_e_686332405b1c83228841073cec81011b