### PR TITLE
Move CLI reload plugins to src for subprocess imports

### DIFF
--- a/src/pipeline/plugins/test_plugins.py
+++ b/src/pipeline/plugins/test_plugins.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pipeline import PipelineStage, PromptPlugin, ToolPlugin, ValidationResult
+
+
+class ReloadPlugin(PromptPlugin):
+    """Simple prompt plugin used for CLI reload tests."""
+
+    stages = [PipelineStage.THINK]
+    name = "reload"
+
+    async def _execute_impl(self, context):
+        # Test plugin does nothing during execution
+        return None
+
+    @classmethod
+    def validate_config(cls, config):
+        if "value" not in config:
+            return ValidationResult.error_result("missing value")
+        return ValidationResult.success_result()
+
+
+class ReloadTool(ToolPlugin):
+    """Echo tool for CLI reload tests."""
+
+    name = "echo"
+
+    async def execute_function(self, params):
+        return params.get("text", "")


### PR DESCRIPTION
## Summary
- move ReloadPlugin and ReloadTool into `pipeline.plugins.test_plugins`
- reference new plugin paths in reload tests
- simplify reload tests and assert on stderr

## Testing
- `pytest tests/test_cli_reload.py -q --color=no`


------
https://chatgpt.com/codex/tasks/task_e_686334d23e788322b2ec423831a8bb2b