### PR TITLE
[Resource] sanitize table names with quote_ident

### DIFF
--- a/tests/test_postgres_resource.py
+++ b/tests/test_postgres_resource.py
@@ -3,6 +3,8 @@ import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import asyncpg
+
 from config.environment import load_env
 from pipeline.plugins.resources.postgres import PostgresResource
 
@@ -48,3 +50,28 @@ async def run_health_check():
 
 def test_health_check_runs_query():
     assert asyncio.run(run_health_check())
+
+
+def test_malicious_table_name_is_quoted():
+    async def run():
+        cfg = {
+            "host": os.environ["DB_HOST"],
+            "port": 5432,
+            "name": "db",
+            "username": os.environ["DB_USERNAME"],
+            "password": os.environ.get("DB_PASSWORD", ""),
+            "db_schema": "public; DROP SCHEMA x;",
+            "history_table": "history; DROP TABLE y;",
+        }
+        conn = AsyncMock()
+        with patch("asyncpg.connect", new=AsyncMock(return_value=conn)):
+            plugin = PostgresResource(cfg)
+            await plugin.initialize()
+            expected_table = (
+                f'{asyncpg.utils._quote_ident(cfg["db_schema"])}.'
+                f'{asyncpg.utils._quote_ident(cfg["history_table"])}'
+            )
+            executed_query = conn.execute.await_args.args[0]
+            assert expected_table in executed_query
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- secure PostgresResource SQL statements
- secure VectorMemoryResource SQL statements
- add tests for malicious table names

## Testing
- `flake8 src/ tests/`
- `mypy src/` *(fails: There are no .py[i] files in directory 'src')*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: Invalid plugin path: llm)*
- `pytest tests/integration/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option: asyncio_mode)*
- `pytest` *(fails: 8 failed, 78 passed, 1 warning in 3.90s)*

------
https://chatgpt.com/codex/tasks/task_e_6863f471e268832285bebb5bef2657af