### PR TITLE
[Core] Add Hypothesis tests and pipeline benchmark

### DIFF
--- a/src/pipeline/validation.py
+++ b/src/pipeline/validation.py
@@ -12,6 +12,11 @@ class ValidationResult:
     error_message: Optional[str] = None
     warnings: List[str] = field(default_factory=list)
 
+    @property
+    def valid(self) -> bool:
+        """Backwards compatibility alias for :attr:`success`."""
+        return self.success
+
     @classmethod
     def success_result(cls) -> "ValidationResult":
         """Create a successful validation result."""

--- a/tests/performance/test_pipeline_benchmark.py
+++ b/tests/performance/test_pipeline_benchmark.py
@@ -1,0 +1,38 @@
+import asyncio
+
+import pytest
+
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+
+
+class NoOpPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        context.set_response("ok")
+
+
+def _make_manager():
+    plugins = PluginRegistry()
+    plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DO)
+    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    return PipelineManager(registries)
+
+
+@pytest.mark.benchmark
+def test_pipeline_execution_benchmark(benchmark):
+    manager = _make_manager()
+
+    def run():
+        return asyncio.run(manager.run_pipeline("hi"))
+
+    result = benchmark(run)
+    assert result == "ok"

--- a/tests/test_calculator_tool_hypothesis.py
+++ b/tests/test_calculator_tool_hypothesis.py
@@ -1,0 +1,29 @@
+import asyncio
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from pipeline.plugins.tools.calculator_tool import CalculatorTool
+
+
+def _eval(expr: str) -> int | float:
+    return eval(expr)
+
+
+@st.composite
+def arithmetic_expr(draw):
+    a = draw(st.integers(-10, 10))
+    op = draw(st.sampled_from(["+", "-", "*", "/"]))
+    if op == "/":
+        b = draw(st.integers(-10, 10).filter(lambda x: x != 0))
+    else:
+        b = draw(st.integers(-10, 10))
+    expr = f"{a} {op} {b}"
+    return expr, _eval(expr)
+
+
+@given(arithmetic_expr())
+def test_calculator_arithmetic(expr_result):
+    expr, expected = expr_result
+    result = asyncio.run(CalculatorTool().execute_function({"expression": expr}))
+    assert result == expected

--- a/tests/test_claude_resource.py
+++ b/tests/test_claude_resource.py
@@ -40,6 +40,7 @@ async def run_generate():
                 "model": "claude-3",
                 "messages": [{"role": "user", "content": "hello"}],
             },
+            params=None,
         )
     return result
 

--- a/tests/test_fastapi_wrapper.py
+++ b/tests/test_fastapi_wrapper.py
@@ -11,7 +11,10 @@ def test_fastapi_wrapper():
     app = create_app(agent)
 
     async def _run():
-        async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
             resp = await client.post("/", json={"message": "ping"})
             assert resp.status_code == 200
             assert resp.json().get("message")

--- a/tests/test_ollama_resource.py
+++ b/tests/test_ollama_resource.py
@@ -33,6 +33,8 @@ async def run_generate():
         mock_post.assert_called_with(
             f"{os.environ['OLLAMA_BASE_URL']}/api/generate",
             json={"model": os.environ["OLLAMA_MODEL"], "prompt": "hello"},
+            headers=None,
+            params=None,
         )
     return result
 

--- a/tests/test_openai_resource.py
+++ b/tests/test_openai_resource.py
@@ -30,6 +30,7 @@ async def run_generate():
             "https://api.openai.com/v1/chat/completions",
             headers={"Authorization": "Bearer key"},
             json={"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]},
+            params=None,
         )
     return result
 


### PR DESCRIPTION
## Summary
- enable `ValidationResult.valid` alias for backward compatibility
- add property-based tests for the calculator tool
- benchmark pipeline runtime
- call FastAPI app using `ASGITransport`
- adjust LLM resource tests to pass headers/params

## Testing
- `pytest`
- `pytest --cov=src --cov-report=term-missing`
- `pytest tests/performance/ -m benchmark`


------
https://chatgpt.com/codex/tasks/task_e_6863f5a40db48322b610f2006d0b2c01