### PR TITLE
[Core] resolve merge conflicts

### DIFF
--- a/src/pipeline/base.py
+++ b/src/pipeline/base.py
@@ -5,11 +5,8 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 
 from .context import PluginContext
-<<<<<<< HEAD
-from .exceptions import CircuitBreakerTripped, PluginExecutionError
-=======
-from .exceptions import CircuitBreakerTripped, PluginError, PluginExecutionError
->>>>>>> 4dbf3a92c50743e827fc62272eb07044f1bb4653
+from .exceptions import (CircuitBreakerTripped, PluginError,
+                         PluginExecutionError)
 from .stages import PipelineStage
 
 
@@ -59,13 +56,10 @@ class BasePlugin(ABC):
             context.record_plugin_duration(self.__class__.__name__, time.time() - start)
             self._failure_count = 0
             return result
-<<<<<<< HEAD
-=======
         except PluginError:
             self._failure_count += 1
             self._last_failure = time.time()
             raise
->>>>>>> 4dbf3a92c50743e827fc62272eb07044f1bb4653
         except Exception as exc:  # noqa: BLE001 - converted to PluginExecutionError
             if self.logger:
                 self.logger.error(

--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -18,11 +18,8 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints only
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .initializer import ClassRegistry
 
-<<<<<<< HEAD
-from .exceptions import CircuitBreakerTripped, PluginExecutionError
-=======
-from .exceptions import CircuitBreakerTripped, PluginError, PluginExecutionError
->>>>>>> 4dbf3a92c50743e827fc62272eb07044f1bb4653
+from .exceptions import (CircuitBreakerTripped, PluginError,
+                         PluginExecutionError)
 from .logging import get_logger
 from .observability.utils import execute_with_observability
 from .stages import PipelineStage
@@ -99,23 +96,16 @@ class BasePlugin(ABC):
             result = await execute_with_observability(
                 run,
                 logger=self.logger,
-<<<<<<< HEAD
                 metrics=context.metrics,
-=======
-                metrics=context._get_state().metrics,
->>>>>>> 4dbf3a92c50743e827fc62272eb07044f1bb4653
                 plugin=self.__class__.__name__,
                 stage=str(context.current_stage),
             )
             self._failure_count = 0
             return result
-<<<<<<< HEAD
-=======
         except PluginError:
             self._failure_count += 1
             self._last_failure = time.time()
             raise
->>>>>>> 4dbf3a92c50743e827fc62272eb07044f1bb4653
         except Exception as exc:  # noqa: BLE001 - convert to PluginExecutionError
             self._failure_count += 1
             self._last_failure = time.time()
@@ -369,4 +359,5 @@ __all__ = [
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .plugins.classifier import PluginAutoClassifier
 else:  # pragma: no cover - runtime import for compatibility
-    from .plugins.classifier import PluginAutoClassifier  # type: ignore  # noqa: E402
+    from .plugins.classifier import \
+        PluginAutoClassifier  # type: ignore  # noqa: E402

--- a/src/pipeline/exceptions.py
+++ b/src/pipeline/exceptions.py
@@ -8,16 +8,12 @@ class PluginError(Exception):
 
 
 class PluginExecutionError(PluginError):
-<<<<<<< HEAD
-    """Exception raised when a plugin fails during execution."""
-=======
     """Exception raised when a plugin fails during execution.
 
     Args:
         plugin_name: Name of the plugin that failed.
         original_exception: The underlying exception that triggered this error.
     """
->>>>>>> 4dbf3a92c50743e827fc62272eb07044f1bb4653
 
     def __init__(self, plugin_name: str, original_exception: Exception) -> None:
         self.plugin_name = plugin_name
@@ -26,15 +22,11 @@ class PluginExecutionError(PluginError):
 
 
 class CircuitBreakerTripped(PluginError):
-<<<<<<< HEAD
-    """Raised when repeated plugin failures prevent execution."""
-=======
     """Raised when repeated plugin failures prevent execution.
 
     Args:
         plugin_name: Name of the plugin whose circuit breaker tripped.
     """
->>>>>>> 4dbf3a92c50743e827fc62272eb07044f1bb4653
 
     def __init__(self, plugin_name: str) -> None:
         self.plugin_name = plugin_name

--- a/src/pipeline/execution.py
+++ b/src/pipeline/execution.py
@@ -7,14 +7,12 @@ from typing import Any, Dict
 from registry import SystemRegistries
 
 from .context import PluginContext
-<<<<<<< HEAD
 from .errors import create_static_error_response
-=======
->>>>>>> 4dbf3a92c50743e827fc62272eb07044f1bb4653
 from .exceptions import CircuitBreakerTripped, PluginExecutionError
 from .manager import PipelineManager
 from .stages import PipelineStage
-from .state import ConversationEntry, FailureInfo, MetricsCollector, PipelineState
+from .state import (ConversationEntry, FailureInfo, MetricsCollector,
+                    PipelineState)
 from .tools.execution import execute_pending_tools
 
 


### PR DESCRIPTION
## Summary
- resolve leftover merge markers in pipeline core

## Testing
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/` *(fails: There are no .py[i] files in directory 'src')*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_686462a890ac8322b8927b8f219a0625