### PR TITLE
[Resource] add generic storage backend

### DIFF
--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -7,7 +7,9 @@ from .http_llm_resource import HttpLLMResource
 from .memory_resource import SimpleMemoryResource
 from .ollama_llm import OllamaLLMResource
 from .openai import OpenAIResource
-from .postgres import ConnectionPoolResource, PostgresPoolResource, PostgresResource
+from .postgres import (ConnectionPoolResource, PostgresPoolResource,
+                       PostgresResource)
+from .storage_backend import StorageBackend, StorageResource
 from .structured_logging import StructuredLogging
 from .vector_memory import VectorMemoryResource
 
@@ -17,6 +19,8 @@ __all__ = [
     "OllamaLLMResource",
     "SimpleMemoryResource",
     "StructuredLogging",
+    "StorageBackend",
+    "StorageResource",
     "ConnectionPoolResource",
     "PostgresPoolResource",
     "PostgresResource",

--- a/src/pipeline/plugins/resources/storage_backend.py
+++ b/src/pipeline/plugins/resources/storage_backend.py
@@ -1,0 +1,3 @@
+from pipeline.resources.storage import StorageBackend, StorageResource
+
+__all__ = ["StorageBackend", "StorageResource"]

--- a/src/pipeline/resources/storage.py
+++ b/src/pipeline/resources/storage.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Dict, Optional, Protocol
+
+from pipeline.plugins import ResourcePlugin
+from pipeline.stages import PipelineStage
+
+
+class StorageBackend(Protocol):
+    """Protocol for asynchronous storage backends.
+
+    Storage implementations should provide basic CRUD operations and a
+    generic command execution method.  All methods return awaitables to
+    support async resources such as databases or object stores.
+    """
+
+    async def save(self, key: str, data: Any) -> None:
+        """Persist ``data`` under ``key``."""
+
+    async def load(self, key: str) -> Any:
+        """Retrieve the value previously stored for ``key``."""
+
+    async def query(self, query: str) -> list[Any]:
+        """Run ``query`` against the backend and return results."""
+
+    async def delete(self, key: str) -> None:
+        """Remove ``key`` and its associated value."""
+
+    async def execute(self, command: str, *args: Any, **kwargs: Any) -> Any:
+        """Execute an arbitrary ``command`` on the backend."""
+
+
+class StorageResource(ResourcePlugin, StorageBackend):
+    """Base class for storage resources with connection pooling support.
+
+    Subclasses provide the logic to create the connection pool during
+    :meth:`initialize`.  The helper :meth:`connection` context manager
+    ensures connections are acquired and released properly.
+    """
+
+    stages = [PipelineStage.PARSE]
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self._pool: Optional[Any] = None
+
+    async def initialize(self) -> None:
+        """Create the underlying connection pool.
+
+        Subclasses must set :attr:`_pool` to an object exposing ``acquire``
+        and ``release`` coroutines.  The default implementation does
+        nothing.
+        """
+
+    @asynccontextmanager
+    async def connection(self) -> AsyncIterator[Any]:
+        """Yield a pooled connection."""
+
+        conn = await self.acquire()
+        try:
+            yield conn
+        finally:
+            await self.release(conn)
+
+    async def acquire(self) -> Any:
+        """Acquire a connection from the pool."""
+
+        if self._pool is None:
+            raise RuntimeError("Pool not initialized")
+        return await self._pool.acquire()  # type: ignore[no-any-return]
+
+    async def release(self, connection: Any) -> None:
+        """Return ``connection`` to the pool."""
+
+        if self._pool is not None:
+            await self._pool.release(connection)
+
+    async def shutdown(self) -> None:
+        """Close the connection pool if it exists."""
+
+        if self._pool is not None:
+            await self._pool.close()
+
+    async def health_check(self) -> bool:
+        """Return ``True`` if a simple command succeeds."""
+
+        if self._pool is None:
+            return False
+        async with self.connection() as conn:
+            try:
+                await self._do_health_check(conn)
+                return True
+            except Exception:
+                return False
+
+    @abstractmethod
+    async def _do_health_check(self, connection: Any) -> None:
+        """Subclasses run a minimal query to verify ``connection`` works."""
+
+    # --- StorageBackend API -------------------------------------------------
+    @abstractmethod
+    async def save(self, key: str, data: Any) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def load(self, key: str) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def query(self, query: str) -> list[Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete(self, key: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def execute(self, command: str, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError

--- a/tests/test_storage_backend.py
+++ b/tests/test_storage_backend.py
@@ -1,0 +1,75 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from pipeline.resources.storage import StorageResource
+
+
+class ExampleStorage(StorageResource):
+    async def initialize(self) -> None:  # pragma: no cover - not used in test
+        pass
+
+    async def _do_health_check(self, connection):
+        await connection.ping()
+
+    async def save(self, key: str, data):
+        async with self.connection() as conn:
+            await conn.save(key, data)
+
+    async def load(self, key: str):
+        async with self.connection() as conn:
+            return await conn.load(key)
+
+    async def query(self, query: str):
+        async with self.connection() as conn:
+            return await conn.query(query)
+
+    async def delete(self, key: str):
+        async with self.connection() as conn:
+            await conn.delete(key)
+
+    async def execute(self, command: str, *args, **kwargs):
+        async with self.connection() as conn:
+            return await conn.execute(command, *args, **kwargs)
+
+
+async def run_calls():
+    storage = ExampleStorage({})
+    conn = AsyncMock()
+    conn.save = AsyncMock()
+    conn.load = AsyncMock(return_value="value")
+    conn.query = AsyncMock(return_value=[1])
+    conn.delete = AsyncMock()
+    conn.execute = AsyncMock(return_value="ok")
+    conn.ping = AsyncMock()
+
+    pool = AsyncMock()
+    pool.acquire = AsyncMock(return_value=conn)
+    pool.release = AsyncMock()
+    storage._pool = pool
+
+    await storage.save("k", 1)
+    await storage.load("k")
+    await storage.query("q")
+    await storage.delete("k")
+    await storage.execute("cmd")
+    health = await storage.health_check()
+
+    return {
+        "conn": conn,
+        "pool": pool,
+        "health": health,
+    }
+
+
+def test_storage_resource_uses_pool():
+    result = asyncio.run(run_calls())
+    conn = result["conn"]
+    pool = result["pool"]
+    assert result["health"]
+    conn.save.assert_awaited_with("k", 1)
+    conn.load.assert_awaited_with("k")
+    conn.query.assert_awaited_with("q")
+    conn.delete.assert_awaited_with("k")
+    conn.execute.assert_awaited_with("cmd")
+    conn.ping.assert_awaited()
+    pool.release.assert_awaited()


### PR DESCRIPTION
## Summary
- add generic storage backend protocol and resource
- re-export storage backend from plugins
- test storage backend connection handling

## Testing
- `flake8 src/pipeline/resources/storage.py src/pipeline/plugins/resources/storage_backend.py src/pipeline/plugins/resources/__init__.py tests/test_storage_backend.py`
- `bandit -r src/pipeline/resources/storage.py src/pipeline/plugins/resources/storage_backend.py src/pipeline/plugins/resources/__init__.py tests/test_storage_backend.py`
- `mypy src/pipeline/resources/storage.py src/pipeline/plugins/resources/storage_backend.py src/pipeline/plugins/resources/__init__.py tests/test_storage_backend.py` *(fails: src/pipeline/__init__.py invalid syntax)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: SyntaxError in src/pipeline/__init__.py)*
- `python -m src.registry.validator` *(fails: SyntaxError in src/pipeline/__init__.py)*
- `pytest tests/test_storage_backend.py -q` *(fails: SyntaxError in src/pipeline/__init__.py)*
- `pytest tests/integration/ -v` *(fails: SyntaxError in src/pipeline/__init__.py)*
- `pytest tests/performance/ -m benchmark` *(fails: SyntaxError in src/pipeline/__init__.py)*

------
https://chatgpt.com/codex/tasks/task_e_68646acc2bf883229d58f2f58d809253