### PR TITLE
[Resource] add sqlite and memory storage backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ plugins:
       model: tinyllama
       base_url: "http://localhost:11434"
 ```
+Lightweight deployments can use SQLite:
+
+```yaml
+plugins:
+  resources:
+    database:
+      type: pipeline.plugins.resources.sqlite_storage:SQLiteStorage
+      path: ./entity.db
+      pool_min_size: 1
+      pool_max_size: 5
+```
+
+For ephemeral sessions, an in-memory backend is available:
+
+```yaml
+plugins:
+  resources:
+    database:
+      type: pipeline.plugins.resources.memory_storage:MemoryStorage
+```
 <!-- end config -->
 
 Every plugin executes with a ``PluginContext`` which grants controlled

--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -5,9 +5,12 @@ from .echo_llm import EchoLLMResource
 from .gemini import GeminiResource
 from .http_llm_resource import HttpLLMResource
 from .memory_resource import SimpleMemoryResource
+from .memory_storage import MemoryStorage
 from .ollama_llm import OllamaLLMResource
 from .openai import OpenAIResource
 from .postgres import ConnectionPoolResource, PostgresPoolResource, PostgresResource
+from .sqlite_storage import SQLiteStorage
+from .storage_backend import StorageBackend
 from .structured_logging import StructuredLogging
 from .vector_memory import VectorMemoryResource
 
@@ -25,4 +28,7 @@ __all__ = [
     "GeminiResource",
     "ClaudeResource",
     "HttpLLMResource",
+    "StorageBackend",
+    "SQLiteStorage",
+    "MemoryStorage",
 ]

--- a/src/pipeline/plugins/resources/memory_storage.py
+++ b/src/pipeline/plugins/resources/memory_storage.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, DefaultDict, Dict, List
+
+from pipeline.context import ConversationEntry
+
+from .storage_backend import StorageBackend
+
+
+class MemoryStorage(StorageBackend):
+    """In-memory storage backend for testing and ephemeral runs."""
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self._data: DefaultDict[str, List[Dict[str, Any]]] = defaultdict(list)
+
+    async def initialize(self) -> None:  # pragma: no cover - no setup needed
+        return None
+
+    @asynccontextmanager
+    async def connection(self) -> AsyncIterator["MemoryStorage"]:
+        yield self
+
+    async def acquire(self) -> "MemoryStorage":  # pragma: no cover - not used
+        return self
+
+    async def release(self, connection: Any) -> None:  # pragma: no cover - no-op
+        return None
+
+    async def execute(self, query: str, *args: Any) -> Any:
+        if self._history_table and query.lower().startswith("insert into"):
+            self._data[self._table_name()].append(
+                {
+                    "conversation_id": args[0],
+                    "role": args[1],
+                    "content": args[2],
+                    "metadata": (
+                        json.loads(args[3]) if isinstance(args[3], str) else args[3]
+                    ),
+                    "timestamp": args[4],
+                }
+            )
+
+    async def fetch(self, query: str, *args: Any) -> Any:
+        if self._history_table and query.lower().startswith("select"):
+            convo_id = args[0]
+            rows = [
+                {
+                    "role": r["role"],
+                    "content": r["content"],
+                    "metadata": r["metadata"],
+                    "timestamp": r["timestamp"],
+                }
+                for r in self._data[self._table_name()]
+                if r["conversation_id"] == convo_id
+            ]
+            return rows
+        return []
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        rows = await self.fetch(query, *args)
+        return rows[0] if rows else None
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        row = await self.fetchrow(query, *args)
+        if row is None:
+            return None
+        if isinstance(row, dict):
+            return next(iter(row.values()))
+        return row[0]
+
+    async def save_history(
+        self, conversation_id: str, history: List[ConversationEntry]
+    ) -> None:
+        for entry in history:
+            await self.execute(
+                f"INSERT INTO {self._table_name()} (conversation_id, role, content, metadata, timestamp) VALUES (?, ?, ?, ?, ?)",
+                conversation_id,
+                entry.role,
+                entry.content,
+                json.dumps(entry.metadata),
+                entry.timestamp,
+            )
+
+    async def load_history(self, conversation_id: str) -> List[ConversationEntry]:
+        rows = await self.fetch(
+            f"SELECT role, content, metadata, timestamp FROM {self._table_name()} WHERE conversation_id=? ORDER BY timestamp",
+            conversation_id,
+        )
+        history: List[ConversationEntry] = []
+        for row in rows:
+            metadata = row["metadata"]
+            history.append(
+                ConversationEntry(
+                    content=row["content"],
+                    role=row["role"],
+                    timestamp=row["timestamp"],
+                    metadata=metadata,
+                )
+            )
+        return history
+
+    async def health_check(self) -> bool:
+        return True

--- a/src/pipeline/plugins/resources/sqlite_storage.py
+++ b/src/pipeline/plugins/resources/sqlite_storage.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Dict
+
+import aiosqlite
+
+from .storage_backend import StorageBackend
+
+
+class SQLiteStorage(StorageBackend):
+    """SQLite based storage backend with a simple connection pool."""
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self._path = str(self.config.get("path", ":memory:"))
+        self._min_size = int(self.config.get("pool_min_size", 1))
+        self._max_size = int(self.config.get("pool_max_size", 5))
+        self._pool: asyncio.Queue[aiosqlite.Connection] = asyncio.Queue()
+        self._size = 0
+
+    async def initialize(self) -> None:
+        for _ in range(self._min_size):
+            await self._add_conn()
+        if self._history_table:
+            async with self.connection() as conn:
+                await conn.execute(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {self._table_name()} (
+                        conversation_id TEXT,
+                        role TEXT,
+                        content TEXT,
+                        metadata TEXT,
+                        timestamp TEXT
+                    )
+                    """
+                )
+                await conn.commit()
+
+    async def _add_conn(self) -> None:
+        conn = await aiosqlite.connect(self._path)
+        await self._pool.put(conn)
+        self._size += 1
+
+    async def acquire(self) -> aiosqlite.Connection:
+        if self._pool.empty() and self._size < self._max_size:
+            await self._add_conn()
+        conn = await self._pool.get()
+        return conn
+
+    async def release(self, connection: aiosqlite.Connection) -> None:
+        if self._pool.qsize() >= self._max_size:
+            await connection.close()
+            self._size -= 1
+        else:
+            await self._pool.put(connection)
+
+    async def shutdown(self) -> None:
+        while not self._pool.empty():
+            conn = await self._pool.get()
+            await conn.close()
+        self._size = 0
+
+    @asynccontextmanager
+    async def connection(self) -> AsyncIterator[aiosqlite.Connection]:
+        conn = await self.acquire()
+        try:
+            yield conn
+        finally:
+            await self.release(conn)
+
+    def _convert_query(self, query: str) -> str:
+        return re.sub(r"\$\d+", "?", query)
+
+    async def execute(self, query: str, *args: Any) -> Any:
+        async with self.connection() as conn:
+            await conn.execute(self._convert_query(query), args)
+            await conn.commit()
+
+    async def fetch(self, query: str, *args: Any) -> Any:
+        async with self.connection() as conn:
+            cursor = await conn.execute(self._convert_query(query), args)
+            rows = await cursor.fetchall()
+            return rows
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        async with self.connection() as conn:
+            cursor = await conn.execute(self._convert_query(query), args)
+            row = await cursor.fetchone()
+            return row
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        row = await self.fetchrow(query, *args)
+        return row[0] if row else None
+
+    async def _do_health_check(self, connection: aiosqlite.Connection) -> None:
+        await connection.execute("SELECT 1")

--- a/src/pipeline/plugins/resources/storage_backend.py
+++ b/src/pipeline/plugins/resources/storage_backend.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Dict, List
+
+from pipeline.context import ConversationEntry
+from pipeline.plugins import ResourcePlugin
+from pipeline.stages import PipelineStage
+
+
+class StorageBackend(ResourcePlugin):
+    """Common interface for conversation storage backends."""
+
+    name = "database"
+    stages = [PipelineStage.PARSE]
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self._history_table = self.config.get("history_table")
+        self._schema = self.config.get("db_schema")
+
+    @asynccontextmanager
+    async def connection(self) -> AsyncIterator[Any]:
+        conn = await self.acquire()
+        try:
+            yield conn
+        finally:
+            await self.release(conn)
+
+    async def acquire(self) -> Any:
+        raise NotImplementedError
+
+    async def release(self, connection: Any) -> None:
+        raise NotImplementedError
+
+    async def execute(self, query: str, *args: Any) -> Any:
+        raise NotImplementedError
+
+    async def fetch(self, query: str, *args: Any) -> Any:
+        raise NotImplementedError
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        raise NotImplementedError
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        raise NotImplementedError
+
+    async def save_history(
+        self, conversation_id: str, history: List[ConversationEntry]
+    ) -> None:
+        if self._history_table is None:
+            return
+        for entry in history:
+            await self.execute(
+                f"INSERT INTO {self._table_name()} "
+                "(conversation_id, role, content, metadata, timestamp) VALUES (?, ?, ?, ?, ?)",
+                conversation_id,
+                entry.role,
+                entry.content,
+                json.dumps(entry.metadata),
+                entry.timestamp,
+            )
+
+    async def load_history(self, conversation_id: str) -> List[ConversationEntry]:
+        if self._history_table is None:
+            return []
+        rows = await self.fetch(
+            f"SELECT role, content, metadata, timestamp FROM {self._table_name()} "
+            "WHERE conversation_id=? ORDER BY timestamp",
+            conversation_id,
+        )
+        history: List[ConversationEntry] = []
+        for row in rows:
+            metadata = row[2] if isinstance(row, (list, tuple)) else row.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = json.loads(metadata) if metadata else {}
+            history.append(
+                ConversationEntry(
+                    content=(
+                        row[1] if isinstance(row, (list, tuple)) else row.get("content")
+                    ),
+                    role=row[0] if isinstance(row, (list, tuple)) else row.get("role"),
+                    timestamp=(
+                        row[3]
+                        if isinstance(row, (list, tuple))
+                        else row.get("timestamp")
+                    ),
+                    metadata=metadata,
+                )
+            )
+        return history
+
+    async def health_check(self) -> bool:
+        try:
+            await self.fetch("SELECT 1")
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def _table_name(self) -> str:
+        return (
+            f"{self._schema + '.' if self._schema else ''}{self._history_table}"
+            if self._history_table
+            else ""
+        )

--- a/tests/test_memory_storage.py
+++ b/tests/test_memory_storage.py
@@ -1,0 +1,22 @@
+import asyncio
+from datetime import datetime
+
+from pipeline.context import ConversationEntry
+from pipeline.plugins.resources.memory_storage import MemoryStorage
+
+
+def test_save_and_load_history():
+    async def run():
+        storage = MemoryStorage({"history_table": "tbl"})
+        await storage.initialize()
+        history = [
+            ConversationEntry(
+                content="hi", role="user", timestamp=datetime.now(), metadata={}
+            ),
+        ]
+        await storage.save_history("1", history)
+        loaded = await storage.load_history("1")
+        return loaded
+
+    loaded = asyncio.run(run())
+    assert loaded[0].content == "hi"

--- a/tests/test_sqlite_storage.py
+++ b/tests/test_sqlite_storage.py
@@ -1,0 +1,33 @@
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from pipeline.plugins.resources.sqlite_storage import SQLiteStorage
+
+
+async def init_resource():
+    cfg = {"path": "./db.sqlite"}
+    conn = AsyncMock()
+    conn.execute = AsyncMock()
+    conn.commit = AsyncMock()
+    with patch("aiosqlite.connect", new=AsyncMock(return_value=conn)) as mock_connect:
+        plugin = SQLiteStorage(cfg)
+        await plugin.initialize()
+        mock_connect.assert_awaited()
+    return plugin, conn
+
+
+def test_initialize_opens_pool():
+    plugin, _ = asyncio.run(init_resource())
+    assert plugin._size >= 1
+
+
+def test_health_check_runs_query():
+    async def run():
+        plugin = SQLiteStorage({})
+        plugin.fetch = AsyncMock(return_value=[(1,)])
+        result = await plugin.health_check()
+        plugin.fetch.assert_awaited_with("SELECT 1")
+        return result
+
+    assert asyncio.run(run())


### PR DESCRIPTION
## Summary
- implement `StorageBackend` abstract resource
- add `SQLiteStorage` with simple connection pool
- add `MemoryStorage` for ephemeral data
- document usage examples
- test new resources

## Testing
- `black src/pipeline/plugins/resources/storage_backend.py src/pipeline/plugins/resources/sqlite_storage.py src/pipeline/plugins/resources/memory_storage.py src/pipeline/plugins/resources/__init__.py tests/test_sqlite_storage.py tests/test_memory_storage.py -q`
- `isort src/pipeline/plugins/resources/storage_backend.py src/pipeline/plugins/resources/sqlite_storage.py src/pipeline/plugins/resources/memory_storage.py src/pipeline/plugins/resources/__init__.py tests/test_sqlite_storage.py tests/test_memory_storage.py`
- `flake8` *(fails: command not found)*
- `mypy` *(fails: invalid syntax in src/pipeline/__init__.py)*
- `bandit` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: SyntaxError in src/pipeline/__init__.py)*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/test_sqlite_storage.py tests/test_memory_storage.py -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68646afb3f94832286d00d532d5723b5