### PR TITLE
[Fix] Resolve merge conflicts in resource plugins

### DIFF
--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -8,15 +8,9 @@ from .memory_resource import SimpleMemoryResource
 from .memory_storage import MemoryStorage
 from .ollama_llm import OllamaLLMResource
 from .openai import OpenAIResource
-<<<<<<< HEAD
-from .postgres import (ConnectionPoolResource, PostgresPoolResource,
-                       PostgresResource)
-from .storage_backend import StorageBackend, StorageResource
-=======
 from .postgres import ConnectionPoolResource, PostgresPoolResource, PostgresResource
 from .sqlite_storage import SQLiteStorage
 from .storage_backend import StorageBackend
->>>>>>> 41e9ce33055fea658287c473f9fa43fe2b5cbcc7
 from .structured_logging import StructuredLogging
 from .vector_memory import VectorMemoryResource
 
@@ -26,8 +20,6 @@ __all__ = [
     "OllamaLLMResource",
     "SimpleMemoryResource",
     "StructuredLogging",
-    "StorageBackend",
-    "StorageResource",
     "ConnectionPoolResource",
     "PostgresPoolResource",
     "PostgresResource",

--- a/src/pipeline/plugins/resources/storage_backend.py
+++ b/src/pipeline/plugins/resources/storage_backend.py
@@ -1,8 +1,3 @@
-<<<<<<< HEAD
-from pipeline.resources.storage import StorageBackend, StorageResource
-
-__all__ = ["StorageBackend", "StorageResource"]
-=======
 from __future__ import annotations
 
 import json
@@ -109,4 +104,3 @@ class StorageBackend(ResourcePlugin):
             if self._history_table
             else ""
         )
->>>>>>> 41e9ce33055fea658287c473f9fa43fe2b5cbcc7


### PR DESCRIPTION
## Summary
- clean up merge artifacts in resource package
- keep StorageBackend implementation

## Testing
- `flake8 src/pipeline/plugins/resources/__init__.py src/pipeline/plugins/resources/storage_backend.py`
- `mypy src/pipeline/plugins/resources/__init__.py src/pipeline/plugins/resources/storage_backend.py` *(fails: Item "None" of "str | None" has no attribute "rstrip")*
- `bandit -r src/pipeline/plugins/resources/__init__.py src/pipeline/plugins/resources/storage_backend.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: Invalid plugin path: llm)*
- `pytest tests/integration/ -v`
- `pytest tests/performance/ -m benchmark` *(fails: 'benchmark' not found in `markers` configuration option)*

------
https://chatgpt.com/codex/tasks/task_e_68646f1417548322bf371109ec825ff0