### PR TITLE
Add benchmark marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
     "tools: Tests related to tool system",
     "api: Tests related to API endpoints",
     "cli: Tests related to CLI interface",
+    "benchmark: Performance benchmarking tests",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",


### PR DESCRIPTION
## Summary
- register a benchmark marker in pytest config

## Testing
- `pytest tests/performance/test_pipeline_benchmark.py -m benchmark -q`

------
https://chatgpt.com/codex/tasks/task_e_68647f5cf3b883228eb287b1e0cd52eb