### PR TITLE
[Adapter] Re-export CLI

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,3 @@
+from ..cli import CLI, main  # re-export
+
+__all__ = ["CLI", "main"]


### PR DESCRIPTION
## Summary
- re-export CLI and main directly from cli package

## Testing
- `pytest tests/test_cli_entrypoint.py --collect-only -q`
- `PYTHONPATH=src pytest tests/test_cli_websocket.py --collect-only -q` *(fails: ImportError: attempted relative import beyond top-level package)*
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/cli.py src/cli/__init__.py` *(fails: duplicate module error)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'httpx')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'httpx')*
- `python -m src.registry.validator` *(fails: No module named 'httpx')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68647f549d4883229a9fff5555bc695b