### PR TITLE
[Resource] add default generate method

### DIFF
--- a/src/pipeline/plugins/prompts/__init__.py
+++ b/src/pipeline/plugins/prompts/__init__.py
@@ -1,8 +1,10 @@
+"""Expose built-in prompt plugins."""
+
 from .chain_of_thought import ChainOfThoughtPrompt
 from .complex_prompt import ComplexPrompt
+from .conversation_history_saver import ConversationHistorySaver
 from .intent_classifier import IntentClassifierPrompt
 from .memory_retrieval import MemoryRetrievalPrompt
-from .conversation_history_saver import ConversationHistorySaver
 from .pii_scrubber import PIIScrubberPrompt
 from .react_prompt import ReActPrompt
 

--- a/src/pipeline/plugins/prompts/chain_of_thought.py
+++ b/src/pipeline/plugins/prompts/chain_of_thought.py
@@ -60,9 +60,13 @@ class ChainOfThoughtPrompt(PromptPlugin):
         context.set_stage_result("reasoning_steps", reasoning_steps)
 
     def _needs_tools(self, reasoning_text: str) -> bool:
+        """Return True if ``reasoning_text`` suggests tool usage."""
+
         tool_indicators = ["need to calculate", "should look up", "requires analysis"]
         return any(indicator in reasoning_text.lower() for indicator in tool_indicators)
 
     def _get_conversation_text(self, conversation: List[ConversationEntry]) -> str:
+        """Return the most recent user message from ``conversation``."""
+
         user_entries = [entry.content for entry in conversation if entry.role == "user"]
         return user_entries[-1] if user_entries else ""

--- a/src/pipeline/plugins/prompts/react_prompt.py
+++ b/src/pipeline/plugins/prompts/react_prompt.py
@@ -80,6 +80,7 @@ class ReActPrompt(PromptPlugin):
     def _build_step_context(
         self, conversation: List[ConversationEntry], question: str
     ) -> str:
+        """Return a summary of ``conversation`` for the next reasoning step."""
         context_parts = [f"Question: {question}"]
 
         recent_entries = conversation[-10:]
@@ -97,6 +98,7 @@ class ReActPrompt(PromptPlugin):
         return "\n".join(context_parts)
 
     def _parse_action(self, action_text: str) -> Tuple[str, Dict[str, Any]]:
+        """Parse an action command from ``action_text``."""
         parts = action_text.split(" ", 1)
         if len(parts) < 2:
             return "search_tool", {"query": action_text}

--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -1,12 +1,12 @@
-from pipeline.resources import LLMResource
+"""Built-in resource plugins for the pipeline framework."""
 
+from .claude import ClaudeResource
 from .echo_llm import EchoLLMResource
+from .gemini import GeminiResource
 from .llm_resource import LLMResource
 from .memory_resource import SimpleMemoryResource
 from .ollama_llm import OllamaLLMResource
 from .openai import OpenAIResource
-from .gemini import GeminiResource
-from .claude import ClaudeResource
 from .postgres import PostgresResource
 from .structured_logging import StructuredLogging
 from .vector_memory import VectorMemoryResource
@@ -19,7 +19,6 @@ __all__ = [
     "StructuredLogging",
     "PostgresResource",
     "VectorMemoryResource",
-    "LLMResource",
     "OpenAIResource",
     "GeminiResource",
     "ClaudeResource",

--- a/src/pipeline/plugins/resources/claude.py
+++ b/src/pipeline/plugins/resources/claude.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Dict
 
 import httpx
 
-from pipeline.plugins import ResourcePlugin, ValidationResult
+from pipeline.plugins import ValidationResult
+from pipeline.plugins.resources.llm_resource import LLMResource
 from pipeline.stages import PipelineStage
 
 
-class ClaudeResource(ResourcePlugin):
+class ClaudeResource(LLMResource):
     """LLM resource for Anthropic's Claude API."""
 
     stages = [PipelineStage.PARSE]
@@ -19,21 +20,11 @@ class ClaudeResource(ResourcePlugin):
         self.api_key: str | None = self.config.get("api_key")
         self.model: str | None = self.config.get("model")
         self.base_url: str | None = self.config.get("base_url")
-        self.params: Dict[str, Any] = {
-            k: v
-            for k, v in self.config.items()
-            if k not in {"api_key", "model", "base_url"}
-        }
+        self.params = self.extract_params(self.config, ["api_key", "model", "base_url"])
 
     @classmethod
     def validate_config(cls, config: Dict) -> ValidationResult:
-        if not config.get("api_key"):
-            return ValidationResult.error_result("'api_key' is required")
-        if not config.get("model"):
-            return ValidationResult.error_result("'model' is required")
-        if not config.get("base_url"):
-            return ValidationResult.error_result("'base_url' is required")
-        return ValidationResult.success_result()
+        return cls.validate_required_fields(config, ["api_key", "model", "base_url"])
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
         return None
@@ -62,5 +53,3 @@ class ClaudeResource(ResourcePlugin):
         data = response.json()
         text = data.get("content", [{}])[0].get("text", "")
         return str(text)
-
-    __call__ = generate

--- a/src/pipeline/plugins/resources/echo_llm.py
+++ b/src/pipeline/plugins/resources/echo_llm.py
@@ -14,5 +14,3 @@ class EchoLLMResource(LLMResource):
 
     async def generate(self, prompt: str) -> str:
         return prompt
-
-    __call__ = generate

--- a/src/pipeline/plugins/resources/llm_resource.py
+++ b/src/pipeline/plugins/resources/llm_resource.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from pipeline.plugins import ResourcePlugin
+from pipeline.plugins import ResourcePlugin, ValidationResult
 from pipeline.resources import LLM
 from pipeline.stages import PipelineStage
 
@@ -16,3 +16,26 @@ class LLMResource(ResourcePlugin, LLM):
 
     async def _execute_impl(self, context) -> None:
         return None
+
+    async def generate(self, prompt: str) -> str:
+        """Return a completion for ``prompt``."""
+
+        raise NotImplementedError
+
+    __call__ = generate
+
+    @staticmethod
+    def validate_required_fields(config: Dict, fields: List[str]) -> "ValidationResult":
+        """Verify that all ``fields`` exist in ``config``."""
+
+        missing = [field for field in fields if not config.get(field)]
+        if missing:
+            joined = ", ".join(missing)
+            return ValidationResult.error_result(f"missing required fields: {joined}")
+        return ValidationResult.success_result()
+
+    @staticmethod
+    def extract_params(config: Dict, required: List[str]) -> Dict[str, Any]:
+        """Return all items in ``config`` except those in ``required``."""
+
+        return {k: v for k, v in config.items() if k not in required}

--- a/src/pipeline/plugins/resources/memory_resource.py
+++ b/src/pipeline/plugins/resources/memory_resource.py
@@ -18,19 +18,19 @@ class SimpleMemoryResource(ResourcePlugin):
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)
-        self._store: Dict[str, Any] = {}
+        self._memory: Dict[str, Any] = {}
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
         return None
 
     def get(self, key: str, default: Any | None = None) -> Any:
         """Retrieve a value from memory."""
-        return self._store.get(key, default)
+        return self._memory.get(key, default)
 
     def set(self, key: str, value: Any) -> None:
         """Store a value in memory."""
-        self._store[key] = value
+        self._memory[key] = value
 
     def clear(self) -> None:
         """Remove all stored values."""
-        self._store.clear()
+        self._memory.clear()

--- a/src/pipeline/plugins/resources/ollama_llm.py
+++ b/src/pipeline/plugins/resources/ollama_llm.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Dict
 
 import httpx
 
@@ -22,17 +22,11 @@ class OllamaLLMResource(LLMResource):
         super().__init__(config)
         self.base_url: str | None = self.config.get("base_url")
         self.model: str | None = self.config.get("model")
-        self.params: Dict[str, Any] = {
-            k: v for k, v in self.config.items() if k not in {"base_url", "model"}
-        }
+        self.params = self.extract_params(self.config, ["base_url", "model"])
 
     @classmethod
     def validate_config(cls, config: Dict) -> ValidationResult:
-        if not config.get("base_url"):
-            return ValidationResult.error_result("'base_url' is required")
-        if not config.get("model"):
-            return ValidationResult.error_result("'model' is required")
-        return ValidationResult.success_result()
+        return cls.validate_required_fields(config, ["base_url", "model"])
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
         return None
@@ -53,5 +47,3 @@ class OllamaLLMResource(LLMResource):
         data = response.json()
         text = data.get("response", "")
         return str(text)
-
-    __call__ = generate

--- a/src/pipeline/plugins/resources/openai.py
+++ b/src/pipeline/plugins/resources/openai.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Dict
 
 import httpx
 
@@ -19,21 +19,11 @@ class OpenAIResource(LLMResource):
         self.api_key: str | None = self.config.get("api_key")
         self.model: str | None = self.config.get("model")
         self.base_url: str | None = self.config.get("base_url")
-        self.params: Dict[str, Any] = {
-            k: v
-            for k, v in self.config.items()
-            if k not in {"api_key", "model", "base_url"}
-        }
+        self.params = self.extract_params(self.config, ["api_key", "model", "base_url"])
 
     @classmethod
     def validate_config(cls, config: Dict) -> ValidationResult:
-        if not config.get("api_key"):
-            return ValidationResult.error_result("'api_key' is required")
-        if not config.get("model"):
-            return ValidationResult.error_result("'model' is required")
-        if not config.get("base_url"):
-            return ValidationResult.error_result("'base_url' is required")
-        return ValidationResult.success_result()
+        return cls.validate_required_fields(config, ["api_key", "model", "base_url"])
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
         return None
@@ -59,5 +49,3 @@ class OpenAIResource(LLMResource):
         data = response.json()
         text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
         return str(text)
-
-    __call__ = generate


### PR DESCRIPTION
## Summary
- add `generate` method to LLMResource so subclasses share a common call interface
- remove duplicate `__call__` definitions from subclasses
- document helper methods in ChainOfThoughtPrompt and ReActPrompt

## Testing
- `flake8 src/pipeline/plugins/resources src/pipeline/plugins/prompts`
- `bandit -r src/pipeline/plugins/resources src/pipeline/plugins/prompts`
- `mypy --ignore-missing-imports src/pipeline/plugins/resources/*.py src/pipeline/plugins/prompts/*.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator --config config/dev.yaml` *(no output)*
- `pytest tests/integration/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option: asyncio_mode)*
- `pytest` *(fails: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_68635764851c8322a52673a9174affd6