### PR TITLE
[Resource] Add VectorStoreResource interface

### DIFF
--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,5 +1,12 @@
 from .database import DatabaseResource
 from .llm import LLM, LLMResource
 from .memory import Memory
+from .vector_store import VectorStoreResource
 
-__all__ = ["LLM", "LLMResource", "Memory", "DatabaseResource"]
+__all__ = [
+    "LLM",
+    "LLMResource",
+    "Memory",
+    "DatabaseResource",
+    "VectorStoreResource",
+]

--- a/src/pipeline/resources/vector_store.py
+++ b/src/pipeline/resources/vector_store.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, List
+
+
+class VectorStoreResource(ABC):
+    """Abstract interface for vector store resources."""
+
+    @abstractmethod
+    async def add_embedding(self, text: str, metadata: Dict | None = None) -> None:
+        """Persist ``text`` embedding with optional ``metadata``."""
+
+    @abstractmethod
+    async def query_similar(self, query: str, k: int) -> List[Dict]:
+        """Return top ``k`` items most similar to ``query``."""


### PR DESCRIPTION
## Summary
- add abstract VectorStoreResource with embedding/query APIs
- expose VectorStoreResource in pipeline.resources

## Testing
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/` *(fails: invalid syntax in template)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68655bf6d4a08322a502963bafa0e6bf