### PR TITLE
[Resource] Add FileSystemResource abstraction

### DIFF
--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,5 +1,12 @@
 from .database import DatabaseResource
+from .filesystem import FileSystemResource
 from .llm import LLM, LLMResource
 from .memory import Memory
 
-__all__ = ["LLM", "LLMResource", "Memory", "DatabaseResource"]
+__all__ = [
+    "LLM",
+    "LLMResource",
+    "Memory",
+    "DatabaseResource",
+    "FileSystemResource",
+]

--- a/src/pipeline/resources/filesystem.py
+++ b/src/pipeline/resources/filesystem.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class FileSystemResource(ABC):
+    """Abstract interface for filesystem-like storage backends."""
+
+    @abstractmethod
+    async def store(self, key: str, content: bytes) -> str:
+        """Persist ``content`` under ``key`` and return storage path."""
+
+    @abstractmethod
+    async def load(self, key: str) -> bytes:
+        """Retrieve previously stored bytes for ``key``."""


### PR DESCRIPTION
## Summary
- define `FileSystemResource` with async `store` and `load` APIs
- export new class from `pipeline.resources`

## Testing
- `isort src/pipeline/resources/filesystem.py src/pipeline/resources/__init__.py`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.registries')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.registries')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'pipeline.registries')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'pipeline.registries')*

------
https://chatgpt.com/codex/tasks/task_e_68655bf7a4a48322be5eb75d2982419e