### PR TITLE
[Resource] implement configurable MemoryResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
-- ``SimpleMemoryResource`` – in-memory storage available across pipeline runs.
+- ``MemoryResource`` – unified interface that delegates to an in-memory backend by default.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
 

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -23,7 +23,9 @@ plugins:
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-      type: pipeline.plugins.resources.memory_resource:SimpleMemoryResource
+      type: pipeline.plugins.resources.memory_resource:MemoryResource
+      backend:
+        type: pipeline.plugins.resources.memory_resource:SimpleMemoryResource
   tools:
     weather:
       type: pipeline.plugins.tools.weather_api_tool:WeatherApiTool

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -24,7 +24,9 @@ plugins:
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-      type: pipeline.plugins.resources.memory_resource:SimpleMemoryResource
+      type: pipeline.plugins.resources.memory_resource:MemoryResource
+      backend:
+        type: pipeline.plugins.resources.memory_resource:SimpleMemoryResource
   tools:
     weather:
       type: pipeline.plugins.tools.weather_api_tool:WeatherApiTool

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -23,7 +23,9 @@ plugins:
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-      type: pipeline.plugins.resources.memory_resource:SimpleMemoryResource
+      type: pipeline.plugins.resources.memory_resource:MemoryResource
+      backend:
+        type: pipeline.plugins.resources.memory_resource:SimpleMemoryResource
   tools:
     weather:
       type: pipeline.plugins.tools.weather_api_tool:WeatherApiTool

--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -42,6 +42,7 @@ class ConfigValidator:
                 config = yaml.safe_load(fh) or {}
             load_env()
             config = ConfigLoader.from_dict(config)
+            self._validate_memory(config)
             self._validate_vector_memory(config)
             initializer = SystemInitializer(config)
             asyncio.run(initializer.initialize())
@@ -52,6 +53,17 @@ class ConfigValidator:
         print("Configuration valid")
         logger.info("Configuration valid.")
         return 0
+
+    def _validate_memory(self, config: dict) -> None:
+        """Validate nested memory configuration."""
+
+        mem_cfg = config.get("plugins", {}).get("resources", {}).get("memory")
+        if not mem_cfg:
+            return
+
+        backend = mem_cfg.get("backend")
+        if backend is not None and not isinstance(backend, dict):
+            raise ValueError("memory: 'backend' must be a mapping")
 
     def _validate_vector_memory(self, config: dict) -> None:
         """Ensure vector memory configuration contains required fields."""

--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -20,7 +20,10 @@ DEFAULT_RESOURCES: Dict[str, Dict[str, Any]] = {
         "provider": "echo",
     },
     "memory": {
-        "type": "pipeline.plugins.resources.memory_resource:SimpleMemoryResource"
+        "type": "pipeline.plugins.resources.memory_resource:MemoryResource",
+        "backend": {
+            "type": "pipeline.plugins.resources.memory_resource:SimpleMemoryResource"
+        },
     },
     "logging": DEFAULT_LOGGING_CONFIG,
 }

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -171,13 +171,13 @@ class SystemInitializer:
         # Phase 3: initialize resources
         resource_registry = ResourceRegistry()
         for cls, config in registry.resource_classes():
-            instance = cls(config)
+            primary_name = getattr(cls, "name", cls.__name__)
+            resource_registry.add_from_config(primary_name, cls, config)
+            instance = resource_registry.get(primary_name)
             if hasattr(instance, "initialize") and callable(
                 getattr(instance, "initialize")
             ):
                 await instance.initialize()
-            primary_name = getattr(instance, "name", cls.__name__)
-            resource_registry.add(primary_name, instance)
             for alias in getattr(instance, "aliases", []):
                 if alias != primary_name:
                     resource_registry.add(alias, instance)

--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -2,7 +2,7 @@ from .claude import ClaudeResource
 from .echo_llm import EchoLLMResource
 from .gemini import GeminiResource
 from .llm_resource import LLMResource
-from .memory_resource import SimpleMemoryResource
+from .memory_resource import MemoryResource, SimpleMemoryResource
 from .ollama_llm import OllamaLLMResource
 from .openai import OpenAIResource
 from .postgres_database import PostgresDatabaseResource
@@ -14,6 +14,7 @@ __all__ = [
     "LLMResource",
     "OllamaLLMResource",
     "SimpleMemoryResource",
+    "MemoryResource",
     "StructuredLogging",
     "PostgresDatabaseResource",
     "VectorMemoryResource",

--- a/src/pipeline/plugins/resources/memory_resource.py
+++ b/src/pipeline/plugins/resources/memory_resource.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
-from pipeline.plugins import ResourcePlugin
+from pipeline.initializer import import_plugin_class
+from pipeline.plugins import ResourcePlugin, ValidationResult
 from pipeline.resources.memory import Memory
 from pipeline.stages import PipelineStage
 
@@ -35,3 +36,48 @@ class SimpleMemoryResource(ResourcePlugin, Memory):
     def clear(self) -> None:
         """Remove all stored values."""
         self._store.clear()
+
+
+class MemoryResource(ResourcePlugin, Memory):
+    """Wrapper that delegates storage to a configurable backend."""
+
+    stages = [PipelineStage.PARSE]
+    name = "memory"
+
+    def __init__(
+        self, backend: Optional[Memory] = None, config: Dict | None = None
+    ) -> None:
+        super().__init__(config)
+        self._backend = backend or SimpleMemoryResource({})
+
+    @classmethod
+    def from_config(cls, config: Dict) -> "MemoryResource":
+        backend_cfg = config.get("backend", {})
+        backend_type = backend_cfg.get(
+            "type",
+            "pipeline.plugins.resources.memory_resource:SimpleMemoryResource",
+        )
+        backend_cls = import_plugin_class(backend_type)
+        backend = backend_cls(backend_cfg)
+        return cls(backend, config)
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
+        return None
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        return self._backend.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        self._backend.set(key, value)
+
+    def clear(self) -> None:
+        self._backend.clear()
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> "ValidationResult":
+        backend = config.get("backend")
+        if backend is not None and not isinstance(backend, dict):
+            return ValidationResult(
+                success=False, error_message="'backend' must be a mapping"
+            )
+        return ValidationResult.success_result()

--- a/src/registry/registries.py
+++ b/src/registry/registries.py
@@ -19,6 +19,15 @@ class ResourceRegistry:
 
         self._resources[name] = resource
 
+    def add_from_config(self, name: str, cls: type, config: Dict) -> None:
+        """Instantiate ``cls`` from ``config`` and register it."""
+
+        if name == "memory" and hasattr(cls, "from_config"):
+            instance = cls.from_config(config)
+        else:
+            instance = cls(config)
+        self.add(getattr(instance, "name", name), instance)
+
     def get(self, name: str) -> Any | None:
         """Return the resource registered as ``name`` if present."""
 


### PR DESCRIPTION
## Summary
- validate nested memory backend config
- delegate memory initialization via `MemoryResource.from_config`
- call `add_from_config` when building resources
- update default configs to use `MemoryResource`

## Testing
- `black --exclude 'src/cli/templates' src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/`
- `mypy --exclude 'src/cli/templates' src/` *(fails: various missing stubs and incompatibilities)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'pipeline.registries')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'pipeline.registries')*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_68655bfca58883228251df4be6ad176b