### PR TITLE
[Resource] Add abstract vector store interface

### DIFF
--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -2,7 +2,8 @@ from .database import DatabaseResource
 from .filesystem import FileSystemResource
 from .llm import LLM, LLMResource
 from .memory import Memory
-from .vectorstore import VectorStore, VectorStoreResource
+from .vector_store import VectorStoreResource
+from .vectorstore import VectorStore
 
 __all__ = [
     "LLM",

--- a/src/pipeline/resources/vector_store.py
+++ b/src/pipeline/resources/vector_store.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class VectorStoreResource(ABC):
+    """Abstract interface for vector store backends."""
+
+    @abstractmethod
+    async def add_embedding(self, text: str, metadata: dict | None = None) -> None:
+        """Persist ``text`` along with optional ``metadata`` as an embedding."""
+
+    @abstractmethod
+    async def query_similar(self, query: str, k: int) -> list[dict]:
+        """Return the ``k`` most similar embeddings to ``query``."""


### PR DESCRIPTION
## Summary
- add abstract VectorStoreResource in new `vector_store` module
- expose VectorStoreResource from resource package

## Testing
- `black src/pipeline/resources/vector_store.py src/pipeline/resources/__init__.py`
- `black src/ tests/` *(fails: cannot parse templates)*
- `isort src/pipeline/resources/__init__.py src/pipeline/resources/vector_store.py`
- `flake8 src/ tests/` *(fails: line too long in pg_vector_store.py)*
- `flake8 src/pipeline/resources/__init__.py src/pipeline/resources/vector_store.py`
- `mypy src/pipeline/resources/vector_store.py src/pipeline/resources/__init__.py` *(fails: attr-defined errors)*
- `mypy --ignore-missing-imports src/pipeline/resources/vector_store.py src/pipeline/resources/__init__.py`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `python -m src.registry.validator` *(fails: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_686584a2c2fc8322b2d5cee77b4603b9