### PR TITLE
[Resource] Refine PgVectorStore docs

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -23,7 +23,7 @@ plugins:
         - "CREATE EXTENSION IF NOT EXISTS vector"
   prompts:
     vector_memory:
-      type: vector_memory
+      type: pipeline.plugins.resources.pg_vector_store:PgVectorStore
       dependencies: ["database"]
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,8 +8,8 @@
 ## Examples
 
 - [`vector_memory_pipeline.py`](../../examples/pipelines/vector_memory_pipeline.py)
-  demonstrates using Postgres, an LLM with the Ollama provider, and simple
-  vector memory.
+  demonstrates using Postgres, an LLM with the Ollama provider, and the
+  `PgVectorStore` resource for vector memory.
 - **Postgres connection pooling**
   ```python
   PostgresResource(

--- a/src/pipeline/plugins/resources/pg_vector_store.py
+++ b/src/pipeline/plugins/resources/pg_vector_store.py
@@ -42,7 +42,10 @@ class PgVectorStore(VectorStoreResource):
             async with self._pool.connection() as conn:
                 await conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
                 await conn.execute(
-                    f"CREATE TABLE IF NOT EXISTS {self._table} (text TEXT, embedding VECTOR({self._dim}))"
+                    (
+                        f"CREATE TABLE IF NOT EXISTS {self._table} "
+                        f"(text TEXT, embedding VECTOR({self._dim}))"
+                    )
                 )
             return
 
@@ -60,7 +63,10 @@ class PgVectorStore(VectorStoreResource):
             async with self._pool.connection() as conn:
                 await conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
                 await conn.execute(
-                    f"CREATE TABLE IF NOT EXISTS {self._table} (text TEXT, embedding VECTOR({self._dim}))"
+                    (
+                        f"CREATE TABLE IF NOT EXISTS {self._table} "
+                        f"(text TEXT, embedding VECTOR({self._dim}))"
+                    )
                 )
             return
 


### PR DESCRIPTION
## Summary
- update docs to reference PgVectorStore
- format PgVectorStore and fix long lines

## Testing
- `poetry run black src tests --exclude 'src/cli/templates'`
- `poetry run flake8 src tests`
- `poetry run mypy src/pipeline/plugins/resources/pg_vector_store.py` *(fails: ModuleErrors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/integration/ -v` *(fails: database "agent_sandbox" does not exist)*
- `poetry run pytest tests/performance/ -m benchmark` *(fails: AttributeError: 'PluginRegistry' object has no attribute 'get_for_stage')*
- `poetry run pytest` *(fails: ImportError: attempted relative import beyond top-level package)*

------
https://chatgpt.com/codex/tasks/task_e_686584a6cab88322839fa47b25adc194