### PR TITLE
[Resource] support nested memory configuration

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -23,7 +23,6 @@ plugins:
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-      type: pipeline.plugins.resources.memory_resource:MemoryResource
       backend:
         type: pipeline.plugins.resources.memory_resource:SimpleMemoryResource
   tools:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -24,7 +24,6 @@ plugins:
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-      type: pipeline.plugins.resources.memory_resource:MemoryResource
       backend:
         type: pipeline.plugins.resources.memory_resource:SimpleMemoryResource
   tools:

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -23,7 +23,6 @@ plugins:
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-      type: pipeline.plugins.resources.memory_resource:MemoryResource
       backend:
         type: pipeline.plugins.resources.memory_resource:SimpleMemoryResource
   tools:

--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -64,6 +64,9 @@ class ConfigValidator:
         backend = mem_cfg.get("backend")
         if backend is not None and not isinstance(backend, dict):
             raise ValueError("memory: 'backend' must be a mapping")
+        if isinstance(backend, dict) and "type" in backend:
+            if not isinstance(backend["type"], str):
+                raise ValueError("memory: 'backend.type' must be a string")
 
     def _validate_vector_memory(self, config: dict) -> None:
         """Ensure vector memory configuration contains required fields."""

--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -20,7 +20,6 @@ DEFAULT_RESOURCES: Dict[str, Dict[str, Any]] = {
         "provider": "echo",
     },
     "memory": {
-        "type": "pipeline.plugins.resources.memory_resource:MemoryResource",
         "backend": {
             "type": "pipeline.plugins.resources.memory_resource:SimpleMemoryResource"
         },

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -140,7 +140,11 @@ class SystemInitializer:
         # Phase 1: register all plugin classes
         resources = self.config.get("plugins", {}).get("resources", {})
         for name, config in resources.items():
-            cls = import_plugin_class(config.get("type", name))
+            if name == "memory" and "type" not in config:
+                cls_path = "pipeline.plugins.resources.memory_resource:MemoryResource"
+            else:
+                cls_path = config.get("type", name)
+            cls = import_plugin_class(cls_path)
             registry.register_class(cls, config, name)
             dep_graph[name] = getattr(cls, "dependencies", [])
 


### PR DESCRIPTION
## Summary
- update defaults to remove explicit MemoryResource type
- validate nested memory backend settings
- handle memory resource configs without a type
- adjust YAML examples

## Testing
- `black src/config/validator.py src/pipeline/initializer.py src/pipeline/defaults.py` *(all files left unchanged)*
- `isort src/config/validator.py src/pipeline/initializer.py src/pipeline/defaults.py src/registry/registries.py`
- `flake8 src/ tests/` *(fails: command not found)*
- `poetry run mypy src/` *(fails: invalid syntax in template file)*
- `bandit -r src/` *(fails: command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `poetry run python -m src.registry.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686584a83f388322aca35975f6c8c2b5