### PR TITLE
[Docs] Update MemoryResource references

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -23,12 +23,7 @@ plugins:
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-<<<<<<< HEAD
       type: pipeline.plugins.resources.memory:MemoryResource
-=======
->>>>>>> 92a5f930cb56f66154cc0e647e0797cfa0c1afaf
-      backend:
-        type: pipeline.plugins.resources.memory:SimpleMemoryResource
   tools:
     weather:
       type: pipeline.plugins.tools.weather_api_tool:WeatherApiTool

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -24,12 +24,7 @@ plugins:
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-<<<<<<< HEAD
       type: pipeline.plugins.resources.memory:MemoryResource
-=======
->>>>>>> 92a5f930cb56f66154cc0e647e0797cfa0c1afaf
-      backend:
-        type: pipeline.plugins.resources.memory:SimpleMemoryResource
   tools:
     weather:
       type: pipeline.plugins.tools.weather_api_tool:WeatherApiTool

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -23,12 +23,7 @@ plugins:
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-<<<<<<< HEAD
       type: pipeline.plugins.resources.memory:MemoryResource
-=======
->>>>>>> 92a5f930cb56f66154cc0e647e0797cfa0c1afaf
-      backend:
-        type: pipeline.plugins.resources.memory:SimpleMemoryResource
   tools:
     weather:
       type: pipeline.plugins.tools.weather_api_tool:WeatherApiTool

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -4,33 +4,48 @@
 :end-before: <!-- end advanced_usage -->
 ```
 
-### Enabling pgvector Storage
+### Composing Memory Backends
 
 PostgreSQL's `pgvector` extension allows vector similarity search for embeddings.
-Add a setup command in your configuration to enable the extension and register a
-vector-aware memory plugin.
+Use `MemoryResource` with a Postgres database and optional S3 file storage:
 
 ```yaml
 plugins:
   resources:
-    database:
-      type: postgres
-      host: localhost
-      port: 5432
-      name: dev_db
-      username: agent
-      setup_commands:
-        - "CREATE EXTENSION IF NOT EXISTS vector"
-  prompts:
-    vector_memory:
-      type: vector_memory
-      dependencies: ["database"]
+    memory:
+      type: memory
+      database:
+        type: postgres
+        host: localhost
+        port: 5432
+        name: dev_db
+        username: agent
+        setup_commands:
+          - "CREATE EXTENSION IF NOT EXISTS vector"
+      vector_store:
+        type: pgvector
+        dimensions: 768
+        table: embeddings
+      filesystem:
+        type: s3
+        bucket: agent-files
+        region: us-east-1
 ```
 
-For a working example, see
-[`vector_memory_pipeline.py`](../../examples/pipelines/vector_memory_pipeline.py).
-These advanced capabilities highlight **Preserve All Power (7)** by allowing
-low-level database features without sacrificing the simple default setup.
+For local experimentation you can swap the database section with SQLite:
+
+```yaml
+plugins:
+  resources:
+    memory:
+      type: memory
+      database:
+        type: sqlite
+        path: ./agent.db
+```
+
+These configurations illustrate **Preserve All Power (7)** by enabling
+advanced storage without sacrificing the simple default setup.
 
 ### Runtime Configuration Reload
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,8 +8,7 @@
 ## Examples
 
 - [`vector_memory_pipeline.py`](../../examples/pipelines/vector_memory_pipeline.py)
-  demonstrates using Postgres, an LLM with the Ollama provider, and simple
-  vector memory.
+  demonstrates composing `MemoryResource` with Postgres, pgvector, and S3.
 - **Postgres connection pooling**
   ```python
   PostgresResource(

--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -20,14 +20,7 @@ DEFAULT_RESOURCES: Dict[str, Dict[str, Any]] = {
         "provider": "echo",
     },
     "memory": {
-<<<<<<< HEAD
         "type": "pipeline.plugins.resources.memory:MemoryResource",
-        "backend": {"type": "pipeline.plugins.resources.memory:SimpleMemoryResource"},
-=======
-        "backend": {
-            "type": "pipeline.plugins.resources.memory_resource:SimpleMemoryResource"
-        },
->>>>>>> 92a5f930cb56f66154cc0e647e0797cfa0c1afaf
     },
     "logging": DEFAULT_LOGGING_CONFIG,
 }

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -141,7 +141,7 @@ class SystemInitializer:
         resources = self.config.get("plugins", {}).get("resources", {})
         for name, config in resources.items():
             if name == "memory" and "type" not in config:
-                cls_path = "pipeline.plugins.resources.memory_resource:MemoryResource"
+                cls_path = "pipeline.plugins.resources.memory:MemoryResource"
             else:
                 cls_path = config.get("type", name)
             cls = import_plugin_class(cls_path)


### PR DESCRIPTION
## Summary
- update docs to reference MemoryResource with backend composition
- config files now point to `MemoryResource`
- fix initializer to use correct default MemoryResource path

## Testing
- `black src tests --exclude 'src/cli/templates'`
- `isort src tests` *(modified many files)*
- `flake8 src tests` *(command not found)*
- `mypy --exclude 'src/cli/templates' src` *(failed with type errors)*
- `bandit -r src` *(command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(failed: ModuleNotFoundError: 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(failed: ModuleNotFoundError: 'yaml')*
- `python -m src.registry.validator` *(failed: ModuleNotFoundError: 'pipeline')*
- `pytest tests/integration/ -v` *(failed: ModuleNotFoundError: 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(failed: ModuleNotFoundError: 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686589bbf074832299cbf2dc66dd1ca1