### PR TITLE
Remove resource aliases

### DIFF
--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -86,13 +86,9 @@ class PluginContext:
         return self._registries.resources.get(name)
 
     def get_llm(self) -> Any | None:
-        """Return the configured LLM resource.
+        """Return the configured LLM resource registered as ``"llm"``."""
 
-        Looks for a resource registered as ``"llm"`` first and falls back to
-        ``"ollama"`` for backward compatibility.
-        """
-        llm = self.get_resource("llm")
-        return llm if llm is not None else self.get_resource("ollama")
+        return self.get_resource("llm")
 
     @property
     def message(self) -> str:

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -182,9 +182,6 @@ class SystemInitializer:
                 getattr(instance, "initialize")
             ):
                 await instance.initialize()
-            for alias in getattr(instance, "aliases", []):
-                if alias != primary_name:
-                    resource_registry.add(alias, instance)
 
         # Phase 3.5: register tools
         tool_registry = ToolRegistry()

--- a/src/pipeline/plugins/resources/claude.py
+++ b/src/pipeline/plugins/resources/claude.py
@@ -13,7 +13,6 @@ class ClaudeResource(LLMResource):
 
     stages = [PipelineStage.PARSE]
     name = "claude"
-    aliases = ["llm"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/src/pipeline/plugins/resources/echo_llm.py
+++ b/src/pipeline/plugins/resources/echo_llm.py
@@ -7,7 +7,6 @@ class EchoLLMResource(LLMResource):
     """Simple LLM resource that echoes the prompt back."""
 
     name = "echo"
-    aliases = ["llm"]
 
     async def _execute_impl(self, context):
         return None

--- a/src/pipeline/plugins/resources/gemini.py
+++ b/src/pipeline/plugins/resources/gemini.py
@@ -13,7 +13,6 @@ class GeminiResource(LLMResource):
 
     stages = [PipelineStage.PARSE]
     name = "gemini"
-    aliases = ["llm"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/src/pipeline/plugins/resources/llm/unified.py
+++ b/src/pipeline/plugins/resources/llm/unified.py
@@ -18,7 +18,6 @@ class UnifiedLLMResource(LLMResource):
     """LLM resource selecting a provider at runtime."""
 
     name = "llm"
-    aliases = ["llm"]
 
     PROVIDERS: Dict[str, Type[LLMResource]] = {
         "openai": OpenAIProvider,
@@ -39,7 +38,6 @@ class UnifiedLLMResource(LLMResource):
         if not result.success:
             raise ValueError(result.error_message)
         self._provider = provider_cls(clean_config)
-        self.aliases = ["llm", provider_name]
 
         fallback_name = str(self.config.get("fallback", "echo")).lower()
         if fallback_name == provider_name:

--- a/src/pipeline/plugins/resources/llm_resource.py
+++ b/src/pipeline/plugins/resources/llm_resource.py
@@ -12,7 +12,6 @@ class LLMResource(ResourcePlugin, LLM):
 
     stages = [PipelineStage.PARSE]
     name = "llm"
-    aliases: List[str] = ["llm"]
 
     async def _execute_impl(self, context) -> None:
         return None

--- a/src/pipeline/plugins/resources/ollama_llm.py
+++ b/src/pipeline/plugins/resources/ollama_llm.py
@@ -15,7 +15,6 @@ class OllamaLLMResource(LLMResource):
     """
 
     name = "ollama"
-    aliases = ["llm"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/src/pipeline/plugins/resources/openai.py
+++ b/src/pipeline/plugins/resources/openai.py
@@ -11,7 +11,6 @@ class OpenAIResource(LLMResource):
     """LLM resource for OpenAI's chat completion API."""
 
     name = "openai"
-    aliases = ["llm"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -126,7 +126,7 @@ def test_initializer_from_json_and_dict(tmp_path):
     assert ry.get("A") and rj.get("A") and rd.get("A")
 
 
-def test_llm_alias_registration(tmp_path):
+def test_llm_resource_registration(tmp_path):
     config = {
         "plugins": {
             "resources": {
@@ -146,4 +146,5 @@ def test_llm_alias_registration(tmp_path):
     initializer = SystemInitializer.from_yaml(str(path))
     _, resources, _ = asyncio.run(initializer.initialize())
 
-    assert resources.get("llm") is resources.get("ollama")
+    assert resources.get("llm") is not None
+    assert resources.get("ollama") is None


### PR DESCRIPTION
## Summary
- drop `aliases` from resource plugin classes
- remove alias registration in `SystemInitializer`
- simplify `get_llm` lookup
- update initializer test for new behavior

## Testing
- `poetry run pytest` *(fails: ImportError: attempted relative import beyond top-level package)*

------
https://chatgpt.com/codex/tasks/task_e_6865a1d44e7c8322b52956ee090d4666