### PR TITLE
[Core] require explicit llm resource

### DIFF
--- a/examples/pipelines/pipeline_example.py
+++ b/examples/pipelines/pipeline_example.py
@@ -70,7 +70,7 @@ def setup_registries() -> SystemRegistries:
     tools.add("calculator", CalculatorTool())
 
     resources.add(
-        "ollama",
+        "llm",
         OllamaLLMResource({"base_url": "http://localhost:11434", "model": "tinyllama"}),
     )
 

--- a/examples/pipelines/vector_memory_pipeline.py
+++ b/examples/pipelines/vector_memory_pipeline.py
@@ -19,9 +19,9 @@ from pipeline import PipelineStage, PromptPlugin, ResourcePlugin  # noqa: E402
 from pipeline.context import PluginContext  # noqa: E402
 from pipeline.plugins.resources.echo_llm import EchoLLMResource  # noqa: E402
 from pipeline.plugins.resources.pg_vector_store import PgVectorStore  # noqa: E402
-from pipeline.plugins.resources.postgres_database import (  # noqa: E402
+from pipeline.plugins.resources.postgres_database import (
     PostgresDatabaseResource,
-)
+)  # noqa: E402
 
 
 class VectorMemoryResource(ResourcePlugin):
@@ -47,7 +47,7 @@ class VectorMemoryResource(ResourcePlugin):
 class ComplexPrompt(PromptPlugin):
     """Example prompt using the vector memory."""
 
-    dependencies = ["database", "ollama", "vector_memory"]
+    dependencies = ["database", "llm", "vector_memory"]
     stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
@@ -72,7 +72,7 @@ def main() -> None:
             }
         ),
     )
-    agent.resource_registry.add("ollama", EchoLLMResource())
+    agent.resource_registry.add("llm", EchoLLMResource())
     agent.resource_registry.add("vector_memory", VectorMemoryResource())
     agent.plugin_registry.register_plugin_for_stage(
         ComplexPrompt(), PipelineStage.THINK

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, cast
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pipeline.resources.llm import LLM
 
 from registry import SystemRegistries
 
@@ -85,14 +88,17 @@ class PluginContext:
         """Return a shared resource plugin registered as ``name``."""
         return self._registries.resources.get(name)
 
-    def get_llm(self) -> Any | None:
+    def get_llm(self) -> LLM:
         """Return the configured LLM resource.
 
-        Looks for a resource registered as ``"llm"`` first and falls back to
-        ``"ollama"`` for backward compatibility.
+        Raises a :class:`RuntimeError` if no ``"llm"`` resource is found.
         """
         llm = self.get_resource("llm")
-        return llm if llm is not None else self.get_resource("ollama")
+        if llm is None:
+            raise RuntimeError(
+                "No LLM resource configured. Add 'llm' to resources section."
+            )
+        return cast(LLM, llm)
 
     @property
     def message(self) -> str:

--- a/tests/test_call_llm_logging.py
+++ b/tests/test_call_llm_logging.py
@@ -39,7 +39,7 @@ def make_context(llm: FakeLLM) -> PluginContext:
         current_stage=PipelineStage.THINK,
     )
     resources = ResourceRegistry()
-    resources.add("ollama", llm)
+    resources.add("llm", llm)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return PluginContext(state, registries)
 


### PR DESCRIPTION
## Summary
- enforce explicit LLM resource on context
- adjust example pipelines for new key
- update test to register the LLM resource

## Testing
- `isort src/pipeline/context.py examples/pipelines/pipeline_example.py examples/pipelines/vector_memory_pipeline.py tests/test_call_llm_logging.py`
- `black src/pipeline/context.py examples/pipelines/pipeline_example.py examples/pipelines/vector_memory_pipeline.py tests/test_call_llm_logging.py`
- `flake8 src/pipeline/context.py examples/pipelines/pipeline_example.py examples/pipelines/vector_memory_pipeline.py tests/test_call_llm_logging.py`
- `mypy src/pipeline/context.py examples/pipelines/pipeline_example.py examples/pipelines/vector_memory_pipeline.py tests/test_call_llm_logging.py` *(fails: ModuleNotFoundError: aioboto3)*
- `bandit -r src/ | head`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ImportError: cannot import name 'ConversationEntry')*
- `PYTHONPATH=src python -m src.registry.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: asyncpg)*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: asyncpg)*
- `pytest tests/performance/ -m benchmark`

------
https://chatgpt.com/codex/tasks/task_e_6865a1d5bdd48322968c99d04f6f5804