### PR TITLE
[Core] require explicit plugin classes

### DIFF
--- a/src/registry/registries.py
+++ b/src/registry/registries.py
@@ -22,7 +22,7 @@ class ResourceRegistry:
     def add_from_config(self, name: str, cls: type, config: Dict) -> None:
         """Instantiate ``cls`` from ``config`` and register it."""
 
-        if name == "memory" and hasattr(cls, "from_config"):
+        if hasattr(cls, "from_config"):
             instance = cls.from_config(config)
         else:
             instance = cls(config)

--- a/tests/test_claude_resource.py
+++ b/tests/test_claude_resource.py
@@ -55,6 +55,7 @@ def test_context_get_llm_with_provider():
         "plugins": {
             "resources": {
                 "llm": {
+                    "type": "pipeline.plugins.resources.llm.unified:UnifiedLLMResource",
                     "provider": "claude",
                     "api_key": "key",
                     "model": "claude-3",

--- a/tests/test_gemini_resource.py
+++ b/tests/test_gemini_resource.py
@@ -52,6 +52,7 @@ def test_context_get_llm_with_provider():
         "plugins": {
             "resources": {
                 "llm": {
+                    "type": "pipeline.plugins.resources.llm.unified:UnifiedLLMResource",
                     "provider": "gemini",
                     "api_key": "key",
                     "model": "gemini-pro",


### PR DESCRIPTION
## Summary
- remove `_apply_llm_provider` helper
- enforce full class path lookup for all plugins
- standardize resource initialization
- update LLM tests

## Testing
- `black src/ tests/ --exclude src/cli/templates`
- `isort src/ tests/`
- `flake8 src/ tests/`
- `mypy src/ --exclude 'src/cli/templates'` *(fails: various typing errors)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database "agent" does not exist)*
- `PYTHONPATH=src python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_6865a1d7dac88322863cd36e37a19d9e