### PR TITLE
Use Unified LLM by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
-- ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
+- ``UnifiedLLMResource`` (provider ``echo``) – minimal LLM resource that simply echoes prompts.
 - ``MemoryResource`` – unified interface that delegates to an in-memory backend by default.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -14,7 +14,8 @@ plugins:
       username: "${DB_USERNAME}"
       password: "${DB_PASSWORD}"
     llm:
-      type: pipeline.plugins.resources.ollama_llm:OllamaLLMResource
+      type: pipeline.plugins.resources.llm.unified:UnifiedLLMResource
+      provider: ollama
       base_url: "${OLLAMA_BASE_URL}"
       model: "${OLLAMA_MODEL}"
     logging:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -14,7 +14,8 @@ plugins:
       username: "${DB_USERNAME}"
       password: "${DB_PASSWORD}"
     llm:
-      type: pipeline.plugins.resources.ollama_llm:OllamaLLMResource
+      type: pipeline.plugins.resources.llm.unified:UnifiedLLMResource
+      provider: ollama
       base_url: "${OLLAMA_BASE_URL}"
       model: "${OLLAMA_MODEL}"
       temperature: 0.7

--- a/examples/pipelines/pipeline_example.py
+++ b/examples/pipelines/pipeline_example.py
@@ -20,7 +20,7 @@ from pipeline import (
     ToolRegistry,
     execute_pipeline,
 )
-from pipeline.plugins.resources.ollama_llm import OllamaLLMResource
+from pipeline.plugins.resources.llm.unified import UnifiedLLMResource
 
 
 class CalculatorTool(ToolPlugin):
@@ -70,8 +70,14 @@ def setup_registries() -> SystemRegistries:
     tools.add("calculator", CalculatorTool())
 
     resources.add(
-        "ollama",
-        OllamaLLMResource({"base_url": "http://localhost:11434", "model": "tinyllama"}),
+        "llm",
+        UnifiedLLMResource(
+            {
+                "provider": "ollama",
+                "base_url": "http://localhost:11434",
+                "model": "tinyllama",
+            }
+        ),
     )
 
     plugins.register_plugin_for_stage(

--- a/examples/pipelines/vector_memory_pipeline.py
+++ b/examples/pipelines/vector_memory_pipeline.py
@@ -17,11 +17,11 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))  # noq
 from entity import Agent  # noqa: E402
 from pipeline import PipelineStage, PromptPlugin, ResourcePlugin  # noqa: E402
 from pipeline.context import PluginContext  # noqa: E402
-from pipeline.plugins.resources.echo_llm import EchoLLMResource  # noqa: E402
+from pipeline.plugins.resources.llm.unified import UnifiedLLMResource  # noqa: E402
 from pipeline.plugins.resources.pg_vector_store import PgVectorStore  # noqa: E402
-from pipeline.plugins.resources.postgres_database import (  # noqa: E402
+from pipeline.plugins.resources.postgres_database import (
     PostgresDatabaseResource,
-)
+)  # noqa: E402
 
 
 class VectorMemoryResource(ResourcePlugin):
@@ -47,7 +47,7 @@ class VectorMemoryResource(ResourcePlugin):
 class ComplexPrompt(PromptPlugin):
     """Example prompt using the vector memory."""
 
-    dependencies = ["database", "ollama", "vector_memory"]
+    dependencies = ["database", "llm", "vector_memory"]
     stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
@@ -72,7 +72,7 @@ def main() -> None:
             }
         ),
     )
-    agent.resource_registry.add("ollama", EchoLLMResource())
+    agent.resource_registry.add("llm", UnifiedLLMResource({"provider": "echo"}))
     agent.resource_registry.add("vector_memory", VectorMemoryResource())
     agent.plugin_registry.register_plugin_for_stage(
         ComplexPrompt(), PipelineStage.THINK

--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -14,11 +14,13 @@ DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
     "file_enabled": False,
 }
 
+DEFAULT_LLM_CONFIG: Dict[str, Any] = {
+    "type": "pipeline.plugins.resources.llm.unified:UnifiedLLMResource",
+    "provider": "echo",
+}
+
 DEFAULT_RESOURCES: Dict[str, Dict[str, Any]] = {
-    "llm": {
-        "type": "pipeline.plugins.resources.llm.unified:UnifiedLLMResource",
-        "provider": "echo",
-    },
+    "llm": DEFAULT_LLM_CONFIG,
     "memory": {
         "type": "pipeline.plugins.resources.memory:MemoryResource",
         "backend": {"type": "pipeline.plugins.resources.memory:SimpleMemoryResource"},


### PR DESCRIPTION
## Summary
- default to using UnifiedLLMResource with the echo provider
- adjust dev/prod config to reference the unified LLM resource
- update example pipelines to use UnifiedLLMResource
- tweak README to document the default echo provider

## Testing
- `flake8 src/pipeline/defaults.py examples/pipelines/pipeline_example.py examples/pipelines/vector_memory_pipeline.py`
- `mypy src/pipeline/defaults.py` *(fails: attr-defined errors)*
- `bandit -r src/pipeline/defaults.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: database does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: database does not exist)*
- `PYTHONPATH=src python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: database does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6865a1d8190883228a96156899a7770d