### PR TITLE
[Resource] introduce Resource protocol and refactor

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -9,6 +9,7 @@ from pipeline import update_plugin_configuration
 from pipeline.base_plugins import ResourcePlugin, ToolPlugin
 from pipeline.initializer import ClassRegistry, SystemInitializer, import_plugin_class
 from pipeline.logging import get_logger
+from pipeline.resources.base import Resource
 
 logger = get_logger(__name__)
 
@@ -117,7 +118,7 @@ class CLI:
                         return False
 
                 instance = cls(conf)
-                if issubclass(cls, ResourcePlugin):
+                if issubclass(cls, ResourcePlugin) or issubclass(cls, Resource):
                     if hasattr(instance, "initialize") and callable(
                         instance.initialize
                     ):

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -33,7 +33,7 @@ from .plugins import (
     ValidationResult,
 )
 from .registries import PluginRegistry, ResourceRegistry, SystemRegistries, ToolRegistry
-from .resources import LLM
+from .resources import LLM, BaseResource, Resource
 from .stages import PipelineStage
 from .state import FailureInfo, LLMResponse, PipelineState
 
@@ -51,6 +51,8 @@ __all__ = [
     "ToolCall",
     "LLMResponse",
     "LLM",
+    "Resource",
+    "BaseResource",
     "FailureInfo",
     "MetricsCollector",
     "BasePlugin",

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -8,6 +8,7 @@ from importlib import import_module
 from typing import Any, Dict, Iterable, List, Tuple
 
 from config.environment import load_env
+from pipeline.resources.base import Resource
 from registry import PluginRegistry, ResourceRegistry, ToolRegistry
 
 from .base_plugins import BasePlugin, ResourcePlugin, ToolPlugin
@@ -45,9 +46,9 @@ class ClassRegistry:
         for name, cls in self._classes.items():
             yield cls, self._configs[name]
 
-    def resource_classes(self) -> Iterable[Tuple[type[ResourcePlugin], Dict]]:
+    def resource_classes(self) -> Iterable[Tuple[type, Dict]]:
         for name, cls in self._classes.items():
-            if issubclass(cls, ResourcePlugin):
+            if issubclass(cls, ResourcePlugin) or issubclass(cls, Resource):
                 yield cls, self._configs[name]
 
     def tool_classes(self) -> Iterable[Tuple[type[ToolPlugin], Dict]]:
@@ -57,7 +58,11 @@ class ClassRegistry:
 
     def non_resource_non_tool_classes(self) -> Iterable[Tuple[type[BasePlugin], Dict]]:
         for name, cls in self._classes.items():
-            if not issubclass(cls, ResourcePlugin) and not issubclass(cls, ToolPlugin):
+            if (
+                not issubclass(cls, ResourcePlugin)
+                and not issubclass(cls, ToolPlugin)
+                and not issubclass(cls, Resource)
+            ):
                 yield cls, self._configs[name]
 
 

--- a/src/pipeline/plugins/resources/claude.py
+++ b/src/pipeline/plugins/resources/claude.py
@@ -2,16 +2,14 @@ from __future__ import annotations
 
 from typing import Dict
 
-from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
 from pipeline.resources.llm import LLMResource
-from pipeline.stages import PipelineStage
+from pipeline.validation import ValidationResult
 
 
 class ClaudeResource(LLMResource):
     """LLM resource for Anthropic's Claude API."""
 
-    stages = [PipelineStage.PARSE]
     name = "claude"
     aliases = ["llm"]
 
@@ -22,9 +20,6 @@ class ClaudeResource(LLMResource):
     @classmethod
     def validate_config(cls, config: Dict) -> ValidationResult:
         return HttpLLMResource(config, require_api_key=True).validate_config()
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     async def generate(self, prompt: str) -> str:
         if not self.http.validate_config().valid:

--- a/src/pipeline/plugins/resources/echo_llm.py
+++ b/src/pipeline/plugins/resources/echo_llm.py
@@ -9,8 +9,5 @@ class EchoLLMResource(LLMResource):
     name = "echo"
     aliases = ["llm"]
 
-    async def _execute_impl(self, context):
-        return None
-
     async def generate(self, prompt: str) -> str:
         return prompt

--- a/src/pipeline/plugins/resources/gemini.py
+++ b/src/pipeline/plugins/resources/gemini.py
@@ -2,16 +2,14 @@ from __future__ import annotations
 
 from typing import Dict
 
-from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
 from pipeline.resources.llm import LLMResource
-from pipeline.stages import PipelineStage
+from pipeline.validation import ValidationResult
 
 
 class GeminiResource(LLMResource):
     """LLM resource for Google's Gemini API."""
 
-    stages = [PipelineStage.PARSE]
     name = "gemini"
     aliases = ["llm"]
 
@@ -22,9 +20,6 @@ class GeminiResource(LLMResource):
     @classmethod
     def validate_config(cls, config: Dict) -> ValidationResult:
         return HttpLLMResource(config, require_api_key=True).validate_config()
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     async def generate(self, prompt: str) -> str:
         if not self.http.validate_config().valid:

--- a/src/pipeline/plugins/resources/in_memory_storage.py
+++ b/src/pipeline/plugins/resources/in_memory_storage.py
@@ -3,23 +3,18 @@ from __future__ import annotations
 from typing import Dict, List
 
 from pipeline.context import ConversationEntry
-from pipeline.plugins import ResourcePlugin
+from pipeline.resources.base import BaseResource
 from pipeline.resources.storage import StorageBackend
-from pipeline.stages import PipelineStage
 
 
-class InMemoryStorageResource(ResourcePlugin, StorageBackend):
+class InMemoryStorageResource(BaseResource, StorageBackend):
     """Simple in-memory storage backend for conversation history."""
 
-    stages = [PipelineStage.PARSE]
     name = "storage"
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)
         self._data: Dict[str, List[ConversationEntry]] = {}
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     async def save_history(
         self, conversation_id: str, history: List[ConversationEntry]

--- a/src/pipeline/plugins/resources/llm/providers/base.py
+++ b/src/pipeline/plugins/resources/llm/providers/base.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Dict, Optional
 
-from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
 from pipeline.resources.llm import LLM
+from pipeline.validation import ValidationResult
 
 
 class BaseProvider(LLM):

--- a/src/pipeline/plugins/resources/llm/unified.py
+++ b/src/pipeline/plugins/resources/llm/unified.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Dict, Type
 
-from pipeline.plugins import ValidationResult
 from pipeline.resources.llm import LLMResource
+from pipeline.validation import ValidationResult
 
 from .providers import (
     ClaudeProvider,
@@ -60,9 +60,6 @@ class UnifiedLLMResource(LLMResource):
                 f"Unknown LLM provider '{provider_name}'"
             )
         return provider_cls.validate_config(config)
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     async def generate(self, prompt: str) -> str:
         try:

--- a/src/pipeline/plugins/resources/llm_resource.py
+++ b/src/pipeline/plugins/resources/llm_resource.py
@@ -2,20 +2,15 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from pipeline.plugins import ResourcePlugin, ValidationResult
-from pipeline.resources import LLM
-from pipeline.stages import PipelineStage
+from pipeline.resources import LLM, BaseResource
+from pipeline.validation import ValidationResult
 
 
-class LLMResource(ResourcePlugin, LLM):
+class LLMResource(BaseResource, LLM):
     """Base class for language model resources."""
 
-    stages = [PipelineStage.PARSE]
     name = "llm"
     aliases: List[str] = ["llm"]
-
-    async def _execute_impl(self, context) -> None:
-        return None
 
     async def generate(self, prompt: str) -> str:
         """Return a completion for ``prompt``."""

--- a/src/pipeline/plugins/resources/local_filesystem.py
+++ b/src/pipeline/plugins/resources/local_filesystem.py
@@ -4,24 +4,19 @@ import asyncio
 import pathlib
 from typing import Dict
 
-from pipeline.plugins import ResourcePlugin
+from pipeline.resources import BaseResource
 from pipeline.resources.filesystem import FileSystemResource
-from pipeline.stages import PipelineStage
 
 
-class LocalFileSystemResource(ResourcePlugin, FileSystemResource):
+class LocalFileSystemResource(BaseResource, FileSystemResource):
     """Persist files on the local disk."""
 
-    stages = [PipelineStage.PARSE]
     name = "filesystem"
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)
         base_path = self.config.get("base_path", "./data")
         self._base = pathlib.Path(base_path)
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     async def store(self, key: str, content: bytes) -> str:
         path = self._base / key

--- a/src/pipeline/plugins/resources/memory.py
+++ b/src/pipeline/plugins/resources/memory.py
@@ -4,28 +4,24 @@ from typing import Any, Dict, List
 
 from pipeline.context import ConversationEntry
 from pipeline.initializer import import_plugin_class
-from pipeline.plugins import ResourcePlugin, ValidationResult
 from pipeline.resources import (
+    BaseResource,
     DatabaseResource,
     FileSystemResource,
     Memory,
     VectorStoreResource,
 )
-from pipeline.stages import PipelineStage
+from pipeline.validation import ValidationResult
 
 
-class SimpleMemoryResource(ResourcePlugin, Memory):
+class SimpleMemoryResource(BaseResource, Memory):
     """Basic in-memory key/value store."""
 
-    stages = [PipelineStage.PARSE]
     name = "memory"
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)
         self._store: Dict[str, Any] = {}
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     def get(self, key: str, default: Any | None = None) -> Any:
         return self._store.get(key, default)
@@ -37,10 +33,9 @@ class SimpleMemoryResource(ResourcePlugin, Memory):
         self._store.clear()
 
 
-class MemoryResource(ResourcePlugin, Memory):
+class MemoryResource(BaseResource, Memory):
     """Composite memory resource composed of optional backends."""
 
-    stages = [PipelineStage.PARSE]
     name = "memory"
 
     def __init__(
@@ -79,9 +74,6 @@ class MemoryResource(ResourcePlugin, Memory):
         vector_store = build("vector_store")
         filesystem = build("filesystem")
         return cls(database, vector_store, filesystem, config)
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     def get(self, key: str, default: Any | None = None) -> Any:
         return self._kv.get(key, default)

--- a/src/pipeline/plugins/resources/ollama_llm.py
+++ b/src/pipeline/plugins/resources/ollama_llm.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Dict
 
-from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
 from pipeline.resources.llm import LLMResource
+from pipeline.validation import ValidationResult
 
 
 class OllamaLLMResource(LLMResource):
@@ -24,9 +24,6 @@ class OllamaLLMResource(LLMResource):
     @classmethod
     def validate_config(cls, config: Dict) -> ValidationResult:
         return HttpLLMResource(config).validate_config()
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     async def generate(self, prompt: str) -> str:
         if not self.http.validate_config().valid:

--- a/src/pipeline/plugins/resources/openai.py
+++ b/src/pipeline/plugins/resources/openai.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Dict
 
-from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
 from pipeline.resources.llm import LLMResource
+from pipeline.validation import ValidationResult
 
 
 class OpenAIResource(LLMResource):
@@ -20,9 +20,6 @@ class OpenAIResource(LLMResource):
     @classmethod
     def validate_config(cls, config: Dict) -> ValidationResult:
         return HttpLLMResource(config, require_api_key=True).validate_config()
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     async def generate(self, prompt: str) -> str:
         if not self.http.validate_config().valid:

--- a/src/pipeline/plugins/resources/pg_vector_store.py
+++ b/src/pipeline/plugins/resources/pg_vector_store.py
@@ -9,13 +9,11 @@ from pgvector.asyncpg import register_vector
 from pipeline.plugins.resources.postgres_database import PostgresDatabaseResource
 from pipeline.plugins.resources.postgres_pool import PostgresConnectionPool
 from pipeline.resources.vectorstore import VectorStoreResource
-from pipeline.stages import PipelineStage
 
 
 class PgVectorStore(VectorStoreResource):
     """Postgres-backed vector store using pgvector."""
 
-    stages = [PipelineStage.PARSE]
     name = "vector_memory"
 
     def __init__(

--- a/src/pipeline/plugins/resources/postgres_database.py
+++ b/src/pipeline/plugins/resources/postgres_database.py
@@ -7,7 +7,6 @@ import asyncpg
 
 from pipeline.context import ConversationEntry
 from pipeline.resources.database import DatabaseResource
-from pipeline.stages import PipelineStage
 
 
 class PostgresDatabaseResource(DatabaseResource):
@@ -17,7 +16,6 @@ class PostgresDatabaseResource(DatabaseResource):
     details in YAML rather than hardcoding them in the class.
     """
 
-    stages = [PipelineStage.PARSE]
     name = "database"
 
     def __init__(self, config: Dict | None = None) -> None:
@@ -52,9 +50,6 @@ class PostgresDatabaseResource(DatabaseResource):
                 )
                 """
             )
-
-    async def _execute_impl(self, context) -> Any:  # pragma: no cover - no op
-        return None
 
     async def health_check(self) -> bool:
         if self._connection is None:

--- a/src/pipeline/plugins/resources/s3_filesystem.py
+++ b/src/pipeline/plugins/resources/s3_filesystem.py
@@ -4,15 +4,13 @@ from typing import Dict
 
 import aioboto3
 
-from pipeline.plugins import ResourcePlugin, ValidationResult
-from pipeline.resources import FileSystemResource
-from pipeline.stages import PipelineStage
+from pipeline.resources import BaseResource, FileSystemResource
+from pipeline.validation import ValidationResult
 
 
-class S3FileSystem(ResourcePlugin, FileSystemResource):
+class S3FileSystem(BaseResource, FileSystemResource):
     """S3-backed file storage using ``aioboto3``."""
 
-    stages = [PipelineStage.PARSE]
     name = "filesystem"
 
     def __init__(self, config: Dict | None = None) -> None:
@@ -25,9 +23,6 @@ class S3FileSystem(ResourcePlugin, FileSystemResource):
         if not config.get("bucket"):
             return ValidationResult.error_result("'bucket' is required")
         return ValidationResult.success_result()
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     async def store(self, key: str, content: bytes) -> str:
         async with aioboto3.client("s3", region_name=self.region) as s3:

--- a/src/pipeline/plugins/resources/sqlite_storage.py
+++ b/src/pipeline/plugins/resources/sqlite_storage.py
@@ -7,15 +7,13 @@ from typing import Dict, List, Optional
 import aiosqlite
 
 from pipeline.context import ConversationEntry
-from pipeline.plugins import ResourcePlugin
+from pipeline.resources.base import BaseResource
 from pipeline.resources.storage import StorageBackend
-from pipeline.stages import PipelineStage
 
 
-class SQLiteStorageResource(ResourcePlugin, StorageBackend):
+class SQLiteStorageResource(BaseResource, StorageBackend):
     """SQLite-based conversation history storage."""
 
-    stages = [PipelineStage.PARSE]
     name = "storage"
 
     def __init__(self, config: Dict | None = None) -> None:
@@ -36,9 +34,6 @@ class SQLiteStorageResource(ResourcePlugin, StorageBackend):
             )"""
         )
         await self._conn.commit()
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None
 
     async def save_history(
         self, conversation_id: str, history: List[ConversationEntry]

--- a/src/pipeline/plugins/resources/structured_logging.py
+++ b/src/pipeline/plugins/resources/structured_logging.py
@@ -6,11 +6,11 @@ import os
 from logging.handlers import RotatingFileHandler
 from typing import Any, Dict
 
-from pipeline.base_plugins import ResourcePlugin, ValidationResult
-from pipeline.stages import PipelineStage
+from pipeline.resources.base import BaseResource
+from pipeline.validation import ValidationResult
 
 
-class StructuredLogging(ResourcePlugin):
+class StructuredLogging(BaseResource):
     """Configure a unified JSON logger based on YAML configuration.
 
     Implements **Observable by Design (16)** by capturing structured logs for
@@ -19,7 +19,6 @@ class StructuredLogging(ResourcePlugin):
     the same location.
     """
 
-    stages = [PipelineStage.PARSE]
     name = "logging"
 
     def __init__(self, config: Dict | None = None) -> None:
@@ -122,8 +121,3 @@ class StructuredLogging(ResourcePlugin):
     async def initialize(self) -> None:
         self._configure_logging()
         self.logger = logging.getLogger(self.__class__.__name__)
-
-    async def _execute_impl(
-        self, context
-    ) -> Any:  # pragma: no cover - no runtime action
-        return None

--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,3 +1,4 @@
+from .base import BaseResource, Resource
 from .database import DatabaseResource
 from .filesystem import FileSystemResource
 from .llm import LLM, LLMResource
@@ -13,4 +14,6 @@ __all__ = [
     "FileSystemResource",
     "VectorStore",
     "VectorStoreResource",
+    "Resource",
+    "BaseResource",
 ]

--- a/src/pipeline/resources/base.py
+++ b/src/pipeline/resources/base.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Protocol, runtime_checkable
+
+from pipeline.logging import get_logger
+
+
+@runtime_checkable
+class Resource(Protocol):
+    """Minimal interface expected from a pipeline resource."""
+
+    async def initialize(self) -> None:
+        """Optional async initialization hook."""
+
+    async def shutdown(self) -> None:
+        """Optional cleanup hook."""
+
+    async def health_check(self) -> bool:
+        """Return ``True`` if the resource is healthy."""
+
+    def get_metrics(self) -> Dict[str, Any]:
+        """Return metrics about the resource."""
+
+
+class BaseResource:
+    """Convenient base class implementing :class:`Resource`."""
+
+    def __init__(self, config: Dict | None = None) -> None:
+        self.config = config or {}
+        self.logger = get_logger(self.__class__.__name__)
+
+    async def initialize(self) -> None:  # pragma: no cover - optional
+        return None
+
+    async def shutdown(self) -> None:  # pragma: no cover - optional
+        return None
+
+    async def health_check(self) -> bool:
+        return True
+
+    def get_metrics(self) -> Dict[str, Any]:
+        return {"status": "healthy"}

--- a/src/pipeline/resources/database.py
+++ b/src/pipeline/resources/database.py
@@ -4,14 +4,12 @@ from abc import ABC, abstractmethod
 from typing import List
 
 from pipeline.context import ConversationEntry
-from pipeline.plugins import ResourcePlugin
-from pipeline.stages import PipelineStage
+from pipeline.resources.base import BaseResource
 
 
-class DatabaseResource(ResourcePlugin, ABC):
+class DatabaseResource(BaseResource, ABC):
     """Abstract base class for database resources."""
 
-    stages = [PipelineStage.PARSE]
     name = "database"
 
     def __init__(self, config: dict | None = None) -> None:

--- a/src/pipeline/resources/llm.py
+++ b/src/pipeline/resources/llm.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
-from pipeline.base_plugins import ResourcePlugin
-from pipeline.stages import PipelineStage
+from pipeline.resources.base import BaseResource
 
 
 class LLM(ABC):
@@ -18,13 +17,8 @@ class LLM(ABC):
         return await self.generate(prompt)
 
 
-class LLMResource(ResourcePlugin, LLM):
+class LLMResource(BaseResource, LLM):
     """Base class for LLM-backed resources."""
-
-    stages = [PipelineStage.PARSE]
-
-    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - no op
-        return None
 
     async def generate(self, prompt: str) -> str:
         raise NotImplementedError

--- a/src/pipeline/resources/storage.py
+++ b/src/pipeline/resources/storage.py
@@ -5,8 +5,7 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict, List, Optional, Protocol
 
 from pipeline.context import ConversationEntry
-from pipeline.plugins import ResourcePlugin
-from pipeline.stages import PipelineStage
+from pipeline.resources.base import BaseResource
 
 
 class StorageBackend(Protocol):
@@ -36,10 +35,8 @@ class StorageBackend(Protocol):
         """Retrieve stored history for ``conversation_id``."""
 
 
-class StorageResource(ResourcePlugin, StorageBackend):
+class StorageResource(BaseResource, StorageBackend):
     """Base class for storage resources with connection pooling support."""
-
-    stages = [PipelineStage.PARSE]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/src/pipeline/resources/vectorstore.py
+++ b/src/pipeline/resources/vectorstore.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Dict, List
 
-from pipeline.base_plugins import ResourcePlugin
-from pipeline.stages import PipelineStage
+from pipeline.resources.base import BaseResource
 
 
 class VectorStore(ABC):
@@ -19,10 +18,5 @@ class VectorStore(ABC):
         """Return the ``k`` most similar items for ``query``."""
 
 
-class VectorStoreResource(ResourcePlugin, VectorStore, ABC):
+class VectorStoreResource(BaseResource, VectorStore, ABC):
     """Base class for vector store resources."""
-
-    stages = [PipelineStage.PARSE]
-
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
-        return None

--- a/src/registry/validator.py
+++ b/src/registry/validator.py
@@ -15,8 +15,8 @@ from pipeline.initializer import ClassRegistry  # noqa: E402
 from pipeline.initializer import SystemInitializer  # noqa: E402
 from pipeline.initializer import import_plugin_class  # noqa: E402
 from pipeline.logging import get_logger  # noqa: E402
-from pipeline.plugins import ValidationResult  # noqa: E402
 from pipeline.stages import PipelineStage  # noqa: E402
+from pipeline.validation import ValidationResult  # noqa: E402
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- introduce `Resource` protocol with a simple `BaseResource`
- refactor resources to implement this protocol instead of `ResourcePlugin`
- update initializer and CLI to recognize the new protocol
- adjust resource implementations to drop plugin inheritance

## Testing
- `black src/ tests/ --exclude 'src/cli/templates'`
- `isort src/ tests/ --skip src/cli/templates`
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/ --exclude 'src/cli/templates'` *(fails: various typing errors)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6865a1d1f98883228fcd2605f3d2329c