### PR TITLE
[Resource] decouple llm interfaces

### DIFF
--- a/src/pipeline/plugins/resources/claude.py
+++ b/src/pipeline/plugins/resources/claude.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
-from pipeline.resources.llm import LLMResource
+from pipeline.plugins.resources.llm_resource import LLMResource
 from pipeline.stages import PipelineStage
 
 

--- a/src/pipeline/plugins/resources/gemini.py
+++ b/src/pipeline/plugins/resources/gemini.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
-from pipeline.resources.llm import LLMResource
+from pipeline.plugins.resources.llm_resource import LLMResource
 from pipeline.stages import PipelineStage
 
 

--- a/src/pipeline/plugins/resources/llm/unified.py
+++ b/src/pipeline/plugins/resources/llm/unified.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, Type
 
 from pipeline.plugins import ValidationResult
-from pipeline.resources.llm import LLMResource
+from pipeline.plugins.resources.llm_resource import LLMResource
 
 from .providers import (
     ClaudeProvider,

--- a/src/pipeline/plugins/resources/ollama_llm.py
+++ b/src/pipeline/plugins/resources/ollama_llm.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
-from pipeline.resources.llm import LLMResource
+from pipeline.plugins.resources.llm_resource import LLMResource
 
 
 class OllamaLLMResource(LLMResource):

--- a/src/pipeline/plugins/resources/openai.py
+++ b/src/pipeline/plugins/resources/openai.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
-from pipeline.resources.llm import LLMResource
+from pipeline.plugins.resources.llm_resource import LLMResource
 
 
 class OpenAIResource(LLMResource):

--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,13 +1,12 @@
 from .database import DatabaseResource
 from .filesystem import FileSystemResource
-from .llm import LLM, LLMResource
+from .llm import LLM
 from .memory import Memory
 from .vector_store import VectorStoreResource
 from .vectorstore import VectorStore
 
 __all__ = [
     "LLM",
-    "LLMResource",
     "Memory",
     "DatabaseResource",
     "FileSystemResource",

--- a/src/pipeline/resources/base.py
+++ b/src/pipeline/resources/base.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Resource(Protocol):
+    """Lightweight interface for runtime resources."""
+
+    async def initialize(self) -> None:
+        """Perform optional async initialization."""
+
+    async def health_check(self) -> bool:
+        """Return ``True`` if the resource is healthy."""
+
+    def get_metrics(self) -> dict[str, Any]:
+        """Return metrics describing the resource."""

--- a/src/pipeline/resources/llm.py
+++ b/src/pipeline/resources/llm.py
@@ -1,32 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
-
-from pipeline.base_plugins import ResourcePlugin
-from pipeline.stages import PipelineStage
 
 
 class LLM(ABC):
-    """Interface for language model resources."""
+    """Abstract interface for language model resources."""
 
     @abstractmethod
     async def generate(self, prompt: str) -> str:
-        """Generate text in response to ``prompt``."""
-
-    async def __call__(self, prompt: str) -> str:
-        return await self.generate(prompt)
-
-
-class LLMResource(ResourcePlugin, LLM):
-    """Base class for LLM-backed resources."""
-
-    stages = [PipelineStage.PARSE]
-
-    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - no op
-        return None
-
-    async def generate(self, prompt: str) -> str:
-        raise NotImplementedError
-
-    __call__ = generate
+        """Return a completion for ``prompt``."""


### PR DESCRIPTION
## Summary
- make `LLM` a simple abstract class
- provide `Resource` protocol for initialization
- update imports to new plugin base

## Testing
- `black src/pipeline/resources tests/`
- `isort src/pipeline/resources tests`
- `flake8 src/ tests/`
- `mypy src/`
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: Configuration invalid: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: Configuration invalid: database "agent" does not exist)*
- `PYTHONPATH=src python -m src.registry.validator --config config/dev.yaml`
- `pytest tests/integration/ -v` *(fails: AttributeError and missing database)*
- `pytest tests/performance/ -m benchmark` *(fails: fixture 'benchmark' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a1d083e08322a47fc71978019451