### PR TITLE
[Resource] simplify MemoryResource registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ plugins:
     memory:
       type: memory
       database:
-        type: sqlite
+        type: pipeline.plugins.resources.sqlite_storage:SQLiteStorageResource
         path: ./agent.db
 ```
 
@@ -211,15 +211,15 @@ plugins:
     memory:
       type: memory
       database:
-        type: postgres
+        type: pipeline.plugins.resources.postgres_database:PostgresDatabaseResource
         host: localhost
         name: agent_db
       vector_store:
-        type: pgvector
+        type: pipeline.plugins.resources.pg_vector_store:PgVectorStore
         dimensions: 768
         table: embeddings
       filesystem:
-        type: s3
+        type: pipeline.plugins.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
 ```

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -28,7 +28,7 @@ plugins:
         type: pipeline.plugins.resources.sqlite_storage:SQLiteStorageResource
         path: ./dev.db
       filesystem:
-        type: s3
+        type: pipeline.plugins.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
   tools:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -33,7 +33,7 @@ plugins:
         username: "${DB_USERNAME}"
         password: "${DB_PASSWORD}"
       filesystem:
-        type: s3
+        type: pipeline.plugins.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
   tools:

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -28,7 +28,7 @@ plugins:
         type: pipeline.plugins.resources.sqlite_storage:SQLiteStorageResource
         path: ./agent.db
       filesystem:
-        type: s3
+        type: pipeline.plugins.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
   tools:

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -15,7 +15,7 @@ plugins:
     memory:
       type: memory
       database:
-        type: postgres
+        type: pipeline.plugins.resources.postgres_database:PostgresDatabaseResource
         host: localhost
         port: 5432
         name: dev_db
@@ -23,11 +23,11 @@ plugins:
         setup_commands:
           - "CREATE EXTENSION IF NOT EXISTS vector"
       vector_store:
-        type: pgvector
+        type: pipeline.plugins.resources.pg_vector_store:PgVectorStore
         dimensions: 768
         table: embeddings
       filesystem:
-        type: s3
+        type: pipeline.plugins.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
 ```
@@ -40,7 +40,7 @@ plugins:
     memory:
       type: memory
       database:
-        type: sqlite
+        type: pipeline.plugins.resources.sqlite_storage:SQLiteStorageResource
         path: ./agent.db
 ```
 

--- a/src/pipeline/plugins/resources/memory.py
+++ b/src/pipeline/plugins/resources/memory.py
@@ -5,12 +5,8 @@ from typing import Any, Dict, List
 from pipeline.context import ConversationEntry
 from pipeline.initializer import import_plugin_class
 from pipeline.plugins import ResourcePlugin, ValidationResult
-from pipeline.resources import (
-    DatabaseResource,
-    FileSystemResource,
-    Memory,
-    VectorStoreResource,
-)
+from pipeline.resources import (DatabaseResource, FileSystemResource, Memory,
+                                VectorStoreResource)
 from pipeline.stages import PipelineStage
 
 
@@ -66,11 +62,6 @@ class MemoryResource(ResourcePlugin, Memory):
             type_hint = cfg.get("type")
             if not type_hint:
                 return None
-
-            if key == "filesystem" and str(type_hint).lower() == "s3":
-                from .s3_filesystem import S3FileSystem
-
-                return S3FileSystem(cfg)
 
             cls_obj = import_plugin_class(type_hint)
             return cls_obj(cfg)

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -1,14 +1,8 @@
 import asyncio
 
-from pipeline import (
-    PipelineStage,
-    PluginRegistry,
-    PromptPlugin,
-    ResourceRegistry,
-    SystemRegistries,
-    ToolRegistry,
-    execute_pipeline,
-)
+from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
+                      ResourceRegistry, SystemRegistries, ToolRegistry,
+                      execute_pipeline)
 from pipeline.plugins.resources.memory import SimpleMemoryResource
 from pipeline.resources.memory import Memory
 
@@ -38,3 +32,10 @@ def test_memory_persists_between_runs():
     second = asyncio.run(execute_pipeline("again", registries))
     assert first == 1
     assert second == 2
+
+
+def test_memory_resource_name_constant():
+    from pipeline.plugins.resources.memory import MemoryResource
+
+    assert MemoryResource.name == "memory"
+    assert not hasattr(MemoryResource, "aliases")


### PR DESCRIPTION
## Summary
- ensure MemoryResource only registers under `"memory"`
- drop special alias handling when loading sub-resources
- document explicit plugin paths in README and docs
- update S3 filesystem config examples
- verify registration name with a new unit test

## Testing
- `black src/pipeline/plugins/resources/memory.py tests/test_memory_resource.py --exclude 'src/cli/templates/'`
- `isort src/pipeline/plugins/resources/memory.py tests/test_memory_resource.py`
- `flake8 src/pipeline/plugins/resources/memory.py tests/test_memory_resource.py`
- `mypy src/pipeline/plugins/resources/memory.py tests/test_memory_resource.py` *(failed: multiple errors)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(failed: database "agent" does not exist)*
- `python -m src.config.validator --config config/prod.yaml` *(failed: database "agent" does not exist)*
- `PYTHONPATH=src python src/registry/validator.py --config config/dev.yaml`
- `pytest tests/performance/ -m benchmark` *(failed: AttributeError: 'PluginRegistry' object has no attribute 'get_for_stage')*
- `pytest tests/integration/test_vector_memory_integration.py -v` *(failed: asyncpg.exceptions.InvalidCatalogNameError: database "agent_sandbox" does not exist)*
- `pytest tests/test_memory_resource.py::test_memory_resource_name_constant -v`


------
https://chatgpt.com/codex/tasks/task_e_6865a1db32708322b2055eb66383fa6c