### PR TITLE
docs: explain single-name resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,14 +122,9 @@ The `PostgresConnectionPool` resource manages asyncpg connections, while the
 
 There is no password.
 
-Ollama is available for LLM interactions. The Ollama server is running locally with the following details:
-
-Host: localhost
-Port: 11434
-Model: tinyllama
-Auth: None (insecure dev only)
-
-Startup: Automatically launched in background by the dev init script.
+A local LLM server is available at `http://localhost:11434` for development.
+Configure the `llm` resource with `provider: ollama` to use it. The dev init
+script launches the server automatically.
 
 ### Pipeline Stages
 
@@ -267,8 +262,9 @@ plugins:
       password: ""
       pool_min_size: 1
       pool_max_size: 5
-    ollama:
-      type: pipeline.plugins.resources.ollama_llm:OllamaLLMResource
+    llm:
+      type: pipeline.plugins.resources.llm.unified:UnifiedLLMResource
+      provider: ollama
       base_url: "http://localhost:11434"
       model: "llama3:8b"
 
@@ -299,8 +295,9 @@ plugins:
       password: "${DB_PASSWORD}"
       pool_min_size: 5
       pool_max_size: 20
-    openai:
-      type: openai_llm
+    llm:
+      type: pipeline.plugins.resources.llm.unified:UnifiedLLMResource
+      provider: openai
       api_key: "${OPENAI_API_KEY}"
       model: "gpt-4"
     logging:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -483,6 +483,35 @@ resource exposes a single canonical name to keep the mental model clear.
 
 **Reconfiguration Example**: Switch from OpenAI to local Ollama by changing one configuration line.
 
+
+### Single-Name Resources and Unified LLM
+
+Every resource registers under a single, unchanging name. The concrete implementation can vary or be composed of other resources, but callers always reference the same key. This keeps configuration small and mental models easy to grasp.
+
+The `UnifiedLLMResource` embodies this principle. Regardless of which provider you choose—OpenAI, Ollama, Claude or Gemini—the resource is simply named `llm`. Provider selection happens through the `provider` field:
+
+```yaml
+plugins:
+  resources:
+    llm:
+      type: pipeline.plugins.resources.llm.unified:UnifiedLLMResource
+      provider: openai
+      api_key: ${OPENAI_API_KEY}
+```
+
+Switching to a local Ollama server requires only a single line change:
+
+```yaml
+plugins:
+  resources:
+    llm:
+      type: pipeline.plugins.resources.llm.unified:UnifiedLLMResource
+      provider: ollama
+      base_url: http://localhost:11434
+      model: llama3:8b
+```
+
+Because the name stays constant, plugins and configuration always refer to the same key. This simplifies reasoning and reinforces the single-name resource principle across the entire framework.
 #### **Tool Plugins** (Functionality - Performs Tasks for Agents)
 - **Weather**: Get current conditions, forecasts
 - **Calculator**: Mathematical computations


### PR DESCRIPTION
## Summary
- document how to select an LLM provider through the unified resource
- clean up provider-specific examples in AGENTS.md
- add a new architecture section describing the single-name resource principle

## Testing
- `black --exclude 'src/cli/templates/' .`
- `isort . --skip src/cli/templates/`
- `flake8` *(fails: command not found)*
- `mypy src/ --exclude 'src/cli/templates/*'` *(fails: several typing errors)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest -k "" -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6865a1dc59408322b7f6bcd0f60c519c