### PR TITLE
[Core] resolve merge conflicts and update LLM resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,7 @@
 When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
-<<<<<<< HEAD
-- ``UnifiedLLMResource`` – configured with the ``echo`` provider by default.
-=======
-- ``UnifiedLLMResource`` (provider ``echo``) – minimal LLM resource that simply echoes prompts.
->>>>>>> 8b97def929145abb996b25b8e31999e109bc9598
+- ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
 - ``MemoryResource`` – unified interface that delegates to an in-memory backend by default.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -12,14 +12,14 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))  # noq
 from entity import Agent  # noqa: E402
 from pipeline import PipelineStage, PromptPlugin  # noqa: E402
 from pipeline.context import PluginContext  # noqa: E402
-from pipeline.plugins.resources.local_filesystem import (  # noqa: E402
+from pipeline.plugins.resources.local_filesystem import (
     LocalFileSystemResource,
-)
+)  # noqa: E402
 from pipeline.plugins.resources.memory import MemoryResource  # noqa: E402
 from pipeline.plugins.resources.pg_vector_store import PgVectorStore  # noqa: E402
-from pipeline.plugins.resources.sqlite_storage import (  # noqa: E402
+from pipeline.plugins.resources.sqlite_storage import (
     SQLiteStorageResource as SQLiteDatabaseResource,
-)
+)  # noqa: E402
 
 
 class StorePrompt(PromptPlugin):

--- a/examples/pipelines/pipeline_example.py
+++ b/examples/pipelines/pipeline_example.py
@@ -20,11 +20,7 @@ from pipeline import (
     ToolRegistry,
     execute_pipeline,
 )
-<<<<<<< HEAD
-from pipeline.plugins.resources.llm import UnifiedLLMResource
-=======
 from pipeline.plugins.resources.llm.unified import UnifiedLLMResource
->>>>>>> 8b97def929145abb996b25b8e31999e109bc9598
 
 
 class CalculatorTool(ToolPlugin):
@@ -74,12 +70,7 @@ def setup_registries() -> SystemRegistries:
     tools.add("calculator", CalculatorTool())
 
     resources.add(
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "ollama",
-=======
         "llm",
->>>>>>> 8b97def929145abb996b25b8e31999e109bc9598
         UnifiedLLMResource(
             {
                 "provider": "ollama",
@@ -87,13 +78,6 @@ def setup_registries() -> SystemRegistries:
                 "model": "tinyllama",
             }
         ),
-<<<<<<< HEAD
-=======
-        "llm",
-        OllamaLLMResource({"base_url": "http://localhost:11434", "model": "tinyllama"}),
->>>>>>> d413bfe50cf145aa10f8b54f30ac78babd0bc417
-=======
->>>>>>> 8b97def929145abb996b25b8e31999e109bc9598
     )
 
     plugins.register_plugin_for_stage(

--- a/examples/pipelines/vector_memory_pipeline.py
+++ b/examples/pipelines/vector_memory_pipeline.py
@@ -17,11 +17,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))  # noq
 from entity import Agent  # noqa: E402
 from pipeline import PipelineStage, PromptPlugin, ResourcePlugin  # noqa: E402
 from pipeline.context import PluginContext  # noqa: E402
-<<<<<<< HEAD
-from pipeline.plugins.resources.llm import UnifiedLLMResource  # noqa: E402
-=======
 from pipeline.plugins.resources.llm.unified import UnifiedLLMResource  # noqa: E402
->>>>>>> 8b97def929145abb996b25b8e31999e109bc9598
 from pipeline.plugins.resources.pg_vector_store import PgVectorStore  # noqa: E402
 from pipeline.plugins.resources.postgres_database import (
     PostgresDatabaseResource,
@@ -76,18 +72,7 @@ def main() -> None:
             }
         ),
     )
-<<<<<<< HEAD
-<<<<<<< HEAD
-    agent.resource_registry.add(
-        "ollama",
-        UnifiedLLMResource({"provider": "echo"}),
-    )
-=======
-    agent.resource_registry.add("llm", EchoLLMResource())
->>>>>>> d413bfe50cf145aa10f8b54f30ac78babd0bc417
-=======
     agent.resource_registry.add("llm", UnifiedLLMResource({"provider": "echo"}))
->>>>>>> 8b97def929145abb996b25b8e31999e109bc9598
     agent.resource_registry.add("vector_memory", VectorMemoryResource())
     agent.plugin_registry.register_plugin_for_stage(
         ComplexPrompt(), PipelineStage.THINK

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -88,16 +88,11 @@ class PluginContext:
         """Return a shared resource plugin registered as ``name``."""
         return self._registries.resources.get(name)
 
-<<<<<<< HEAD
-    def get_llm(self) -> Any | None:
-        """Return the configured LLM resource registered as ``"llm"``."""
-
-        return self.get_resource("llm")
-=======
     def get_llm(self) -> LLM:
         """Return the configured LLM resource.
 
-        Raises a :class:`RuntimeError` if no ``"llm"`` resource is found.
+        Raises:
+            RuntimeError: If no ``"llm"`` resource is found.
         """
         llm = self.get_resource("llm")
         if llm is None:
@@ -105,7 +100,6 @@ class PluginContext:
                 "No LLM resource configured. Add 'llm' to resources section."
             )
         return cast(LLM, llm)
->>>>>>> d413bfe50cf145aa10f8b54f30ac78babd0bc417
 
     @property
     def message(self) -> str:

--- a/src/pipeline/plugins/resources/claude.py
+++ b/src/pipeline/plugins/resources/claude.py
@@ -3,13 +3,8 @@ from __future__ import annotations
 from typing import Dict
 
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
-<<<<<<< HEAD
-from pipeline.resources.llm import LLMResource
-from pipeline.validation import ValidationResult
-=======
 from pipeline.plugins.resources.llm_resource import LLMResource
-from pipeline.stages import PipelineStage
->>>>>>> cf2f639e2825c3c5653576aef6ed05524944e947
+from pipeline.validation import ValidationResult
 
 
 class ClaudeResource(LLMResource):

--- a/src/pipeline/plugins/resources/gemini.py
+++ b/src/pipeline/plugins/resources/gemini.py
@@ -3,13 +3,8 @@ from __future__ import annotations
 from typing import Dict
 
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
-<<<<<<< HEAD
-from pipeline.resources.llm import LLMResource
-from pipeline.validation import ValidationResult
-=======
 from pipeline.plugins.resources.llm_resource import LLMResource
-from pipeline.stages import PipelineStage
->>>>>>> cf2f639e2825c3c5653576aef6ed05524944e947
+from pipeline.validation import ValidationResult
 
 
 class GeminiResource(LLMResource):

--- a/src/pipeline/plugins/resources/llm/unified.py
+++ b/src/pipeline/plugins/resources/llm/unified.py
@@ -2,13 +2,8 @@ from __future__ import annotations
 
 from typing import Dict, Type
 
-<<<<<<< HEAD
-from pipeline.resources.llm import LLMResource
-from pipeline.validation import ValidationResult
-=======
 from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.llm_resource import LLMResource
->>>>>>> cf2f639e2825c3c5653576aef6ed05524944e947
 
 from .providers import (
     ClaudeProvider,

--- a/src/pipeline/plugins/resources/memory.py
+++ b/src/pipeline/plugins/resources/memory.py
@@ -4,31 +4,28 @@ from typing import Any, Dict, List
 
 from pipeline.context import ConversationEntry
 from pipeline.initializer import import_plugin_class
-<<<<<<< HEAD
+from pipeline.plugins import ResourcePlugin, ValidationResult
 from pipeline.resources import (
-    BaseResource,
     DatabaseResource,
     FileSystemResource,
     Memory,
     VectorStoreResource,
 )
-from pipeline.validation import ValidationResult
-=======
-from pipeline.plugins import ResourcePlugin, ValidationResult
-from pipeline.resources import (DatabaseResource, FileSystemResource, Memory,
-                                VectorStoreResource)
 from pipeline.stages import PipelineStage
->>>>>>> 2f11255869dff0db634640e503f183cca2160667
 
 
-class SimpleMemoryResource(BaseResource, Memory):
+class SimpleMemoryResource(ResourcePlugin, Memory):
     """Basic in-memory key/value store."""
 
+    stages = [PipelineStage.PARSE]
     name = "memory"
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)
         self._store: Dict[str, Any] = {}
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
+        return None
 
     def get(self, key: str, default: Any | None = None) -> Any:
         return self._store.get(key, default)
@@ -40,9 +37,10 @@ class SimpleMemoryResource(BaseResource, Memory):
         self._store.clear()
 
 
-class MemoryResource(BaseResource, Memory):
+class MemoryResource(ResourcePlugin, Memory):
     """Composite memory resource composed of optional backends."""
 
+    stages = [PipelineStage.PARSE]
     name = "memory"
 
     def __init__(
@@ -76,6 +74,9 @@ class MemoryResource(BaseResource, Memory):
         vector_store = build("vector_store")
         filesystem = build("filesystem")
         return cls(database, vector_store, filesystem, config)
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
+        return None
 
     def get(self, key: str, default: Any | None = None) -> Any:
         return self._kv.get(key, default)

--- a/src/pipeline/plugins/resources/ollama_llm.py
+++ b/src/pipeline/plugins/resources/ollama_llm.py
@@ -3,12 +3,8 @@ from __future__ import annotations
 from typing import Dict
 
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
-<<<<<<< HEAD
-from pipeline.resources.llm import LLMResource
-from pipeline.validation import ValidationResult
-=======
 from pipeline.plugins.resources.llm_resource import LLMResource
->>>>>>> cf2f639e2825c3c5653576aef6ed05524944e947
+from pipeline.validation import ValidationResult
 
 
 class OllamaLLMResource(LLMResource):

--- a/src/pipeline/plugins/resources/openai.py
+++ b/src/pipeline/plugins/resources/openai.py
@@ -3,12 +3,8 @@ from __future__ import annotations
 from typing import Dict
 
 from pipeline.plugins.resources.http_llm_resource import HttpLLMResource
-<<<<<<< HEAD
-from pipeline.resources.llm import LLMResource
-from pipeline.validation import ValidationResult
-=======
 from pipeline.plugins.resources.llm_resource import LLMResource
->>>>>>> cf2f639e2825c3c5653576aef6ed05524944e947
+from pipeline.validation import ValidationResult
 
 
 class OpenAIResource(LLMResource):

--- a/src/pipeline/plugins/resources/postgres_database.py
+++ b/src/pipeline/plugins/resources/postgres_database.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import asyncpg
 

--- a/src/pipeline/plugins/resources/structured_logging.py
+++ b/src/pipeline/plugins/resources/structured_logging.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from logging.handlers import RotatingFileHandler
-from typing import Any, Dict
+from typing import Dict
 
 from pipeline.resources.base import BaseResource
 from pipeline.validation import ValidationResult

--- a/src/pipeline/resources/base.py
+++ b/src/pipeline/resources/base.py
@@ -1,37 +1,25 @@
 from __future__ import annotations
 
-<<<<<<< HEAD
 from typing import Any, Dict, Protocol, runtime_checkable
 
 from pipeline.logging import get_logger
-=======
-from typing import Any, Protocol, runtime_checkable
->>>>>>> cf2f639e2825c3c5653576aef6ed05524944e947
 
 
 @runtime_checkable
 class Resource(Protocol):
-<<<<<<< HEAD
-    """Minimal interface expected from a pipeline resource."""
-
-    async def initialize(self) -> None:
-        """Optional async initialization hook."""
-
-    async def shutdown(self) -> None:
-        """Optional cleanup hook."""
-=======
     """Lightweight interface for runtime resources."""
 
     async def initialize(self) -> None:
         """Perform optional async initialization."""
->>>>>>> cf2f639e2825c3c5653576aef6ed05524944e947
+
+    async def shutdown(self) -> None:
+        """Perform optional cleanup."""
 
     async def health_check(self) -> bool:
         """Return ``True`` if the resource is healthy."""
 
-<<<<<<< HEAD
-    def get_metrics(self) -> Dict[str, Any]:
-        """Return metrics about the resource."""
+    def get_metrics(self) -> dict[str, Any]:
+        """Return metrics describing the resource."""
 
 
 class BaseResource:
@@ -50,9 +38,5 @@ class BaseResource:
     async def health_check(self) -> bool:
         return True
 
-    def get_metrics(self) -> Dict[str, Any]:
-        return {"status": "healthy"}
-=======
     def get_metrics(self) -> dict[str, Any]:
-        """Return metrics describing the resource."""
->>>>>>> cf2f639e2825c3c5653576aef6ed05524944e947
+        return {"status": "healthy"}

--- a/src/pipeline/resources/llm.py
+++ b/src/pipeline/resources/llm.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-<<<<<<< HEAD
-from typing import Any
-
-from pipeline.resources.base import BaseResource
-=======
->>>>>>> cf2f639e2825c3c5653576aef6ed05524944e947
 
 
 class LLM(ABC):
@@ -14,20 +8,7 @@ class LLM(ABC):
 
     @abstractmethod
     async def generate(self, prompt: str) -> str:
-<<<<<<< HEAD
-        """Generate text in response to ``prompt``."""
+        """Return text in response to ``prompt``."""
 
     async def __call__(self, prompt: str) -> str:
         return await self.generate(prompt)
-
-
-class LLMResource(BaseResource, LLM):
-    """Base class for LLM-backed resources."""
-
-    async def generate(self, prompt: str) -> str:
-        raise NotImplementedError
-
-    __call__ = generate
-=======
-        """Return a completion for ``prompt``."""
->>>>>>> cf2f639e2825c3c5653576aef6ed05524944e947

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -146,9 +146,5 @@ def test_llm_resource_registration(tmp_path):
     initializer = SystemInitializer.from_yaml(str(path))
     _, resources, _ = asyncio.run(initializer.initialize())
 
-<<<<<<< HEAD
-    assert resources.get("llm")
-=======
     assert resources.get("llm") is not None
     assert resources.get("ollama") is None
->>>>>>> 76ab4f7efc6ba6494c4bfcf402a8f75b50b54588

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -1,8 +1,14 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      ResourceRegistry, SystemRegistries, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.plugins.resources.memory import SimpleMemoryResource
 from pipeline.resources.memory import Memory
 


### PR DESCRIPTION
## Summary
- clean up leftover merge conflict markers
- simplify LLM resources and imports
- fix examples
- enforce formatting with black and isort

## Testing
- `flake8 src/ tests/`
- `mypy src/pipeline src/pipeline/plugins src/pipeline/resources` *(fails: Duplicate module named "pipeline.plugins")*
- `bandit -r src/ -q`
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'asyncpg')*
- `python -m src.registry.validator` *(fails: No module named 'pipeline')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_6865a6a3d8c48322bb291d92fda6af64