### PR TITLE
[Resource] Add DuckDB database resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,18 @@ plugins:
         path: ./agent.db
 ```
 
+### DuckDB Configuration
+```yaml
+plugins:
+  resources:
+    memory:
+      type: memory
+      database:
+        type: pipeline.plugins.resources.duckdb_database:DuckDBDatabaseResource
+        path: ./agent.duckdb
+        history_table: chat_history
+```
+
 ### Advanced Configuration
 ```yaml
 plugins:
@@ -230,6 +242,10 @@ plugins:
 memory = MemoryResource(
     database=SQLiteDatabaseResource("./agent.db")
 )
+
+# Use DuckDB
+duckdb_resource = DuckDBDatabaseResource({"path": "./agent.duckdb"})
+memory_duckdb = MemoryResource(database=duckdb_resource)
 
 # Evolve to complex
 postgres = PostgresDatabaseResource(connection_str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ aiosqlite = "^0.20.0"
 pgvector = "^0.4.1"
 httpx = "^0.27.0"
 aioboto3 = "^15.0.0"
+duckdb = "^1.3.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"

--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -1,3 +1,5 @@
+from .duckdb_database import DuckDBDatabaseResource
+from .duckdb_vector_store import DuckDBVectorStore
 from .llm import UnifiedLLMResource
 from .llm_resource import LLMResource
 from .local_filesystem import LocalFileSystemResource
@@ -14,7 +16,9 @@ __all__ = [
     "SimpleMemoryResource",
     "StructuredLogging",
     "PostgresDatabaseResource",
+    "DuckDBDatabaseResource",
     "PgVectorStore",
+    "DuckDBVectorStore",
     "LocalFileSystemResource",
     "S3FileSystem",
 ]

--- a/src/pipeline/plugins/resources/duckdb_database.py
+++ b/src/pipeline/plugins/resources/duckdb_database.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Dict, List, Optional
+
+import duckdb
+
+from pipeline.context import ConversationEntry
+from pipeline.resources.database import DatabaseResource
+
+
+class DuckDBDatabaseResource(DatabaseResource):
+    """DuckDB-based conversation history storage."""
+
+    name = "database"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self._path = self.config.get("path", ":memory:")
+        self._history_table = self.config.get("history_table")
+        self._connection: Optional[duckdb.DuckDBPyConnection] = None
+
+    async def initialize(self) -> None:
+        self._connection = await asyncio.to_thread(duckdb.connect, self._path)
+        if self._history_table:
+            await asyncio.to_thread(
+                self._connection.execute,
+                f"""CREATE TABLE IF NOT EXISTS {self._history_table} (
+                conversation_id TEXT,
+                role TEXT,
+                content TEXT,
+                metadata TEXT,
+                timestamp TIMESTAMP
+            )""",
+            )
+
+    async def health_check(self) -> bool:
+        if self._connection is None:
+            return False
+        try:
+            await asyncio.to_thread(self._connection.execute, "SELECT 1")
+            return True
+        except Exception:
+            return False
+
+    async def save_history(
+        self, conversation_id: str, history: List[ConversationEntry]
+    ) -> None:
+        if self._connection is None or not self._history_table:
+            return
+        for entry in history:
+            await asyncio.to_thread(
+                self._connection.execute,
+                (
+                    f"INSERT INTO {self._history_table} "
+                    "(conversation_id, role, content, metadata, timestamp) "
+                    "VALUES (?, ?, ?, ?, ?)"
+                ),
+                [
+                    conversation_id,
+                    entry.role,
+                    entry.content,
+                    json.dumps(entry.metadata),
+                    entry.timestamp,
+                ],
+            )
+
+    async def load_history(self, conversation_id: str) -> List[ConversationEntry]:
+        if self._connection is None or not self._history_table:
+            return []
+        rel = await asyncio.to_thread(
+            self._connection.execute,
+            (
+                f"SELECT role, content, metadata, timestamp FROM {self._history_table} "
+                "WHERE conversation_id = ? ORDER BY timestamp"
+            ),
+            [conversation_id],
+        )
+        rows = await asyncio.to_thread(rel.fetchall)
+        history: List[ConversationEntry] = []
+        for role, content, metadata, ts in rows:
+            metadata_dict = json.loads(metadata) if metadata else {}
+            history.append(
+                ConversationEntry(
+                    content=content,
+                    role=role,
+                    metadata=metadata_dict,
+                    timestamp=ts,
+                )
+            )
+        return history
+
+    async def shutdown(self) -> None:
+        if self._connection is not None:
+            await asyncio.to_thread(self._connection.close)
+            self._connection = None

--- a/src/pipeline/plugins/resources/duckdb_vector_store.py
+++ b/src/pipeline/plugins/resources/duckdb_vector_store.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List, Optional
+
+import duckdb
+
+from pipeline.plugins.resources.duckdb_database import DuckDBDatabaseResource
+from pipeline.resources.vectorstore import VectorStoreResource
+
+
+class DuckDBVectorStore(VectorStoreResource):
+    """Simple DuckDB-backed vector store."""
+
+    name = "vector_memory"
+
+    def __init__(
+        self,
+        config: Dict | None = None,
+        connection: DuckDBDatabaseResource | None = None,
+    ) -> None:
+        super().__init__(config)
+        self._table = self.config.get("table", "vector_memory")
+        self._dim = int(self.config.get("dimensions", 3))
+        self._external = connection
+        self._connection: Optional[duckdb.DuckDBPyConnection] = None
+        if isinstance(connection, DuckDBDatabaseResource):
+            self._connection = connection._connection
+
+    async def initialize(self) -> None:
+        if self._connection is None:
+            self._connection = await asyncio.to_thread(
+                duckdb.connect, self.config.get("path", ":memory:")
+            )
+        await asyncio.to_thread(
+            self._connection.execute,
+            f"CREATE TABLE IF NOT EXISTS {self._table} (text TEXT, embedding DOUBLE[{self._dim}])",
+        )
+
+    def _embed(self, text: str) -> List[float]:
+        values = [0.0] * self._dim
+        for i, byte in enumerate(text.encode("utf-8")):
+            values[i % self._dim] += float(byte)
+        return [v / 255.0 for v in values]
+
+    async def add_embedding(self, text: str, metadata: Dict | None = None) -> None:
+        embedding = self._embed(text)
+        if self._connection is None:
+            raise RuntimeError("Resource not initialized")
+        await asyncio.to_thread(
+            self._connection.execute,
+            f"INSERT INTO {self._table} (text, embedding) VALUES (?, ?)",
+            [text, embedding],
+        )
+
+    async def query_similar(self, query: str, k: int) -> List[str]:
+        embedding = self._embed(query)
+        if self._connection is None:
+            return []
+        query = (
+            f"SELECT text FROM {self._table} "
+            "ORDER BY list_cosine_similarity(embedding, ?) DESC LIMIT ?"
+        )
+        rel = await asyncio.to_thread(
+            self._connection.execute,
+            query,
+            [embedding, k],
+        )
+        rows = await asyncio.to_thread(rel.fetchall)
+        return [row[0] for row in rows]
+
+    async def shutdown(self) -> None:
+        if self._connection is not None and not self._external:
+            await asyncio.to_thread(self._connection.close)
+            self._connection = None

--- a/tests/test_duckdb_resource.py
+++ b/tests/test_duckdb_resource.py
@@ -1,0 +1,20 @@
+import asyncio
+from datetime import datetime
+
+from pipeline.context import ConversationEntry
+from pipeline.plugins.resources.duckdb_database import DuckDBDatabaseResource
+
+
+def test_duckdb_history_roundtrip(tmp_path):
+    async def run():
+        cfg = {"path": tmp_path / "test.duckdb", "history_table": "history"}
+        resource = DuckDBDatabaseResource(cfg)
+        await resource.initialize()
+        entry = ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        await resource.save_history("conv1", [entry])
+        rows = await resource.load_history("conv1")
+        await resource.shutdown()
+        return rows
+
+    history = asyncio.run(run())
+    assert history and history[0].content == "hi"

--- a/tests/test_duckdb_vector_store.py
+++ b/tests/test_duckdb_vector_store.py
@@ -1,0 +1,17 @@
+import asyncio
+
+from pipeline.plugins.resources.duckdb_vector_store import DuckDBVectorStore
+
+
+def test_vector_store_roundtrip(tmp_path):
+    async def run():
+        cfg = {"path": tmp_path / "vec.duckdb", "table": "vectors", "dimensions": 3}
+        store = DuckDBVectorStore(cfg)
+        await store.initialize()
+        await store.add_embedding("hello")
+        results = await store.query_similar("hello", 1)
+        await store.shutdown()
+        return results
+
+    result = asyncio.run(run())
+    assert result == ["hello"]


### PR DESCRIPTION
## Summary
- add DuckDBDatabaseResource and DuckDBVectorStore
- export them via resources package
- document DuckDB usage
- include basic tests and integration coverage

## Testing
- `flake8 src/pipeline/plugins/resources/duckdb_database.py src/pipeline/plugins/resources/duckdb_vector_store.py tests/test_duckdb_resource.py tests/test_duckdb_vector_store.py tests/integration/test_chat_history_backends.py src/pipeline/plugins/resources/__init__.py`
- `mypy src/ --exclude 'src/cli/templates/'` *(fails: invalid syntax in templates)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: PostgresDatabaseResource has no attribute validate_dependencies)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: PostgresDatabaseResource has no attribute validate_dependencies)*
- `PYTHONPATH=src python -m src.registry.validator --config config/dev.yaml` *(fails: Plugin 'database' does not specify any stages)*
- `pytest tests/integration/ -v` *(fails: multiple tests fail due to missing dependencies)*
- `pytest tests/performance/ -m benchmark` *(fails: benchmark fixture missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865c05b32d0832292f9c99b4bba8055