### PR TITLE
[Infrastructure] Add Terraform helper and docs

### DIFF
--- a/docs/source/aws_deployment.md
+++ b/docs/source/aws_deployment.md
@@ -1,0 +1,17 @@
+# AWS Deployment Guide
+
+This guide shows how to deploy basic AWS resources using the
+``Infrastructure`` wrapper, which leverages the Terraform Python SDK
+(``cdktf``).
+
+## Example
+
+```python
+from infrastructure.aws_basic import BasicAwsInfrastructure
+
+infra = BasicAwsInfrastructure("us-east-1")
+infra.deploy()
+```
+
+The ``deploy`` method synthesizes Terraform configuration. You can then
+run ``cdktf deploy`` to provision resources.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -53,6 +53,7 @@ config
 context
 plugin_guide
 advanced_usage
+aws_deployment
 principle_checklist
 apidocs/index
 ```

--- a/mypy.ini
+++ b/mypy.ini
@@ -26,3 +26,9 @@ ignore_missing_imports = True
 [mypy-pgvector.*]
 ignore_missing_imports = True
 
+[mypy-cdktf.*]
+ignore_missing_imports = True
+
+[mypy-cdktf_cdktf_provider_aws.*]
+ignore_missing_imports = True
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ pgvector = "^0.4.1"
 httpx = "^0.27.0"
 aioboto3 = "^15.0.0"
 duckdb = "^1.3.1"
+cdktf = "^0.20.0"
+cdktf-cdktf-provider-aws = "^14.0.0"
+constructs = "^10.3.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"

--- a/src/infrastructure/__init__.py
+++ b/src/infrastructure/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure utilities for deploying resources with Terraform."""
+
+from .infrastructure import Infrastructure
+
+__all__ = ["Infrastructure"]

--- a/src/infrastructure/aws_basic.py
+++ b/src/infrastructure/aws_basic.py
@@ -1,0 +1,18 @@
+"""Minimal AWS example using :class:`Infrastructure`."""
+
+from cdktf import TerraformOutput
+from cdktf_cdktf_provider_aws.provider import AwsProvider
+
+from .infrastructure import Infrastructure
+
+
+class BasicAwsInfrastructure(Infrastructure):
+    def __init__(self, region: str) -> None:
+        super().__init__("aws-basic")
+        AwsProvider(self.stack, "aws", region=region)
+        TerraformOutput(self.stack, "region", value=region)
+
+
+if __name__ == "__main__":
+    infra = BasicAwsInfrastructure("us-east-1")
+    infra.deploy()

--- a/src/infrastructure/infrastructure.py
+++ b/src/infrastructure/infrastructure.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from cdktf import App, TerraformStack
+
+
+class Infrastructure:
+    """Simplified wrapper around a Terraform stack."""
+
+    def __init__(self, name: str) -> None:
+        self.app = App()
+        self.stack = TerraformStack(self.app, name)
+
+    def deploy(self) -> None:
+        """Generate Terraform configuration for this stack."""
+        self.app.synth()


### PR DESCRIPTION
## Summary
- add `infrastructure` package
- provide `Infrastructure` class and AWS example
- document deployment steps in new guide
- link AWS docs in index
- ignore cdktf imports in mypy
- add cdktf dependencies

## Testing
- `black src/ tests/`
- `isort src/infrastructure`
- `flake8 src/infrastructure`
- `mypy src/infrastructure`
- `bandit -r src/infrastructure`
- `python -m src.config.validator --config config/dev.yaml` *(failed: No module named 'duckdb')*
- `python -m src.config.validator --config config/prod.yaml` *(failed: No module named 'duckdb')*
- `PYTHONPATH=src python -m src.registry.validator --config config/dev.yaml` *(failed: plugin validation error)*
- `pytest tests/integration/ -v` *(failed: missing fixture 'benchmark')*
- `pytest tests/performance/ -m benchmark` *(failed: fixture 'benchmark' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a2bdeb0c832292728ad2e07a27c7