### PR TITLE
[Docs] Add AWS deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,3 +317,8 @@ The `S3FileSystem` backend persists files in Amazon S3. Configure the
    - Clear interfaces for each backend
 
 This composition pattern would significantly improve the framework's usability while maintaining its flexibility. It's a perfect example of "simple things simple, complex things possible."
+
+## AWS Deployment
+
+Use Terraform's Python SDK to provision AWS databases, storage, and compute resources. The [deployment guide](docs/source/deploy_aws.md) walks through a minimal setup on Amazon Web Services.
+

--- a/docs/source/deploy_aws.md
+++ b/docs/source/deploy_aws.md
@@ -1,0 +1,66 @@
+# AWS Deployment Guide
+
+Deploying the Entity Pipeline Framework on AWS lets you scale reliably with managed services. This guide outlines required resources and provides a Python example that drives Terraform to create them.
+
+## Required AWS Resources
+
+- **Database**: Amazon RDS (PostgreSQL) or DynamoDB for durable state.
+- **Storage**: S3 bucket for file uploads and static assets.
+- **Compute**: ECS service or AWS Lambda function to run the agent.
+- **Networking**: VPC, subnets and security groups to control access.
+- **IAM Roles**: permissions for the compute layer to access the database and S3.
+
+## Terraform with Python
+
+The [python-terraform](https://github.com/beelit94/python-terraform) package lets you drive Terraform commands from Python. Keep your `.tf` files in an `infra/` directory and orchestrate them with a small helper class.
+
+```python
+from python_terraform import Terraform
+
+class EntityAWSInfra:
+    """Wrap Terraform commands for object oriented clarity."""
+
+    def __init__(self, working_dir: str = "infra") -> None:
+        self.tf = Terraform(working_dir=working_dir)
+
+    def init(self) -> None:
+        self.tf.init()
+
+    def apply(self) -> None:
+        # --auto-approve avoids interactive prompts
+        self.tf.apply(skip_plan=True, auto_approve=True)
+
+if __name__ == "__main__":
+    infra = EntityAWSInfra()
+    infra.init()
+    infra.apply()
+```
+
+### Example Terraform Files
+
+Below is a minimal `main.tf` showing the core resources. Adjust values to fit your environment.
+
+```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "files" {
+  bucket = "entity-files"
+}
+
+resource "aws_db_instance" "postgres" {
+  allocated_storage    = 20
+  engine               = "postgres"
+  instance_class       = "db.t3.micro"
+  name                 = "entity"
+  username             = "entity"
+  password             = "${var.db_password}"
+  skip_final_snapshot  = true
+}
+
+resource "aws_ecs_cluster" "agent" {}
+```
+
+Run the Python helper after creating these `.tf` files to provision the infrastructure.
+

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -12,6 +12,7 @@
 - [`memory_composition_pipeline.py`](../../examples/pipelines/memory_composition_pipeline.py)
   shows how to compose the ``MemoryResource`` with SQLite, PGVector, and a local
   filesystem backend.
+- [AWS deployment guide](deploy_aws.md) shows how to provision AWS resources with the Terraform Python SDK.
 - **Postgres connection pooling**
   ```python
   PostgresResource(
@@ -54,6 +55,7 @@ context
 plugin_guide
 advanced_usage
 principle_checklist
+deploy_aws
 apidocs/index
 ```
 


### PR DESCRIPTION
## Summary
- document required AWS services and Terraform steps
- link new deployment doc from docs/index
- mention deployment guide in README

## Testing
- `poetry run black src tests`
- `poetry run isort src tests` *(reverted changes)*
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: PostgresDatabaseResource has no attribute validate_dependencies)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: PostgresDatabaseResource has no attribute validate_dependencies)*
- `PYTHONPATH=src poetry run python -m src.registry.validator --config config/dev.yaml` *(fails: Plugin 'database' does not specify any stages)*
- `PYTHONPATH=src poetry run python -m src.registry.validator --config config/prod.yaml` *(fails: Plugin 'database' does not specify any stages)*
- `poetry run pytest tests/integration/ -v` *(fails: 5 failed, 1 skipped)*
- `poetry run pytest tests/performance/ -m benchmark`

------
https://chatgpt.com/codex/tasks/task_e_6866a2c0db18832291f834835c4c7b12