### PR TITLE
Add AWS deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ pip install entity-pipeline
 python src/cli.py --config config.yaml
 ```
 <!-- end quick_start -->
+For an infrastructure walkthrough on Amazon Web Services, see the [AWS deployment guide](docs/source/deploy_aws.md).
 
 <!-- start config -->
 The ``llm`` resource now accepts a ``provider`` key. Choose from ``openai``,

--- a/docs/source/deploy_aws.md
+++ b/docs/source/deploy_aws.md
@@ -1,0 +1,59 @@
+# AWS Deployment Guide
+
+This guide outlines the core AWS services required to run the framework in production and demonstrates how to provision them using the Terraform Python SDK.
+
+## Required Resources
+
+- **Database**: either Amazon RDS for relational workloads or DynamoDB for serverless NoSQL.
+- **Object Storage**: an S3 bucket for file and model storage.
+- **Compute**: choose between ECS for containerized workloads or Lambda for serverless functions.
+- **Networking**: a VPC with public and private subnets, plus the necessary security groups.
+
+## Provisioning with Terraform in Python
+
+The `python-terraform` package exposes a simple interface for executing Terraform commands from Python. The following example uses an object-oriented wrapper around the library. The class encapsulates init, plan, and apply steps.
+
+```python
+from python_terraform import Terraform
+
+class AwsDeployer:
+    def __init__(self, working_dir: str):
+        self.terraform = Terraform(working_dir=working_dir)
+
+    def deploy(self) -> None:
+        self.terraform.init()
+        return_code, stdout, stderr = self.terraform.plan()
+        if return_code != 0:
+            raise RuntimeError(f"Plan failed: {stderr}")
+        return_code, stdout, stderr = self.terraform.apply(auto_approve=True)
+        if return_code != 0:
+            raise RuntimeError(f"Apply failed: {stderr}")
+```
+
+Use Terraform configuration files in the chosen `working_dir` to define each AWS resource. A minimal example could look like:
+
+```hcl
+resource "aws_s3_bucket" "agent_storage" {
+  bucket = "agent-files"
+}
+
+resource "aws_dynamodb_table" "agent_sessions" {
+  name         = "agent-sessions"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "session_id"
+
+  attribute {
+    name = "session_id"
+    type = "S"
+  }
+}
+```
+
+Instantiate the deployer with the directory containing these files:
+
+```python
+deployer = AwsDeployer("./terraform")
+deployer.deploy()
+```
+
+This approach keeps infrastructure management fully scripted while retaining the readability of Python.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -7,6 +7,7 @@
 
 ## Examples
 
+For deployment details on Amazon Web Services, see [Deployment on AWS](deploy_aws.md).
 - [`vector_memory_pipeline.py`](../../examples/pipelines/vector_memory_pipeline.py)
   demonstrates using Postgres, an LLM with the Ollama provider, and simple vector memory.
 - [`memory_composition_pipeline.py`](../../examples/pipelines/memory_composition_pipeline.py)
@@ -53,6 +54,7 @@ config
 context
 plugin_guide
 advanced_usage
+deploy_aws
 principle_checklist
 apidocs/index
 ```


### PR DESCRIPTION
## Summary
- document AWS deployment resources
- explain Terraform SDK usage
- link new docs in README and index

## Testing
- `black src tests`
- `isort src tests` *(reverted changes)*
- `flake8 src tests`
- `mypy src` *(failed: src/cli/templates/adapter.py:5: error: invalid syntax)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(failed: ModuleNotFoundError: No module named 'httpx')*
- `python -m src.registry.validator` *(failed: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(failed: Unknown config option: asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(failed: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_6866a94e368483228e63bcbcbdbb9808