### PR TITLE
[Infrastructure] Add Terraform CDK helper and docs

### DIFF
--- a/docs/source/aws_deployment.md
+++ b/docs/source/aws_deployment.md
@@ -1,0 +1,16 @@
+# AWS Deployment Guide
+
+This guide shows how to use the infrastructure helpers to provision a simple AWS stack.
+
+```python
+from infrastructure.aws_basic import deploy
+
+# create an S3 bucket in us-east-1
+deploy()
+```
+
+The :mod:`infrastructure` package wraps the `cdktf` library. `Infrastructure`
+creates a CDK application and uses the `cdktf` CLI to deploy your stacks.
+
+The example stack in `aws_basic.py` creates a single S3 bucket. You can extend
+`BasicAwsStack` with additional AWS resources as needed.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -53,6 +53,7 @@ config
 context
 plugin_guide
 advanced_usage
+aws_deployment
 principle_checklist
 apidocs/index
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ pgvector = "^0.4.1"
 httpx = "^0.27.0"
 aioboto3 = "^15.0.0"
 duckdb = "^1.3.1"
+cdktf = "^0.21.0"
+cdktf-cdktf-provider-aws = "^21.1.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"

--- a/src/infrastructure/__init__.py
+++ b/src/infrastructure/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure utilities built on Terraform CDK."""
+
+from .infrastructure import Infrastructure
+
+__all__ = ["Infrastructure"]

--- a/src/infrastructure/aws_basic.py
+++ b/src/infrastructure/aws_basic.py
@@ -1,0 +1,25 @@
+"""Example AWS deployment using :class:`Infrastructure`."""
+
+from cdktf import TerraformStack
+from cdktf_cdktf_provider_aws.provider import AwsProvider
+from cdktf_cdktf_provider_aws.s3_bucket import S3Bucket
+from constructs import Construct
+
+from .infrastructure import Infrastructure
+
+
+class BasicAwsStack(TerraformStack):
+    def __init__(self, scope: Construct, ns: str) -> None:
+        super().__init__(scope, ns)
+        AwsProvider(self, "aws", region="us-east-1")
+        S3Bucket(self, "bucket", bucket="entity-demo-bucket")
+
+
+def deploy() -> None:
+    infra = Infrastructure()
+    infra.add_stack(BasicAwsStack)
+    infra.deploy()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual example
+    deploy()

--- a/src/infrastructure/infrastructure.py
+++ b/src/infrastructure/infrastructure.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Type
+
+from cdktf import App, TerraformStack
+
+
+class Infrastructure:
+    """Simple wrapper around the Terraform CDK app."""
+
+    def __init__(self) -> None:
+        self.app = App()
+        self._stack_count = 0
+
+    def add_stack(
+        self, stack_cls: Type[TerraformStack], name: str | None = None
+    ) -> TerraformStack:
+        """Instantiate and register a stack with the app."""
+        stack_name = name or f"stack{self._stack_count}"
+        self._stack_count += 1
+        return stack_cls(self.app, stack_name)
+
+    def synth(self) -> None:
+        """Generate Terraform configuration."""
+        self.app.synth()
+
+    def deploy(self) -> None:
+        """Synthesize and deploy using the ``cdktf`` CLI."""
+        self.synth()
+        subprocess.run(["cdktf", "deploy", "--auto-approve"], check=True)


### PR DESCRIPTION
## Summary
- add `cdktf` dependencies
- introduce `Infrastructure` helper class
- show basic AWS stack example
- document AWS deployment guide
- include page in docs index

## Testing
- `black src/infrastructure`
- `isort src/infrastructure`
- `flake8 src/infrastructure`
- `mypy src/infrastructure`
- `bandit -r src/infrastructure`
- `python -m src.config.validator --config config/dev.yaml` *(fails: PostgresDatabaseResource validate_dependencies)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: PostgresDatabaseResource validate_dependencies)*
- `python -m src.registry.validator` *(fails: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: Unknown config option asyncio_mode)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_6866a94d20e083228bad28818b1dd292