### PR TITLE
[Docs] Add AWS deployment mental model

### DIFF
--- a/docs/source/deploy_aws.md
+++ b/docs/source/deploy_aws.md
@@ -1,0 +1,17 @@
+# Deploying to AWS
+
+This guide outlines how to deploy an Entity agent using Amazon Web Services (AWS). The framework assumes you are familiar with basic AWS tools like Terraform and Docker.
+
+## Deployment Mental Model
+
+Infrastructure setup mirrors the plugin configuration approach. Define your environment in an `Infrastructure` class, then let it run Terraform to provision the resources before starting the agent service.
+
+```mermaid
+flowchart TD
+    A[Define Infrastructure] --> B[Run Terraform via class]
+    B --> C[Deploy agent service]
+```
+
+- **Define Infrastructure** – create an `Infrastructure` subclass describing resources such as VPCs and compute instances.
+- **Run Terraform** – call the class to execute Terraform and apply the configuration.
+- **Deploy Service** – once resources exist, launch the agent container or ECS task.


### PR DESCRIPTION
## Summary
- add an AWS deployment guide
- describe how infrastructure can be managed through an `Infrastructure` class
- include a simple diagram of the deployment process

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/` *(fails: invalid syntax)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6866a94f43408322aca1aae4ac8e8570