### PR TITLE
[Docs] resolve merge conflicts in AWS deployment guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,11 +318,4 @@ The `S3FileSystem` backend persists files in Amazon S3. Configure the
    - Clear interfaces for each backend
 
 This composition pattern would significantly improve the framework's usability while maintaining its flexibility. It's a perfect example of "simple things simple, complex things possible."
-<<<<<<< HEAD
 
-## AWS Deployment
-
-Use Terraform's Python SDK to provision AWS databases, storage, and compute resources. The [deployment guide](docs/source/deploy_aws.md) walks through a minimal setup on Amazon Web Services.
-
-=======
->>>>>>> 7966420636c5eba71f9deaf1bc4b88c234ab703d

--- a/docs/source/aws_deployment.md
+++ b/docs/source/aws_deployment.md
@@ -1,22 +1,5 @@
 # AWS Deployment Guide
 
-<<<<<<< HEAD
-This guide shows how to deploy basic AWS resources using the
-``Infrastructure`` wrapper, which leverages the Terraform Python SDK
-(``cdktf``).
-
-## Example
-
-```python
-from infrastructure.aws_basic import BasicAwsInfrastructure
-
-infra = BasicAwsInfrastructure("us-east-1")
-infra.deploy()
-```
-
-The ``deploy`` method synthesizes Terraform configuration. You can then
-run ``cdktf deploy`` to provision resources.
-=======
 This guide shows how to use the infrastructure helpers to provision a simple AWS stack.
 
 ```python
@@ -31,4 +14,3 @@ creates a CDK application and uses the `cdktf` CLI to deploy your stacks.
 
 The example stack in `aws_basic.py` creates a single S3 bucket. You can extend
 `BasicAwsStack` with additional AWS resources as needed.
->>>>>>> fdd01ee24c0cc5f74953ed08a44185415b3acc61

--- a/docs/source/deploy_aws.md
+++ b/docs/source/deploy_aws.md
@@ -1,7 +1,5 @@
-<<<<<<< HEAD
 # AWS Deployment Guide
 
-<<<<<<< HEAD
 Deploying the Entity Pipeline Framework on AWS lets you scale reliably with managed services. This guide outlines required resources and provides a Python example that drives Terraform to create them.
 
 ## Required AWS Resources
@@ -15,73 +13,10 @@ Deploying the Entity Pipeline Framework on AWS lets you scale reliably with mana
 ## Terraform with Python
 
 The [python-terraform](https://github.com/beelit94/python-terraform) package lets you drive Terraform commands from Python. Keep your `.tf` files in an `infra/` directory and orchestrate them with a small helper class.
-=======
-This guide outlines the core AWS services required to run the framework in production and demonstrates how to provision them using the Terraform Python SDK.
-
-## Required Resources
-
-- **Database**: either Amazon RDS for relational workloads or DynamoDB for serverless NoSQL.
-- **Object Storage**: an S3 bucket for file and model storage.
-- **Compute**: choose between ECS for containerized workloads or Lambda for serverless functions.
-- **Networking**: a VPC with public and private subnets, plus the necessary security groups.
-
-## Provisioning with Terraform in Python
-
-The `python-terraform` package exposes a simple interface for executing Terraform commands from Python. The following example uses an object-oriented wrapper around the library. The class encapsulates init, plan, and apply steps.
->>>>>>> 7966420636c5eba71f9deaf1bc4b88c234ab703d
 
 ```python
 from python_terraform import Terraform
 
-<<<<<<< HEAD
-class EntityAWSInfra:
-    """Wrap Terraform commands for object oriented clarity."""
-
-    def __init__(self, working_dir: str = "infra") -> None:
-        self.tf = Terraform(working_dir=working_dir)
-
-    def init(self) -> None:
-        self.tf.init()
-
-    def apply(self) -> None:
-        # --auto-approve avoids interactive prompts
-        self.tf.apply(skip_plan=True, auto_approve=True)
-
-if __name__ == "__main__":
-    infra = EntityAWSInfra()
-    infra.init()
-    infra.apply()
-```
-
-### Example Terraform Files
-
-Below is a minimal `main.tf` showing the core resources. Adjust values to fit your environment.
-
-```hcl
-provider "aws" {
-  region = "us-east-1"
-}
-
-resource "aws_s3_bucket" "files" {
-  bucket = "entity-files"
-}
-
-resource "aws_db_instance" "postgres" {
-  allocated_storage    = 20
-  engine               = "postgres"
-  instance_class       = "db.t3.micro"
-  name                 = "entity"
-  username             = "entity"
-  password             = "${var.db_password}"
-  skip_final_snapshot  = true
-}
-
-resource "aws_ecs_cluster" "agent" {}
-```
-
-Run the Python helper after creating these `.tf` files to provision the infrastructure.
-
-=======
 class AwsDeployer:
     def __init__(self, working_dir: str):
         self.terraform = Terraform(working_dir=working_dir)
@@ -123,11 +58,6 @@ deployer.deploy()
 ```
 
 This approach keeps infrastructure management fully scripted while retaining the readability of Python.
->>>>>>> 7966420636c5eba71f9deaf1bc4b88c234ab703d
-=======
-# Deploying to AWS
-
-This guide outlines how to deploy an Entity agent using Amazon Web Services (AWS). The framework assumes you are familiar with basic AWS tools like Terraform and Docker.
 
 ## Deployment Mental Model
 
@@ -142,4 +72,3 @@ flowchart TD
 - **Define Infrastructure** – create an `Infrastructure` subclass describing resources such as VPCs and compute instances.
 - **Run Terraform** – call the class to execute Terraform and apply the configuration.
 - **Deploy Service** – once resources exist, launch the agent container or ECS task.
->>>>>>> 93bbbe9bd3ccb2f20c2b69411577aac908922e28

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -11,8 +11,7 @@ For deployment details on Amazon Web Services, see [Deployment on AWS](deploy_aw
 - [`vector_memory_pipeline.py`](../../examples/pipelines/vector_memory_pipeline.py)
   demonstrates using Postgres, an LLM with the Ollama provider, and simple vector memory.
 - [`memory_composition_pipeline.py`](../../examples/pipelines/memory_composition_pipeline.py)
-  shows how to compose the ``MemoryResource`` with SQLite, PGVector, and a local
-  filesystem backend.
+  shows how to compose the `MemoryResource` with SQLite, PGVector, and a local filesystem backend.
 - [AWS deployment guide](deploy_aws.md) shows how to provision AWS resources with the Terraform Python SDK.
 - **Postgres connection pooling**
   ```python
@@ -55,13 +54,8 @@ config
 context
 plugin_guide
 advanced_usage
-<<<<<<< HEAD
 aws_deployment
-=======
 deploy_aws
->>>>>>> 7966420636c5eba71f9deaf1bc4b88c234ab703d
 principle_checklist
-deploy_aws
 apidocs/index
 ```
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,14 +33,9 @@ pgvector = "^0.4.1"
 httpx = "^0.27.0"
 aioboto3 = "^15.0.0"
 duckdb = "^1.3.1"
-<<<<<<< HEAD
-cdktf = "^0.20.0"
-cdktf-cdktf-provider-aws = "^14.0.0"
-constructs = "^10.3.0"
-=======
 cdktf = "^0.21.0"
 cdktf-cdktf-provider-aws = "^21.1.0"
->>>>>>> fdd01ee24c0cc5f74953ed08a44185415b3acc61
+constructs = "^10.3.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"

--- a/src/infrastructure/__init__.py
+++ b/src/infrastructure/__init__.py
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-"""Infrastructure utilities for deploying resources with Terraform."""
-=======
 """Infrastructure utilities built on Terraform CDK."""
->>>>>>> fdd01ee24c0cc5f74953ed08a44185415b3acc61
 
 from .infrastructure import Infrastructure
 

--- a/src/infrastructure/aws_basic.py
+++ b/src/infrastructure/aws_basic.py
@@ -1,32 +1,13 @@
-<<<<<<< HEAD
-"""Minimal AWS example using :class:`Infrastructure`."""
-
-from cdktf import TerraformOutput
-from cdktf_cdktf_provider_aws.provider import AwsProvider
-=======
 """Example AWS deployment using :class:`Infrastructure`."""
 
 from cdktf import TerraformStack
 from cdktf_cdktf_provider_aws.provider import AwsProvider
 from cdktf_cdktf_provider_aws.s3_bucket import S3Bucket
 from constructs import Construct
->>>>>>> fdd01ee24c0cc5f74953ed08a44185415b3acc61
 
 from .infrastructure import Infrastructure
 
 
-<<<<<<< HEAD
-class BasicAwsInfrastructure(Infrastructure):
-    def __init__(self, region: str) -> None:
-        super().__init__("aws-basic")
-        AwsProvider(self.stack, "aws", region=region)
-        TerraformOutput(self.stack, "region", value=region)
-
-
-if __name__ == "__main__":
-    infra = BasicAwsInfrastructure("us-east-1")
-    infra.deploy()
-=======
 class BasicAwsStack(TerraformStack):
     def __init__(self, scope: Construct, ns: str) -> None:
         super().__init__(scope, ns)
@@ -42,4 +23,3 @@ def deploy() -> None:
 
 if __name__ == "__main__":  # pragma: no cover - manual example
     deploy()
->>>>>>> fdd01ee24c0cc5f74953ed08a44185415b3acc61

--- a/src/infrastructure/infrastructure.py
+++ b/src/infrastructure/infrastructure.py
@@ -1,26 +1,12 @@
 from __future__ import annotations
 
-<<<<<<< HEAD
-=======
 import subprocess
 from typing import Type
 
->>>>>>> fdd01ee24c0cc5f74953ed08a44185415b3acc61
 from cdktf import App, TerraformStack
 
 
 class Infrastructure:
-<<<<<<< HEAD
-    """Simplified wrapper around a Terraform stack."""
-
-    def __init__(self, name: str) -> None:
-        self.app = App()
-        self.stack = TerraformStack(self.app, name)
-
-    def deploy(self) -> None:
-        """Generate Terraform configuration for this stack."""
-        self.app.synth()
-=======
     """Simple wrapper around the Terraform CDK app."""
 
     def __init__(self) -> None:
@@ -43,4 +29,3 @@ class Infrastructure:
         """Synthesize and deploy using the ``cdktf`` CLI."""
         self.synth()
         subprocess.run(["cdktf", "deploy", "--auto-approve"], check=True)
->>>>>>> fdd01ee24c0cc5f74953ed08a44185415b3acc61


### PR DESCRIPTION
## Summary
- resolve merge conflicts in AWS deployment docs
- consolidate navigation and clean up README
- update infrastructure helpers and dependencies

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/`
- `mypy src/ --exclude "src/cli/templates"` *(fails: invalid imports)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: missing module)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: Unknown config option)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_6866ae2610c8832298d1b85f71a55292