### PR TITLE
[Resource] add AWS Bedrock stack and provider

### DIFF
--- a/docs/source/aws_deployment.md
+++ b/docs/source/aws_deployment.md
@@ -14,3 +14,15 @@ creates a CDK application and uses the `cdktf` CLI to deploy your stacks.
 
 The example stack in `aws_basic.py` creates a single S3 bucket. You can extend
 `BasicAwsStack` with additional AWS resources as needed.
+
+## Bedrock Example
+
+The :mod:`aws_bedrock` module provisions a minimal IAM role and log bucket so
+you can call Bedrock models using :class:`aioboto3`.
+
+```python
+from infrastructure.aws_bedrock import deploy
+
+# deploy IAM role and bucket, then destroy with ``cdktf destroy`` when done
+deploy()
+```

--- a/examples/bedrock_deploy.py
+++ b/examples/bedrock_deploy.py
@@ -1,0 +1,13 @@
+"""Auto deploy AWS Bedrock infrastructure."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from infrastructure.aws_bedrock import deploy
+
+if __name__ == "__main__":  # pragma: no cover - manual example
+    deploy()

--- a/src/infrastructure/aws_bedrock.py
+++ b/src/infrastructure/aws_bedrock.py
@@ -1,0 +1,57 @@
+"""Example AWS Bedrock deployment."""
+
+from __future__ import annotations
+
+import json
+
+from cdktf import TerraformStack
+from cdktf_cdktf_provider_aws.iam_role import IamRole
+from cdktf_cdktf_provider_aws.iam_role_policy_attachment import IamRolePolicyAttachment
+from cdktf_cdktf_provider_aws.provider import AwsProvider
+from cdktf_cdktf_provider_aws.s3_bucket import S3Bucket
+from constructs import Construct
+
+from .infrastructure import Infrastructure
+
+
+class BedrockLLMStack(TerraformStack):
+    """Minimal infrastructure for invoking Bedrock models."""
+
+    def __init__(self, scope: Construct, ns: str) -> None:
+        super().__init__(scope, ns)
+        AwsProvider(self, "aws", region="us-east-1")
+        S3Bucket(self, "logs", bucket="entity-bedrock-logs")
+        assume = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "bedrock.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        role = IamRole(
+            self,
+            "bedrockRole",
+            name="entity-bedrock-role",
+            assume_role_policy=json.dumps(assume),
+        )
+        IamRolePolicyAttachment(
+            self,
+            "bedrockAccess",
+            role=role.name,
+            policy_arn="arn:aws:iam::aws:policy/AmazonBedrockFullAccess",
+        )
+
+
+def deploy() -> None:
+    """Deploy the Bedrock stack using Terraform CDK."""
+
+    infra = Infrastructure()
+    infra.add_stack(BedrockLLMStack)
+    infra.deploy()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual example
+    deploy()

--- a/src/pipeline/plugins/resources/__init__.py
+++ b/src/pipeline/plugins/resources/__init__.py
@@ -1,3 +1,4 @@
+from .bedrock import BedrockResource
 from .duckdb_database import DuckDBDatabaseResource
 from .duckdb_vector_store import DuckDBVectorStore
 from .llm import UnifiedLLMResource
@@ -21,4 +22,5 @@ __all__ = [
     "DuckDBVectorStore",
     "LocalFileSystemResource",
     "S3FileSystem",
+    "BedrockResource",
 ]

--- a/src/pipeline/plugins/resources/bedrock.py
+++ b/src/pipeline/plugins/resources/bedrock.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from typing import Dict
+
+import aioboto3
+
+from pipeline.plugins.resources.llm_resource import LLMResource
+from pipeline.validation import ValidationResult
+
+
+class BedrockResource(LLMResource):
+    """LLM resource for AWS Bedrock."""
+
+    name = "bedrock"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self.region = str(self.config.get("region", "us-east-1"))
+        self.model_id = str(self.config.get("model_id", ""))
+        self.params = self.extract_params(self.config, ["region", "model_id"])
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        if not config.get("model_id"):
+            return ValidationResult.error_result("'model_id' is required")
+        return ValidationResult.success_result()
+
+    async def generate(self, prompt: str) -> str:
+        if not self.validate_config(self.config).valid:
+            raise RuntimeError("Bedrock resource not properly configured")
+        payload = {"prompt": prompt, **self.params}
+        async with aioboto3.client(
+            "bedrock-runtime", region_name=self.region
+        ) as client:
+            response = await client.invoke_model(
+                modelId=self.model_id,
+                body=json.dumps(payload),
+                contentType="application/json",
+                accept="application/json",
+            )
+            body = json.loads(response["body"].read())
+            return str(body.get("outputText") or body.get("completion", ""))
+
+    __call__ = generate

--- a/src/pipeline/plugins/resources/llm/providers/__init__.py
+++ b/src/pipeline/plugins/resources/llm/providers/__init__.py
@@ -1,3 +1,4 @@
+from .bedrock import BedrockProvider
 from .claude import ClaudeProvider
 from .echo import EchoProvider
 from .gemini import GeminiProvider
@@ -10,4 +11,5 @@ __all__ = [
     "GeminiProvider",
     "ClaudeProvider",
     "EchoProvider",
+    "BedrockProvider",
 ]

--- a/src/pipeline/plugins/resources/llm/providers/bedrock.py
+++ b/src/pipeline/plugins/resources/llm/providers/bedrock.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Dict
+
+import aioboto3
+
+from pipeline.resources.llm import LLM
+from pipeline.validation import ValidationResult
+
+
+class BedrockProvider(LLM):
+    """Adapter for AWS Bedrock runtime."""
+
+    name = "bedrock"
+
+    def __init__(self, config: Dict) -> None:
+        self.config = config
+        self.model_id: str = str(config.get("model_id", ""))
+        self.region: str = str(config.get("region", "us-east-1"))
+        self.params = {
+            k: v
+            for k, v in config.items()
+            if k not in {"model_id", "region", "retries"}
+        }
+        self.retry_attempts = int(config.get("retries", 3))
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        if not config.get("model_id"):
+            return ValidationResult.error_result("'model_id' is required")
+        return ValidationResult.success_result()
+
+    async def _invoke(self, prompt: str) -> str:
+        payload = {"prompt": prompt, **self.params}
+        async with aioboto3.client(
+            "bedrock-runtime", region_name=self.region
+        ) as client:
+            response = await client.invoke_model(
+                modelId=self.model_id,
+                body=json.dumps(payload),
+                contentType="application/json",
+                accept="application/json",
+            )
+            body = json.loads(response["body"].read())
+            return str(body.get("outputText") or body.get("completion", ""))
+
+    async def generate(self, prompt: str) -> str:
+        last_exc: Exception | None = None
+        for attempt in range(self.retry_attempts):
+            try:
+                return await self._invoke(prompt)
+            except Exception as exc:  # noqa: BLE001 - simple retry
+                last_exc = exc
+                await asyncio.sleep(2**attempt)
+        raise RuntimeError("bedrock provider request failed") from last_exc

--- a/src/pipeline/plugins/resources/llm/unified.py
+++ b/src/pipeline/plugins/resources/llm/unified.py
@@ -6,6 +6,7 @@ from pipeline.plugins import ValidationResult
 from pipeline.plugins.resources.llm_resource import LLMResource
 
 from .providers import (
+    BedrockProvider,
     ClaudeProvider,
     EchoProvider,
     GeminiProvider,
@@ -24,6 +25,7 @@ class UnifiedLLMResource(LLMResource):
         "ollama": OllamaProvider,
         "gemini": GeminiProvider,
         "claude": ClaudeProvider,
+        "bedrock": BedrockProvider,
         "echo": EchoProvider,
     }
 

--- a/tests/test_bedrock_resource.py
+++ b/tests/test_bedrock_resource.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+import io
+from unittest.mock import patch
+
+from pipeline.plugins.resources.llm.unified import UnifiedLLMResource
+
+
+class FakeClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def invoke_model(self, **kwargs):
+        self.kwargs = kwargs
+        return {"body": io.BytesIO(b'{"outputText":"hi"}')}
+
+
+async def run_generate():
+    resource = UnifiedLLMResource({"provider": "bedrock", "model_id": "mi"})
+    with patch("aioboto3.client", return_value=FakeClient()) as mock_client:
+        result = await resource.generate("hello")
+        mock_client.assert_called_with("bedrock-runtime", region_name="us-east-1")
+        assert mock_client.return_value.kwargs["modelId"] == "mi"
+    return result
+
+
+def test_generate_sends_prompt_and_returns_text():
+    assert asyncio.run(run_generate()) == "hi"


### PR DESCRIPTION
## Summary
- add Bedrock CDK stack for Terraform deployment
- implement Bedrock LLM resource and provider
- register Bedrock provider in unified LLM resource
- document new Bedrock deployment example
- provide example script that auto-deploys Bedrock infrastructure
- add basic Bedrock provider test

## Testing
- `poetry run flake8 src tests`
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: PostgresDatabaseResource missing validate_dependencies)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: PostgresDatabaseResource missing validate_dependencies)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `poetry run pytest tests/infrastructure/ -v`
- `poetry run pytest tests/performance/ -m benchmark`
- `poetry run pytest -k bedrock -v` *(fails: ImportError in tests/test_cli_websocket.py)*


------
https://chatgpt.com/codex/tasks/task_e_6866b2ce5a68832288c71c1f38eb0c5a