### PR TITLE
[Config] Add programmatic config builder

### DIFF
--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -67,3 +67,24 @@ plugins:
       model: gpt-4
       api_key: ${OPENAI_API_KEY}
 ```
+
+### Building Configurations in Code
+Instead of YAML, you can create a configuration programmatically:
+
+```python
+from config import ConfigBuilder
+from pipeline import SystemInitializer
+
+builder = (
+    ConfigBuilder.dev_preset()
+    .add_resource(
+        "llm",
+        "pipeline.plugins.resources.llm.unified:UnifiedLLMResource",
+        provider="ollama",
+        base_url="http://localhost:11434",
+        model="tinyllama",
+    )
+)
+config = builder.build()
+initializer = SystemInitializer.from_dict(config)
+```

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,3 @@
+from .builder import ConfigBuilder
+
+__all__ = ["ConfigBuilder"]

--- a/src/config/builder.py
+++ b/src/config/builder.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+from pipeline.config import ConfigLoader
+
+
+@dataclass
+class ConfigBuilder:
+    """Programmatic builder for Entity configuration."""
+
+    config: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "server": {
+                "host": "0.0.0.0",
+                "port": 8000,
+                "reload": False,
+                "log_level": "info",
+            },
+            "plugins": {
+                "resources": {},
+                "tools": {},
+                "adapters": {},
+                "prompts": {},
+            },
+        }
+    )
+    env_file: str = ".env"
+
+    # ------------------------------------------------------------------
+    # Section: Factory Methods
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_yaml(cls, path: str | Path, env_file: str = ".env") -> "ConfigBuilder":
+        cfg = ConfigLoader.from_yaml(path, env_file)
+        return cls(cfg, env_file)
+
+    @classmethod
+    def dev_preset(cls) -> "ConfigBuilder":
+        path = Path(__file__).resolve().parents[2] / "config" / "dev.yaml"
+        return cls.from_yaml(path)
+
+    @classmethod
+    def prod_preset(cls) -> "ConfigBuilder":
+        path = Path(__file__).resolve().parents[2] / "config" / "prod.yaml"
+        return cls.from_yaml(path)
+
+    # ------------------------------------------------------------------
+    # Section: Builder Methods
+    # ------------------------------------------------------------------
+    def set_server(
+        self, host: str, port: int, reload: bool = False, log_level: str = "info"
+    ) -> "ConfigBuilder":
+        self.config["server"] = {
+            "host": host,
+            "port": port,
+            "reload": reload,
+            "log_level": log_level,
+        }
+        return self
+
+    def add_resource(
+        self, name: str, type_path: str, **options: Any
+    ) -> "ConfigBuilder":
+        self.config["plugins"]["resources"][name] = {"type": type_path, **options}
+        return self
+
+    def add_tool(self, name: str, type_path: str, **options: Any) -> "ConfigBuilder":
+        self.config["plugins"]["tools"][name] = {"type": type_path, **options}
+        return self
+
+    def add_adapter(self, name: str, type_path: str, **options: Any) -> "ConfigBuilder":
+        self.config["plugins"]["adapters"][name] = {"type": type_path, **options}
+        return self
+
+    def add_prompt(self, name: str, type_path: str, **options: Any) -> "ConfigBuilder":
+        self.config["plugins"]["prompts"][name] = {"type": type_path, **options}
+        return self
+
+    # ------------------------------------------------------------------
+    # Section: Validation
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _validate_memory(cfg: dict) -> None:
+        mem_cfg = cfg.get("plugins", {}).get("resources", {}).get("memory")
+        if not mem_cfg:
+            return
+        backend = mem_cfg.get("backend")
+        if backend is not None and not isinstance(backend, dict):
+            raise ValueError("memory: 'backend' must be a mapping")
+        if isinstance(backend, dict) and "type" in backend:
+            if not isinstance(backend["type"], str):
+                raise ValueError("memory: 'backend.type' must be a string")
+
+    @staticmethod
+    def _validate_vector_memory(cfg: dict) -> None:
+        vm_cfg = cfg.get("plugins", {}).get("resources", {}).get("vector_memory")
+        if not vm_cfg:
+            return
+        table = vm_cfg.get("table")
+        if not isinstance(table, str) or not table:
+            raise ValueError("vector_memory: 'table' is required")
+        embedding = vm_cfg.get("embedding_model")
+        if not isinstance(embedding, dict):
+            raise ValueError("vector_memory: 'embedding_model' must be a mapping")
+        if not embedding.get("name"):
+            raise ValueError("vector_memory: 'embedding_model.name' is required")
+        if "dimensions" in embedding:
+            try:
+                int(embedding["dimensions"])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "vector_memory: 'embedding_model.dimensions' must be an integer"
+                ) from exc
+
+    def validate(self) -> None:
+        self._validate_memory(self.config)
+        self._validate_vector_memory(self.config)
+
+    def build(self) -> Dict[str, Any]:
+        self.validate()
+        return ConfigLoader.from_dict(self.config, self.env_file)
+
+
+__all__ = ["ConfigBuilder"]


### PR DESCRIPTION
## Summary
- add `ConfigBuilder` for programmatic configuration construction
- expose `ConfigBuilder` in `src.config` package
- document builder usage in quick start docs

## Testing
- `poetry run black src/ tests/`
- `poetry run isort src/config/builder.py src/config/__init__.py`
- `poetry run flake8 src/ tests/` *(fails: Command not found)*
- `poetry run mypy src/` *(fails: invalid syntax)*
- `poetry run bandit -r src/` *(fails: Command not found)*
- `PYTHONPATH=./src poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `PYTHONPATH=./src poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `PYTHONPATH=./src poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `PYTHONPATH=./src poetry run pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `PYTHONPATH=./src poetry run pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `PYTHONPATH=./src poetry run pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_6866d2911c408322b11b0bbcad3d2405