### PR TITLE
[Adapter] add auth and throttling middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ plugins:
     database:
       type: pipeline.plugins.resources.memory_storage:MemoryStorage
 ```
+
+HTTP adapter configuration with authentication and rate limiting:
+
+```yaml
+plugins:
+  adapters:
+    http:
+      type: pipeline.adapters.http:HTTPAdapter
+      auth_tokens:
+        - ${HTTP_TOKEN}
+      rate_limit:
+        requests: 60
+        interval: 60
+      audit_log_path: logs/audit.log
+```
 <!-- end config -->
 
 Every plugin executes with a ``PluginContext`` which grants controlled

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -42,6 +42,12 @@ plugins:
   adapters:
     http:
       type: pipeline.adapters.http:HTTPAdapter
+      auth_tokens:
+        - dev-secret
+      rate_limit:
+        requests: 60
+        interval: 60
+      audit_log_path: logs/audit.log
     cli:
       type: pipeline.adapters.cli:CLIAdapter
   prompts:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -49,6 +49,12 @@ plugins:
   adapters:
     http:
       type: pipeline.adapters.http:HTTPAdapter
+      auth_tokens:
+        - ${HTTP_TOKEN}
+      rate_limit:
+        requests: 100
+        interval: 60
+      audit_log_path: logs/audit.log
     cli:
       type: pipeline.adapters.cli:CLIAdapter
   prompts:

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -41,6 +41,12 @@ plugins:
   adapters:
     http:
       type: pipeline.adapters.http:HTTPAdapter
+      auth_tokens:
+        - ${HTTP_TOKEN}
+      rate_limit:
+        requests: 60
+        interval: 60
+      audit_log_path: logs/audit.log
     cli:
       type: pipeline.adapters.cli:CLIAdapter
   prompts:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,7 @@
 [mypy]
 python_version = 3.11
 mypy_path = src
-exclude =
-    ^src/pipeline/observability\.py$
-    ^src/cli/templates/
+exclude = ^src/pipeline/observability\.py$|^src/cli/templates/
 
 [mypy-langchain_core.*]
 ignore_missing_imports = True

--- a/src/pipeline/adapters/http.py
+++ b/src/pipeline/adapters/http.py
@@ -7,11 +7,16 @@ application with a single POST route. Incoming messages are forwarded
 to the pipeline and the JSON response is returned to the caller.
 """
 
+import logging
+import time
+from collections import defaultdict, deque
+from logging.handlers import RotatingFileHandler
 from typing import Any, cast
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from registry import SystemRegistries
 
@@ -19,6 +24,61 @@ from ..manager import PipelineManager
 from ..pipeline import execute_pipeline
 from ..plugins import AdapterPlugin
 from ..stages import PipelineStage
+
+
+class TokenAuthMiddleware(BaseHTTPMiddleware):
+    """Validate bearer tokens on incoming requests."""
+
+    def __init__(
+        self, app: FastAPI, tokens: list[str], audit_logger: logging.Logger
+    ) -> None:
+        super().__init__(app)
+        self.tokens = set(tokens)
+        self.audit_logger = audit_logger
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        if self.tokens:
+            auth = request.headers.get("authorization")
+            token = auth.split(" ")[-1] if auth and " " in auth else None
+            if token not in self.tokens:
+                client = request.client.host if request.client else "unknown"
+                self.audit_logger.info("invalid token from %s", client)
+                raise HTTPException(status_code=401, detail="Unauthorized")
+        return await call_next(request)
+
+
+class ThrottleMiddleware(BaseHTTPMiddleware):
+    """Apply simple request rate limiting."""
+
+    def __init__(
+        self,
+        app: FastAPI,
+        requests: int,
+        interval: float,
+        audit_logger: logging.Logger,
+    ) -> None:
+        super().__init__(app)
+        self.requests = requests
+        self.interval = interval
+        self.audit_logger = audit_logger
+        self.access: dict[str, deque[float]] = defaultdict(deque)
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        key = request.headers.get("authorization")
+        if key and " " in key:
+            key = key.split(" ")[-1]
+        else:
+            key = request.client.host if request.client else "anonymous"
+
+        record = self.access[key]
+        now = time.monotonic()
+        record.append(now)
+        while record and now - record[0] > self.interval:
+            record.popleft()
+        if len(record) > self.requests:
+            self.audit_logger.info("rate limit exceeded for %s", key)
+            raise HTTPException(status_code=429, detail="Too Many Requests")
+        return await call_next(request)
 
 
 class MessageRequest(BaseModel):
@@ -38,9 +98,38 @@ class HTTPAdapter(AdapterPlugin):
         super().__init__(config)
         self.manager = manager
         self.app = FastAPI()
+        self._setup_audit_logger()
+        self._setup_middleware()
         self._server: uvicorn.Server | None = None
         self._registries: SystemRegistries | None = None
         self._setup_routes()
+
+    def _setup_audit_logger(self) -> None:
+        path = str(self.config.get("audit_log_path", "audit.log"))
+        self.audit_logger = logging.getLogger("audit")
+        if not self.audit_logger.handlers:
+            handler = RotatingFileHandler(path, maxBytes=1_048_576, backupCount=5)
+            handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
+            self.audit_logger.addHandler(handler)
+        self.audit_logger.setLevel(logging.INFO)
+
+    def _setup_middleware(self) -> None:
+        tokens: list[str] = list(self.config.get("auth_tokens", []))
+        if tokens:
+            self.app.add_middleware(
+                TokenAuthMiddleware, tokens=tokens, audit_logger=self.audit_logger
+            )
+
+        rl_cfg = self.config.get("rate_limit", {})
+        requests = int(rl_cfg.get("requests", 0))
+        interval = float(rl_cfg.get("interval", 60))
+        if requests:
+            self.app.add_middleware(
+                ThrottleMiddleware,
+                requests=requests,
+                interval=interval,
+                audit_logger=self.audit_logger,
+            )
 
     def _setup_routes(self) -> None:
         @self.app.post("/")


### PR DESCRIPTION
## Summary
- implement token auth and request throttling middleware for `HTTPAdapter`
- log auth failures and rate-limit hits to `audit.log`
- support adapter configuration for auth secrets and rate limits
- document new config options
- test security middleware

## Testing
- `black src/ tests/`
- `isort --profile black tests/test_http_adapter.py src/pipeline/adapters/http.py`
- `flake8 src/pipeline/adapters/http.py tests/test_http_adapter.py`
- `mypy --config-file mypy.ini src/` *(fails: ModuleNotFoundError: No module named 'pgvector')*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'asyncpg')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: Required environment variable HTTP_TOKEN not found)*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
- `pytest tests/infrastructure/ -v`
- `pytest tests/performance/ -m benchmark`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6866d29516cc83229c10e24f7fb1777f