### PR TITLE
[Adapter] Project scaffolding CLI

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -50,6 +50,8 @@ long-running agents responsive.
 :hidden:
 
 quick_start
+tutorial_setup
+tutorial_first_pipeline
 config
 context
 plugin_guide

--- a/docs/source/tutorial_first_pipeline.md
+++ b/docs/source/tutorial_first_pipeline.md
@@ -1,0 +1,24 @@
+# First Pipeline Execution
+
+Run the sample agent created in the previous step.
+
+1. Change into the new directory:
+
+```bash
+cd my_agent
+```
+
+2. Start the HTTP server:
+
+```bash
+python src/main.py
+```
+
+3. Send a test message:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"message": "hello"}' http://localhost:8000/
+```
+
+The response comes from the default EchoLLMResource.

--- a/docs/source/tutorial_setup.md
+++ b/docs/source/tutorial_setup.md
@@ -1,0 +1,14 @@
+# Project Setup
+
+Follow these steps to install dependencies and scaffold a new project.
+
+1. Install Python 3.11+ and [Poetry](https://python-poetry.org/).
+2. Run `poetry install` to create the virtual environment.
+3. Copy `.env.example` to `.env` and provide any required credentials.
+4. Generate a starter project:
+
+```bash
+python -m src.cli -c config/template.yaml new my_agent
+```
+
+This creates `my_agent/config/dev.yaml` and `my_agent/src/main.py`.


### PR DESCRIPTION
## Summary
- add `new` command to CLI for project scaffolding
- document setup and first pipeline run tutorials

## Testing
- `black src/cli.py` and `isort src/cli.py`
- `flake8 src/ tests/`
- `mypy --exclude 'src/cli/templates/' src` *(fails: invalid syntax error in template)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: missing aioboto3)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: missing aioboto3)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: 'aioboto3')*
- `pytest tests/infrastructure/ -v`
- `pytest tests/performance/ -m benchmark`

------
https://chatgpt.com/codex/tasks/task_e_6866d2989c988322897efa432339ffdd