### PR TITLE
[Docs] reorganize docs structure with cheat sheets

### DIFF
--- a/docs/source/config_cheatsheet.md
+++ b/docs/source/config_cheatsheet.md
@@ -1,0 +1,29 @@
+# Configuration Cheat Sheet
+
+Minimal YAML layout for a working agent.
+
+```yaml
+entity:
+  entity_id: "demo"
+  name: "Demo Agent"
+
+plugins:
+  resources:
+    database:
+      type: pipeline.plugins.resources.sqlite_storage:SQLiteStorage
+      path: ./entity.db
+    llm:
+      provider: openai
+      model: gpt-4
+  tools:
+    search:
+      type: pipeline.plugins.tools.search:SearchTool
+  prompts:
+    main:
+      type: pipeline.plugins.prompts.simple:SimplePrompt
+  adapters:
+    http:
+      type: pipeline.plugins.adapters.http:HTTPAdapter
+```
+
+Use `entity src/cli.py --config config.yaml` to start the agent.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,3 +1,6 @@
+# Entity Pipeline Documentation
+
+Welcome to the Entity Pipeline framework. These pages explain how to configure an agent, write plugins, and deploy the system.
 
 ```{include} ../../README.md
 :relative-images:
@@ -5,55 +8,37 @@
 :end-before: <!-- end quick_start -->
 ```
 
-## Examples
+## Documentation Map
 
-For deployment details on Amazon Web Services, see [Deployment on AWS](deploy_aws.md).
-- [`vector_memory_pipeline.py`](../../examples/pipelines/vector_memory_pipeline.py)
-  demonstrates using Postgres, an LLM with the Ollama provider, and simple vector memory.
-- [`memory_composition_pipeline.py`](../../examples/pipelines/memory_composition_pipeline.py)
-  shows how to compose the `MemoryResource` with SQLite, PGVector, and a local filesystem backend.
-- [AWS deployment guide](deploy_aws.md) shows how to provision AWS resources with the Terraform Python SDK.
-- **Postgres connection pooling**
-  ```python
-  PostgresResource(
-      {
-          "host": "localhost",
-          "name": "dev_db",
-          "username": "agent",
-          "password": "",
-          "pool_min_size": 1,
-          "pool_max_size": 5,
-      }
-  )
-  ```
-- **Storage interface usage**
-  ```python
-  db = context.get_resource("database")
-  await db.save_history(
-      context.pipeline_id,
-      context.get_conversation_history(),
-  )
-  ```
+### Getting Started
+- [Quick start](quick_start.md)
+- [Configuration cheat sheet](config_cheatsheet.md)
 
-## Runtime Configuration Reload
+### Plugin Development
+- [Plugin cheat sheet](plugin_cheatsheet.md)
+- [Detailed guide](plugin_guide.md)
 
-Reload plugin configuration on the fly:
+### Reference
+- [Context API](context.md)
+- [Advanced usage](advanced_usage.md)
+- [Module map](module_map.md)
+- [Troubleshooting](troubleshooting.md)
 
-```bash
-python -m src.cli reload-config updated.yaml
-```
-
-This feature highlights **Dynamic Configuration Updates** and keeps
-long-running agents responsive.
+### Deployment
+- [AWS deployment](aws_deployment.md)
+- [Terraform guide](deploy_aws.md)
 
 ```{toctree}
 :hidden:
-
 quick_start
+config_cheatsheet
 config
-context
+plugin_cheatsheet
 plugin_guide
+context
 advanced_usage
+module_map
+troubleshooting
 aws_deployment
 deploy_aws
 principle_checklist

--- a/docs/source/plugin_cheatsheet.md
+++ b/docs/source/plugin_cheatsheet.md
@@ -1,0 +1,32 @@
+# Plugin Development Cheat Sheet
+
+Brief reminders for writing plugins.
+
+## Base Classes
+- `ResourcePlugin` – provides infrastructure like databases and LLMs.
+- `ToolPlugin` – exposes a callable tool to other plugins.
+- `PromptPlugin` – contains reasoning or memory logic.
+- `AdapterPlugin` – handles external interfaces such as HTTP or CLI.
+- `FailurePlugin` – formats and logs errors.
+
+All plugins declare their `stages` and any `dependencies`.
+
+## Skeleton
+```python
+from pipeline.plugins import PromptPlugin
+from pipeline.stages import PipelineStage
+
+class ExamplePlugin(PromptPlugin):
+    dependencies = ["database", "llm"]
+    stages = [PipelineStage.THINK]
+
+    @classmethod
+    def validate_config(cls, config):
+        return ValidationResult.success()
+
+    async def _execute_impl(self, context):
+        # plugin logic here
+        pass
+```
+
+Register plugins through `Agent.add_plugin()` or in a YAML configuration file.

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -1,0 +1,12 @@
+# Troubleshooting
+
+## Initialization failures
+- **Invalid plugin path** – ensure each plugin `type` is a full import path.
+- **Missing environment variable** – check `${VAR}` placeholders in YAML and your `.env` file.
+- **Circular dependency detected** – review plugin `dependencies` for cycles.
+
+## Dependency validation errors
+- **Plugin requires a resource not registered** – confirm that all names in `dependencies` exist under `plugins:` in the config file.
+- **Config validation failed** – run `python -m src.config.validator --config your.yaml` to see detailed messages.
+
+If initialization still fails, enable debug logging with `LOG_LEVEL=DEBUG` when running the validator for verbose output.


### PR DESCRIPTION
## Summary
- reorganize `docs/source/index.md` with a more readable hierarchy
- add a concise plugin development cheat sheet
- add a configuration cheat sheet
- document common initialization problems in a new troubleshooting guide

## Testing
- `black .`
- `isort .` *(fails: modifies files but reverted)*
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/` *(fails: 38 errors)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6866d29a01908322a3c1bcd3564c578f