### PR TITLE
[Maintenance] Fix storage health checks and tool interface

### DIFF
--- a/src/pipeline/agent.py
+++ b/src/pipeline/agent.py
@@ -80,3 +80,14 @@ class Agent:
         if self._runtime is None:
             raise RuntimeError("Agent not initialized")
         return self._runtime.registries
+
+    # ------------------------------------------------------------------
+    # Compatibility helpers
+    # ------------------------------------------------------------------
+    @property
+    def plugin_registry(self):  # pragma: no cover - passthrough
+        return self.get_registries().plugins
+
+    @property
+    def plugins(self):  # pragma: no cover - passthrough
+        return self.get_registries().plugins

--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -18,8 +18,7 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints only
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .initializer import ClassRegistry
 
-from .exceptions import (CircuitBreakerTripped, PluginError,
-                         PluginExecutionError)
+from .exceptions import CircuitBreakerTripped, PluginError, PluginExecutionError
 from .logging import get_logger
 from .observability.utils import execute_with_observability
 from .stages import PipelineStage
@@ -289,10 +288,9 @@ class ToolPlugin(BasePlugin):
         self.max_retries = int(self.config.get("max_retries", 1))
         self.retry_delay = float(self.config.get("retry_delay", 1.0))
 
-    @abstractmethod
     async def execute(self, params: Dict[str, Any]) -> Any:  # type: ignore[override]
-        """Execute the tool with ``params``."""
-        raise NotImplementedError
+        """Execute the tool and return its result."""
+        return await self.execute_function_with_retry(params)
 
     async def execute_function(self, params: Dict[str, Any]):
         raise NotImplementedError()
@@ -381,5 +379,4 @@ __all__ = [
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .plugins.classifier import PluginAutoClassifier
 else:  # pragma: no cover - runtime import for compatibility
-    from .plugins.classifier import \
-        PluginAutoClassifier  # type: ignore  # noqa: E402
+    from .plugins.classifier import PluginAutoClassifier  # type: ignore  # noqa: E402

--- a/src/pipeline/resources/base.py
+++ b/src/pipeline/resources/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, Protocol, runtime_checkable
 
 from pipeline.logging import get_logger
+from pipeline.validation import ValidationResult
 
 
 @runtime_checkable
@@ -40,3 +41,14 @@ class BaseResource:
 
     def get_metrics(self) -> dict[str, Any]:
         return {"status": "healthy"}
+
+    # ------------------------------------------------------------------
+    # Validation helpers matching BasePlugin API
+    # ------------------------------------------------------------------
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        return ValidationResult.success_result()
+
+    @classmethod
+    def validate_dependencies(cls, registry: "ClassRegistry") -> ValidationResult:
+        return ValidationResult.success_result()

--- a/src/pipeline/resources/duckdb_database.py
+++ b/src/pipeline/resources/duckdb_database.py
@@ -39,10 +39,13 @@ class DuckDBDatabaseResource(DatabaseResource):
         if self._connection is None:
             return False
         try:
-            await asyncio.to_thread(self._connection.execute, "SELECT 1")
+            await self._do_health_check(self._connection)
             return True
         except Exception:
             return False
+
+    async def _do_health_check(self, connection: duckdb.DuckDBPyConnection) -> None:
+        await asyncio.to_thread(connection.execute, "SELECT 1")
 
     async def save_history(
         self, conversation_id: str, history: List[ConversationEntry]

--- a/src/pipeline/resources/in_memory_storage.py
+++ b/src/pipeline/resources/in_memory_storage.py
@@ -15,6 +15,13 @@ class InMemoryStorageResource(DatabaseResource):
         super().__init__(config)
         self._data: Dict[str, List[ConversationEntry]] = {}
 
+    async def _do_health_check(self, connection: None) -> None:
+        """In-memory storage is always healthy."""
+        return None
+
+    async def health_check(self) -> bool:  # pragma: no cover - trivial
+        return True
+
     async def save_history(
         self, conversation_id: str, history: List[ConversationEntry]
     ) -> None:

--- a/src/pipeline/resources/llm/providers/echo.py
+++ b/src/pipeline/resources/llm/providers/echo.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from typing import Dict
+
+from pipeline.validation import ValidationResult
+
 from .base import BaseProvider
 
 
@@ -7,6 +11,11 @@ class EchoProvider(BaseProvider):
     """Adapter that simply echoes the prompt."""
 
     name = "echo"
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        """Echo provider requires no specific configuration."""
+        return ValidationResult.success_result()
 
     async def generate(self, prompt: str) -> str:  # noqa: D401 - simple echo
         return prompt


### PR DESCRIPTION
## Summary
- add health check implementations for in-memory and DuckDB storage
- allow `EchoProvider` with no config
- expose plugin registry on `Agent`
- provide default execute method for tools
- support plugin validation on resources

## Testing
- `poetry run pytest tests/integration/test_chat_history_backends.py::test_in_memory_history -q`
- `poetry run pytest tests/integration/test_chat_history_backends.py::test_duckdb_history -q`
- `poetry run pytest tests/test_bedrock_resource.py::test_generate_sends_prompt_and_returns_text -q` *(fails: AttributeError: <module 'aioboto3' ...> does not have the attribute 'client')*
- `poetry run flake8 src/ tests/ | head` *(fails: F401 unused imports)*
- `poetry run mypy src/ | tail -n 20` *(fails: import-not-found and other errors)*
- `poetry run bandit -r src/ | head`
- `poetry run python -m src.config.validator --config config/dev.yaml | head` *(fails: Configuration invalid)*
- `poetry run python -m src.registry.validator --config config/dev.yaml | head` *(fails: Validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6867b3da0aec8322a1c2ea0eee52919a