### PR TITLE
Fix plugin registry helpers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -288,6 +288,19 @@ files = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+description = "Timeout context manager for asyncio programs"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_version == \"3.11\" and python_full_version < \"3.11.3\""
+files = [
+    {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
+    {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.30.0"
 description = "An asyncio PostgreSQL driver"
@@ -520,6 +533,68 @@ urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >
 crt = ["awscrt (==0.23.8)"]
 
 [[package]]
+name = "cattrs"
+version = "24.1.3"
+description = "Composable complex class support for attrs and dataclasses."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "cattrs-24.1.3-py3-none-any.whl", hash = "sha256:adf957dddd26840f27ffbd060a6c4dd3b2192c5b7c2c0525ef1bd8131d8a83f5"},
+    {file = "cattrs-24.1.3.tar.gz", hash = "sha256:981a6ef05875b5bb0c7fb68885546186d306f10f0f6718fe9b96c226e68821ff"},
+]
+
+[package.dependencies]
+attrs = ">=23.1.0"
+
+[package.extras]
+bson = ["pymongo (>=4.4.0)"]
+cbor2 = ["cbor2 (>=5.4.6)"]
+msgpack = ["msgpack (>=1.0.5)"]
+msgspec = ["msgspec (>=0.18.5) ; implementation_name == \"cpython\""]
+orjson = ["orjson (>=3.9.2) ; implementation_name == \"cpython\""]
+pyyaml = ["pyyaml (>=6.0)"]
+tomlkit = ["tomlkit (>=0.11.8)"]
+ujson = ["ujson (>=5.7.0)"]
+
+[[package]]
+name = "cdktf"
+version = "0.21.0"
+description = "Cloud Development Kit for Terraform"
+optional = false
+python-versions = "~=3.9"
+groups = ["main"]
+files = [
+    {file = "cdktf-0.21.0-py3-none-any.whl", hash = "sha256:0a897ff88729bbd37d4d712b55bdc05d130a8786de537beb1951cc029334dd09"},
+    {file = "cdktf-0.21.0.tar.gz", hash = "sha256:7025510eb043317ab6fdf20f81d696cb682fed537eed060d9bdd9809b19903e6"},
+]
+
+[package.dependencies]
+constructs = ">=10.4.2,<11.0.0"
+jsii = ">=1.112.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<4.3.0"
+
+[[package]]
+name = "cdktf-cdktf-provider-aws"
+version = "21.1.0"
+description = "Prebuilt aws Provider for Terraform CDK (cdktf)"
+optional = false
+python-versions = "~=3.9"
+groups = ["main"]
+files = [
+    {file = "cdktf_cdktf_provider_aws-21.1.0-py3-none-any.whl", hash = "sha256:5a8b7c23453057a0bd9db21a0d4321716611e61bccdc7cddb53d4cf19c7825c7"},
+    {file = "cdktf_cdktf_provider_aws-21.1.0.tar.gz", hash = "sha256:ac64cd2440b97b0123dca8f74077d4615cd3e2a1677be713cfceeb22b2a16c57"},
+]
+
+[package.dependencies]
+cdktf = ">=0.21.0,<0.22.0"
+constructs = ">=10.4.2,<11.0.0"
+jsii = ">=1.112.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<4.3.0"
+
+[[package]]
 name = "certifi"
 version = "2025.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -660,6 +735,23 @@ files = [
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+
+[[package]]
+name = "constructs"
+version = "10.4.2"
+description = "A programming model for software-defined state"
+optional = false
+python-versions = "~=3.8"
+groups = ["main"]
+files = [
+    {file = "constructs-10.4.2-py3-none-any.whl", hash = "sha256:1f0f59b004edebfde0f826340698b8c34611f57848139b7954904c61645f13c1"},
+    {file = "constructs-10.4.2.tar.gz", hash = "sha256:ce54724360fffe10bab27d8a081844eb81f5ace7d7c62c84b719c49f164d5307"},
+]
+
+[package.dependencies]
+jsii = ">=1.102.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "coverage"
@@ -1174,6 +1266,26 @@ files = [
 ]
 
 [[package]]
+name = "importlib-resources"
+version = "6.5.2"
+description = "Read resources from Python packages"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec"},
+    {file = "importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
+type = ["pytest-mypy"]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
@@ -1214,6 +1326,27 @@ files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
+
+[[package]]
+name = "jsii"
+version = "1.112.0"
+description = "Python client for jsii runtime"
+optional = false
+python-versions = "~=3.9"
+groups = ["main"]
+files = [
+    {file = "jsii-1.112.0-py3-none-any.whl", hash = "sha256:6510c223074d9b206fd0570849a791e4d9ecfff7ffe68428de73870cea9f55a1"},
+    {file = "jsii-1.112.0.tar.gz", hash = "sha256:6b7d19f361c2565b76828ecbe8cbed8b8d6028a82aa98a46b206a4ee5083157e"},
+]
+
+[package.dependencies]
+attrs = ">=21.2,<26.0"
+cattrs = ">=1.8,<24.2"
+importlib_resources = ">=5.2.0"
+publication = ">=0.0.3"
+python-dateutil = "*"
+typeguard = ">=2.13.3,<4.5.0"
+typing_extensions = ">=3.8,<5.0"
 
 [[package]]
 name = "lxml"
@@ -1257,10 +1390,12 @@ files = [
     {file = "lxml-6.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:219e0431ea8006e15005767f0351e3f7f9143e793e58519dc97fe9e07fae5563"},
     {file = "lxml-6.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bd5913b4972681ffc9718bc2d4c53cde39ef81415e1671ff93e9aa30b46595e7"},
     {file = "lxml-6.0.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:390240baeb9f415a82eefc2e13285016f9c8b5ad71ec80574ae8fa9605093cd7"},
+    {file = "lxml-6.0.0-cp312-cp312-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d6e200909a119626744dd81bae409fc44134389e03fbf1d68ed2a55a2fb10991"},
     {file = "lxml-6.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ca50bd612438258a91b5b3788c6621c1f05c8c478e7951899f492be42defc0da"},
     {file = "lxml-6.0.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:c24b8efd9c0f62bad0439283c2c795ef916c5a6b75f03c17799775c7ae3c0c9e"},
     {file = "lxml-6.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:afd27d8629ae94c5d863e32ab0e1d5590371d296b87dae0a751fb22bf3685741"},
     {file = "lxml-6.0.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:54c4855eabd9fc29707d30141be99e5cd1102e7d2258d2892314cf4c110726c3"},
+    {file = "lxml-6.0.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c907516d49f77f6cd8ead1322198bdfd902003c3c330c77a1c5f3cc32a0e4d16"},
     {file = "lxml-6.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:36531f81c8214e293097cd2b7873f178997dae33d3667caaae8bdfb9666b76c0"},
     {file = "lxml-6.0.0-cp312-cp312-win32.whl", hash = "sha256:690b20e3388a7ec98e899fd54c924e50ba6693874aa65ef9cb53de7f7de9d64a"},
     {file = "lxml-6.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:310b719b695b3dd442cdfbbe64936b2f2e231bb91d998e99e6f0daf991a3eba3"},
@@ -1271,10 +1406,12 @@ files = [
     {file = "lxml-6.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d18a25b19ca7307045581b18b3ec9ead2b1db5ccd8719c291f0cd0a5cec6cb81"},
     {file = "lxml-6.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4f0c66df4386b75d2ab1e20a489f30dc7fd9a06a896d64980541506086be1f1"},
     {file = "lxml-6.0.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f4b481b6cc3a897adb4279216695150bbe7a44c03daba3c894f49d2037e0a24"},
+    {file = "lxml-6.0.0-cp313-cp313-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a78d6c9168f5bcb20971bf3329c2b83078611fbe1f807baadc64afc70523b3a"},
     {file = "lxml-6.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae06fbab4f1bb7db4f7c8ca9897dc8db4447d1a2b9bee78474ad403437bcc29"},
     {file = "lxml-6.0.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:1fa377b827ca2023244a06554c6e7dc6828a10aaf74ca41965c5d8a4925aebb4"},
     {file = "lxml-6.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1676b56d48048a62ef77a250428d1f31f610763636e0784ba67a9740823988ca"},
     {file = "lxml-6.0.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0e32698462aacc5c1cf6bdfebc9c781821b7e74c79f13e5ffc8bfe27c42b1abf"},
+    {file = "lxml-6.0.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4d6036c3a296707357efb375cfc24bb64cd955b9ec731abf11ebb1e40063949f"},
     {file = "lxml-6.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7488a43033c958637b1a08cddc9188eb06d3ad36582cebc7d4815980b47e27ef"},
     {file = "lxml-6.0.0-cp313-cp313-win32.whl", hash = "sha256:5fcd7d3b1d8ecb91445bd71b9c88bdbeae528fefee4f379895becfc72298d181"},
     {file = "lxml-6.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:2f34687222b78fff795feeb799a7d44eca2477c3d9d3a46ce17d51a4f383e32e"},
@@ -1935,6 +2072,18 @@ files = [
 ]
 
 [[package]]
+name = "publication"
+version = "0.0.3"
+description = "Publication helps you maintain public-api-friendly modules by preventing unintentional access to private implementation details via introspection."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "publication-0.0.3-py2.py3-none-any.whl", hash = "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6"},
+    {file = "publication-0.0.3.tar.gz", hash = "sha256:68416a0de76dddcdd2930d1c8ef853a743cc96c82416c4e4d3b5d901c6276dc4"},
+]
+
+[[package]]
 name = "py-cpuinfo"
 version = "9.0.0"
 description = "Get CPU info with pure Python"
@@ -2118,6 +2267,24 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyjwt"
+version = "2.9.0"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850"},
+    {file = "pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c"},
+]
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pytest"
@@ -2309,6 +2476,26 @@ files = [
     {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
     {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
 ]
+
+[[package]]
+name = "redis"
+version = "5.3.0"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "redis-5.3.0-py3-none-any.whl", hash = "sha256:f1deeca1ea2ef25c1e4e46b07f4ea1275140526b1feea4c6459c0ec27a10ef83"},
+    {file = "redis-5.3.0.tar.gz", hash = "sha256:8d69d2dde11a12dc85d0dbf5c45577a5af048e2456f7077d87ad35c1c81c310e"},
+]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\""}
+PyJWT = ">=2.9.0,<2.10.0"
+
+[package.extras]
+hiredis = ["hiredis (>=3.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"]
 
 [[package]]
 name = "requests"
@@ -2718,6 +2905,22 @@ files = [
 
 [package.dependencies]
 pbr = ">=2.0.0"
+
+[[package]]
+name = "typeguard"
+version = "2.13.3"
+description = "Run-time type checker for Python"
+optional = false
+python-versions = ">=3.5.3"
+groups = ["main"]
+files = [
+    {file = "typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1"},
+    {file = "typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4"},
+]
+
+[package.extras]
+doc = ["sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["mypy ; platform_python_implementation != \"PyPy\"", "pytest", "typing-extensions"]
 
 [[package]]
 name = "typing-extensions"
@@ -3252,4 +3455,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "8868db75a7b1e135ea651d45938e54ee4476b5b2bddd72f655c1cc00940016f2"
+content-hash = "2c70b3a23ddb81c9bf4a3aeb21ccc81aca93919925161fa31b1f339c9b5bcb51"

--- a/src/pipeline/agent.py
+++ b/src/pipeline/agent.py
@@ -86,8 +86,12 @@ class Agent:
     # ------------------------------------------------------------------
     @property
     def plugin_registry(self):  # pragma: no cover - passthrough
-        return self.get_registries().plugins
+        if self._runtime is not None:
+            return self._runtime.registries.plugins
+        return self.builder.plugin_registry
 
     @property
     def plugins(self):  # pragma: no cover - passthrough
-        return self.get_registries().plugins
+        if self._runtime is not None:
+            return self._runtime.registries.plugins
+        return self.builder.plugin_registry

--- a/src/pipeline/builder.py
+++ b/src/pipeline/builder.py
@@ -5,12 +5,16 @@ from pathlib import Path
 from types import ModuleType
 from typing import Callable, Optional
 
-from registry import (PluginRegistry, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from .logging import get_logger
+
+from registry import PluginRegistry, ResourceRegistry, SystemRegistries, ToolRegistry
 
 from .plugins import BasePlugin, PluginAutoClassifier
 from .runtime import AgentRuntime
 from .stages import PipelineStage
+
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -77,7 +81,8 @@ class AgentBuilder:
         ):
             try:
                 module = importlib.import_module(info.name)
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Failed to import plugin module %s: %s", info.name, exc)
                 continue
             self._register_module_plugins(module)
 
@@ -101,7 +106,8 @@ class AgentBuilder:
                 spec.loader.exec_module(module)
                 return module
             raise ImportError(f"Cannot load spec for {file}")
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to import plugin module %s: %s", file, exc)
             return None
 
     def _register_module_plugins(self, module: ModuleType) -> None:
@@ -119,5 +125,11 @@ class AgentBuilder:
                     self.add_plugin(obj({}))
                 elif callable(obj) and name.endswith("_plugin"):
                     self.plugin(obj)
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "Failed to register plugin from %s.%s: %s",
+                    module.__name__,
+                    name,
+                    exc,
+                )
                 continue

--- a/src/pipeline/plugins/classifier.py
+++ b/src/pipeline/plugins/classifier.py
@@ -42,14 +42,10 @@ class PluginAutoClassifier:
             base = cast(type[BasePlugin], AdapterPlugin)
         elif any(k in source for k in ["return", "response", "answer"]):
             stage = PipelineStage.DO
-            base = (
-                cast(type[BasePlugin], ToolPlugin)
-                if any(x in source for x in ["use_tool", "execute_tool", "tool"])
-                else cast(type[BasePlugin], PromptPlugin)
-            )
+            base = cast(type[BasePlugin], PromptPlugin)
         else:
             stage = PipelineStage.DO
-            base = cast(type[BasePlugin], ToolPlugin)
+            base = cast(type[BasePlugin], PromptPlugin)
 
         if "stage" in hints:
             stage = PipelineStage.from_str(str(hints["stage"]))

--- a/src/registry/registries.py
+++ b/src/registry/registries.py
@@ -57,6 +57,8 @@ class PluginRegistry:
     def __init__(self) -> None:
         self._stage_plugins: Dict[PipelineStage, List[BasePlugin]] = defaultdict(list)
         self._names: Dict[BasePlugin, str] = {}
+        self._plugins_by_name: Dict[str, BasePlugin] = {}
+        self._dependents: Dict[str, List[BasePlugin]] = defaultdict(list)
 
     def register_plugin_for_stage(
         self, plugin: BasePlugin, stage: PipelineStage | str, name: str | None = None
@@ -66,14 +68,41 @@ class PluginRegistry:
             stage = PipelineStage(stage)
         except ValueError as exc:
             raise ValueError(f"Invalid stage: {stage}") from exc
-        self._stage_plugins[stage].append(plugin)
-        if name:
-            self._names[plugin] = name
+        plugins = self._stage_plugins[stage]
+        insert_at = len(plugins)
+        for idx, existing in enumerate(plugins):
+            if plugin.priority < existing.priority:
+                insert_at = idx
+                break
+        plugins.insert(insert_at, plugin)
+
+        plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
+        self._names[plugin] = plugin_name
+        self._plugins_by_name[plugin_name] = plugin
+
+        for dep in getattr(plugin, "dependencies", []):
+            self._dependents.setdefault(dep, []).append(plugin)
 
     def get_plugins_for_stage(self, stage: PipelineStage) -> List[BasePlugin]:
         """Return list of plugins registered for ``stage``."""
 
         return self._stage_plugins.get(stage, [])
+
+    # Backwards compatibility for older API
+    def get_for_stage(self, stage: PipelineStage) -> List[BasePlugin]:
+        return self.get_plugins_for_stage(stage)
+
+    def list_plugins(self) -> List[BasePlugin]:
+        plugins: List[BasePlugin] = []
+        for plist in self._stage_plugins.values():
+            plugins.extend(plist)
+        return plugins
+
+    def get_plugin_name(self, plugin: BasePlugin) -> str:
+        return self._names.get(plugin, plugin.__class__.__name__)
+
+    def get_dependents(self, plugin_name: str) -> List[BasePlugin]:
+        return self._dependents.get(plugin_name, [])
 
     def get_name(self, plugin: BasePlugin) -> str | None:
         """Return registered name for ``plugin`` if any."""


### PR DESCRIPTION
## Summary
- stabilize plugin registry API
- log plugin loading failures
- default tool classification to prompt plugins
- expose builder plugins before runtime

## Testing
- `poetry run pytest tests/test_agent.py::test_plugin_decorator_registration -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ba26b40c8322833d32e49baa1be7