### PR TITLE
[Docs] Add documentation and ADR

### DIFF
--- a/docs/adr/0001-core-architecture.md
+++ b/docs/adr/0001-core-architecture.md
@@ -1,0 +1,13 @@
+# ADR 0001: Core Architecture
+
+The Entity Pipeline framework relies on a plugin based pipeline. Each request flows through explicit stages controlled by registered plugins. Resources, tools and prompts are managed via registries so behavior can be reconfigured without code changes.
+
+## Decision
+
+We adopted a single execution pipeline with fail fast validation. Plugins declare their stage and dependencies up front. The initializer verifies configuration before any runtime work is performed.
+
+## Consequences
+
+* Clear stage boundaries make reasoning about execution simple.
+* Swapping plugins or resources only requires configuration changes.
+* Initialization fails early when dependencies or configuration are invalid.

--- a/docs/source/api_reference.md
+++ b/docs/source/api_reference.md
@@ -1,0 +1,9 @@
+# API Reference
+
+This section is generated from the project source using autodoc. Every public object is documented directly from its docstrings.
+
+::: entity
+    options:
+        members: true
+        undoc-members: true
+        show-source: true

--- a/docs/source/deploy_cloud.md
+++ b/docs/source/deploy_cloud.md
@@ -1,0 +1,10 @@
+# Cloud Deployment
+
+Use the provided infrastructure helpers to deploy to your preferred cloud provider.
+
+1. Define your infrastructure in `infrastructure/` using CDKTF.
+2. Deploy the stack:
+   ```bash
+   python -m infrastructure.aws_basic deploy
+   ```
+3. Update the configuration file with the URLs or credentials for the cloud resources.

--- a/docs/source/deploy_docker.md
+++ b/docs/source/deploy_docker.md
@@ -1,0 +1,13 @@
+# Docker Deployment
+
+Containerize the system to run anywhere Docker is available.
+
+1. Build the image:
+   ```bash
+   docker build -t entity-agent .
+   ```
+2. Run the container:
+   ```bash
+   docker run -p 8000:8000 entity-agent
+   ```
+3. Connect to `http://localhost:8000` just as you would locally.

--- a/docs/source/deploy_local.md
+++ b/docs/source/deploy_local.md
@@ -1,0 +1,13 @@
+# Local Deployment
+
+Run the agent directly on your machine during development.
+
+1. Install dependencies:
+   ```bash
+   pip install -e .
+   ```
+2. Start the HTTP adapter:
+   ```bash
+   python -m entity.cli --config config/dev.yaml
+   ```
+3. Send messages to `http://localhost:8000` to interact with the agent.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -20,6 +20,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 
 ### Reference
 - [Context API](context.md)
+- [API reference](api_reference.md)
 - [Advanced usage](advanced_usage.md)
 - [Module map](module_map.md)
 - [Troubleshooting](troubleshooting.md)
@@ -27,6 +28,9 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 ### Deployment
 - [AWS deployment](aws_deployment.md)
 - [Terraform guide](deploy_aws.md)
+- [Local](deploy_local.md)
+- [Docker](deploy_docker.md)
+- [Cloud](deploy_cloud.md)
 
 ```{toctree}
 :hidden:
@@ -51,6 +55,10 @@ module_map
 troubleshooting
 aws_deployment
 deploy_aws
+deploy_local
+deploy_docker
+deploy_cloud
 principle_checklist
 apidocs/index
+api_reference
 ```

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -86,3 +86,34 @@ Any plugin can now call `context.get_resource("database")` and use these
 methods, enabling a consistent storage interface across resources.
 
 
+
+## Example Pipelines
+
+Several example pipelines in the `examples/` directory showcase more advanced patterns.
+
+### Memory Composition
+
+`examples/pipelines/memory_composition_pipeline.py` demonstrates how to combine SQLite, PGVector and a local file system into a single `MemoryResource`:
+
+```python
+memory = MemoryResource(
+    database=SQLiteDatabaseResource({"path": "./agent.db"}),
+    vector_store=PgVectorStore({"table": "embeddings"}),
+    filesystem=LocalFileSystemResource({"base_path": "./files"}),
+)
+```
+
+### Vector Memory
+
+`examples/pipelines/vector_memory_pipeline.py` shows a custom `ResourcePlugin` that stores vectors in memory. A prompt plugin retrieves vectors and interacts with the LLM:
+
+```python
+class VectorMemoryResource(ResourcePlugin):
+    stages = [PipelineStage.PARSE]
+    name = "vector_memory"
+
+    def add(self, key: str, vector: List[float]) -> None:
+        self.vectors[key] = vector
+```
+
+These scripts are great starting points when designing your own plugins.

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -10,3 +10,11 @@
 - **Config validation failed** – run `python -m src.config.validator --config your.yaml` to see detailed messages.
 
 If initialization still fails, enable debug logging with `LOG_LEVEL=DEBUG` when running the validator for verbose output.
+
+## Runtime errors
+- **No response generated** – verify each stage sets the pipeline response or passes control to the next stage.
+- **Tool not found** – make sure the tool is registered in `tool_registry` and that the calling plugin uses the correct name.
+
+## Docker issues
+- **Container exits immediately** – check the command in your `Dockerfile` and ensure the configuration file path is correct.
+- **Ports not exposed** – run the container with `-p 8000:8000` so the HTTP adapter is reachable from the host.


### PR DESCRIPTION
## Summary
- add new API reference page
- extend plugin guide with examples from the `examples` directory
- expand troubleshooting notes
- add local, Docker, and cloud deployment guides
- document first architecture decision

## Testing
- `flake8 src/ tests/ | head -n 5`
- `mypy src/ | head -n 5` *(fails: KeyboardInterrupt)*
- `bandit -r src/ | head -n 5`
- `python -m src.config.validator --config config/dev.yaml | head -n 3`
- `python -m src.config.validator --config config/prod.yaml | head -n 3`
- `python -m src.registry.validator --config config/dev.yaml | head -n 3`
- `python -m src.registry.validator --config config/prod.yaml | head -n 3`
- `pytest tests/integration/ -v | head -n 5`
- `pytest tests/infrastructure/ -v | head -n 5`
- `pytest tests/performance/ -m benchmark | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6867c0f974548322b3d78eaebdea3dfe