### PR TITLE
[Infrastructure] Add Docker wrapper and sandbox improvements

### DIFF
--- a/docs/source/security.md
+++ b/docs/source/security.md
@@ -1,0 +1,11 @@
+# Sandbox Security
+
+This project can run plugins inside isolated Docker containers. Each plugin must
+provide a `plugin.toml` manifest defining required resources and runtime limits.
+The :class:`pipeline.sandbox.DockerSandboxRunner` applies CPU and memory limits
+based on the manifest and verifies the plugin signature before execution. The
+runner uses :class:`infrastructure.DockerInfrastructure` so you can also build
+a Docker image for your agent.
+
+To validate manifests outside of runtime, use :class:`pipeline.sandbox.PluginAuditor`.
+It checks requested resources against a whitelist and reports any violations.

--- a/src/infrastructure/__init__.py
+++ b/src/infrastructure/__init__.py
@@ -2,4 +2,9 @@
 
 from .infrastructure import Infrastructure
 
-__all__ = ["Infrastructure"]
+try:  # optional dependency
+    from .docker import DockerInfrastructure
+except Exception:  # pragma: no cover - missing docker library
+    DockerInfrastructure = None  # type: ignore
+
+__all__ = ["Infrastructure", "DockerInfrastructure"]

--- a/src/infrastructure/docker.py
+++ b/src/infrastructure/docker.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import docker
+
+
+class DockerInfrastructure:
+    """Build and run Docker images for the agent."""
+
+    def __init__(self, base_image: str = "python:3.11-slim") -> None:
+        self.client = docker.from_env()
+        self.base_image = base_image
+
+    def build_image(
+        self, context: str, tag: str = "agent:latest", dockerfile: str = "Dockerfile"
+    ) -> None:
+        """Build a Docker image from ``context``."""
+        self.client.images.build(path=context, tag=tag, dockerfile=dockerfile)
+
+    def run_container(
+        self,
+        image: str,
+        command: list[str],
+        *,
+        cpu: float = 1.0,
+        memory: str = "512m",
+        volumes: Dict[str, Dict[str, str]] | None = None,
+    ) -> None:
+        """Run a container with resource limits."""
+        self.client.containers.run(
+            image,
+            command=command,
+            volumes=volumes or {},
+            cpus=cpu,
+            mem_limit=memory,
+            remove=True,
+        )

--- a/src/pipeline/sandbox/__init__.py
+++ b/src/pipeline/sandbox/__init__.py
@@ -1,0 +1,4 @@
+from .audit import PluginAuditor
+from .runner import DockerSandboxRunner
+
+__all__ = ["DockerSandboxRunner", "PluginAuditor"]

--- a/src/pipeline/sandbox/audit.py
+++ b/src/pipeline/sandbox/audit.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Iterable, List
+
+
+class PluginAuditor:
+    """Validate plugin permission manifests."""
+
+    def __init__(self, allowed_resources: Iterable[str] | None = None) -> None:
+        self.allowed_resources = set(allowed_resources or [])
+
+    def audit(self, plugin_dir: str) -> List[str]:
+        """Return list of disallowed resources."""
+        manifest_path = Path(plugin_dir) / "plugin.toml"
+        manifest = tomllib.loads(manifest_path.read_text())
+        requested = set(manifest.get("resources", []))
+        return sorted(requested - self.allowed_resources)

--- a/src/pipeline/sandbox/runner.py
+++ b/src/pipeline/sandbox/runner.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Any, Dict
+
+from infrastructure import DockerInfrastructure
+
+
+class DockerSandboxRunner:
+    """Run plugins inside isolated Docker containers."""
+
+    def __init__(self, infrastructure: DockerInfrastructure | None = None) -> None:
+        if infrastructure is not None:
+            self.infra = infrastructure
+        else:
+            if DockerInfrastructure is None:
+                raise ImportError(
+                    "Docker infrastructure is unavailable. Install the 'docker' package."
+                )
+            self.infra = DockerInfrastructure()
+
+    def _verify_signature(self, plugin_dir: Path) -> None:
+        """Verify plugin GPG signature."""
+        manifest = plugin_dir / "plugin.toml"
+        sig = plugin_dir / "plugin.toml.sig"
+        if not sig.exists():
+            raise RuntimeError(f"Signature file missing: {sig}")
+        result = subprocess.run(
+            ["gpg", "--verify", str(sig), str(manifest)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Invalid plugin signature: {result.stderr}")
+
+    def _load_manifest(self, plugin_dir: Path) -> Dict[str, Any]:
+        data = (plugin_dir / "plugin.toml").read_text()
+        return tomllib.loads(data)
+
+    def run_plugin(self, plugin_dir: str) -> None:
+        """Execute plugin in a Docker container with limits."""
+        path = Path(plugin_dir)
+        self._verify_signature(path)
+        manifest = self._load_manifest(path)
+        cpu = float(manifest.get("cpu", 1))
+        memory = manifest.get("memory", "512m")
+        command = ["python", "-m", manifest.get("entrypoint", "main")]
+        volumes = {str(path): {"bind": "/plugin", "mode": "ro"}}
+        self.infra.run_container(
+            self.infra.base_image,
+            command,
+            cpu=cpu,
+            memory=memory,
+            volumes=volumes,
+        )

--- a/tests/infrastructure/test_docker_infrastructure.py
+++ b/tests/infrastructure/test_docker_infrastructure.py
@@ -1,0 +1,27 @@
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("docker")
+infrastructure = pytest.importorskip("infrastructure")
+DockerInfrastructure = infrastructure.DockerInfrastructure
+
+
+@mock.patch("docker.from_env")
+def test_build_image(from_env):
+    client = mock.Mock()
+    from_env.return_value = client
+    infra = DockerInfrastructure()
+    infra.build_image(".", tag="agent:test")
+    client.images.build.assert_called_with(
+        path=".", tag="agent:test", dockerfile="Dockerfile"
+    )
+
+
+@mock.patch("docker.from_env")
+def test_run_container(from_env):
+    client = mock.Mock()
+    from_env.return_value = client
+    infra = DockerInfrastructure()
+    infra.run_container("image", ["echo", "hi"])
+    client.containers.run.assert_called()

--- a/tests/test_sandbox_audit.py
+++ b/tests/test_sandbox_audit.py
@@ -1,0 +1,10 @@
+from pipeline.sandbox import PluginAuditor
+
+
+def test_audit_detects_invalid_resources(tmp_path):
+    manifest = """
+resources = ["net", "disk", "evil"]
+"""
+    (tmp_path / "plugin.toml").write_text(manifest)
+    auditor = PluginAuditor(["net", "disk"])
+    assert auditor.audit(str(tmp_path)) == ["evil"]


### PR DESCRIPTION
## Summary
- document Docker infrastructure in security guide
- introduce `DockerInfrastructure` for building and running containers
- update Docker sandbox runner to depend on the new infrastructure
- make Docker integration optional for environments without docker
- add unit tests for `DockerInfrastructure`

## Testing
- `poetry run black src/infrastructure/__init__.py src/pipeline/sandbox/runner.py tests/infrastructure/test_docker_infrastructure.py src/infrastructure/docker.py tests/test_sandbox_audit.py`
- `poetry run isort src/infrastructure/__init__.py src/pipeline/sandbox/runner.py tests/infrastructure/test_docker_infrastructure.py`
- `poetry run flake8 src/infrastructure/__init__.py src/infrastructure/docker.py src/pipeline/sandbox/runner.py tests/infrastructure/test_docker_infrastructure.py tests/test_sandbox_audit.py`
- `poetry run mypy src/infrastructure/docker.py src/infrastructure/__init__.py src/pipeline/sandbox/runner.py tests/infrastructure/test_docker_infrastructure.py tests/test_sandbox_audit.py` *(fails: missing stubs)*
- `poetry run bandit -r src/infrastructure src/pipeline/sandbox/runner.py`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: missing resources)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: HTTP_TOKEN missing)*
- `poetry run python -m src.registry.validator --config config/dev.yaml` *(fails: missing stages)*
- `poetry run pytest tests/integration/ -v` *(fails: database does not exist)*
- `poetry run pytest tests/infrastructure/ -v`
- `poetry run pytest tests/performance/ -m benchmark`


------
https://chatgpt.com/codex/tasks/task_e_6867c0ed6aa88322a0b5d5126d60abc0