### PR TITLE
[Core] Make sandbox optional

### DIFF
--- a/src/pipeline/sandbox/__init__.py
+++ b/src/pipeline/sandbox/__init__.py
@@ -1,4 +1,10 @@
-from .audit import PluginAuditor
-from .runner import DockerSandboxRunner
+"""Sandbox utilities for running and auditing plugins."""
 
-__all__ = ["DockerSandboxRunner", "PluginAuditor"]
+from .audit import PluginAuditor
+
+try:  # optional dependency
+    from .runner import DockerSandboxRunner
+except Exception:  # pragma: no cover - missing docker or cdktf
+    DockerSandboxRunner = None  # type: ignore
+
+__all__ = ["PluginAuditor", "DockerSandboxRunner"]


### PR DESCRIPTION
## Summary
- avoid importing Docker sandbox runner if dependencies are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_6867cfe14a688322bdfd184bad1bdec8