### PR TITLE
Move cache and sandbox modules to user_plugins

### DIFF
--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -44,7 +44,7 @@ plugins:
     cache:
       type: plugins.resources.cache:CacheResource
       backend:
-        type: pipeline.cache.redis:RedisCache
+        type: user_plugins.resources.cache_backends.redis:RedisCache
   tools:
     weather:
       type: plugins.tools.weather_api_tool:WeatherApiTool

--- a/docs/source/security.md
+++ b/docs/source/security.md
@@ -2,10 +2,10 @@
 
 This project can run plugins inside isolated Docker containers. Each plugin must
 provide a `plugin.toml` manifest defining required resources and runtime limits.
-The :class:`pipeline.sandbox.DockerSandboxRunner` applies CPU and memory limits
+The :class:`user_plugins.infrastructure.sandbox.DockerSandboxRunner` applies CPU and memory limits
 based on the manifest and verifies the plugin signature before execution. The
 runner uses :class:`infrastructure.DockerInfrastructure` so you can also build
 a Docker image for your agent.
 
-To validate manifests outside of runtime, use :class:`pipeline.sandbox.PluginAuditor`.
+To validate manifests outside of runtime, use :class:`user_plugins.infrastructure.sandbox.PluginAuditor`.
 It checks requested resources against a whitelist and reports any violations.

--- a/src/pipeline/cache/__init__.py
+++ b/src/pipeline/cache/__init__.py
@@ -1,8 +1,9 @@
 """Caching utilities with pluggable backends."""
 
+from user_plugins.resources.cache_backends.redis import RedisCache
+from user_plugins.resources.cache_backends.semantic import SemanticCache
+
 from .base import CacheBackend
 from .memory import InMemoryCache
-from .redis import RedisCache
-from .semantic import SemanticCache
 
 __all__ = ["CacheBackend", "InMemoryCache", "RedisCache", "SemanticCache"]

--- a/src/pipeline/cache/redis.py
+++ b/src/pipeline/cache/redis.py
@@ -1,28 +1,13 @@
 from __future__ import annotations
 
-from typing import Any
+import warnings
 
-import redis.asyncio as redis
+from user_plugins.resources.cache_backends.redis import RedisCache
 
-from .base import CacheBackend
+warnings.warn(
+    "pipeline.cache.redis is deprecated; use user_plugins.resources.cache_backends.redis instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-
-class RedisCache(CacheBackend):
-    """Redis-based cache backend."""
-
-    def __init__(
-        self, url: str = "redis://localhost:6379/0", default_ttl: int | None = None
-    ) -> None:
-        self._client = redis.from_url(url)
-        self._default_ttl = default_ttl
-
-    async def get(self, key: str) -> Any:
-        value = await self._client.get(key)
-        return value.decode() if isinstance(value, bytes) else value
-
-    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
-        ttl = ttl if ttl is not None else self._default_ttl
-        await self._client.set(key, value, ex=ttl)
-
-    async def clear(self) -> None:
-        await self._client.flushdb()
+__all__ = ["RedisCache"]

--- a/src/pipeline/cache/semantic.py
+++ b/src/pipeline/cache/semantic.py
@@ -1,42 +1,16 @@
 from __future__ import annotations
 
-from typing import Any
+import warnings
 
-from pipeline.resources.vectorstore import VectorStoreResource
+from user_plugins.resources.cache_backends.semantic import SemanticCache
 
-from .base import CacheBackend
+warnings.warn(
+    (
+        "pipeline.cache.semantic is deprecated; "
+        "use user_plugins.resources.cache_backends.semantic instead"
+    ),
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-
-class SemanticCache(CacheBackend):
-    """Cache that retrieves values using vector similarity."""
-
-    def __init__(self, store: VectorStoreResource, inner: CacheBackend) -> None:
-        self.store = store
-        self.inner = inner
-        self._prompt_map: dict[str, str] = {}
-
-    async def get(self, key: str) -> Any:
-        return await self.inner.get(key)
-
-    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
-        await self.inner.set(key, value, ttl)
-
-    async def clear(self) -> None:
-        await self.inner.clear()
-
-    async def get_semantic(self, prompt: str) -> Any:
-        similar = await self.store.query_similar(prompt, 1)
-        if not similar:
-            return None
-        key = self._prompt_map.get(similar[0])
-        if not key:
-            return None
-        return await self.inner.get(key)
-
-    async def set_semantic(
-        self, prompt: str, value: Any, ttl: int | None = None
-    ) -> None:
-        key = f"semantic:{len(self._prompt_map)}"
-        self._prompt_map[prompt] = key
-        await self.store.add_embedding(prompt)
-        await self.inner.set(key, value, ttl)
+__all__ = ["SemanticCache"]

--- a/src/pipeline/sandbox/__init__.py
+++ b/src/pipeline/sandbox/__init__.py
@@ -1,10 +1,13 @@
-"""Sandbox utilities for running and auditing plugins."""
+"""Compatibility wrapper for sandbox utilities."""
 
-from .audit import PluginAuditor
+import warnings
 
-try:  # optional dependency
-    from .runner import DockerSandboxRunner
-except Exception:  # pragma: no cover - missing docker or cdktf
-    DockerSandboxRunner = None  # type: ignore
+from user_plugins.infrastructure.sandbox import DockerSandboxRunner, PluginAuditor
+
+warnings.warn(
+    "pipeline.sandbox is deprecated; use user_plugins.infrastructure.sandbox instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["PluginAuditor", "DockerSandboxRunner"]

--- a/src/pipeline/sandbox/audit.py
+++ b/src/pipeline/sandbox/audit.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
-import tomllib
-from pathlib import Path
-from typing import Iterable, List
+import warnings
 
+from user_plugins.infrastructure.sandbox.audit import PluginAuditor
 
-class PluginAuditor:
-    """Validate plugin permission manifests."""
+warnings.warn(
+    "pipeline.sandbox.audit is deprecated; use user_plugins.infrastructure.sandbox.audit instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-    def __init__(self, allowed_resources: Iterable[str] | None = None) -> None:
-        self.allowed_resources = set(allowed_resources or [])
-
-    def audit(self, plugin_dir: str) -> List[str]:
-        """Return list of disallowed resources."""
-        manifest_path = Path(plugin_dir) / "plugin.toml"
-        manifest = tomllib.loads(manifest_path.read_text())
-        requested = set(manifest.get("resources", []))
-        return sorted(requested - self.allowed_resources)
+__all__ = ["PluginAuditor"]

--- a/src/pipeline/sandbox/runner.py
+++ b/src/pipeline/sandbox/runner.py
@@ -1,57 +1,13 @@
 from __future__ import annotations
 
-import subprocess
-import tomllib
-from pathlib import Path
-from typing import Any, Dict
+import warnings
 
-from infrastructure import DockerInfrastructure
+from user_plugins.infrastructure.sandbox.runner import DockerSandboxRunner
 
+warnings.warn(
+    "pipeline.sandbox.runner is deprecated; use user_plugins.infrastructure.sandbox.runner instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-class DockerSandboxRunner:
-    """Run plugins inside isolated Docker containers."""
-
-    def __init__(self, infrastructure: DockerInfrastructure | None = None) -> None:
-        if infrastructure is not None:
-            self.infra = infrastructure
-        else:
-            if DockerInfrastructure is None:
-                raise ImportError(
-                    "Docker infrastructure is unavailable. Install the 'docker' package."
-                )
-            self.infra = DockerInfrastructure()
-
-    def _verify_signature(self, plugin_dir: Path) -> None:
-        """Verify plugin GPG signature."""
-        manifest = plugin_dir / "plugin.toml"
-        sig = plugin_dir / "plugin.toml.sig"
-        if not sig.exists():
-            raise RuntimeError(f"Signature file missing: {sig}")
-        result = subprocess.run(
-            ["gpg", "--verify", str(sig), str(manifest)],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(f"Invalid plugin signature: {result.stderr}")
-
-    def _load_manifest(self, plugin_dir: Path) -> Dict[str, Any]:
-        data = (plugin_dir / "plugin.toml").read_text()
-        return tomllib.loads(data)
-
-    def run_plugin(self, plugin_dir: str) -> None:
-        """Execute plugin in a Docker container with limits."""
-        path = Path(plugin_dir)
-        self._verify_signature(path)
-        manifest = self._load_manifest(path)
-        cpu = float(manifest.get("cpu", 1))
-        memory = manifest.get("memory", "512m")
-        command = ["python", "-m", manifest.get("entrypoint", "main")]
-        volumes = {str(path): {"bind": "/plugin", "mode": "ro"}}
-        self.infra.run_container(
-            self.infra.base_image,
-            command,
-            cpu=cpu,
-            memory=memory,
-            volumes=volumes,
-        )
+__all__ = ["DockerSandboxRunner"]

--- a/src/user_plugins/infrastructure/__init__.py
+++ b/src/user_plugins/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure helpers for user plugins."""

--- a/src/user_plugins/infrastructure/sandbox/__init__.py
+++ b/src/user_plugins/infrastructure/sandbox/__init__.py
@@ -1,0 +1,10 @@
+"""Sandbox utilities for running and auditing plugins."""
+
+from .audit import PluginAuditor
+
+try:  # optional dependency
+    from .runner import DockerSandboxRunner
+except Exception:  # pragma: no cover - missing docker or cdktf
+    DockerSandboxRunner = None  # type: ignore
+
+__all__ = ["PluginAuditor", "DockerSandboxRunner"]

--- a/src/user_plugins/infrastructure/sandbox/audit.py
+++ b/src/user_plugins/infrastructure/sandbox/audit.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Iterable, List
+
+
+class PluginAuditor:
+    """Validate plugin permission manifests."""
+
+    def __init__(self, allowed_resources: Iterable[str] | None = None) -> None:
+        self.allowed_resources = set(allowed_resources or [])
+
+    def audit(self, plugin_dir: str) -> List[str]:
+        """Return list of disallowed resources."""
+        manifest_path = Path(plugin_dir) / "plugin.toml"
+        manifest = tomllib.loads(manifest_path.read_text())
+        requested = set(manifest.get("resources", []))
+        return sorted(requested - self.allowed_resources)

--- a/src/user_plugins/infrastructure/sandbox/runner.py
+++ b/src/user_plugins/infrastructure/sandbox/runner.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Any, Dict
+
+from infrastructure import DockerInfrastructure
+
+
+class DockerSandboxRunner:
+    """Run plugins inside isolated Docker containers."""
+
+    def __init__(self, infrastructure: DockerInfrastructure | None = None) -> None:
+        if infrastructure is not None:
+            self.infra = infrastructure
+        else:
+            if DockerInfrastructure is None:
+                raise ImportError(
+                    "Docker infrastructure is unavailable. Install the 'docker' package."
+                )
+            self.infra = DockerInfrastructure()
+
+    def _verify_signature(self, plugin_dir: Path) -> None:
+        """Verify plugin GPG signature."""
+        manifest = plugin_dir / "plugin.toml"
+        sig = plugin_dir / "plugin.toml.sig"
+        if not sig.exists():
+            raise RuntimeError(f"Signature file missing: {sig}")
+        result = subprocess.run(
+            ["gpg", "--verify", str(sig), str(manifest)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Invalid plugin signature: {result.stderr}")
+
+    def _load_manifest(self, plugin_dir: Path) -> Dict[str, Any]:
+        data = (plugin_dir / "plugin.toml").read_text()
+        return tomllib.loads(data)
+
+    def run_plugin(self, plugin_dir: str) -> None:
+        """Execute plugin in a Docker container with limits."""
+        path = Path(plugin_dir)
+        self._verify_signature(path)
+        manifest = self._load_manifest(path)
+        cpu = float(manifest.get("cpu", 1))
+        memory = manifest.get("memory", "512m")
+        command = ["python", "-m", manifest.get("entrypoint", "main")]
+        volumes = {str(path): {"bind": "/plugin", "mode": "ro"}}
+        self.infra.run_container(
+            self.infra.base_image,
+            command,
+            cpu=cpu,
+            memory=memory,
+            volumes=volumes,
+        )

--- a/src/user_plugins/resources/__init__.py
+++ b/src/user_plugins/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Collection of user-provided resource plugins."""

--- a/src/user_plugins/resources/cache_backends/__init__.py
+++ b/src/user_plugins/resources/cache_backends/__init__.py
@@ -1,0 +1,6 @@
+"""User-provided cache backends."""
+
+from .redis import RedisCache
+from .semantic import SemanticCache
+
+__all__ = ["RedisCache", "SemanticCache"]

--- a/src/user_plugins/resources/cache_backends/redis.py
+++ b/src/user_plugins/resources/cache_backends/redis.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+import redis.asyncio as redis
+
+from pipeline.cache.base import CacheBackend
+
+
+class RedisCache(CacheBackend):
+    """Redis-based cache backend."""
+
+    def __init__(
+        self, url: str = "redis://localhost:6379/0", default_ttl: int | None = None
+    ) -> None:
+        self._client = redis.from_url(url)
+        self._default_ttl = default_ttl
+
+    async def get(self, key: str) -> Any:
+        value = await self._client.get(key)
+        return value.decode() if isinstance(value, bytes) else value
+
+    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
+        ttl = ttl if ttl is not None else self._default_ttl
+        await self._client.set(key, value, ex=ttl)
+
+    async def clear(self) -> None:
+        await self._client.flushdb()

--- a/src/user_plugins/resources/cache_backends/semantic.py
+++ b/src/user_plugins/resources/cache_backends/semantic.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pipeline.cache.base import CacheBackend
+from pipeline.resources.vectorstore import VectorStoreResource
+
+
+class SemanticCache(CacheBackend):
+    """Cache that retrieves values using vector similarity."""
+
+    def __init__(self, store: VectorStoreResource, inner: CacheBackend) -> None:
+        self.store = store
+        self.inner = inner
+        self._prompt_map: dict[str, str] = {}
+
+    async def get(self, key: str) -> Any:
+        return await self.inner.get(key)
+
+    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
+        await self.inner.set(key, value, ttl)
+
+    async def clear(self) -> None:
+        await self.inner.clear()
+
+    async def get_semantic(self, prompt: str) -> Any:
+        similar = await self.store.query_similar(prompt, 1)
+        if not similar:
+            return None
+        key = self._prompt_map.get(similar[0])
+        if not key:
+            return None
+        return await self.inner.get(key)
+
+    async def set_semantic(
+        self, prompt: str, value: Any, ttl: int | None = None
+    ) -> None:
+        key = f"semantic:{len(self._prompt_map)}"
+        self._prompt_map[prompt] = key
+        await self.store.add_embedding(prompt)
+        await self.inner.set(key, value, ttl)

--- a/tests/test_sandbox_audit.py
+++ b/tests/test_sandbox_audit.py
@@ -1,4 +1,4 @@
-from pipeline.sandbox import PluginAuditor
+from user_plugins.infrastructure.sandbox import PluginAuditor
 
 
 def test_audit_detects_invalid_resources(tmp_path):


### PR DESCRIPTION
## Summary
- relocate Redis and semantic caches into `user_plugins.resources.cache_backends`
- move sandbox utilities into `user_plugins.infrastructure.sandbox`
- provide compatibility wrappers at previous locations
- update docs and config to reference new modules
- adjust tests for new import paths

## Testing
- `black src/ tests/`
- `isort src/ tests/`
- `flake8 src/ tests/` *(fails: F401 imported but unused)*
- `mypy src/` *(fails: many missing stubs)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'duckdb')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: 'duckdb')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: 'duckdb')*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: 'duckdb')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: 'duckdb')*


------
https://chatgpt.com/codex/tasks/task_e_6867e2a3eac083228f7b6c8c4c0b9070