### PR TITLE
[Resource] fix unified LLM import

### DIFF
--- a/plugins/resources/llm/__init__.py
+++ b/plugins/resources/llm/__init__.py
@@ -1,3 +1,5 @@
+from pipeline.resources.llm.unified import UnifiedLLMResource
+
 from ..llm_base import LLM
 from .providers import (
     ClaudeProvider,
@@ -6,7 +8,6 @@ from .providers import (
     OllamaProvider,
     OpenAIProvider,
 )
-from .unified import UnifiedLLMResource
 
 __all__ = [
     "LLM",


### PR DESCRIPTION
## Summary
- import `UnifiedLLMResource` from `pipeline.resources.llm.unified`
- keep re-export from `plugins.resources`

## Testing
- `black plugins/resources/llm/__init__.py plugins/resources/__init__.py`
- `isort plugins/resources/llm/__init__.py plugins/resources/__init__.py`
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/` *(fails: missing dependencies)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: missing dependency yaml)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: missing dependency yaml)*
- `python -m src.registry.validator` *(fails: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68681e0b3d688322a1442b8a3bc2b78d