### PR TITLE
[Examples] Initialize plugins namespace earlier

### DIFF
--- a/examples/advanced_llm.py
+++ b/examples/advanced_llm.py
@@ -13,13 +13,25 @@ def _enable_plugins_namespace() -> None:
     import pkgutil
     import types
 
+    plugins_mod = types.ModuleType("plugins")
+    plugins_mod.__path__ = [
+        str(pathlib.Path(__file__).resolve().parents[1] / "plugins")
+    ]
+    import importlib.machinery
+
+    plugins_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "plugins", None, is_package=True
+    )
+    sys.modules["plugins"] = plugins_mod
+
+    # isort: off
     import pipeline.user_plugins
     import pipeline.user_plugins.resources as plugin_resources
     import pipeline.resources
 
-    plugins_mod = types.ModuleType("plugins")
+    # isort: on
+
     plugins_mod.__dict__.update(vars(pipeline.user_plugins))
-    sys.modules["plugins"] = plugins_mod
     sys.modules["user_plugins.resources"] = plugin_resources
     plugins_mod.resources = plugin_resources
 

--- a/examples/bedrock_deploy.py
+++ b/examples/bedrock_deploy.py
@@ -13,13 +13,25 @@ def _enable_plugins_namespace() -> None:
     import pkgutil
     import types
 
+    plugins_mod = types.ModuleType("plugins")
+    plugins_mod.__path__ = [
+        str(pathlib.Path(__file__).resolve().parents[1] / "plugins")
+    ]
+    import importlib.machinery
+
+    plugins_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "plugins", None, is_package=True
+    )
+    sys.modules["plugins"] = plugins_mod
+
+    # isort: off
     import pipeline.user_plugins
     import pipeline.user_plugins.resources as plugin_resources
     import pipeline.resources
 
-    plugins_mod = types.ModuleType("plugins")
+    # isort: on
+
     plugins_mod.__dict__.update(vars(pipeline.user_plugins))
-    sys.modules["plugins"] = plugins_mod
     sys.modules["user_plugins.resources"] = plugin_resources
     plugins_mod.resources = plugin_resources
 

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -15,13 +15,25 @@ def _enable_plugins_namespace() -> None:
     import pkgutil
     import types
 
-    import pipeline.resources
+    plugins_mod = types.ModuleType("plugins")
+    plugins_mod.__path__ = [
+        str(pathlib.Path(__file__).resolve().parents[2] / "plugins")
+    ]
+    import importlib.machinery
+
+    plugins_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "plugins", None, is_package=True
+    )
+    sys.modules["plugins"] = plugins_mod
+
+    # isort: off
     import pipeline.user_plugins
     import pipeline.user_plugins.resources as plugin_resources
+    import pipeline.resources
 
-    plugins_mod = types.ModuleType("plugins")
+    # isort: on
+
     plugins_mod.__dict__.update(vars(pipeline.user_plugins))
-    sys.modules["plugins"] = plugins_mod
     sys.modules["user_plugins.resources"] = plugin_resources
     plugins_mod.resources = plugin_resources
 
@@ -49,8 +61,9 @@ from pipeline.context import PluginContext  # noqa: E402
 from user_plugins.local_filesystem import LocalFileSystemResource  # noqa: E402
 from user_plugins.memory_resource import MemoryResource  # noqa: E402
 from user_plugins.pg_vector_store import PgVectorStore  # noqa: E402
-from user_plugins.sqlite_storage import \
-    SQLiteStorageResource as SQLiteDatabaseResource  # noqa: E402
+from user_plugins.sqlite_storage import (
+    SQLiteStorageResource as SQLiteDatabaseResource,
+)  # noqa: E402
 
 
 class StorePrompt(PromptPlugin):

--- a/examples/pipelines/pipeline_example.py
+++ b/examples/pipelines/pipeline_example.py
@@ -15,13 +15,25 @@ def _enable_plugins_namespace() -> None:
     import pkgutil
     import types
 
+    plugins_mod = types.ModuleType("plugins")
+    plugins_mod.__path__ = [
+        str(pathlib.Path(__file__).resolve().parents[2] / "plugins")
+    ]
+    import importlib.machinery
+
+    plugins_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "plugins", None, is_package=True
+    )
+    sys.modules["plugins"] = plugins_mod
+
+    # isort: off
     import pipeline.user_plugins
     import pipeline.user_plugins.resources as plugin_resources
     import pipeline.resources
 
-    plugins_mod = types.ModuleType("plugins")
+    # isort: on
+
     plugins_mod.__dict__.update(vars(pipeline.user_plugins))
-    sys.modules["plugins"] = plugins_mod
     sys.modules["user_plugins.resources"] = plugin_resources
     plugins_mod.resources = plugin_resources
 

--- a/examples/pipelines/vector_memory_pipeline.py
+++ b/examples/pipelines/vector_memory_pipeline.py
@@ -20,13 +20,25 @@ def _enable_plugins_namespace() -> None:
     import pkgutil
     import types
 
-    import pipeline.resources
+    plugins_mod = types.ModuleType("plugins")
+    plugins_mod.__path__ = [
+        str(pathlib.Path(__file__).resolve().parents[2] / "plugins")
+    ]
+    import importlib.machinery
+
+    plugins_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "plugins", None, is_package=True
+    )
+    sys.modules["plugins"] = plugins_mod
+
+    # isort: off
     import pipeline.user_plugins
     import pipeline.user_plugins.resources as plugin_resources
+    import pipeline.resources
 
-    plugins_mod = types.ModuleType("plugins")
+    # isort: on
+
     plugins_mod.__dict__.update(vars(pipeline.user_plugins))
-    sys.modules["plugins"] = plugins_mod
     sys.modules["user_plugins.resources"] = plugin_resources
     plugins_mod.resources = plugin_resources
 

--- a/examples/servers/http_server.py
+++ b/examples/servers/http_server.py
@@ -13,13 +13,25 @@ def _enable_plugins_namespace() -> None:
     import pkgutil
     import types
 
+    plugins_mod = types.ModuleType("plugins")
+    plugins_mod.__path__ = [
+        str(pathlib.Path(__file__).resolve().parents[2] / "plugins")
+    ]
+    import importlib.machinery
+
+    plugins_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "plugins", None, is_package=True
+    )
+    sys.modules["plugins"] = plugins_mod
+
+    # isort: off
     import pipeline.user_plugins
     import pipeline.user_plugins.resources as plugin_resources
     import pipeline.resources
 
-    plugins_mod = types.ModuleType("plugins")
+    # isort: on
+
     plugins_mod.__dict__.update(vars(pipeline.user_plugins))
-    sys.modules["plugins"] = plugins_mod
     sys.modules["user_plugins.resources"] = plugin_resources
     plugins_mod.resources = plugin_resources
 

--- a/examples/utilities/plugin_loader.py
+++ b/examples/utilities/plugin_loader.py
@@ -13,13 +13,25 @@ def _enable_plugins_namespace() -> None:
     import pkgutil
     import types
 
+    plugins_mod = types.ModuleType("plugins")
+    plugins_mod.__path__ = [
+        str(pathlib.Path(__file__).resolve().parents[2] / "plugins")
+    ]
+    import importlib.machinery
+
+    plugins_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "plugins", None, is_package=True
+    )
+    sys.modules["plugins"] = plugins_mod
+
+    # isort: off
     import pipeline.user_plugins
     import pipeline.user_plugins.resources as plugin_resources
     import pipeline.resources
 
-    plugins_mod = types.ModuleType("plugins")
+    # isort: on
+
     plugins_mod.__dict__.update(vars(pipeline.user_plugins))
-    sys.modules["plugins"] = plugins_mod
     sys.modules["user_plugins.resources"] = plugin_resources
     plugins_mod.resources = plugin_resources
 


### PR DESCRIPTION
## Summary
- initialize a `plugins` module alias before importing `pipeline.user_plugins`
- alias the local `plugins` directory to avoid `ModuleNotFoundError`

## Testing
- `isort examples/ >/tmp/isort.log && tail -n 20 /tmp/isort.log`
- `black examples/ >/tmp/black.log && tail -n 20 /tmp/black.log`
- `flake8 examples/ src/ tests/ >/tmp/flake8.log && tail -n 20 /tmp/flake8.log`
- `mypy src/ >/tmp/mypy.log && tail -n 20 /tmp/mypy.log` *(fails: ModuleNotFoundError: duckdb)*
- `bandit -r src/ >/tmp/bandit.log && tail -n 20 /tmp/bandit.log`
- `python -m src.config.validator --config config/dev.yaml >/tmp/config_dev.log && tail -n 20 /tmp/config_dev.log` *(fails: ModuleNotFoundError: aioboto3)*
- `python -m src.registry.validator >/tmp/registry_val.log && tail -n 20 /tmp/registry_val.log` *(fails: ModuleNotFoundError: pipeline)*
- `pytest tests/integration/ -v >/tmp/pytest_integration.log && tail -n 20 /tmp/pytest_integration.log` *(fails: ModuleNotFoundError: aioboto3)*
- `pytest tests/infrastructure/ -v >/tmp/pytest_infrastructure.log && tail -n 20 /tmp/pytest_infrastructure.log` *(fails: ModuleNotFoundError: aioboto3)*
- `pytest tests/performance/ -m benchmark >/tmp/pytest_performance.log && tail -n 20 /tmp/pytest_performance.log` *(fails: ModuleNotFoundError: aioboto3)*
- `python examples/pipelines/pipeline_example.py > /tmp/example.log 2>&1 && tail -n 15 /tmp/example.log`
- `python examples/advanced_llm.py > /tmp/advanced.log 2>&1 && tail -n 15 /tmp/advanced.log`
- `python examples/servers/http_server.py > /tmp/server.log 2>&1 && tail -n 15 /tmp/server.log`


------
https://chatgpt.com/codex/tasks/task_e_68681e0e12c0832282f0b8fc60906d12