### PR TITLE
Run black and isort

### DIFF
--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,4 +1,5 @@
 from plugins.adapters.server import AgentServer
+
 from .agent import Agent
 from .builder import AgentBuilder
 from .config_update import ConfigUpdateResult, update_plugin_configuration

--- a/src/pipeline/resources/llm/unified.py
+++ b/src/pipeline/resources/llm/unified.py
@@ -6,8 +6,14 @@ from pipeline.state import LLMResponse
 from pipeline.user_plugins import ValidationResult
 from plugins.resources.llm_resource import LLMResource
 
-from .providers import (BedrockProvider, ClaudeProvider, EchoProvider,
-                        GeminiProvider, OllamaProvider, OpenAIProvider)
+from .providers import (
+    BedrockProvider,
+    ClaudeProvider,
+    EchoProvider,
+    GeminiProvider,
+    OllamaProvider,
+    OpenAIProvider,
+)
 
 
 class UnifiedLLMResource(LLMResource):

--- a/src/pipeline/sandbox/__init__.py
+++ b/src/pipeline/sandbox/__init__.py
@@ -2,8 +2,7 @@
 
 import warnings
 
-from user_plugins.infrastructure.sandbox import (DockerSandboxRunner,
-                                                 PluginAuditor)
+from user_plugins.infrastructure.sandbox import DockerSandboxRunner, PluginAuditor
 
 warnings.warn(
     "pipeline.sandbox is deprecated; use user_plugins.infrastructure.sandbox instead",

--- a/tests/integration/test_chat_history_backends.py
+++ b/tests/integration/test_chat_history_backends.py
@@ -6,9 +6,17 @@ from pathlib import Path
 import pytest
 
 from config.environment import load_env
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginContext, PluginRegistry,
-                      ResourceRegistry, SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources.duckdb_database import DuckDBDatabaseResource
 from pipeline.resources.in_memory_storage import InMemoryStorageResource
 from pipeline.resources.memory_resource import MemoryResource

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -6,9 +6,16 @@ from pathlib import Path
 import pytest
 
 from config.environment import load_env
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources.llm import UnifiedLLMResource
 from pipeline.resources.pg_vector_store import PgVectorStore
 from pipeline.resources.postgres import PostgresResource

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,9 +1,17 @@
 from datetime import datetime
 
 import pipeline.context as context_module
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginContext, PluginRegistry,
-                      ResourceRegistry, SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.base_plugins import PromptPlugin
 from pipeline.cache import InMemoryCache
 from pipeline.resources.llm_base import LLM

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -1,9 +1,16 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from user_plugins.prompts.chain_of_thought import ChainOfThoughtPrompt
 
 

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,8 +1,14 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      ResourceRegistry, SystemRegistries, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter
 

--- a/tests/test_complex_prompt.py
+++ b/tests/test_complex_prompt.py
@@ -2,9 +2,16 @@ import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources.memory_resource import MemoryResource
 from user_plugins.prompts.complex_prompt import ComplexPrompt
 

--- a/tests/test_conversation_history_plugin.py
+++ b/tests/test_conversation_history_plugin.py
@@ -2,9 +2,16 @@ import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources.memory_resource import MemoryResource
 from pipeline.stages import PipelineStage
 from user_plugins.prompts.conversation_history import ConversationHistory

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,8 +1,15 @@
 import asyncio
 
-from pipeline import (FailurePlugin, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry, execute_pipeline)
+from pipeline import (
+    FailurePlugin,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.errors import create_static_error_response
 from user_plugins.failure.basic_logger import BasicLogger
 

--- a/tests/test_intent_classifier_prompt.py
+++ b/tests/test_intent_classifier_prompt.py
@@ -1,9 +1,16 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from user_plugins.prompts.intent_classifier import IntentClassifierPrompt
 
 

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -1,8 +1,14 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      ResourceRegistry, SystemRegistries, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.resources.memory import Memory
 from pipeline.resources.memory_resource import SimpleMemoryResource
 

--- a/tests/test_memory_retrieval_prompt.py
+++ b/tests/test_memory_retrieval_prompt.py
@@ -1,11 +1,17 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
-from pipeline.resources.memory_resource import (MemoryResource,
-                                                SimpleMemoryResource)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources.memory_resource import MemoryResource, SimpleMemoryResource
 from user_plugins.prompts.memory_retrieval import MemoryRetrievalPrompt
 
 

--- a/tests/test_pii_scrubber_plugin.py
+++ b/tests/test_pii_scrubber_plugin.py
@@ -1,9 +1,16 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from user_plugins.prompts.pii_scrubber import PIIScrubberPrompt
 
 

--- a/tests/test_react_prompt.py
+++ b/tests/test_react_prompt.py
@@ -1,9 +1,16 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from user_plugins.prompts.react_prompt import ReActPrompt
 from user_plugins.tools.calculator_tool import CalculatorTool
 

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -2,9 +2,16 @@ import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.pipeline import execute_pending_tools
 from user_plugins.tools.search_tool import SearchTool
 

--- a/tests/test_weather_api_tool.py
+++ b/tests/test_weather_api_tool.py
@@ -5,9 +5,16 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from config.environment import load_env
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.pipeline import execute_pending_tools
 from user_plugins.tools.weather_api_tool import WeatherApiTool
 


### PR DESCRIPTION
## Summary
- format `src` with isort+black
- format `tests` with isort+black

## Testing
- `poetry run black src/ tests/ --check`
- `poetry run isort src/ tests/ --profile black`
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/` *(fails: ModuleNotFoundError)*
- `poetry run bandit -r src/`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/integration/ -v` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68682302ba988322ad2d5551c63b4465