### PR TITLE
[Resource] Update UnifiedLLMResource providers import

### DIFF
--- a/src/pipeline/resources/llm/unified.py
+++ b/src/pipeline/resources/llm/unified.py
@@ -4,9 +4,7 @@ from typing import Any, AsyncIterator, Dict, List, Type
 
 from pipeline.state import LLMResponse
 from pipeline.user_plugins import ValidationResult
-from plugins.resources.llm_resource import LLMResource
-
-from .providers import (
+from plugins.resources.llm.providers import (
     BedrockProvider,
     ClaudeProvider,
     EchoProvider,
@@ -14,6 +12,7 @@ from .providers import (
     OllamaProvider,
     OpenAIProvider,
 )
+from plugins.resources.llm_resource import LLMResource
 
 
 class UnifiedLLMResource(LLMResource):


### PR DESCRIPTION
## Summary
- fix provider import path in `UnifiedLLMResource`

## Testing
- `python -m py_compile src/pipeline/resources/llm/unified.py`
- `flake8 src/ tests/`
- `mypy src/` *(fails: jsonschema stubs missing and other issues)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: pipeline.resources.database)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: pipeline.resources.database)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: pipeline)*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: pipeline.resources.database)*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: pipeline.resources.database)*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: pipeline.resources.database)*

------
https://chatgpt.com/codex/tasks/task_e_686827fc33a483228ab0879e16b99a92