### PR TITLE
[Tests] Add provider initialization test

### DIFF
--- a/tests/integration/test_llm_providers.py
+++ b/tests/integration/test_llm_providers.py
@@ -1,0 +1,38 @@
+import pytest
+
+from pipeline.resources.llm import UnifiedLLMResource
+
+PROVIDER_CONFIGS = {
+    "openai": {
+        "provider": "openai",
+        "api_key": "key",
+        "model": "model",
+        "base_url": "http://localhost",
+    },
+    "ollama": {
+        "provider": "ollama",
+        "model": "model",
+        "base_url": "http://localhost",
+    },
+    "gemini": {
+        "provider": "gemini",
+        "api_key": "key",
+        "model": "model",
+        "base_url": "http://localhost",
+    },
+    "claude": {
+        "provider": "claude",
+        "api_key": "key",
+        "model": "model",
+        "base_url": "http://localhost",
+    },
+    "bedrock": {"provider": "bedrock", "model_id": "model"},
+    "echo": {"provider": "echo"},
+}
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("provider,cfg", PROVIDER_CONFIGS.items())
+def test_unified_llm_provider_initialization(provider: str, cfg: dict) -> None:
+    resource = UnifiedLLMResource(cfg)
+    assert resource._providers[0].name == provider


### PR DESCRIPTION
## Summary
- add integration test ensuring each LLM provider initializes

## Testing
- `isort tests/integration/test_llm_providers.py`
- `black src/ tests/`
- `/root/.cache/pypoetry/virtualenvs/entity-pBA_rQHY-py3.11/bin/flake8 src/ tests/`
- `mypy src/` *(fails: missing stubs and modules)*
- `/root/.cache/pypoetry/virtualenvs/entity-pBA_rQHY-py3.11/bin/bandit -r src/`
- `/root/.cache/pypoetry/virtualenvs/entity-pBA_rQHY-py3.11/bin/python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `/root/.cache/pypoetry/virtualenvs/entity-pBA_rQHY-py3.11/bin/python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `/root/.cache/pypoetry/virtualenvs/entity-pBA_rQHY-py3.11/bin/python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `/root/.cache/pypoetry/virtualenvs/entity-pBA_rQHY-py3.11/bin/pytest tests/integration/ -v` *(fails: ModuleNotFoundError)*
- `/root/.cache/pypoetry/virtualenvs/entity-pBA_rQHY-py3.11/bin/pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError)*
- `/root/.cache/pypoetry/virtualenvs/entity-pBA_rQHY-py3.11/bin/pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68682d57cc3483228c6ce457bbf5da59