### PR TITLE
[Resource] clarify LLM provider import

### DIFF
--- a/src/pipeline/resources/llm/unified.py
+++ b/src/pipeline/resources/llm/unified.py
@@ -4,6 +4,9 @@ from typing import Any, AsyncIterator, Dict, List, Type
 
 from pipeline.state import LLMResponse
 from pipeline.user_plugins import ValidationResult
+
+# Import provider implementations from the public plugin package. Using the
+# fully qualified path avoids ambiguity if this module is restructured.
 from plugins.resources.llm.providers import (
     BedrockProvider,
     ClaudeProvider,


### PR DESCRIPTION
## Summary
- ensure unified LLM resource imports provider classes from plugin package

## Testing
- `black src/pipeline/resources/llm/unified.py`
- `flake8 src/ tests/` *(fails: command not found)*
- `mypy src/` *(fails with errors)*
- `bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68682d5689e88322b0211a6c0b7c382a