### PR TITLE
Add example script tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ markers = [
     "api: Tests related to API endpoints",
     "cli: Tests related to CLI interface",
     "benchmark: Performance benchmarking tests",
+    "examples: Tests that run example scripts",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+class TestExamples:
+    """Ensure example scripts run without errors."""
+
+    scripts = [
+        Path("examples/advanced_llm.py"),
+        Path("examples/pipelines/pipeline_example.py"),
+    ]
+
+    @pytest.mark.slow
+    @pytest.mark.examples
+    @pytest.mark.parametrize("script", scripts)
+    def test_run(self, script: Path) -> None:
+        if not os.environ.get("RUN_EXAMPLE_TESTS"):
+            pytest.skip("RUN_EXAMPLE_TESTS not set")
+        subprocess.run([sys.executable, str(script)], check=True)


### PR DESCRIPTION
## Summary
- test example scripts with optional RUN_EXAMPLE_TESTS flag
- allow pytest to mark these as 'examples'

## Testing
- `black src/ tests/`
- `isort src/ tests/` *(reverted changes)*
- `flake8 src/ tests/` *(failed: command not found)*
- `mypy src/` *(failed: found 81 errors)*
- `bandit -r src/` *(failed: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(failed: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(failed: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(failed: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(failed: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/infrastructure/ -v` *(failed: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/performance/ -m benchmark` *(failed: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686834ea50248322aee7183796def3bd