### PR TITLE
[Resource] add missing wrappers for tests

### DIFF
--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,8 +1,33 @@
 from .llm.unified import UnifiedLLMResource
 from .memory_resource import MemoryResource, SimpleMemoryResource
+from .database import DatabaseResource
+from .duckdb_database import DuckDBDatabaseResource
+from .filesystem import FileSystemResource
+from .in_memory_storage import InMemoryStorageResource
+from .memory import Memory
+from .pg_vector_store import PgVectorStore
+from .postgres import PostgresResource
+from .sqlite_storage import SQLiteStorageResource
+from .container import ResourceContainer
+from plugins.resources.base import BaseResource, Resource
+from plugins.resources.llm_base import LLM
+from plugins.resources.llm_resource import LLMResource
 
 __all__ = [
     "MemoryResource",
     "SimpleMemoryResource",
     "UnifiedLLMResource",
+    "DatabaseResource",
+    "DuckDBDatabaseResource",
+    "FileSystemResource",
+    "InMemoryStorageResource",
+    "Memory",
+    "PgVectorStore",
+    "PostgresResource",
+    "SQLiteStorageResource",
+    "ResourceContainer",
+    "LLM",
+    "LLMResource",
+    "Resource",
+    "BaseResource",
 ]

--- a/src/pipeline/resources/container.py
+++ b/src/pipeline/resources/container.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Wrapper for ResourceContainer."""
+
+from plugins.resources.container import ResourceContainer
+
+__all__ = ["ResourceContainer"]

--- a/src/pipeline/resources/database.py
+++ b/src/pipeline/resources/database.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Database resource wrapper used by tests."""
+
+from plugins.resources.database import DatabaseResource
+
+__all__ = ["DatabaseResource"]

--- a/src/pipeline/resources/duckdb_database.py
+++ b/src/pipeline/resources/duckdb_database.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Wrapper for DuckDBDatabaseResource."""
+
+from plugins.resources.duckdb_database import DuckDBDatabaseResource
+
+__all__ = ["DuckDBDatabaseResource"]

--- a/src/pipeline/resources/filesystem.py
+++ b/src/pipeline/resources/filesystem.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Filesystem resource wrapper used by pipeline components."""
+
+from plugins.resources.filesystem import FileSystemResource
+
+__all__ = ["FileSystemResource"]

--- a/src/pipeline/resources/in_memory_storage.py
+++ b/src/pipeline/resources/in_memory_storage.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Wrapper for InMemoryStorageResource."""
+
+from plugins.resources.in_memory_storage import InMemoryStorageResource
+
+__all__ = ["InMemoryStorageResource"]

--- a/src/pipeline/resources/memory.py
+++ b/src/pipeline/resources/memory.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Memory resource interface wrapper."""
+
+from plugins.resources.memory import Memory
+
+__all__ = ["Memory"]

--- a/src/pipeline/resources/pg_vector_store.py
+++ b/src/pipeline/resources/pg_vector_store.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Wrapper for PgVectorStore."""
+
+from plugins.resources.pg_vector_store import PgVectorStore
+
+__all__ = ["PgVectorStore"]

--- a/src/pipeline/resources/postgres.py
+++ b/src/pipeline/resources/postgres.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Wrapper for PostgresResource."""
+
+from plugins.resources.postgres import PostgresResource
+
+__all__ = ["PostgresResource"]

--- a/src/pipeline/resources/sqlite_storage.py
+++ b/src/pipeline/resources/sqlite_storage.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Wrapper for SQLiteStorageResource."""
+
+from plugins.resources.sqlite_storage import SQLiteStorageResource
+
+__all__ = ["SQLiteStorageResource"]

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -1,6 +1,10 @@
-<<<<<< codex/update-ci-config-for-test_examples.py
 from importlib import import_module
+import os
+import subprocess
+import sys
+from pathlib import Path
 
+import pytest
 from pipeline import SystemRegistries
 
 
@@ -21,13 +25,6 @@ def test_example_modules_importable() -> None:
     ]
     for name in modules:
         import_module(name)
-======
-import os
-import subprocess
-import sys
-from pathlib import Path
-
-import pytest
 
 
 class TestExamples:
@@ -45,4 +42,3 @@ class TestExamples:
         if not os.environ.get("RUN_EXAMPLE_TESTS"):
             pytest.skip("RUN_EXAMPLE_TESTS not set")
         subprocess.run([sys.executable, str(script)], check=True)
->>>>>> main


### PR DESCRIPTION
## Summary
- wrap plugin resources with pipeline import paths
- fix merge conflict in example tests

## Testing
- `flake8 src/ tests/`
- `mypy src/` *(fails: CacheBackend return type error, LLMResource missing attributes)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'pipeline.resources.structured_logging')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'pipeline.resources.structured_logging')*
- `pytest -q` *(fails: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686837b26a9083228dac5894f13c9550