### PR TITLE
[Docs] Add gRPC service stubs and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -805,6 +805,10 @@ This architecture ensures fast, structured, and maintainable communication betwe
 
 > ✅ All model components must be gRPC-compatible and expose Protobuf-defined streaming interfaces for maximum performance and interoperability.
 
+The repository's `src/grpc_services` package contains example protocol
+definitions and a stub server implementation. Use these files as templates when
+adding new model services.
+
 
 ---
 

--- a/docs/source/grpc_services.md
+++ b/docs/source/grpc_services.md
@@ -1,0 +1,46 @@
+# gRPC Service Stubs
+
+Entity uses gRPC for all backend model communication. The `src/grpc_services`
+package contains protocol definitions and stub implementations. Below is a
+minimal example for text generation services.
+
+```proto
+syntax = "proto3";
+package entity.grpc;
+
+service LLMService {
+    rpc Generate (GenerateRequest) returns (stream GenerateResponse);
+}
+
+message GenerateRequest {
+    string prompt = 1;
+}
+
+message GenerateResponse {
+    string token = 1;
+}
+```
+
+Generate the Python bindings with `grpcio-tools` and implement the server using
+`grpc.aio`:
+
+```python
+import asyncio
+import grpc
+
+from grpc_services import llm_pb2, llm_pb2_grpc
+from grpc_services.llm_service import LLMService
+
+async def serve() -> None:
+    server = grpc.aio.server()
+    llm_pb2_grpc.add_LLMServiceServicer_to_server(LLMService(), server)
+    server.add_insecure_port("[::]:50051")
+    await server.start()
+    await server.wait_for_termination()
+
+if __name__ == "__main__":
+    asyncio.run(serve())
+```
+
+``src/grpc_services/llm.proto`` and ``llm_service.py`` act as references for
+future model services.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -23,6 +23,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [API reference](api_reference.md)
 - [Advanced usage](advanced_usage.md)
 - [Module map](module_map.md)
+- [gRPC service stubs](grpc_services.md)
 - [Troubleshooting](troubleshooting.md)
 
 ### Deployment
@@ -45,6 +46,7 @@ context
 logging
 advanced_usage
 module_map
+grpc_services
 troubleshooting
 aws_deployment
 deploy_aws

--- a/src/grpc_services/llm.proto
+++ b/src/grpc_services/llm.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package entity.grpc;
+
+service LLMService {
+    // Streams generated tokens from the model
+    rpc Generate (GenerateRequest) returns (stream GenerateResponse);
+}
+
+message GenerateRequest {
+    string prompt = 1; // Raw prompt for text generation
+}
+
+message GenerateResponse {
+    string token = 1; // Token emitted by the model
+}

--- a/src/grpc_services/llm_service.py
+++ b/src/grpc_services/llm_service.py
@@ -1,0 +1,45 @@
+"""Minimal gRPC service stub for model components."""
+
+# mypy: ignore-errors
+
+from __future__ import annotations
+
+import asyncio
+
+import grpc  # type: ignore
+
+# These modules are generated from ``llm.proto`` using ``grpcio-tools``.
+# They are intentionally excluded from version control and should be
+# regenerated when the protocol changes.
+try:  # pragma: no cover - stubs for illustration
+    from . import llm_pb2, llm_pb2_grpc  # type: ignore
+except Exception:  # pragma: no cover - stub fallback
+    llm_pb2 = None
+    llm_pb2_grpc = None
+
+
+class LLMService(
+    llm_pb2_grpc.LLMServiceServicer if llm_pb2_grpc else object
+):  # type: ignore[misc]
+    """Example text generation service."""
+
+    async def Generate(
+        self, request: "llm_pb2.GenerateRequest", context: grpc.aio.ServicerContext
+    ) -> "llm_pb2.GenerateResponse":  # type: ignore[name-defined]
+        # TODO: integrate actual model inference
+        for word in ["hello", "world"]:
+            yield llm_pb2.GenerateResponse(token=word)
+
+
+async def serve(port: int = 50051) -> None:
+    """Run the example service."""
+    server = grpc.aio.server()
+    if llm_pb2_grpc:
+        llm_pb2_grpc.add_LLMServiceServicer_to_server(LLMService(), server)
+    server.add_insecure_port(f"[::]:{port}")
+    await server.start()
+    await server.wait_for_termination()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    asyncio.run(serve())


### PR DESCRIPTION
## Summary
- add an example gRPC service definition under `src/grpc_services`
- document how to implement model services using gRPC
- link the new page from the docs index
- note the gRPC module in `AGENTS.md`

## Testing
- `black src/grpc_services/llm_service.py src/grpc_services/__init__.py`
- `isort src/grpc_services/llm_service.py src/grpc_services/__init__.py`
- `flake8 src/grpc_services/llm_service.py src/grpc_services/__init__.py`
- `mypy src/grpc_services/llm_service.py src/grpc_services/__init__.py`
- `bandit -r src/grpc_services`
- `python -m src.config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: Required environment variable HTTP_TOKEN not found)*
- `PYTHONPATH=src python -m src.registry.validator --config config/dev.yaml` *(fails: Validation failed)*
- `pytest tests/integration/ -v` *(fails: Unknown config option)*
- `pytest tests/infrastructure/ -v` *(fails: Unknown config option)*
- `pytest tests/performance/ -m benchmark` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_68683f1046608322b9a88aec9f4b2820