### PR TITLE
Unify plugin path references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ PLEASE REVIEW IT FOR ALL ARCHITECTURE DECISIONS!  (Architecture is outlined at b
 ## Project Structure for AI Agent Navigation
 
 - `/src/pipeline` – core execution engine, context system and shared abstractions
-- `/src/pipeline/user_plugins` – plugin implementations organized by type
+- `/plugins` – plugin implementations organized by type
   - `/resources` – databases, LLMs and storage backends
   - `/tools` – user functions such as weather or search
   - `/prompts` – reasoning logic and memory helpers
@@ -550,8 +550,8 @@ The framework's core value is **making agent behavior adjustable** without code 
 
 The codebase now consolidates the core engine under `src/pipeline`. This module
 contains the context system, execution logic and shared abstractions. Plugins
-reside in the new `src/plugins` package, grouped by type. The old
-`src/pipeline/plugins` directory remains as **temporary shims** re-exporting
+reside in the new `plugins` package, grouped by type. The old
+`src/pipeline/user_plugins` directory remains as **temporary shims** re-exporting
 from `plugins`:
 
 - `resources` for databases, LLM providers and storage backends
@@ -1091,9 +1091,9 @@ Because the name stays constant, plugins and configuration always refer to the s
 
 **Note**: Plugin use is discouraged in the error stage to maintain reliability. Keep error stage plugins minimal and ensure static fallback responses are available.
 
-Plugin implementations live in `src/plugins/<type>` directories. For example,
-error-handling plugins are located in `src/plugins/failure`. The
-`src/pipeline/plugins` paths are just thin wrappers to maintain backward
+Plugin implementations live in `plugins/<type>` directories. For example,
+error-handling plugins are located in `plugins/failure`. The
+`src/pipeline/user_plugins` paths are just thin wrappers to maintain backward
 compatibility during the transition.
 
 ### Plugin Stage Assignment System

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,9 +20,9 @@ The framework's core value is **making agent behavior adjustable** without code 
 
 The codebase now consolidates the core engine under `src/pipeline`. This module
 contains the context system, execution logic and shared abstractions. Plugins
-reside in the new `src/user_plugins` package, grouped by type. The old
+reside in the new `plugins` package, grouped by type. The old
 `src/pipeline/user_plugins` directory provides thin wrappers re-exporting
-from `user_plugins`:
+from `plugins`:
 
 - `resources` for databases, LLM providers and storage backends
 - `tools` for user-facing functions
@@ -526,14 +526,14 @@ Because the name stays constant, plugins and configuration always refer to the s
 - **Output**: Formatting, validation, filtering
 - **Tool Coordination**: Execute tools during processing with immediate access to results
 
-**Reconfiguration Example**: Change agent personality from formal to casual by swapping personality prompt user_plugins.
+**Reconfiguration Example**: Change agent personality from formal to casual by swapping personality prompt plugins.
 
 #### **Adapter Plugins** (Input/Output - Interface Handling)
 - **Input Adapters**: HTTP, WebSocket, CLI interfaces
 - **Output Adapters**: HTTP responses, TTS, formatted output
   - **TTS**: Text-to-speech services
 
-**Reconfiguration Example**: Add voice interface to a text-based agent by including TTS adapter user_plugins.
+**Reconfiguration Example**: Add voice interface to a text-based agent by including TTS adapter plugins.
 
 #### **Failure Plugins** (Error Communication - User-Facing Error Handling)
 - **Error Formatters**: Convert technical errors to user-friendly messages
@@ -542,8 +542,8 @@ Because the name stays constant, plugins and configuration always refer to the s
 
 **Note**: Plugin use is discouraged in the error stage to maintain reliability. Keep error stage plugins minimal and ensure static fallback responses are available.
 
-Plugin implementations live in `src/user_plugins/<type>` directories. For example,
-error-handling plugins are located in `src/user_plugins/failure`. The
+Plugin implementations live in `plugins/<type>` directories. For example,
+error-handling plugins are located in `plugins/failure`. The
 `src/pipeline/user_plugins` paths are thin wrappers kept for backward
 compatibility during the transition.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Lightweight deployments can use SQLite:
 plugins:
   resources:
     database:
-      type: user_plugins.sqlite_storage:SQLiteStorageResource
+      type: plugins.resources.sqlite_storage:SQLiteStorageResource
       path: ./entity.db
       pool_min_size: 1
       pool_max_size: 5
@@ -216,7 +216,7 @@ plugins:
     memory:
       type: memory
       database:
-        type: user_plugins.sqlite_storage:SQLiteStorageResource
+        type: plugins.resources.sqlite_storage:SQLiteStorageResource
         path: ./agent.db
 ```
 
@@ -227,7 +227,7 @@ plugins:
     memory:
       type: memory
       database:
-        type: user_plugins.duckdb_database:DuckDBDatabaseResource
+        type: plugins.resources.duckdb_database:DuckDBDatabaseResource
         path: ./agent.duckdb
         history_table: chat_history
 ```
@@ -239,15 +239,15 @@ plugins:
     memory:
       type: memory
       database:
-        type: user_plugins.postgres:PostgresResource
+        type: plugins.resources.postgres:PostgresResource
         host: localhost
         name: agent_db
       vector_store:
-        type: user_plugins.pg_vector_store:PgVectorStore
+        type: plugins.resources.pg_vector_store:PgVectorStore
         dimensions: 768
         table: embeddings
       filesystem:
-        type: user_plugins.s3_filesystem:S3FileSystem
+        type: plugins.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
 ```

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -7,7 +7,7 @@ server:
 plugins:
   resources:
     database:
-      type: user_plugins.postgres:PostgresResource
+      type: plugins.resources.postgres:PostgresResource
       host: "${DB_HOST}"
       port: 5432
       name: "${DB_USERNAME}"
@@ -16,37 +16,37 @@ plugins:
       retries: 3
       backoff: 1.0
     llm:
-      type: user_plugins.llm.unified:UnifiedLLMResource
+      type: plugins.resources.llm.unified:UnifiedLLMResource
       provider: ollama
       base_url: "${OLLAMA_BASE_URL}"
       model: "${OLLAMA_MODEL}"
       retries: 3
       backoff: 1.0
     logging:
-      type: user_plugins.structured_logging:StructuredLogging
+      type: plugins.resources.structured_logging:StructuredLogging
       level: "DEBUG"
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-      type: user_plugins.memory_resource:MemoryResource
+      type: pipeline.resources.memory_resource:MemoryResource
       database:
-        type: user_plugins.sqlite_storage:SQLiteStorageResource
+        type: plugins.resources.sqlite_storage:SQLiteStorageResource
         path: ./dev.db
       filesystem:
-        type: user_plugins.s3_filesystem:S3FileSystem
+        type: plugins.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
     cache:
-      type: user_plugins.resources.cache:CacheResource
+      type: plugins.resources.cache:CacheResource
       backend:
         type: pipeline.cache.memory:InMemoryCache
   tools:
     weather:
-      type: user_plugins.tools.weather_api_tool:WeatherApiTool
+      type: plugins.tools.weather_api_tool:WeatherApiTool
       api_key: "${WEATHER_API_KEY}"
       base_url: "https://api.weather.com"
     calculator:
-      type: user_plugins.tools.calculator_tool:CalculatorTool
+      type: plugins.tools.calculator_tool:CalculatorTool
   adapters:
     http:
       type: plugins.adapters.http:HTTPAdapter
@@ -61,14 +61,14 @@ plugins:
       type: plugins.adapters.cli:CLIAdapter
   prompts:
     chain_of_thought:
-      type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
+      type: plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
     conversation_history:
-      type: user_plugins.prompts.conversation_history:ConversationHistory
+      type: plugins.prompts.conversation_history:ConversationHistory
       history_table: chat_history
     memory_retrieval:
-      type: user_plugins.prompts.memory_retrieval:MemoryRetrievalPrompt
+      type: plugins.prompts.memory_retrieval:MemoryRetrievalPrompt
       max_context_length: 4000
     intent_classifier:
-      type: user_plugins.prompts.intent_classifier:IntentClassifierPrompt
+      type: plugins.prompts.intent_classifier:IntentClassifierPrompt
       confidence_threshold: 0.8

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -7,7 +7,7 @@ server:
 plugins:
   resources:
     database:
-      type: user_plugins.postgres:PostgresResource
+      type: plugins.resources.postgres:PostgresResource
       host: "${DB_HOST}"
       port: 5432
       name: "${DB_USERNAME}"
@@ -16,7 +16,7 @@ plugins:
       retries: 5
       backoff: 2.0
     llm:
-      type: user_plugins.llm.unified:UnifiedLLMResource
+      type: plugins.resources.llm.unified:UnifiedLLMResource
       provider: ollama
       base_url: "${OLLAMA_BASE_URL}"
       model: "${OLLAMA_MODEL}"
@@ -24,35 +24,35 @@ plugins:
       retries: 5
       backoff: 2.0
     logging:
-      type: user_plugins.structured_logging:StructuredLogging
+      type: plugins.resources.structured_logging:StructuredLogging
       level: "INFO"
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-      type: user_plugins.memory_resource:MemoryResource
+      type: pipeline.resources.memory_resource:MemoryResource
       database:
-        type: user_plugins.postgres:PostgresResource
+        type: plugins.resources.postgres:PostgresResource
         host: "${DB_HOST}"
         port: 5432
         name: "${DB_NAME}"
         username: "${DB_USERNAME}"
         password: "${DB_PASSWORD}"
       filesystem:
-        type: user_plugins.s3_filesystem:S3FileSystem
+        type: plugins.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
     cache:
-      type: user_plugins.resources.cache:CacheResource
+      type: plugins.resources.cache:CacheResource
       backend:
-        type: user_plugins.resources.cache_backends.redis:RedisCache
+        type: plugins.resources.cache_backends.redis:RedisCache
   tools:
     weather:
-      type: user_plugins.tools.weather_api_tool:WeatherApiTool
+      type: plugins.tools.weather_api_tool:WeatherApiTool
       api_key: "${WEATHER_API_KEY}"
       base_url: "https://api.weather.com"
       timeout: 30
     calculator:
-      type: user_plugins.tools.calculator_tool:CalculatorTool
+      type: plugins.tools.calculator_tool:CalculatorTool
       precision: 10
   adapters:
     http:
@@ -68,17 +68,17 @@ plugins:
       type: plugins.adapters.cli:CLIAdapter
   prompts:
     chain_of_thought:
-      type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
+      type: plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
       max_steps: 5
     conversation_history:
-      type: user_plugins.prompts.conversation_history:ConversationHistory
+      type: plugins.prompts.conversation_history:ConversationHistory
       db_schema: public
       history_table: chat_history
     memory_retrieval:
-      type: user_plugins.prompts.memory_retrieval:MemoryRetrievalPrompt
+      type: plugins.prompts.memory_retrieval:MemoryRetrievalPrompt
       max_context_length: 4000
       similarity_threshold: 0.7
     intent_classifier:
-      type: user_plugins.prompts.intent_classifier:IntentClassifierPrompt
+      type: plugins.prompts.intent_classifier:IntentClassifierPrompt
       confidence_threshold: 0.8

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -7,7 +7,7 @@ server:
 plugins:
   resources:
     database:
-      type: user_plugins.postgres:PostgresResource
+      type: plugins.resources.postgres:PostgresResource
       host: "${DB_HOST}"
       port: 5432
       name: "${DB_USERNAME}"
@@ -18,30 +18,30 @@ plugins:
       base_url: "${OLLAMA_BASE_URL}"
       model: "${OLLAMA_MODEL}"
     logging:
-      type: user_plugins.structured_logging:StructuredLogging
+      type: plugins.resources.structured_logging:StructuredLogging
       level: "INFO"
       file_enabled: true
       file_path: "logs/entity.log"
     memory:
-      type: user_plugins.memory_resource:MemoryResource
+      type: pipeline.resources.memory_resource:MemoryResource
       database:
-        type: user_plugins.sqlite_storage:SQLiteStorageResource
+        type: plugins.resources.sqlite_storage:SQLiteStorageResource
         path: ./agent.db
       filesystem:
-        type: user_plugins.s3_filesystem:S3FileSystem
+        type: plugins.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
     cache:
-      type: user_plugins.resources.cache:CacheResource
+      type: plugins.resources.cache:CacheResource
       backend:
         type: pipeline.cache.memory:InMemoryCache
   tools:
     weather:
-      type: user_plugins.tools.weather_api_tool:WeatherApiTool
+      type: plugins.tools.weather_api_tool:WeatherApiTool
       api_key: "${WEATHER_API_KEY}"
       base_url: "https://api.weather.com"
     calculator:
-      type: user_plugins.tools.calculator_tool:CalculatorTool
+      type: plugins.tools.calculator_tool:CalculatorTool
   adapters:
     http:
       type: plugins.adapters.http:HTTPAdapter
@@ -55,11 +55,11 @@ plugins:
       type: plugins.adapters.cli:CLIAdapter
   prompts:
     chain_of_thought:
-      type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
+      type: plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
     memory_retrieval:
-      type: user_plugins.prompts.memory_retrieval:MemoryRetrievalPrompt
+      type: plugins.prompts.memory_retrieval:MemoryRetrievalPrompt
       max_context_length: 4000
     intent_classifier:
-      type: user_plugins.prompts.intent_classifier:IntentClassifierPrompt
+      type: plugins.prompts.intent_classifier:IntentClassifierPrompt
       confidence_threshold: 0.8

--- a/docs/adr/0001-core-architecture.md
+++ b/docs/adr/0001-core-architecture.md
@@ -1,6 +1,6 @@
 # ADR 0001: Core Architecture
 
-The Entity Pipeline framework relies on a plugin based pipeline. Each request flows through explicit stages controlled by registered user_plugins. Resources, tools and prompts are managed via registries so behavior can be reconfigured without code changes.
+The Entity Pipeline framework relies on a plugin based pipeline. Each request flows through explicit stages controlled by registered plugins. Resources, tools and prompts are managed via registries so behavior can be reconfigured without code changes.
 
 ## Decision
 

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -15,7 +15,7 @@ plugins:
     memory:
       type: memory
       database:
-        type: user_plugins.postgres:PostgresResource
+        type: plugins.resources.postgres:PostgresResource
         host: localhost
         port: 5432
         name: dev_db
@@ -23,11 +23,11 @@ plugins:
         setup_commands:
           - "CREATE EXTENSION IF NOT EXISTS vector"
       vector_store:
-        type: user_plugins.pg_vector_store:PgVectorStore
+        type: plugins.resources.pg_vector_store:PgVectorStore
         dimensions: 768
         table: embeddings
       filesystem:
-        type: user_plugins.s3_filesystem:S3FileSystem
+        type: plugins.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
 ```
@@ -40,7 +40,7 @@ plugins:
     memory:
       type: memory
       database:
-        type: user_plugins.sqlite_storage:SQLiteStorageResource
+        type: plugins.resources.sqlite_storage:SQLiteStorageResource
         path: ./agent.db
 ```
 

--- a/docs/source/config_cheatsheet.md
+++ b/docs/source/config_cheatsheet.md
@@ -10,20 +10,20 @@ entity:
 plugins:
   resources:
     database:
-      type: user_plugins.resources.sqlite_storage:SQLiteStorage
+      type: plugins.resources.sqlite_storage:SQLiteStorage
       path: ./entity.db
     llm:
       provider: openai
       model: gpt-4
   tools:
     search:
-      type: user_plugins.tools.search:SearchTool
+      type: plugins.tools.search:SearchTool
   prompts:
     main:
-      type: user_plugins.prompts.simple:SimplePrompt
+      type: plugins.prompts.simple:SimplePrompt
   adapters:
     http:
-      type: user_plugins.adapters.http:HTTPAdapter
+      type: plugins.adapters.http:HTTPAdapter
 ```
 
 Use `entity src/cli.py --config config.yaml` to start the agent.

--- a/docs/source/module_map.md
+++ b/docs/source/module_map.md
@@ -5,7 +5,7 @@ This document describes the key modules and their responsibilities after consoli
 ## `pipeline.base_plugins`
 All abstract plugin base classes live in this module. Other packages import from here rather than maintaining duplicates.
 
-## `user_plugins`
+## `plugins`
 Concrete plugin implementations organized by type. The package re-exports the base classes for backward compatibility but no longer defines them.
 
 ## `pipeline`

--- a/docs/source/plugin_cheatsheet.md
+++ b/docs/source/plugin_cheatsheet.md
@@ -1,10 +1,10 @@
 # Plugin Development Cheat Sheet
 
-Brief reminders for writing user_plugins.
+Brief reminders for writing plugins.
 
 ## Base Classes
 - `ResourcePlugin` – provides infrastructure like databases and LLMs.
-- `ToolPlugin` – exposes a callable tool to other user_plugins.
+- `ToolPlugin` – exposes a callable tool to other plugins.
 - `PromptPlugin` – contains reasoning or memory logic.
 - `AdapterPlugin` – handles external interfaces such as HTTP or CLI.
 - `FailurePlugin` – formats and logs errors.
@@ -13,7 +13,7 @@ All plugins declare their `stages` and any `dependencies`.
 
 ## Skeleton
 ```python
-from user_plugins import PromptPlugin
+from plugins import PromptPlugin
 from pipeline.stages import PipelineStage
 
 class ExamplePlugin(PromptPlugin):

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -1,6 +1,6 @@
 # Writing Plugins
 
-The Entity framework is built around extensible user_plugins. Plugins run during specific pipeline stages and interact with the system through `PluginContext`.
+The Entity framework is built around extensible plugins. Plugins run during specific pipeline stages and interact with the system through `PluginContext`.
 
 ## Basic Class Plugin
 
@@ -43,7 +43,7 @@ async def weather_plugin(ctx):
 Place plugin modules inside a directory and load them with `Agent.from_directory(path)` or `Agent.from_package(package)`.
 
 ```
-agent = Agent.from_directory("./user_plugins")
+agent = Agent.from_directory("./plugins")
 ```
 
 Any import errors are logged and the remaining plugins continue to load.
@@ -56,7 +56,7 @@ new backend, subclass `ResourcePlugin` and implement the `save_history` and
 
 ```python
 import asyncpg
-from user_plugins import ResourcePlugin
+from plugins import ResourcePlugin
 from pipeline.stages import PipelineStage
 
 
@@ -116,4 +116,4 @@ class VectorMemoryResource(ResourcePlugin):
         self.vectors[key] = vector
 ```
 
-These scripts are great starting points when designing your own user_plugins.
+These scripts are great starting points when designing your own plugins.

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -79,7 +79,7 @@ builder = (
     ConfigBuilder.dev_preset()
     .add_resource(
         "llm",
-        "user_plugins.resources.llm.unified:UnifiedLLMResource",
+        "plugins.resources.llm.unified:UnifiedLLMResource",
         provider="ollama",
         base_url="http://localhost:11434",
         model="tinyllama",

--- a/docs/source/security.md
+++ b/docs/source/security.md
@@ -2,10 +2,10 @@
 
 This project can run plugins inside isolated Docker containers. Each plugin must
 provide a `plugin.toml` manifest defining required resources and runtime limits.
-The :class:`user_plugins.infrastructure.sandbox.DockerSandboxRunner` applies CPU and memory limits
+The :class:`plugins.infrastructure.sandbox.DockerSandboxRunner` applies CPU and memory limits
 based on the manifest and verifies the plugin signature before execution. The
 runner uses :class:`infrastructure.DockerInfrastructure` so you can also build
 a Docker image for your agent.
 
-To validate manifests outside of runtime, use :class:`user_plugins.infrastructure.sandbox.PluginAuditor`.
+To validate manifests outside of runtime, use :class:`plugins.infrastructure.sandbox.PluginAuditor`.
 It checks requested resources against a whitelist and reports any violations.

--- a/old.md
+++ b/old.md
@@ -89,7 +89,7 @@ def smart_assistant(context):
 
 ### Instant Plugin Discovery
 The pipeline automatically registers plugin classes placed under
-`src/pipeline/user_plugins`. Simply create a new plugin class that inherits from the
+`plugins`. Simply create a new plugin class that inherits from the
 appropriate base class and it becomes available when the agent loads.
 
 ```python
@@ -114,7 +114,7 @@ class MyCustomPrompt(PromptPlugin):
     async def _execute_impl(self, context):
         return "Hello from my plugin"
 
-agent = Agent.from_package("pipeline.user_plugins")
+agent = Agent.from_package("plugins")
 agent.run_http()
 ```
 
@@ -385,7 +385,7 @@ The framework maintains the sophisticated five-layer plugin architecture underne
 
 **Note**: Plugin use is discouraged in the error stage to maintain reliability. Keep error stage plugins minimal and ensure static fallback responses are available.
 
-Plugin implementations live in `src/user_plugins/<type>` directories. For example, error-handling plugins are located in `src/user_plugins/failure`.
+Plugin implementations live in `plugins/<type>` directories. For example, error-handling plugins are located in `plugins/failure`.
 
 ### Plugin Stage Assignment System
 


### PR DESCRIPTION
## Summary
- clarify `plugins` as the canonical plugin package
- update docs and configuration examples
- clean up outdated paths in old guides

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68683f0f669c8322945933f9ab463a5f