### PR TITLE
[Internal] Centralize env var interpolation

### DIFF
--- a/src/pipeline/config/__init__.py
+++ b/src/pipeline/config/__init__.py
@@ -3,28 +3,13 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any, Dict
 
 import yaml
 
 from config.environment import load_env
-
-
-def _interpolate_env_vars(config: Any) -> Any:
-    """Recursively replace ${VAR} in config with environment variables."""
-    if isinstance(config, dict):
-        return {k: _interpolate_env_vars(v) for k, v in config.items()}
-    if isinstance(config, list):
-        return [_interpolate_env_vars(item) for item in config]
-    if isinstance(config, str) and config.startswith("${") and config.endswith("}"):
-        key = config[2:-1]
-        value = os.environ.get(key)
-        if value is None:
-            raise EnvironmentError(f"Required environment variable {key} not found")
-        return value
-    return config
+from .utils import interpolate_env_vars
 
 
 class ConfigLoader:
@@ -34,15 +19,15 @@ class ConfigLoader:
     def from_yaml(path: str | Path, env_file: str = ".env") -> Dict[str, Any]:
         load_env(env_file)
         data = yaml.safe_load(Path(path).read_text()) or {}
-        return _interpolate_env_vars(data)
+        return interpolate_env_vars(data)
 
     @staticmethod
     def from_json(path: str | Path, env_file: str = ".env") -> Dict[str, Any]:
         load_env(env_file)
         data = json.loads(Path(path).read_text() or "{}")
-        return _interpolate_env_vars(data)
+        return interpolate_env_vars(data)
 
     @staticmethod
     def from_dict(cfg: Dict[str, Any], env_file: str = ".env") -> Dict[str, Any]:
         load_env(env_file)
-        return _interpolate_env_vars(dict(cfg))
+        return interpolate_env_vars(dict(cfg))

--- a/src/pipeline/config/utils.py
+++ b/src/pipeline/config/utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def interpolate_env_vars(config: Any) -> Any:
+    """Recursively replace ``${VAR}`` strings with environment variables."""
+    if isinstance(config, dict):
+        return {k: interpolate_env_vars(v) for k, v in config.items()}
+    if isinstance(config, list):
+        return [interpolate_env_vars(item) for item in config]
+    if isinstance(config, str) and config.startswith("${") and config.endswith("}"):
+        key = config[2:-1]
+        value = os.environ.get(key)
+        if value is None:
+            raise EnvironmentError(f"Required environment variable {key} not found")
+        return value
+    return config

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import copy
 import json
-import os
 from contextlib import contextmanager
 from typing import Any, Dict, Iterable, List, Tuple
 
 from config.environment import load_env
+from pipeline.config.utils import interpolate_env_vars
 from plugins.resources.base import Resource
 from plugins.resources.container import ResourceContainer
 from registry import PluginRegistry, ToolRegistry
@@ -86,7 +86,7 @@ class SystemInitializer:
             content = fh.read()
         config = yaml.safe_load(content)
         load_env(env_file)
-        config = cls._interpolate_env_vars(config)
+        config = interpolate_env_vars(config)
         return cls(config, env_file)
 
     @classmethod
@@ -95,7 +95,7 @@ class SystemInitializer:
             content = fh.read()
         config = json.loads(content or "{}")
         load_env(env_file)
-        config = cls._interpolate_env_vars(config)
+        config = interpolate_env_vars(config)
         return cls(config, env_file)
 
     @classmethod
@@ -103,7 +103,7 @@ class SystemInitializer:
         cls, cfg: Dict[str, Any], env_file: str = ".env"
     ) -> "SystemInitializer":
         load_env(env_file)
-        config = cls._interpolate_env_vars(dict(cfg))
+        config = interpolate_env_vars(dict(cfg))
         return cls(config, env_file)
 
     def get_resource_config(self, name: str) -> Dict:
@@ -233,19 +233,3 @@ class SystemInitializer:
         if len(processed) != len(in_degree):
             cycle_nodes = [n for n in in_degree if n not in processed]
             raise SystemError(f"Circular dependency detected involving: {cycle_nodes}")
-
-    @staticmethod
-    def _interpolate_env_vars(config: Any) -> Any:
-        if isinstance(config, dict):
-            return {
-                k: SystemInitializer._interpolate_env_vars(v) for k, v in config.items()
-            }
-        if isinstance(config, list):
-            return [SystemInitializer._interpolate_env_vars(i) for i in config]
-        if isinstance(config, str) and config.startswith("${") and config.endswith("}"):
-            key = config[2:-1]
-            value = os.environ.get(key)
-            if value is None:
-                raise EnvironmentError(f"Required environment variable {key} not found")
-            return value
-        return config


### PR DESCRIPTION
## Summary
- extract `interpolate_env_vars` helper into `pipeline.config.utils`
- reuse helper in `ConfigLoader` and `SystemInitializer`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6868551a1a848322be38adad852388a9