### PR TITLE
Add active pipeline count helper

### DIFF
--- a/plugins/adapters/http.py
+++ b/plugins/adapters/http.py
@@ -140,10 +140,10 @@ class HTTPAdapter(AdapterPlugin):
 
             @self.app.get("/dashboard")
             async def dashboard() -> dict[str, Any]:
-                active = 0
+                count = 0
                 if self.manager is not None:
-                    active = len(self.manager._active)
-                return {"active_pipelines": active}
+                    count = self.manager.active_pipeline_count()
+                return {"active_pipelines": count}
 
     async def _handle_message(self, message: str) -> dict[str, Any]:
         """Send a message through the pipeline and return the response."""

--- a/src/pipeline/manager.py
+++ b/src/pipeline/manager.py
@@ -58,3 +58,14 @@ class PipelineManager:
     def has_active_pipelines(self) -> bool:
         self._tasks = {t for t in self._tasks if not t.done()}
         return bool(self._tasks or self._active)
+
+    async def active_pipeline_count_async(self) -> int:
+        """Return the number of pipelines currently executing."""
+        async with self._lock:
+            self._tasks = {t for t in self._tasks if not t.done()}
+            return max(len(self._tasks), len(self._active))
+
+    def active_pipeline_count(self) -> int:
+        """Return the number of pipelines currently executing."""
+        self._tasks = {t for t in self._tasks if not t.done()}
+        return max(len(self._tasks), len(self._active))

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -87,3 +87,19 @@ def test_http_adapter_rate_limit(tmp_path):
 
     asyncio.run(_requests())
     assert "rate limit" in (tmp_path / "audit.log").read_text().lower()
+
+
+def test_http_adapter_dashboard():
+    adapter = make_adapter({"dashboard": True})
+
+    async def _requests():
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=adapter.app),
+            base_url="http://testserver",
+        ) as client:
+            await client.post("/", json={"message": "hi"})
+            resp = await client.get("/dashboard")
+            assert resp.status_code == 200
+            assert resp.json() == {"active_pipelines": 0}
+
+    asyncio.run(_requests())

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -38,3 +38,17 @@ def test_pipeline_manager_active_flag():
     result = asyncio.run(run_task())
     assert result == "ok"
     assert not manager.has_active_pipelines()
+
+
+def test_pipeline_manager_active_count():
+    manager = make_manager()
+
+    async def run_task():
+        task = manager.start_pipeline("hi")
+        assert manager.active_pipeline_count() == 1
+        res = await task
+        return res
+
+    result = asyncio.run(run_task())
+    assert result == "ok"
+    assert manager.active_pipeline_count() == 0


### PR DESCRIPTION
## Summary
- add `active_pipeline_count` methods to the manager
- show the count on HTTP dashboard
- test new methods

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plugins.resources.llm.unified')*

------
https://chatgpt.com/codex/tasks/task_e_686855313d008322ae8ebcac7607cb41