### PR TITLE
[Examples] Fix site customizations and initializer

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,7 +1,10 @@
-import sys
-import pathlib
+"""Ensure the repository's ``src`` directory is on ``sys.path``."""
 
-print("sitecustomize loaded")
-path = pathlib.Path(__file__).resolve().parent / "src"
-if str(path) not in sys.path:
-    sys.path.insert(0, str(path))
+from __future__ import annotations
+
+import pathlib
+import sys
+
+SRC_PATH = pathlib.Path(__file__).resolve().parent / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))


### PR DESCRIPTION
## Summary
- clean up `sitecustomize.py` to avoid stdout pollution
- rebuild `SystemInitializer` with proper dependency graph validation

## Testing
- `poetry run isort sitecustomize.py src/pipeline/initializer.py`
- `poetry run black sitecustomize.py src/pipeline/initializer.py`
- `poetry run flake8 sitecustomize.py src/pipeline/initializer.py`
- `poetry run mypy sitecustomize.py src/pipeline/initializer.py` *(fails: missing stubs)*
- `poetry run bandit -r sitecustomize.py src/pipeline/initializer.py`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.registry.validator --config config/dev.yaml` *(fails: Validation failed)*
- `poetry run pytest tests/examples/test_examples.py::TestExamples::test_run -q`
- `poetry run pytest -k initializer -q` *(fails: 13 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6868590e0e6883229908cbaf4f730860