### PR TITLE
[Adapter] Add WebSocket server example

### DIFF
--- a/examples/servers/websocket_server.py
+++ b/examples/servers/websocket_server.py
@@ -1,0 +1,46 @@
+"""Run a simple WebSocket server using the Entity framework."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+
+from utilities import enable_plugins_namespace
+
+enable_plugins_namespace()
+
+from pipeline import PipelineManager
+from pipeline.initializer import SystemInitializer
+from plugins.adapters.websocket import WebSocketAdapter
+
+
+async def send_test_message() -> None:
+    import websockets
+
+    uri = "ws://127.0.0.1:8001/"
+    async with websockets.connect(uri) as websocket:
+        await websocket.send("hello")
+        response = await websocket.recv()
+        print("Received:", response)
+
+
+async def main() -> None:
+    initializer = SystemInitializer.from_yaml("config/dev.yaml")
+    registries = await initializer.initialize()
+    manager = PipelineManager(registries)
+    adapter = WebSocketAdapter(manager, {"host": "127.0.0.1", "port": 8001})
+
+    server_task = asyncio.create_task(adapter.serve(registries))
+    await asyncio.sleep(1)
+    await send_test_message()
+    server_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await server_task
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add websocket server example demonstrating WebSocketAdapter usage

## Testing
- `flake8 src tests examples/servers/websocket_server.py`
- `mypy src`
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'psutil')*


------
https://chatgpt.com/codex/tasks/task_e_686860ed25a48322893f71a1566abc8a