### PR TITLE
Add failure example script

### DIFF
--- a/examples/failure_example.py
+++ b/examples/failure_example.py
@@ -1,0 +1,52 @@
+"""Example demonstrating error handling with BasicLogger and ErrorFormatter."""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+
+# Make the repository's ``src`` directory importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from utilities import enable_plugins_namespace
+
+# Expose the local ``plugins`` namespace
+enable_plugins_namespace()
+
+from entity import Agent
+from pipeline import PipelineStage, PromptPlugin
+from pipeline.context import PluginContext
+from user_plugins.failure import BasicLogger, ErrorFormatter
+
+
+class FailingPrompt(PromptPlugin):
+    """Prompt that intentionally raises an error."""
+
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        raise RuntimeError("simulated failure")
+
+
+def main() -> None:
+    agent = Agent()
+    agent.builder.plugin_registry.register_plugin_for_stage(
+        BasicLogger(), PipelineStage.ERROR
+    )
+    agent.builder.plugin_registry.register_plugin_for_stage(
+        ErrorFormatter(), PipelineStage.ERROR
+    )
+    agent.builder.plugin_registry.register_plugin_for_stage(
+        FailingPrompt(), PipelineStage.THINK
+    )
+
+    async def run() -> None:
+        response = await agent.handle("trigger failure")
+        print(response)
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `failure_example.py` that demonstrates error handling
- register `BasicLogger` and `ErrorFormatter` with an Agent
- implement a prompt plugin that raises an error to show the failure stage

## Testing
- `poetry run black . --check`
- `poetry run isort examples/failure_example.py --check-only`
- `poetry run flake8 examples/failure_example.py`
- `poetry run mypy examples/failure_example.py` *(fails: missing stubs)*
- `poetry run bandit -r src/ | head -n 20`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: module not found)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: environment variable missing)*
- `poetry run python -m src.registry.validator --config config/dev.yaml` *(fails: plugin validation)*
- `poetry run pytest -q` *(fails: module import errors)*
- `poetry run python examples/failure_example.py`

------
https://chatgpt.com/codex/tasks/task_e_686860eedbe483228b7036f42336d52f