### PR TITLE
[Adapter] Add CLI server example

### DIFF
--- a/examples/servers/cli_adapter.py
+++ b/examples/servers/cli_adapter.py
@@ -1,0 +1,30 @@
+"""Run a simple CLI adapter using the Entity framework."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+
+from utilities import enable_plugins_namespace
+
+enable_plugins_namespace()
+
+import asyncio
+
+from pipeline import PipelineManager
+from pipeline.initializer import SystemInitializer
+from plugins.adapters.cli import CLIAdapter
+
+
+async def main() -> None:
+    initializer = SystemInitializer.from_yaml("config/dev.yaml")
+    registries = await initializer.initialize()
+    manager = PipelineManager(registries)
+    adapter = CLIAdapter(manager)
+    await adapter.serve(registries)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add CLI adapter example script mirroring HTTP server example

## Testing
- `black examples/servers/cli_adapter.py`
- `isort examples/servers/cli_adapter.py`
- `poetry run flake8 src/ tests/` *(fails: module level import not at top of file)*
- `poetry run mypy src/` *(fails: many typing errors)*
- `poetry run bandit -r src/`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: Required environment variable HTTP_TOKEN not found)*
- `poetry run python -m src.registry.validator --config config/dev.yaml` *(fails: Plugin 'database' does not specify any stages)*
- `poetry run pytest tests/integration/ -v` *(fails: InvalidCatalogNameError)*
- `poetry run pytest tests/infrastructure/ -v` *(fails: TypeError in Infrastructure)*
- `poetry run pytest tests/performance/ -m benchmark`
- `poetry run pytest` *(fails: 13 errors during collection)*
- `poetry run pytest --cov=src --cov-report=html` *(fails: 13 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686860ec00748322a4cfb72c3e595193