### PR TITLE
Update docs with CLI and WebSocket examples

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -68,3 +68,26 @@ features in action:
 ```bash
 python examples/advanced_llm.py
 ```
+
+### Running the Example Servers
+
+Start the demo HTTP server:
+
+```bash
+python examples/servers/http_server.py
+```
+
+For a WebSocket server use the CLI:
+
+```bash
+python src/cli.py serve-websocket --config config/dev.yaml
+```
+
+### DuckDB Pipeline Example
+
+The `examples/pipelines/duckdb_pipeline.py` script demonstrates a local vector
+store backed by DuckDB:
+
+```bash
+python examples/pipelines/duckdb_pipeline.py
+```

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -117,3 +117,17 @@ class VectorMemoryResource(ResourcePlugin):
 ```
 
 These scripts are great starting points when designing your own plugins.
+
+### Adapter and Failure Examples
+
+The repository also includes short examples for different adapters and basic
+failure handling. Use `src/cli.py` to run the agent interactively or over a
+WebSocket connection:
+
+```bash
+python src/cli.py --config config/dev.yaml
+python src/cli.py serve-websocket --config config/dev.yaml
+```
+
+When implementing custom error handling, refer to the failure plugin template at
+`src/cli/templates/failure.py`.


### PR DESCRIPTION
## Summary
- document adapter and failure examples
- describe how to run example servers and DuckDB script

## Testing
- `pytest tests/test_cli_adapter.py tests/test_websocket_adapter.py` *(fails: `Client.__init__()` unexpected `app` argument)*

------
https://chatgpt.com/codex/tasks/task_e_686860f048848322b343571bdcf4022e