### PR TITLE
Add LLM wrapper modules

### DIFF
--- a/plugins/resources/llm/unified.py
+++ b/plugins/resources/llm/unified.py
@@ -1,0 +1,3 @@
+from pipeline.resources.llm.unified import UnifiedLLMResource
+
+__all__ = ["UnifiedLLMResource"]

--- a/src/pipeline/resources/llm_base.py
+++ b/src/pipeline/resources/llm_base.py
@@ -1,0 +1,3 @@
+from plugins.resources.llm_base import LLM
+
+__all__ = ["LLM"]

--- a/src/pipeline/resources/llm_resource.py
+++ b/src/pipeline/resources/llm_resource.py
@@ -1,0 +1,3 @@
+from plugins.resources.llm_resource import LLMResource
+
+__all__ = ["LLMResource"]


### PR DESCRIPTION
## Summary
- re-export `UnifiedLLMResource` via `plugins.resources.llm.unified`
- expose `LLMResource` and `LLM` through new modules under `pipeline.resources`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68686df2520c832299cb9af10dc19e2a