### PR TITLE
Fix resource container cleanup

### DIFF
--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -67,18 +67,20 @@ sys.modules["pipeline"] = ModuleType("pipeline")
 sys.modules["plugins.resources"] = ModuleType("plugins.resources")
 module = importlib.util.module_from_spec(spec)
 sys.modules["plugins.resources.container"] = module
-spec.loader.exec_module(module)  # type: ignore[arg-type]
+try:
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+finally:
+    if _orig_pipeline is not None:
+        sys.modules["pipeline"] = _orig_pipeline
+    else:
+        del sys.modules["pipeline"]
+
+    if _orig_resources is not None:
+        sys.modules["plugins.resources"] = _orig_resources
+    else:
+        del sys.modules["plugins.resources"]
+
 ResourceContainerDynamic = module.ResourceContainer
-
-if _orig_pipeline is not None:
-    sys.modules["pipeline"] = _orig_pipeline
-else:
-    del sys.modules["pipeline"]
-
-if _orig_resources is not None:
-    sys.modules["plugins.resources"] = _orig_resources
-else:
-    del sys.modules["plugins.resources"]
 
 
 class Dummy:


### PR DESCRIPTION
## Summary
- ensure the `pipeline` and `plugins.resources` modules are restored even if
  import fails
- format `tests/test_resource_container.py`

## Testing
- `poetry run pytest tests/test_resource_container.py -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68686dff64bc8322a7aed2a74ea1dd1b