### PR TITLE
[Resource] add container passthrough

### DIFF
--- a/src/plugins/resources/__init__.py
+++ b/src/plugins/resources/__init__.py
@@ -1,0 +1,5 @@
+"""Public re-exports for resource container."""
+
+from .container import PoolConfig, ResourceContainer, ResourcePool
+
+__all__ = ["PoolConfig", "ResourcePool", "ResourceContainer"]

--- a/src/plugins/resources/container.py
+++ b/src/plugins/resources/container.py
@@ -1,0 +1,3 @@
+"""Compatibility layer for plugins.resources.container."""
+
+from plugins.resources.container import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- add `src/plugins/resources` package for resource API
- re-export `plugins.resources.container` inside `src/plugins/resources/container.py`

## Testing
- `poetry run black src/plugins/resources/__init__.py src/plugins/resources/container.py`
- `poetry run isort src/plugins/resources/__init__.py src/plugins/resources/container.py`
- `poetry run flake8 src/plugins/resources/__init__.py src/plugins/resources/container.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml`
- `poetry run python -m src.config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator --config config/dev.yaml`
- `poetry run pytest tests/integration/ -v`
- `poetry run pytest tests/infrastructure/ -v`
- `poetry run pytest tests/performance/ -m benchmark`


------
https://chatgpt.com/codex/tasks/task_e_68686df9405483228afc7a49bf12ee74