### PR TITLE
Fix resource container cleanup

### DIFF
--- a/plugins/resources/container.py
+++ b/plugins/resources/container.py
@@ -163,5 +163,10 @@ class ResourceContainer(ResourceRegistry):
         return cls(config=cfg)
 
     def _resolve_order(self) -> List[str]:
-        graph = DependencyGraph(self._deps)
+        # Build dependency graph with edges from each dependency to its dependents
+        graph_map: Dict[str, List[str]] = {name: [] for name in self._deps}
+        for name, deps in self._deps.items():
+            for dep in deps:
+                graph_map.setdefault(dep, []).append(name)
+        graph = DependencyGraph(graph_map)
         return graph.topological_sort()

--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -57,7 +57,7 @@ def test_health_report():
 root = Path(__file__).resolve().parents[1]
 spec = importlib.util.spec_from_file_location(
     "plugins.resources.container",
-    root / "src/plugins.resources/container.py",
+    root / "plugins/resources/container.py",
 )
 
 _orig_pipeline = sys.modules.get("pipeline")
@@ -67,18 +67,20 @@ sys.modules["pipeline"] = ModuleType("pipeline")
 sys.modules["plugins.resources"] = ModuleType("plugins.resources")
 module = importlib.util.module_from_spec(spec)
 sys.modules["plugins.resources.container"] = module
-spec.loader.exec_module(module)  # type: ignore[arg-type]
+try:
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+finally:
+    if _orig_pipeline is not None:
+        sys.modules["pipeline"] = _orig_pipeline
+    else:
+        del sys.modules["pipeline"]
+
+    if _orig_resources is not None:
+        sys.modules["plugins.resources"] = _orig_resources
+    else:
+        del sys.modules["plugins.resources"]
+
 ResourceContainerDynamic = module.ResourceContainer
-
-if _orig_pipeline is not None:
-    sys.modules["pipeline"] = _orig_pipeline
-else:
-    del sys.modules["pipeline"]
-
-if _orig_resources is not None:
-    sys.modules["plugins.resources"] = _orig_resources
-else:
-    del sys.modules["plugins.resources"]
 
 
 class Dummy:


### PR DESCRIPTION
## Summary
- restore sys.modules in a try/finally block during dynamic import
- correct the file path for dynamic import in tests
- resolve dependency build order in `ResourceContainer`

## Testing
- `poetry run pytest tests/test_resource_container.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68686dff64bc8322a7aed2a74ea1dd1b