### PR TITLE
Lazy load cache backends

### DIFF
--- a/src/pipeline/cache/__init__.py
+++ b/src/pipeline/cache/__init__.py
@@ -1,9 +1,28 @@
 """Caching utilities with pluggable backends."""
 
-from user_plugins.resources.cache_backends.redis import RedisCache
-from user_plugins.resources.cache_backends.semantic import SemanticCache
-
 from .base import CacheBackend
 from .memory import InMemoryCache
 
-__all__ = ["CacheBackend", "InMemoryCache", "RedisCache", "SemanticCache"]
+
+def get_redis_cache() -> type[CacheBackend]:
+    """Return the :class:`RedisCache` class with a lazy import."""
+
+    from user_plugins.resources.cache_backends.redis import RedisCache
+
+    return RedisCache
+
+
+def get_semantic_cache() -> type[CacheBackend]:
+    """Return the :class:`SemanticCache` class with a lazy import."""
+
+    from user_plugins.resources.cache_backends.semantic import SemanticCache
+
+    return SemanticCache
+
+
+__all__ = [
+    "CacheBackend",
+    "InMemoryCache",
+    "get_redis_cache",
+    "get_semantic_cache",
+]


### PR DESCRIPTION
## Summary
- avoid importing optional cache plugins at module load
- expose helper functions `get_redis_cache` and `get_semantic_cache`

## Testing
- `poetry run flake8 src/pipeline/cache/__init__.py`
- `poetry run mypy src/pipeline/cache/__init__.py` *(fails: Cannot find implementation or library stub for module named "tenacity", etc.)*
- `poetry run bandit -r src/pipeline/cache/__init__.py`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: Configuration invalid: No module named 'plugins.resources.llm.unified')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: Configuration invalid: Required environment variable HTTP_TOKEN not found)*
- `poetry run python -m src.registry.validator` *(fails: validator.py: error: the following arguments are required: --config)*
- `poetry run pytest tests/integration/ -v` *(fails: asyncpg.exceptions.InvalidCatalogNameError: database "agent_sandbox" does not exist)*
- `poetry run pytest tests/infrastructure/ -v` *(fails: TypeError: Infrastructure.__init__() takes 1 positional argument but 2 were given)*
- `poetry run pytest tests/performance/ -m benchmark`
- `poetry run pytest` *(fails: 13 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68686df421ec8322b93e5dbcd4fcdd08