### PR TITLE
Fix cache imports and LLM call

### DIFF
--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -146,7 +146,11 @@ class BasePlugin(ABC):
         start = time.time()
 
         if hasattr(llm, "generate"):
-            response = await llm.generate(prompt, functions)
+            sig = inspect.signature(llm.generate)
+            if "functions" in sig.parameters:
+                response = await llm.generate(prompt, functions)
+            else:
+                response = await llm.generate(prompt)
         else:
             func = getattr(llm, "__call__", None)
             if func is None:

--- a/src/pipeline/cache/__init__.py
+++ b/src/pipeline/cache/__init__.py
@@ -1,9 +1,11 @@
 """Caching utilities with pluggable backends."""
 
-from user_plugins.resources.cache_backends.redis import RedisCache
-from user_plugins.resources.cache_backends.semantic import SemanticCache
-
+# Core backends
 from .base import CacheBackend
 from .memory import InMemoryCache
+
+# Optional user-provided implementations
+from .redis import RedisCache
+from .semantic import SemanticCache
 
 __all__ = ["CacheBackend", "InMemoryCache", "RedisCache", "SemanticCache"]

--- a/src/user_plugins/resources/cache.py
+++ b/src/user_plugins/resources/cache.py
@@ -58,3 +58,6 @@ class CacheResource(ResourcePlugin, CacheBackend):
 
     async def delete(self, key: str) -> None:
         await self._backend.delete(key)
+
+    async def clear(self) -> None:
+        await self._backend.clear()


### PR DESCRIPTION
## Summary
- refactor cache package imports to avoid circular dependency
- implement `clear()` in `CacheResource`
- make `call_llm` compatible with LLMs lacking `functions` parameter

## Testing
- `poetry run pytest tests/test_cache.py::test_llm_results_are_cached -q`
- `poetry run pytest -q` *(fails: ModuleNotFoundError, AttributeError, AssertionError, HTTPException)*

------
https://chatgpt.com/codex/tasks/task_e_6868746bf9188322a83f6b284bed8a12