### PR TITLE
Fix cache import merge conflict

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -6,7 +6,8 @@ if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
 from .builder import ConfigBuilder  # noqa: E402
-from .validators import _validate_cache, _validate_memory, _validate_vector_memory
+from .validators import _validate_memory  # noqa: E402
+from .validators import _validate_cache, _validate_vector_memory
 
 __all__ = [
     "ConfigBuilder",

--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -18,7 +18,8 @@ from pipeline import SystemInitializer  # noqa: E402
 from pipeline.config import ConfigLoader  # noqa: E402
 from pipeline.logging import configure_logging, get_logger  # noqa: E402
 
-from .validators import _validate_cache, _validate_memory, _validate_vector_memory
+from .validators import _validate_memory  # noqa: E402
+from .validators import _validate_cache, _validate_vector_memory
 
 logger = get_logger(__name__)
 

--- a/src/pipeline/cache/__init__.py
+++ b/src/pipeline/cache/__init__.py
@@ -1,16 +1,5 @@
 """Caching utilities with pluggable backends."""
 
-<<<<<< codex/fix-merge-conflicts-and-run-tests
-# Core backends
-from .base import CacheBackend
-from .memory import InMemoryCache
-
-# Optional user-provided implementations
-from .redis import RedisCache
-from .semantic import SemanticCache
-
-__all__ = ["CacheBackend", "InMemoryCache", "RedisCache", "SemanticCache"]
-======
 from .base import CacheBackend
 from .memory import InMemoryCache
 
@@ -37,4 +26,3 @@ __all__ = [
     "get_redis_cache",
     "get_semantic_cache",
 ]
->>>>>> main

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -7,7 +7,7 @@ import json
 import os
 import time
 from datetime import datetime
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 from registry import SystemRegistries
 


### PR DESCRIPTION
## Summary
- resolve merge markers in `pipeline.cache`
- clean up unused imports and flake8 warnings

## Testing
- `poetry run flake8 src/ tests/`
- `poetry run mypy src/` *(fails: missing stubs and typing errors)*
- `poetry run bandit -r src/`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: circular import)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: missing env var)*
- `poetry run python -m src.registry.validator --config config/dev.yaml` *(fails: plugin stages)*
- `poetry run pytest tests/integration/ -v` *(fails: missing database)*
- `poetry run pytest tests/infrastructure/ -v` *(fails: Infrastructure init)*
- `poetry run pytest tests/performance/ -m benchmark`
- `poetry run pytest` *(fails: multiple assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68687d7025e88322b3bd9b1a701d7873