### PR TITLE
Lazy load RedisCache and SemanticCache

### DIFF
--- a/src/pipeline/cache/redis.py
+++ b/src/pipeline/cache/redis.py
@@ -2,12 +2,21 @@ from __future__ import annotations
 
 import warnings
 
-from user_plugins.resources.cache_backends.redis import RedisCache
-
 warnings.warn(
     "pipeline.cache.redis is deprecated; use user_plugins.resources.cache_backends.redis instead",
     DeprecationWarning,
     stacklevel=2,
 )
+
+
+def __getattr__(name: str):
+    """Lazily import :class:`RedisCache` when requested."""
+
+    if name == "RedisCache":
+        from user_plugins.resources.cache_backends.redis import RedisCache
+
+        return RedisCache
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
 
 __all__ = ["RedisCache"]

--- a/src/pipeline/cache/semantic.py
+++ b/src/pipeline/cache/semantic.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import warnings
 
-from user_plugins.resources.cache_backends.semantic import SemanticCache
-
 warnings.warn(
     (
         "pipeline.cache.semantic is deprecated; "
@@ -12,5 +10,16 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+
+def __getattr__(name: str):
+    """Lazily import :class:`SemanticCache` when requested."""
+
+    if name == "SemanticCache":
+        from user_plugins.resources.cache_backends.semantic import SemanticCache
+
+        return SemanticCache
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
 
 __all__ = ["SemanticCache"]


### PR DESCRIPTION
## Summary
- lazily import RedisCache and SemanticCache to avoid plugin imports on module load

## Testing
- `black .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68688232d4d08322b512ef9da44f27ca