### PR TITLE
Add LLM re-export modules

### DIFF
--- a/plugins/resources/llm/unified.py
+++ b/plugins/resources/llm/unified.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+"""Unified LLM resource wrapper for plugin imports."""
+
 from pipeline.resources.llm.unified import UnifiedLLMResource
 
 __all__ = ["UnifiedLLMResource"]

--- a/src/pipeline/resources/llm_base.py
+++ b/src/pipeline/resources/llm_base.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+"""Public re-export of :class:`LLM`."""
+
 from plugins.resources.llm_base import LLM
 
 __all__ = ["LLM"]

--- a/src/pipeline/resources/llm_resource.py
+++ b/src/pipeline/resources/llm_resource.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+"""Public re-export of :class:`LLMResource`."""
+
 from plugins.resources.llm_resource import LLMResource
 
 __all__ = ["LLMResource"]


### PR DESCRIPTION
## Summary
- add `plugins/resources/llm/unified.py` wrapper
- re-export LLM resource classes in `src/pipeline/resources`

## Testing
- `poetry run black plugins/resources/llm/unified.py src/pipeline/resources/llm_resource.py src/pipeline/resources/llm_base.py`
- `poetry run isort plugins/resources/llm/unified.py src/pipeline/resources/llm_resource.py src/pipeline/resources/llm_base.py --check`
- `poetry run flake8 plugins/resources/llm/unified.py src/pipeline/resources/llm_resource.py src/pipeline/resources/llm_base.py`
- `poetry run mypy plugins/resources/llm/unified.py src/pipeline/resources/llm_resource.py src/pipeline/resources/llm_base.py` *(fails: Missing stubs and other errors)*
- `poetry run bandit -r src/pipeline/resources/llm_resource.py src/pipeline/resources/llm_base.py plugins/resources/llm/unified.py`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: CacheResource circular import)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: missing HTTP_TOKEN)*
- `poetry run python -m src.registry.validator` *(fails: missing --config argument)*
- `poetry run pytest tests/integration/ -v` *(fails: Postgres DB missing)*
- `poetry run pytest tests/infrastructure/ -v -s --maxfail=1` *(fails: Infrastructure init argument)*
- `poetry run pytest tests/performance/ -m benchmark`

------
https://chatgpt.com/codex/tasks/task_e_686882317f5c8322ba92063c8f4fbe23