### PR TITLE
Add poetry install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ poetry run python src/cli.py --config config.yaml
 ```
 This project relies on `httpx==0.27.*`, which Poetry will install automatically.
 <!-- end quick_start -->
+## Environment Setup
+
+1. Install Python 3.11+ and [Poetry](https://python-poetry.org/).
+2. Run `poetry install` to create the virtual environment. This installs all
+   dependencies, including `httpx==0.27.*`.
+3. Start the agent with your desired configuration file.
+
 For an infrastructure walkthrough on Amazon Web Services, see the [AWS deployment guide](docs/source/deploy_aws.md).
 
 <!-- start config -->


### PR DESCRIPTION
## Summary
- add environment setup section to README

## Testing
- `poetry run black src plugins tests`
- `poetry run pytest tests/test_http_adapter.py::test_http_adapter_basic -vv`

------
https://chatgpt.com/codex/tasks/task_e_68688237c7508322b29a23a8306cf756