### PR TITLE
[Tests] Fix module restoration in resource container

### DIFF
--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -63,22 +63,22 @@ spec = importlib.util.spec_from_file_location(
 _orig_pipeline = sys.modules.get("pipeline")
 _orig_resources = sys.modules.get("plugins.resources")
 
-sys.modules["pipeline"] = ModuleType("pipeline")
-sys.modules["plugins.resources"] = ModuleType("plugins.resources")
 module = importlib.util.module_from_spec(spec)
 sys.modules["plugins.resources.container"] = module
 try:
+    sys.modules["pipeline"] = ModuleType("pipeline")
+    sys.modules["plugins.resources"] = ModuleType("plugins.resources")
     spec.loader.exec_module(module)  # type: ignore[arg-type]
 finally:
     if _orig_pipeline is not None:
         sys.modules["pipeline"] = _orig_pipeline
     else:
-        del sys.modules["pipeline"]
+        sys.modules.pop("pipeline", None)
 
     if _orig_resources is not None:
         sys.modules["plugins.resources"] = _orig_resources
     else:
-        del sys.modules["plugins.resources"]
+        sys.modules.pop("plugins.resources", None)
 
 ResourceContainerDynamic = module.ResourceContainer
 


### PR DESCRIPTION
## Summary
- ensure `sys.modules` is restored around `exec_module`

## Testing
- `flake8 tests/test_resource_container.py` *(fails: command not found)*
- `poetry run mypy src | head` *(fails: found 74 errors)*
- `poetry run bandit -r src/` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68688238960c8322aff658da94b3c4bc