### PR TITLE
[Tool/Prompt] Fix re-export import path

### DIFF
--- a/plugins/test_plugins.py
+++ b/plugins/test_plugins.py
@@ -1,4 +1,4 @@
-from plugins.test_plugins import ReloadPlugin, ReloadTool
+from user_plugins.test_plugins import ReloadPlugin, ReloadTool
 
 __all__ = [
     "ReloadPlugin",


### PR DESCRIPTION
## Summary
- fix `plugins.test_plugins` import path

## Testing
- `poetry run pytest -q` *(fails: 25 failed, 107 passed, 7 skipped)*
- `poetry run isort src/ tests/ --check` *(fails: imports not sorted)*
- `poetry run flake8 src/ tests/` *(fails: E402, F822 errors)*
- `poetry run mypy src/` *(fails: invalid package name)*
- `poetry run bandit -r src/`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: configuration invalid)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: HTTP_TOKEN not found)*
- `poetry run python -m src.registry.validator --config config/dev.yaml` *(fails: plugin stage error)*
- `poetry run pytest tests/integration/ -v` *(fails: 2 failed, 13 passed)*
- `poetry run pytest tests/infrastructure/ -v` *(fails: 2 failed)*
- `poetry run pytest tests/performance/ -m benchmark`

------
https://chatgpt.com/codex/tasks/task_e_68689c59eb9883229dc1f4390492a904