### PR TITLE
Fix cache import re-export

### DIFF
--- a/plugins/resources/cache.py
+++ b/plugins/resources/cache.py
@@ -1,3 +1,6 @@
-from plugins.resources.cache import CacheResource
+"""Compatibility shim for accessing :class:`CacheResource`."""
+
+# Import the implementation from the user_plugins package to avoid recursion.
+from pipeline.user_plugins.resources.cache import CacheResource
 
 __all__ = ["CacheResource"]


### PR DESCRIPTION
## Summary
- fix self-referential import in `plugins/resources/cache.py`
- re-export `CacheResource` from the canonical implementation

## Testing
- `poetry run pytest tests/test_cache.py::test_llm_results_are_cached -q`
- `poetry run pytest tests/test_cache.py::test_tool_results_are_cached -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a99c93308322b5bb93748f1b180c