### PR TITLE
Implement delete for cache backends

### DIFF
--- a/src/pipeline/cache/base.py
+++ b/src/pipeline/cache/base.py
@@ -16,5 +16,9 @@ class CacheBackend(ABC):
         """Store ``value`` for ``key`` with optional ``ttl`` in seconds."""
 
     @abstractmethod
+    async def delete(self, key: str) -> None:
+        """Remove ``key`` from the cache."""
+
+    @abstractmethod
     async def clear(self) -> None:
         """Remove all cached values."""

--- a/src/pipeline/cache/memory.py
+++ b/src/pipeline/cache/memory.py
@@ -30,5 +30,8 @@ class InMemoryCache(CacheBackend):
             expire_at = time.time() + ttl
         self._store[key] = (value, expire_at)
 
+    async def delete(self, key: str) -> None:
+        self._store.pop(key, None)
+
     async def clear(self) -> None:
         self._store.clear()

--- a/src/user_plugins/resources/cache.py
+++ b/src/user_plugins/resources/cache.py
@@ -57,7 +57,9 @@ class CacheResource(ResourcePlugin, CacheBackend):
         await self._backend.set(key, value, ttl)
 
     async def delete(self, key: str) -> None:
-        await self._backend.delete(key)
+        delete_fn = getattr(self._backend, "delete", None)
+        if callable(delete_fn):
+            await delete_fn(key)
 
     async def clear(self) -> None:
         await self._backend.clear()

--- a/src/user_plugins/resources/cache_backends/redis.py
+++ b/src/user_plugins/resources/cache_backends/redis.py
@@ -24,5 +24,8 @@ class RedisCache(CacheBackend):
         ttl = ttl if ttl is not None else self._default_ttl
         await self._client.set(key, value, ex=ttl)
 
+    async def delete(self, key: str) -> None:
+        await self._client.delete(key)
+
     async def clear(self) -> None:
         await self._client.flushdb()

--- a/src/user_plugins/resources/cache_backends/semantic.py
+++ b/src/user_plugins/resources/cache_backends/semantic.py
@@ -20,6 +20,12 @@ class SemanticCache(CacheBackend):
     async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
         await self.inner.set(key, value, ttl)
 
+    async def delete(self, key: str) -> None:
+        await self.inner.delete(key)
+        for prompt, mapped_key in list(self._prompt_map.items()):
+            if mapped_key == key:
+                del self._prompt_map[prompt]
+
     async def clear(self) -> None:
         await self.inner.clear()
 


### PR DESCRIPTION
## Summary
- support deleting cache entries with a new CacheBackend.delete abstract method
- implement delete on InMemoryCache, RedisCache, and SemanticCache
- guard CacheResource.delete if the backend doesn't implement delete

## Testing
- `poetry run black src/pipeline/cache/base.py src/pipeline/cache/memory.py src/user_plugins/resources/cache_backends/redis.py src/user_plugins/resources/cache_backends/semantic.py src/user_plugins/resources/cache.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml', 25 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6868a9a5d6c8832290785ea1e5cbf778