### PR TITLE
[Resource] implement async resource lifecycle

### DIFF
--- a/plugins/resources/base.py
+++ b/plugins/resources/base.py
@@ -46,6 +46,13 @@ class BaseResource:
     def get_metrics(self) -> dict[str, Any]:
         return {"status": "healthy"}
 
+    async def __aenter__(self) -> "BaseResource":
+        await self.initialize()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.shutdown()
+
     # ------------------------------------------------------------------
     # Validation helpers matching BasePlugin API
     # ------------------------------------------------------------------

--- a/plugins/resources/cache.py
+++ b/plugins/resources/cache.py
@@ -1,12 +1,5 @@
-<<<<<< codex/review-modules-and-add-docstrings
-"""Simple caching resource."""
-
-from plugins.resources.cache import CacheResource
-======
 """Compatibility shim for accessing :class:`CacheResource`."""
 
-# Import the implementation from the user_plugins package to avoid recursion.
 from pipeline.user_plugins.resources.cache import CacheResource
->>>>>> main
 
 __all__ = ["CacheResource"]

--- a/plugins/resources/container.py
+++ b/plugins/resources/container.py
@@ -27,6 +27,7 @@ class ResourcePool:
         self._pool: asyncio.Queue[Any] = asyncio.Queue()
         self._total_size = 0
         self._lock = asyncio.Lock()
+        self._ctx_resource: Any | None = None
 
     async def initialize(self) -> None:
         for _ in range(self._cfg.min_size):
@@ -70,6 +71,15 @@ class ResourcePool:
             "in_use": self._total_size - self._pool.qsize(),
             "available": self._pool.qsize(),
         }
+
+    async def __aenter__(self) -> Any:
+        self._ctx_resource = await self.acquire()
+        return self._ctx_resource
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._ctx_resource is not None:
+            await self.release(self._ctx_resource)
+            self._ctx_resource = None
 
 
 class ResourceContainer(ResourceRegistry):
@@ -156,6 +166,12 @@ class ResourceContainer(ResourceRegistry):
 
     def get_metrics(self) -> Dict[str, Dict[str, int]]:
         return {name: pool.metrics() for name, pool in self._pools.items()}
+
+    async def __aenter__(self) -> "ResourceContainer":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.shutdown_all()
 
     def _instantiate(self, cls: type, cfg: Dict) -> Any:
         if hasattr(cls, "from_config"):

--- a/plugins/resources/database.py
+++ b/plugins/resources/database.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 """Database-backed conversation storage."""
+from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, List, Optional, Protocol
 

--- a/src/interfaces/resource.py
+++ b/src/interfaces/resource.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Shared resource lifecycle protocol."""
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ResourceLifecycle(Protocol):
+    """Async context manager interface for resources."""
+
+    async def __aenter__(self) -> Any:
+        """Enter the resource context."""
+        ...
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Cleanup the resource on exit."""
+        ...

--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -18,7 +18,8 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints only
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .initializer import ClassRegistry
 
-from .exceptions import CircuitBreakerTripped, PluginError, PluginExecutionError
+from .exceptions import (CircuitBreakerTripped, PluginError,
+                         PluginExecutionError)
 from .logging import get_logger
 from .observability.utils import execute_with_observability
 from .stages import PipelineStage
@@ -294,6 +295,13 @@ class ResourcePlugin(BasePlugin):
     def get_metrics(self) -> Dict[str, Any]:
         """Return metrics about this resource."""
         return {"status": "healthy"}
+
+    async def __aenter__(self) -> "ResourcePlugin":
+        await self.initialize()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.shutdown()
 
 
 class ToolPlugin(BasePlugin):

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -117,25 +117,26 @@ async def execute_pipeline(
     if pipeline_manager is not None:
         await pipeline_manager.register(state.pipeline_id)
     try:
-        for stage in [
-            PipelineStage.PARSE,
-            PipelineStage.THINK,
-            PipelineStage.DO,
-            PipelineStage.REVIEW,
-            PipelineStage.DELIVER,
-        ]:
-            if (
-                state.last_completed_stage is not None
-                and stage.value <= state.last_completed_stage.value
-            ):
-                continue
-            await execute_stage(stage, state, registries)
-            if state.failure_info:
-                break
-            state.last_completed_stage = stage
-            if state_file:
-                with open(state_file, "w", encoding="utf-8") as fh:
-                    json.dump(state.to_dict(), fh)
+        async with registries.resources:
+            for stage in [
+                PipelineStage.PARSE,
+                PipelineStage.THINK,
+                PipelineStage.DO,
+                PipelineStage.REVIEW,
+                PipelineStage.DELIVER,
+            ]:
+                if (
+                    state.last_completed_stage is not None
+                    and stage.value <= state.last_completed_stage.value
+                ):
+                    continue
+                await execute_stage(stage, state, registries)
+                if state.failure_info:
+                    break
+                state.last_completed_stage = stage
+                if state_file:
+                    with open(state_file, "w", encoding="utf-8") as fh:
+                        json.dump(state.to_dict(), fh)
 
         if state.failure_info:
             try:


### PR DESCRIPTION
## Summary
- define `ResourceLifecycle` protocol
- add context manager support to `BaseResource`, `ResourcePlugin`, `ResourcePool`, and `ResourceContainer`
- ensure `AgentRuntime` and `execute_pipeline` use resources via async context managers
- import missing ABC in `DatabaseResource`
- provide clean `CacheResource` shim

## Testing
- `flake8 plugins/resources/base.py plugins/resources/cache.py plugins/resources/container.py plugins/resources/database.py src/pipeline/base_plugins.py src/pipeline/pipeline.py src/pipeline/runtime.py src/interfaces/resource.py`
- `mypy plugins/resources/base.py plugins/resources/cache.py plugins/resources/container.py plugins/resources/database.py src/pipeline/base_plugins.py src/pipeline/pipeline.py src/pipeline/runtime.py src/interfaces/resource.py` *(fails: missing stubs and modules)*
- `bandit -r plugins/resources/base.py plugins/resources/cache.py plugins/resources/container.py plugins/resources/database.py src/pipeline/base_plugins.py src/pipeline/pipeline.py src/pipeline/runtime.py src/interfaces/resource.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: missing dependencies)*
- `python -m src.registry.validator` *(fails: missing module 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: duckdb)*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: duckdb)*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: duckdb)*

------
https://chatgpt.com/codex/tasks/task_e_6868b0380dd08322b28277f4000d8fb5