### PR TITLE
Improve generics and typing

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,10 @@
 [mypy]
 python_version = 3.11
 mypy_path = src
-exclude = ^src/pipeline/observability\.py$|^src/cli/templates/
+exclude = ^src/pipeline/observability\.py$|^src/cli/templates/|^src/plugins\.resources/
+strict = True
+files = src/pipeline/context.py,src/pipeline/manager.py,src/pipeline/runtime.py,src/pipeline/tools/execution.py,src/interfaces
+follow_imports = skip
 
 [mypy-langchain_core.*]
 ignore_missing_imports = True

--- a/src/interfaces/__init__.py
+++ b/src/interfaces/__init__.py
@@ -1,0 +1,8 @@
+from .plugin import ToolPluginProtocol, ToolResultT, ResourcePluginProtocol, ResourceT
+
+__all__ = [
+    "ToolPluginProtocol",
+    "ToolResultT",
+    "ResourcePluginProtocol",
+    "ResourceT",
+]

--- a/src/interfaces/plugin.py
+++ b/src/interfaces/plugin.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Dict, Protocol, TypeVar
+
+
+ToolResultT = TypeVar("ToolResultT", covariant=True)
+
+
+class ToolPluginProtocol(Protocol[ToolResultT]):
+    """Interface for tool plugins."""
+
+    max_retries: int
+    retry_delay: float
+
+    async def execute_function_with_retry(
+        self, params: Dict[str, Any], max_retries: int, delay: float
+    ) -> ToolResultT: ...
+
+    async def execute_function(self, params: Dict[str, Any]) -> ToolResultT: ...
+
+    def run(self, params: Dict[str, Any]) -> Awaitable[ToolResultT] | ToolResultT: ...
+
+
+ResourceT = TypeVar("ResourceT", covariant=True)
+
+
+class ResourcePluginProtocol(Protocol):
+    """Interface for resource plugins."""
+
+    async def initialize(self) -> None: ...
+
+    async def health_check(self) -> bool: ...
+
+    def get_metrics(self) -> Dict[str, Any]: ...

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    AsyncIterator,
+    TypeVar,
+    cast,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from plugins.resources.llm_base import LLM
@@ -21,14 +31,19 @@ from .tools.base import RetryOptions
 from .tools.execution import execute_tool
 
 
+ResourceT = TypeVar("ResourceT", covariant=True)
+
+
 class PluginContext:
     """Object exposing pipeline state and utilities to user_plugins."""
+
+    __state: PipelineState
 
     def __init__(self, state: PipelineState, registries: SystemRegistries) -> None:
         """Initialize context with immutable ``state`` and ``registries``."""
 
         # store state privately to discourage direct access from plugins
-        self.__state = state
+        self.__state: PipelineState = state
         self._registries = registries
 
     # do not allow external code to read _state
@@ -81,22 +96,22 @@ class PluginContext:
     @property
     def pipeline_id(self) -> str:
         """Unique identifier for the current pipeline run."""
-        return self.__state.pipeline_id
+        return cast(str, self.__state.pipeline_id)
 
     @property
     def request_id(self) -> str:
         """Correlation identifier for logging."""
-
-        return self.__state.pipeline_id
+        return cast(str, self.__state.pipeline_id)
 
     @property
     def current_stage(self) -> Optional[PipelineStage]:
         """Stage currently being executed."""
         return self.__state.current_stage
 
-    def get_resource(self, name: str) -> Any:
+    def get_resource(self, name: str) -> Optional[ResourceT]:
         """Return a shared resource plugin registered as ``name``."""
-        return self._registries.resources.get(name)
+
+        return cast(Optional[ResourceT], self._registries.resources.get(name))
 
     def get_llm(self) -> LLM:
         """Return the configured LLM resource.
@@ -116,7 +131,7 @@ class PluginContext:
         """Return the latest user message."""
         for entry in reversed(self.__state.conversation):
             if entry.role == "user":
-                return entry.content
+                return cast(str, entry.content)
         return ""
 
     def execute_tool(
@@ -221,12 +236,12 @@ class PluginContext:
     @property
     def user(self) -> str:
         """Return the user identifier from metadata."""
-        return self.__state.metadata.get("user", "user")
+        return cast(str, self.__state.metadata.get("user", "user"))
 
     @property
     def location(self) -> Optional[str]:
         """Return location metadata if available."""
-        return self.__state.metadata.get("location")
+        return cast(Optional[str], self.__state.metadata.get("location"))
 
     def say(self, message: str) -> None:
         """Shortcut for :meth:`set_response`."""
@@ -310,10 +325,10 @@ class PluginContext:
         )
 
         if isinstance(response, LLMResponse):
-            return response.content
+            return cast(str, response.content)
         return str(response)
 
-    async def stream_llm(self, prompt: str):
+    async def stream_llm(self, prompt: str) -> AsyncIterator[str]:
         """Stream LLM output using server-sent events."""
         llm = self.get_llm()
         self.record_llm_call("PluginContext", "stream_llm")

--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,26 +1,26 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, cast
+from typing import Any, Dict, Generic, cast
 
 from registry import SystemRegistries
 
-from .manager import PipelineManager
+from .manager import PipelineManager, ResultT
 
 
 @dataclass
-class AgentRuntime:
+class AgentRuntime(Generic[ResultT]):
     """Execute messages through the pipeline."""
 
     registries: SystemRegistries
 
     def __post_init__(self) -> None:
-        self.manager = PipelineManager(self.registries)
+        self.manager = PipelineManager[ResultT](self.registries)
 
-    async def run_pipeline(self, message: str) -> Dict[str, Any]:
+    async def run_pipeline(self, message: str) -> ResultT:
         return await self.manager.run_pipeline(message)
 
-    async def handle(self, message: str) -> Dict[str, Any]:
+    async def handle(self, message: str) -> ResultT:
         """Alias for :meth:`run_pipeline`."""
 
-        return cast(Dict[str, Any], await self.run_pipeline(message))
+        return await self.run_pipeline(message)

--- a/src/registry/registries.py
+++ b/src/registry/registries.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, TypeVar, cast
 
 from pipeline.stages import PipelineStage
 from pipeline.user_plugins import BasePlugin
+
+
+T = TypeVar("T")
 
 
 class ResourceRegistry:
@@ -28,10 +31,10 @@ class ResourceRegistry:
             instance = cls(config)
         self.add(getattr(instance, "name", name), instance)
 
-    def get(self, name: str) -> Any | None:
+    def get(self, name: str) -> Optional[T]:
         """Return the resource registered as ``name`` if present."""
 
-        return self._resources.get(name)
+        return cast(Optional[T], self._resources.get(name))
 
     def remove(self, name: str) -> None:
         self._resources.pop(name, None)
@@ -48,10 +51,10 @@ class ToolRegistry:
 
         self._tools[name] = tool
 
-    def get(self, name: str) -> Any | None:
+    def get(self, name: str) -> Optional[T]:
         """Return the tool registered as ``name`` if present."""
 
-        return self._tools.get(name)
+        return cast(Optional[T], self._tools.get(name))
 
 
 class PluginRegistry:


### PR DESCRIPTION
## Summary
- introduce plugin interface protocols
- use generic helpers in plugin context and manager
- return typed results from tool execution helpers
- update mypy configuration to run in strict mode on key files

## Testing
- `mypy 2>&1 | tee /tmp/mypy.log`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aioboto3')*

------
https://chatgpt.com/codex/tasks/task_e_6868b039ed348322aaacb660a2ce1522