### PR TITLE
Improve plugin builder

### DIFF
--- a/src/pipeline/builder.py
+++ b/src/pipeline/builder.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import importlib
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
@@ -13,6 +16,8 @@ from .runtime import AgentRuntime
 from .user_plugins import BasePlugin
 
 logger = get_logger(__name__)
+
+PLUGIN_CACHE_FILE = "plugins.json"
 
 
 @dataclass
@@ -58,31 +63,89 @@ class AgentBuilder:
         return builder
 
     def load_plugins_from_directory(self, directory: str) -> None:
-        for file in Path(directory).glob("*.py"):
-            if file.name.startswith("_"):
-                continue
-            module = self._import_module(file)
-            if module is not None:
-                self._register_module_plugins(module)
+        async def _load() -> None:
+            path = Path(directory)
+            cache = path / PLUGIN_CACHE_FILE
+            plugin_files: list[Path] = []
+            plugins: list[BasePlugin] = []
+
+            if cache.exists():
+                try:
+                    data = json.loads(cache.read_text())
+                    plugin_files = [Path(p) for p in data.get("files", [])]
+                except Exception:  # noqa: BLE001
+                    plugin_files = []
+
+            discovered: list[Path] = []
+            if not plugin_files:
+                for file in path.glob("*.py"):
+                    if file.name.startswith("_"):
+                        continue
+                    module = await self._import_module(file)
+                    if module is None:
+                        continue
+                    found = self._collect_module_plugins(module)
+                    if found:
+                        plugins.extend(found)
+                        discovered.append(file)
+                cache.write_text(json.dumps({"files": [str(f) for f in discovered]}))
+                plugin_files = discovered
+            else:
+                for file in plugin_files:
+                    module = await self._import_module(file)
+                    if module is not None:
+                        plugins.extend(self._collect_module_plugins(module))
+
+            self._register_plugins(plugins)
+
+        asyncio.run(_load())
 
     def load_plugins_from_package(self, package_name: str) -> None:
-        import importlib
-        import pkgutil
+        async def _load() -> None:
+            import pkgutil
 
-        package = importlib.import_module(package_name)
-        if not hasattr(package, "__path__"):
-            self._register_module_plugins(package)
-            return
+            cache_dir = Path(".plugin_cache")
+            cache_dir.mkdir(exist_ok=True)
+            cache = cache_dir / f"{package_name.replace('.', '_')}_{PLUGIN_CACHE_FILE}"
 
-        for info in pkgutil.walk_packages(
-            package.__path__, prefix=package.__name__ + "."
-        ):
-            try:
-                module = importlib.import_module(info.name)
-            except Exception as exc:  # noqa: BLE001
-                logger.error("Failed to import plugin module %s: %s", info.name, exc)
-                continue
-            self._register_module_plugins(module)
+            modules: list[str] = []
+            plugins: list[BasePlugin] = []
+
+            if cache.exists():
+                try:
+                    data = json.loads(cache.read_text())
+                    modules = list(data.get("modules", []))
+                except Exception:  # noqa: BLE001
+                    modules = []
+
+            if not modules:
+                package = importlib.import_module(package_name)
+                if not hasattr(package, "__path__"):
+                    mod = await self._import_module_name(package_name)
+                    if mod is not None:
+                        plugins.extend(self._collect_module_plugins(mod))
+                        modules = [package_name]
+                else:
+                    for info in pkgutil.walk_packages(
+                        package.__path__, prefix=package.__name__ + "."
+                    ):
+                        mod = await self._import_module_name(info.name)
+                        if mod is None:
+                            continue
+                        found = self._collect_module_plugins(mod)
+                        if found:
+                            plugins.extend(found)
+                            modules.append(info.name)
+                cache.write_text(json.dumps({"modules": modules}))
+            else:
+                for name in modules:
+                    mod = await self._import_module_name(name)
+                    if mod is not None:
+                        plugins.extend(self._collect_module_plugins(mod))
+
+            self._register_plugins(plugins)
+
+        asyncio.run(_load())
 
     # ------------------------------ runtime build -----------------------------
     def build_runtime(self) -> "AgentRuntime":
@@ -94,7 +157,7 @@ class AgentBuilder:
         return AgentRuntime(registries)
 
     # ------------------------------ internals --------------------------------
-    def _import_module(self, file: Path) -> ModuleType | None:
+    def _import_module_sync(self, file: Path) -> ModuleType | None:
         import importlib.util
 
         try:
@@ -108,9 +171,39 @@ class AgentBuilder:
             logger.error("Failed to import plugin module %s: %s", file, exc)
             return None
 
-    def _register_module_plugins(self, module: ModuleType) -> None:
+    async def _import_module(self, file: Path) -> ModuleType | None:
+        return await asyncio.to_thread(self._import_module_sync, file)
+
+    def _import_module_name_sync(self, name: str) -> ModuleType | None:
+        try:
+            return importlib.import_module(name)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to import plugin module %s: %s", name, exc)
+            return None
+
+    async def _import_module_name(self, name: str) -> ModuleType | None:
+        return await asyncio.to_thread(self._import_module_name_sync, name)
+
+    def _register_plugins(self, plugins: list[BasePlugin]) -> None:
+        from pipeline.utils.dependency_graph import DependencyGraph
+
+        graph = {}
+        plugin_map = {}
+        for plugin in plugins:
+            name = getattr(plugin, "name", plugin.__class__.__name__)
+            plugin_map[name] = plugin
+            graph[name] = list(getattr(plugin, "dependencies", []))
+
+        order = DependencyGraph(graph).topological_sort()
+        for name in order:
+            plugin = plugin_map[name]
+            for stage in getattr(plugin, "stages", []):
+                self.plugin_registry.register_plugin_for_stage(plugin, stage, name)
+
+    def _collect_module_plugins(self, module: ModuleType) -> list[BasePlugin]:
         import inspect
 
+        found: list[BasePlugin] = []
         for name, obj in vars(module).items():
             if name.startswith("_"):
                 continue
@@ -120,9 +213,10 @@ class AgentBuilder:
                     and issubclass(obj, BasePlugin)
                     and obj is not BasePlugin
                 ):
-                    self.add_plugin(obj({}))
+                    found.append(obj({}))
                 elif callable(obj) and name.endswith("_plugin"):
-                    self.plugin(obj)
+                    plugin = PluginAutoClassifier.classify(obj, {})
+                    found.append(plugin)
             except Exception as exc:  # noqa: BLE001
                 logger.error(
                     "Failed to register plugin from %s.%s: %s",
@@ -131,3 +225,5 @@ class AgentBuilder:
                     exc,
                 )
                 continue
+
+        return found


### PR DESCRIPTION
## Summary
- cache discovered plugin module file paths for reuse
- load plugin modules using `asyncio.to_thread`
- compute plugin dependency order before registration

## Testing
- `poetry run black src/pipeline/builder.py`
- `poetry run isort --check src tests` *(fails: imports not sorted)*
- `poetry run flake8 src tests` *(command not found)*
- `poetry run mypy src` *(fails: invalid package name)*
- `bandit -r src` *(command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: missing PyYAML)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: missing PyYAML)*
- `python -m src.registry.validator` *(fails: no module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: missing PyYAML)*
- `pytest tests/infrastructure/ -v` *(fails: missing PyYAML)*
- `pytest tests/performance/ -m benchmark` *(fails: missing PyYAML)*
- `pytest` *(fails: missing PyYAML)*

------
https://chatgpt.com/codex/tasks/task_e_6868b03c95fc83229339a647535f9fc4