### PR TITLE
[Tests] Add full pipeline integration and chaos tests

### DIFF
--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -1,0 +1,40 @@
+import asyncio
+
+import pytest
+
+from entity import Agent
+from pipeline import PipelineStage
+
+
+class ParsePlugin:
+    stages = [PipelineStage.PARSE]
+
+    async def execute(self, context):
+        context.set_stage_result("parsed", True)
+
+
+class ThinkPlugin:
+    stages = [PipelineStage.THINK]
+
+    async def execute(self, context):
+        context.set_stage_result("thought", True)
+
+
+class RespondPlugin:
+    stages = [PipelineStage.DO]
+
+    async def execute(self, context):
+        context.set_response("ok")
+
+
+@pytest.mark.integration
+def test_full_agent_pipeline():
+    agent = Agent()
+    agent.add_plugin(ParsePlugin())
+    agent.add_plugin(ThinkPlugin())
+    agent.add_plugin(RespondPlugin())
+
+    result = asyncio.run(agent.handle("hi"))
+    assert result["message"] == "ok"
+    assert result["stage_results"].get("parsed") is True
+    assert result["stage_results"].get("thought") is True

--- a/tests/integration/test_stage_failures.py
+++ b/tests/integration/test_stage_failures.py
@@ -1,0 +1,57 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from pipeline import PipelineStage, execute_pipeline
+from registry import PluginRegistry, ResourceRegistry, SystemRegistries, ToolRegistry
+
+
+class RespondPlugin:
+    stages = [PipelineStage.DO]
+
+    async def execute(self, context):
+        context.set_response("ok")
+
+
+def make_failing_plugin(stage: PipelineStage):
+    class FailingPlugin:
+        stages = [stage]
+
+        async def execute(self, context):
+            if not context.metadata.get("failed"):
+                context.metadata["failed"] = True
+                raise RuntimeError("boom")
+            context.set_stage_result(str(stage), True)
+
+    return FailingPlugin()
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "stage",
+    [
+        PipelineStage.PARSE,
+        PipelineStage.THINK,
+        PipelineStage.DO,
+        PipelineStage.REVIEW,
+        PipelineStage.DELIVER,
+    ],
+)
+def test_pipeline_recovers_from_stage_failure(
+    tmp_path: Path, stage: PipelineStage
+) -> None:
+    async def run() -> str:
+        state_file = tmp_path / "state.json"
+        plugins = PluginRegistry()
+        plugins.register_plugin_for_stage(make_failing_plugin(stage), stage)
+        plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DO)
+        registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+        try:
+            await execute_pipeline("hi", registries, state_file=str(state_file))
+        except RuntimeError:
+            pass
+        result = await execute_pipeline("hi", registries, state_file=str(state_file))
+        return result.get("message", "")
+
+    assert asyncio.run(run()) == "ok"

--- a/tests/test_plugin_interfaces_hypothesis.py
+++ b/tests/test_plugin_interfaces_hypothesis.py
@@ -1,0 +1,32 @@
+from hypothesis import given
+from hypothesis import strategies as st
+
+from pipeline import PipelineStage
+from pipeline.interfaces import PluginAutoClassifier
+
+
+@given(st.sampled_from([s.name for s in PipelineStage]))
+def test_classifier_respects_stage_hint(stage_name: str) -> None:
+    async def dummy(ctx):
+        return "ok"
+
+    plugin = PluginAutoClassifier.classify(dummy, {"stage": stage_name})
+    assert plugin.stages == [PipelineStage.from_str(stage_name)]
+
+
+@given(st.integers(min_value=1, max_value=100))
+def test_classifier_sets_priority(priority: int) -> None:
+    async def dummy(ctx):
+        return "ok"
+
+    plugin = PluginAutoClassifier.classify(dummy, {"priority": priority})
+    assert plugin.priority == priority
+
+
+@given(st.text(min_size=1, max_size=20))
+def test_classifier_assigns_name(name: str) -> None:
+    async def dummy(ctx):
+        return "ok"
+
+    plugin = PluginAutoClassifier.classify(dummy, {"name": name})
+    assert plugin.name == name


### PR DESCRIPTION
## Summary
- test full pipeline execution with agent and simple plugins
- property-based tests for PluginAutoClassifier
- chaos tests for each stage to verify recovery
- benchmark test for full pipeline

## Testing
- `flake8 tests/integration/test_full_pipeline.py tests/integration/test_stage_failures.py tests/performance/test_full_pipeline_benchmark.py tests/test_plugin_interfaces_hypothesis.py`
- `mypy src/` *(failed: plugins.resources is not a valid Python package name)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(failed: ModuleNotFoundError: No module named 'aioboto3')*
- `python -m src.config.validator --config config/prod.yaml` *(failed: ModuleNotFoundError: No module named 'aioboto3')*
- `python -m src.registry.validator` *(failed: ModuleNotFoundError: No module named 'aioboto3')*
- `pytest tests/integration/ -v` *(failed: ModuleNotFoundError: No module named 'aioboto3')*
- `pytest tests/infrastructure/ -v` *(failed: ModuleNotFoundError: No module named 'aioboto3')*
- `pytest tests/performance/ -m benchmark` *(failed: ModuleNotFoundError: No module named 'aioboto3')*

------
https://chatgpt.com/codex/tasks/task_e_6868b0410b58832281107a193bab8670