### PR TITLE
[Config] Add dataclass schema validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ packages = [
 [tool.poetry.scripts]
 entity-cli = "src.cli:main"
 entity-config-validate = "src.config.validator:main"
+entity-config-migrate = "src.config.migrate:main"
 
 
 [tool.poetry.urls]

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -6,6 +6,14 @@ if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
 from .builder import ConfigBuilder  # noqa: E402
+from .models import (
+    CONFIG_SCHEMA,
+    EntityConfig,
+    PluginConfig,
+    PluginsSection,
+    ServerConfig,
+    validate_config,
+)
 from .validators import _validate_memory  # noqa: E402
 from .validators import _validate_cache, _validate_vector_memory
 
@@ -14,4 +22,10 @@ __all__ = [
     "_validate_memory",
     "_validate_vector_memory",
     "_validate_cache",
+    "PluginConfig",
+    "PluginsSection",
+    "ServerConfig",
+    "EntityConfig",
+    "CONFIG_SCHEMA",
+    "validate_config",
 ]

--- a/src/config/migrate.py
+++ b/src/config/migrate.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+from config.models import EntityConfig, asdict
+from pipeline.config import ConfigLoader
+
+
+class ConfigMigrator:
+    """CLI for migrating configuration files to the latest schema."""
+
+    def __init__(self) -> None:
+        self.args = self._parse_args()
+
+    def _parse_args(self) -> argparse.Namespace:
+        parser = argparse.ArgumentParser(
+            description="Migrate an Entity configuration file to the latest schema"
+        )
+        parser.add_argument("src", help="Existing configuration file")
+        parser.add_argument(
+            "dest",
+            nargs="?",
+            default="-",
+            help="Output path or '-' for stdout",
+        )
+        return parser.parse_args()
+
+    def run(self) -> int:
+        data = ConfigLoader.from_yaml(self.args.src)
+        config = EntityConfig.from_dict(data)
+        text = yaml.safe_dump(asdict(config), sort_keys=False)
+        if self.args.dest == "-":
+            print(text)
+        else:
+            out = Path(self.args.dest)
+            out.write_text(text)
+            print(f"Wrote migrated config to {out}")
+        return 0
+
+
+def main() -> None:
+    raise SystemExit(ConfigMigrator().run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import MISSING, asdict, dataclass, field, is_dataclass
+from typing import Any, Dict, get_args, get_origin
+
+from jsonschema import validate
+
+
+@dataclass
+class PluginConfig:
+    """Configuration for a single plugin."""
+
+    type: str
+    options: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PluginsSection:
+    """Collection of user-defined plugins."""
+
+    resources: Dict[str, PluginConfig] = field(default_factory=dict)
+    tools: Dict[str, PluginConfig] = field(default_factory=dict)
+    adapters: Dict[str, PluginConfig] = field(default_factory=dict)
+    prompts: Dict[str, PluginConfig] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PluginsSection":
+        def _load(section: str) -> Dict[str, PluginConfig]:
+            result = {}
+            for name, conf in data.get(section, {}).items():
+                conf = dict(conf)
+                result[name] = PluginConfig(conf.pop("type"), conf)
+            return result
+
+        return cls(
+            resources=_load("resources"),
+            tools=_load("tools"),
+            adapters=_load("adapters"),
+            prompts=_load("prompts"),
+        )
+
+
+@dataclass
+class ServerConfig:
+    host: str
+    port: int
+    reload: bool = False
+    log_level: str = "info"
+
+
+@dataclass
+class EntityConfig:
+    server: ServerConfig
+    plugins: PluginsSection = field(default_factory=PluginsSection)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "EntityConfig":
+        server = ServerConfig(**data.get("server", {}))
+        plugins = PluginsSection.from_dict(data.get("plugins", {}))
+        return cls(server, plugins)
+
+
+# ---------------------------------------------------------------------------
+# Schema generation and validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _type_to_schema(tp: Any) -> Dict[str, Any]:
+    origin = get_origin(tp)
+    if origin is dict:
+        args = get_args(tp)
+        if args and len(args) == 2 and is_dataclass(args[1]):
+            return {
+                "type": "object",
+                "additionalProperties": _class_to_schema(args[1]),
+                "default": {},
+            }
+        return {"type": "object", "default": {}}
+    if is_dataclass(tp):
+        return _class_to_schema(tp)
+    if tp is str:
+        return {"type": "string"}
+    if tp is int:
+        return {"type": "integer"}
+    if tp is bool:
+        return {"type": "boolean"}
+    return {}
+
+
+def _class_to_schema(cls: type) -> Dict[str, Any]:
+    schema = {"type": "object", "properties": {}, "additionalProperties": False}
+    required = []
+    for field_obj in cls.__dataclass_fields__.values():
+        schema["properties"][field_obj.name] = _type_to_schema(field_obj.type)
+        if field_obj.default is MISSING and field_obj.default_factory is MISSING:
+            required.append(field_obj.name)
+    if required:
+        schema["required"] = required
+    return schema
+
+
+CONFIG_SCHEMA = _class_to_schema(EntityConfig)
+
+
+def validate_config(data: Dict[str, Any]) -> None:
+    """Validate ``data`` using the generated schema."""
+
+    validate(instance=data, schema=CONFIG_SCHEMA)
+
+
+__all__ = [
+    "PluginConfig",
+    "PluginsSection",
+    "ServerConfig",
+    "EntityConfig",
+    "CONFIG_SCHEMA",
+    "validate_config",
+    "asdict",
+]

--- a/src/pipeline/config/__init__.py
+++ b/src/pipeline/config/__init__.py
@@ -9,6 +9,8 @@ from typing import Any, Dict
 import yaml
 
 from config.environment import load_env
+from config.models import validate_config
+
 from .utils import interpolate_env_vars
 
 
@@ -19,15 +21,21 @@ class ConfigLoader:
     def from_yaml(path: str | Path, env_file: str = ".env") -> Dict[str, Any]:
         load_env(env_file)
         data = yaml.safe_load(Path(path).read_text()) or {}
-        return interpolate_env_vars(data)
+        data = interpolate_env_vars(data)
+        validate_config(data)
+        return data
 
     @staticmethod
     def from_json(path: str | Path, env_file: str = ".env") -> Dict[str, Any]:
         load_env(env_file)
         data = json.loads(Path(path).read_text() or "{}")
-        return interpolate_env_vars(data)
+        data = interpolate_env_vars(data)
+        validate_config(data)
+        return data
 
     @staticmethod
     def from_dict(cfg: Dict[str, Any], env_file: str = ".env") -> Dict[str, Any]:
         load_env(env_file)
-        return interpolate_env_vars(dict(cfg))
+        data = interpolate_env_vars(dict(cfg))
+        validate_config(data)
+        return data

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -1,0 +1,19 @@
+import pytest
+from jsonschema import ValidationError
+
+from pipeline.config import ConfigLoader
+
+
+def test_valid_config_load():
+    data = {
+        "server": {"host": "localhost", "port": 8000},
+        "plugins": {"resources": {"a": {"type": "tests.test_initializer:A"}}},
+    }
+    cfg = ConfigLoader.from_dict(data)
+    assert cfg["server"]["port"] == 8000
+
+
+def test_invalid_config_load():
+    data = {"server": {"host": "localhost", "port": "bad"}}
+    with pytest.raises(ValidationError):
+        ConfigLoader.from_dict(data)


### PR DESCRIPTION
## Summary
- generate JSON schema from new dataclasses in `src/config`
- validate config files on load
- add `entity-config-migrate` CLI for converting legacy configs
- provide unit tests for dataclass validation logic

## Testing
- `black src/config/models.py src/pipeline/config/__init__.py src/config/__init__.py src/config/migrate.py tests/config/test_validation.py`
- `isort src/config/models.py src/pipeline/config/__init__.py src/config/__init__.py src/config/migrate.py tests/config/test_validation.py`
- `flake8 src/ tests/` *(fails: E402, F822)*
- `mypy src/` *(fails: plugins.resources is not a valid Python package name)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: psutil)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: psutil)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: pipeline)*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: psutil)*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: psutil)*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: psutil)*
- `pytest tests/config/test_validation.py -q` *(fails: ModuleNotFoundError: psutil)*


------
https://chatgpt.com/codex/tasks/task_e_6868b059b7dc8322a52921773836517c