### PR TITLE
Add asyncio locks for registries

### DIFF
--- a/plugins/resources/container.py
+++ b/plugins/resources/container.py
@@ -101,7 +101,7 @@ class ResourceContainer(ResourceRegistry):
                         f"Resource '{name}' requires '{dep}' which is missing"
                     )
                 setattr(instance, dep, dep_obj)
-            self.add(getattr(instance, "name", name), instance)
+            await self.add(getattr(instance, "name", name), instance)
             init = getattr(instance, "initialize", None)
             if callable(init):
                 await init()
@@ -141,7 +141,7 @@ class ResourceContainer(ResourceRegistry):
         pool = ResourcePool(factory, cfg)
         await pool.initialize()
         self._pools[name] = pool
-        super().add(name, pool)
+        await super().add(name, pool)
 
     async def acquire(self, name: str) -> Any:
         pool = self._pools.get(name)

--- a/src/cli.py
+++ b/src/cli.py
@@ -193,12 +193,14 @@ class CLI:
                         instance.initialize
                     ):
                         await instance.initialize()
-                    resource_registry.add(name, instance)
+                    await resource_registry.add(name, instance)
                 elif issubclass(cls, ToolPlugin):
-                    tool_registry.add(name, instance)
+                    await tool_registry.add(name, instance)
                 else:
                     for stage in getattr(cls, "stages", []):
-                        plugin_registry.register_plugin_for_stage(instance, stage, name)
+                        await plugin_registry.register_plugin_for_stage(
+                            instance, stage, name
+                        )
                 logger.info("Registered %s", name)
                 return True
 

--- a/src/pipeline/agent.py
+++ b/src/pipeline/agent.py
@@ -20,8 +20,8 @@ class Agent:
     # ------------------------------------------------------------------
     # Delegated plugin helpers
     # ------------------------------------------------------------------
-    def add_plugin(self, plugin: Any) -> None:  # pragma: no cover - delegation
-        self.builder.add_plugin(plugin)
+    async def add_plugin(self, plugin: Any) -> None:  # pragma: no cover - delegation
+        await self.builder.add_plugin(plugin)
 
     def plugin(
         self, func: Optional[Callable] = None, **hints

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -172,7 +172,7 @@ class SystemInitializer:
         for name, healthy in report.items():
             if not healthy:
                 degraded.append(name)
-                resource_registry.remove(name)
+                await resource_registry.remove(name)
 
         # Phase 3.5: register tools
         tool_registry = ToolRegistry()
@@ -180,7 +180,7 @@ class SystemInitializer:
             if any(dep in degraded for dep in getattr(cls, "dependencies", [])):
                 continue
             instance = cls(config)
-            tool_registry.add(getattr(instance, "name", cls.__name__), instance)
+            await tool_registry.add(getattr(instance, "name", cls.__name__), instance)
 
         # Phase 4: instantiate prompt and adapter plugins
         plugin_registry = PluginRegistry()
@@ -189,7 +189,7 @@ class SystemInitializer:
                 continue
             instance = cls(config)
             for stage in getattr(cls, "stages", []):
-                plugin_registry.register_plugin_for_stage(instance, stage)
+                await plugin_registry.register_plugin_for_stage(instance, stage)
 
         if degraded:
             self.config.setdefault("_disabled_resources", degraded)

--- a/tests/integration/test_chaos.py
+++ b/tests/integration/test_chaos.py
@@ -23,7 +23,7 @@ def test_pipeline_resume_after_crash(tmp_path: Path):
     async def run() -> str:
         state_file = tmp_path / "state.json"
         plugins = PluginRegistry()
-        plugins.register_plugin_for_stage(CrashPlugin(), PipelineStage.PARSE)
+        await plugins.register_plugin_for_stage(CrashPlugin(), PipelineStage.PARSE)
         registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
         try:
             await execute_pipeline("hi", registries, state_file=str(state_file))

--- a/tests/integration/test_chat_history_backends.py
+++ b/tests/integration/test_chat_history_backends.py
@@ -46,7 +46,7 @@ async def run_history_test(resource):
 
     memory = MemoryResource(resource)
     resources = ResourceRegistry()
-    resources.add("memory", memory)
+    await resources.add("memory", memory)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     state = PipelineState(
         conversation=[

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -75,9 +75,9 @@ def test_vector_memory_integration():
         await db.save_history("conv1", [history_entry])
         await vm.add_embedding("previous")
         resources = ResourceRegistry()
-        resources.add("database", db)
-        resources.add("vector_memory", vm)
-        resources.add("llm", llm)
+        await resources.add("database", db)
+        await resources.add("vector_memory", vm)
+        await resources.add("llm", llm)
         registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
         state = PipelineState(
             conversation=[

--- a/tests/performance/test_pipeline_benchmark.py
+++ b/tests/performance/test_pipeline_benchmark.py
@@ -22,7 +22,7 @@ class NoOpPlugin(PromptPlugin):
 
 def _make_manager():
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DO))
     registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 

--- a/tests/registry/test_thread_safety.py
+++ b/tests/registry/test_thread_safety.py
@@ -1,0 +1,42 @@
+import asyncio
+
+from registry.registries import PluginRegistry, ResourceRegistry, ToolRegistry
+from pipeline.stages import PipelineStage
+from pipeline.user_plugins import PromptPlugin
+
+
+class DummyPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        return None
+
+
+async def test_plugin_registry_thread_safety():
+    registry = PluginRegistry()
+
+    async def register(i):
+        plugin = DummyPlugin({})
+        await registry.register_plugin_for_stage(plugin, PipelineStage.DO)
+
+    await asyncio.gather(*(register(i) for i in range(10)))
+    assert len(registry.get_plugins_for_stage(PipelineStage.DO)) == 10
+
+
+async def test_resource_and_tool_registry_thread_safety():
+    resources = ResourceRegistry()
+    tools = ToolRegistry()
+
+    async def add_resource(i):
+        await resources.add(f"r{i}", object())
+
+    async def add_tool(i):
+        await tools.add(f"t{i}", object())
+
+    await asyncio.gather(
+        *(add_resource(i) for i in range(5)),
+        *(add_tool(i) for i in range(5)),
+    )
+
+    assert len(resources._resources) == 5
+    assert len(tools._tools) == 5

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -28,13 +28,13 @@ async def use_tool_plugin(ctx: PluginContext) -> None:
 def make_registries() -> SystemRegistries:
     resources = ResourceRegistry()
     tools = ToolRegistry()
-    tools.add("sleep", SleepTool({}))
+    asyncio.run(tools.add("sleep", SleepTool({})))
     plugins = PluginRegistry()
     plugin = PluginAutoClassifier.classify(
         use_tool_plugin,
         {"stage": PipelineStage.DO, "name": "UseToolPlugin"},
     )
-    plugins.register_plugin_for_stage(plugin, PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DO))
     return SystemRegistries(resources, tools, plugins)
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -57,8 +57,8 @@ async def make_context(cache: CacheResource, llm: FakeLLM):
         current_stage=PipelineStage.THINK,
     )
     resources = ResourceRegistry()
-    resources.add("llm", llm)
-    resources.add("cache", cache)
+    await resources.add("llm", llm)
+    await resources.add("cache", cache)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return PluginContext(state, registries), state, registries
 
@@ -81,7 +81,7 @@ async def test_tool_results_are_cached():
     ctx, state, registries = await make_context(cache, llm)
 
     tool = FakeTool()
-    registries.tools.add("fake", tool)
+    await registries.tools.add("fake", tool)
 
     state.pending_tool_calls.append(
         ToolCall(name="fake", params={"x": 2}, result_key="r1")

--- a/tests/test_call_llm_logging.py
+++ b/tests/test_call_llm_logging.py
@@ -39,7 +39,7 @@ def make_context(llm: FakeLLM) -> PluginContext:
         current_stage=PipelineStage.THINK,
     )
     resources = ResourceRegistry()
-    resources.add("llm", llm)
+    asyncio.run(resources.add("llm", llm))
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return PluginContext(state, registries)
 

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -42,8 +42,8 @@ def make_context(llm: FakeLLM):
     resources = ResourceRegistry()
     tools = ToolRegistry()
     plugins = PluginRegistry()
-    resources.add("llm", llm)
-    tools.add("analysis_tool", DummyTool())
+    asyncio.run(resources.add("llm", llm))
+    asyncio.run(tools.add("analysis_tool", DummyTool()))
     registries = SystemRegistries(resources, tools, plugins)
     return state, PluginContext(state, registries)
 

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -22,12 +22,16 @@ class UnstablePlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(
-        UnstablePlugin({"failure_threshold": 2, "failure_reset_timeout": 60}),
-        PipelineStage.DO,
+    asyncio.run(
+        plugins.register_plugin_for_stage(
+            UnstablePlugin({"failure_threshold": 2, "failure_reset_timeout": 60}),
+            PipelineStage.DO,
+        )
     )
-    plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR)
-    plugins.register_plugin_for_stage(ErrorFormatter({}), PipelineStage.ERROR)
+    asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
+    asyncio.run(
+        plugins.register_plugin_for_stage(ErrorFormatter({}), PipelineStage.ERROR)
+    )
     return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
 
 

--- a/tests/test_cli_adapter.py
+++ b/tests/test_cli_adapter.py
@@ -24,7 +24,7 @@ class EchoPlugin(PromptPlugin):
 
 def make_adapter() -> tuple[CLIAdapter, SystemRegistries]:
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO))
     registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return CLIAdapter(manager), registries

--- a/tests/test_complex_prompt.py
+++ b/tests/test_complex_prompt.py
@@ -47,8 +47,8 @@ def make_context(llm, memory):
         metrics=MetricsCollector(),
     )
     resources = ResourceRegistry()
-    resources.add("llm", llm)
-    resources.add("memory", memory)
+    asyncio.run(resources.add("llm", llm))
+    asyncio.run(resources.add("memory", memory))
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return state, PluginContext(state, registries)
 

--- a/tests/test_config_update.py
+++ b/tests/test_config_update.py
@@ -41,9 +41,9 @@ class SlowPlugin(PromptPlugin):
 def make_registry(add_slow: bool = False):
     reg = PluginRegistry()
     plugin = TestReconfigPlugin({"value": "one"})
-    reg.register_plugin_for_stage(plugin, PipelineStage.THINK)
+    asyncio.run(reg.register_plugin_for_stage(plugin, PipelineStage.THINK))
     if add_slow:
-        reg.register_plugin_for_stage(SlowPlugin(), PipelineStage.THINK)
+        asyncio.run(reg.register_plugin_for_stage(SlowPlugin(), PipelineStage.THINK))
     return reg, plugin
 
 
@@ -64,7 +64,7 @@ def test_update_plugin_configuration_restart_required():
 
     reg = PluginRegistry()
     p = NRPlugin({"value": "x"})
-    reg.register_plugin_for_stage(p, PipelineStage.THINK)
+    asyncio.run(reg.register_plugin_for_stage(p, PipelineStage.THINK))
     result = asyncio.run(
         update_plugin_configuration(reg, "test_plugin", {"value": "y"})
     )

--- a/tests/test_conversation_history_plugin.py
+++ b/tests/test_conversation_history_plugin.py
@@ -40,7 +40,7 @@ def make_context(db: FakeMemory):
         metrics=MetricsCollector(),
     )
     resources = ResourceRegistry()
-    resources.add("memory", db)
+    asyncio.run(resources.add("memory", db))
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return state, PluginContext(state, registries)
 

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -30,8 +30,8 @@ class RespondPlugin(PromptPlugin):
 
 def make_manager():
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DO)
-    plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DO))
+    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
     registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     conv = ConversationManager(registries, manager)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -31,9 +31,9 @@ class FallbackPlugin(FailurePlugin):
 
 def make_registries(error_plugin):
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(BoomPlugin({}), PipelineStage.DO)
-    plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR)
-    plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
+    asyncio.run(plugins.register_plugin_for_stage(BoomPlugin({}), PipelineStage.DO))
+    asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
+    asyncio.run(plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR))
     return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
 
 

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -43,9 +43,9 @@ class BadErrorPlugin(FailurePlugin):
 
 def make_registries(error_plugin):
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(FailPlugin({}), PipelineStage.DO)
-    plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR)
-    plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
+    asyncio.run(plugins.register_plugin_for_stage(FailPlugin({}), PipelineStage.DO))
+    asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
+    asyncio.run(plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR))
     return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
 
 

--- a/tests/test_execute_pending_tools.py
+++ b/tests/test_execute_pending_tools.py
@@ -36,7 +36,7 @@ def make_state():
 def test_execute_pending_tools_returns_mapping_by_result_key():
     state = make_state()
     registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), PluginRegistry())
-    registries.tools.add("echo", EchoTool())
+    asyncio.run(registries.tools.add("echo", EchoTool()))
 
     results = asyncio.run(execute_pending_tools(state, registries))
 

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -24,7 +24,7 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter(config=None):
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
     registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return HTTPAdapter(manager, config)

--- a/tests/test_intent_classifier_prompt.py
+++ b/tests/test_intent_classifier_prompt.py
@@ -28,7 +28,7 @@ def make_context(llm: FakeLLM):
         metrics=MetricsCollector(),
     )
     resources = ResourceRegistry()
-    resources.add("llm", llm)
+    asyncio.run(resources.add("llm", llm))
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return state, PluginContext(state, registries)
 

--- a/tests/test_llm_helpers.py
+++ b/tests/test_llm_helpers.py
@@ -32,7 +32,7 @@ def make_context(llm=None) -> PluginContext:
     )
     resources = ResourceRegistry()
     if llm is not None:
-        resources.add("llm", llm)
+        asyncio.run(resources.add("llm", llm))
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return PluginContext(state, registries)
 

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -26,9 +26,11 @@ class IncrementPlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(IncrementPlugin({}), PipelineStage.DO)
+    asyncio.run(
+        plugins.register_plugin_for_stage(IncrementPlugin({}), PipelineStage.DO)
+    )
     resources = ResourceRegistry()
-    resources.add("memory", SimpleMemoryResource())
+    asyncio.run(resources.add("memory", SimpleMemoryResource()))
     return SystemRegistries(resources, ToolRegistry(), plugins)
 
 

--- a/tests/test_memory_retrieval_prompt.py
+++ b/tests/test_memory_retrieval_prompt.py
@@ -36,7 +36,7 @@ def make_context(memory: MemoryResource | None = None):
     memory = memory or SimpleMemoryResource()
     asyncio.run(memory.save_conversation("1", past))
     resources = ResourceRegistry()
-    resources.add("memory", memory)
+    asyncio.run(resources.add("memory", memory))
 
     state = PipelineState(
         conversation=[

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -36,11 +36,11 @@ class MetricsPlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DO))
     resources = ResourceRegistry()
-    resources.add("llm", EchoLLM())
+    asyncio.run(resources.add("llm", EchoLLM()))
     tools = ToolRegistry()
-    tools.add("echo", EchoTool({}))
+    asyncio.run(tools.add("echo", EchoTool({})))
     return SystemRegistries(resources, tools, plugins)
 
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -22,7 +22,7 @@ class TimedPlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(TimedPlugin({}), PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(TimedPlugin({}), PipelineStage.DO))
     return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
 
 

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -21,7 +21,7 @@ class WaitPlugin(PromptPlugin):
 
 def make_manager():
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(WaitPlugin({}), PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(WaitPlugin({}), PipelineStage.DO))
     registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 

--- a/tests/test_plugin_layers.py
+++ b/tests/test_plugin_layers.py
@@ -35,15 +35,15 @@ async def my_prompt(ctx: PluginContext) -> None:
 
 def make_registries() -> SystemRegistries:
     resources = ResourceRegistry()
-    resources.add("resource", MyResource({}))
+    asyncio.run(resources.add("resource", MyResource({})))
     tools = ToolRegistry()
-    tools.add("tool", MyTool({}))
+    asyncio.run(tools.add("tool", MyTool({})))
     plugins = PluginRegistry()
     plugin = PluginAutoClassifier.classify(
         my_prompt,
         {"stage": PipelineStage.DO, "name": "MyPrompt"},
     )
-    plugins.register_plugin_for_stage(plugin, PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DO))
     return SystemRegistries(resources, tools, plugins)
 
 

--- a/tests/test_plugin_registry_order.py
+++ b/tests/test_plugin_registry_order.py
@@ -52,9 +52,9 @@ def _set_final_response(context):
 
 def test_plugin_priority_order_matches_execution():
     registry = PluginRegistry()
-    registry.register_plugin_for_stage(First({}), PipelineStage.DO)
-    registry.register_plugin_for_stage(Third({}), PipelineStage.DO)
-    registry.register_plugin_for_stage(Second({}), PipelineStage.DO)
+    asyncio.run(registry.register_plugin_for_stage(First({}), PipelineStage.DO))
+    asyncio.run(registry.register_plugin_for_stage(Third({}), PipelineStage.DO))
+    asyncio.run(registry.register_plugin_for_stage(Second({}), PipelineStage.DO))
     registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), registry)
     result = asyncio.run(execute_pipeline("hi", registries))
     assert result == ["third", "second", "first"]

--- a/tests/test_react_prompt.py
+++ b/tests/test_react_prompt.py
@@ -38,10 +38,10 @@ def make_context(llm: FakeLLM):
     resources = ResourceRegistry()
     tools = ToolRegistry()
     plugins = PluginRegistry()
-    resources.add("llm", llm)
+    asyncio.run(resources.add("llm", llm))
 
     calculator = CalculatorTool()
-    tools.add("calculator_tool", calculator)
+    asyncio.run(tools.add("calculator_tool", calculator))
 
     registries = SystemRegistries(resources, tools, plugins)
     return state, PluginContext(state, registries)

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -35,7 +35,7 @@ async def run_search():
         metrics=MetricsCollector(),
     )
     tools = ToolRegistry()
-    tools.add("search", SearchTool())
+    await tools.add("search", SearchTool())
     registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
     ctx = PluginContext(state, registries)
     with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=FakeResponse())):

--- a/tests/test_stage_checks.py
+++ b/tests/test_stage_checks.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from pipeline import PipelineStage, PluginRegistry, PromptPlugin
@@ -31,4 +32,4 @@ def test_registry_rejects_invalid_stage():
     reg = PluginRegistry()
     plugin = GoodPlugin({})
     with pytest.raises(ValueError):
-        reg.register_plugin_for_stage(plugin, "bogus")
+        asyncio.run(reg.register_plugin_for_stage(plugin, "bogus"))

--- a/tests/test_weather_api_tool.py
+++ b/tests/test_weather_api_tool.py
@@ -43,7 +43,7 @@ async def run_weather():
     tool = WeatherApiTool(
         {"base_url": "http://test/weather", "api_key": os.environ["WEATHER_API_KEY"]}
     )
-    tools.add("weather", tool)
+    await tools.add("weather", tool)
     registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
     ctx = PluginContext(state, registries)
     with patch(

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -1,3 +1,4 @@
+import asyncio
 from fastapi.testclient import TestClient
 
 from pipeline import (
@@ -22,7 +23,7 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter():
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
     registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return WebSocketAdapter(manager)


### PR DESCRIPTION
## Summary
- ensure registries use `asyncio.Lock`
- adapt builder to async plugin registration
- update initializer and CLI for async APIs
- add thread safety regression tests
- adjust tests for async registry methods

## Testing
- `pytest tests/registry/test_thread_safety.py -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6868b05dbba88322baaeffca423f24fe