### PR TITLE
[Failure] propagate tool errors

### DIFF
--- a/src/pipeline/exceptions.py
+++ b/src/pipeline/exceptions.py
@@ -21,6 +21,18 @@ class PluginExecutionError(PluginError):
         super().__init__(str(original_exception))
 
 
+class ToolExecutionError(PluginError):
+    """Exception raised when a tool fails during execution."""
+
+    def __init__(
+        self, tool_name: str, original_exception: Exception, result_key: str
+    ) -> None:
+        self.tool_name = tool_name
+        self.original_exception = original_exception
+        self.result_key = result_key
+        super().__init__(str(original_exception))
+
+
 class CircuitBreakerTripped(PluginError):
     """Raised when repeated plugin failures prevent execution.
 

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -13,7 +13,7 @@ from registry import SystemRegistries
 
 from .context import ConversationEntry, PluginContext, SimpleContext
 from .errors import create_static_error_response
-from .exceptions import CircuitBreakerTripped, PluginExecutionError
+from .exceptions import CircuitBreakerTripped, PluginExecutionError, ToolExecutionError
 from .logging import reset_request_id, set_request_id
 from .manager import PipelineManager
 from .observability.metrics import _metrics_server
@@ -73,6 +73,15 @@ async def execute_stage(
             state.failure_info = FailureInfo(
                 stage=str(stage),
                 plugin_name=getattr(plugin, "name", plugin.__class__.__name__),
+                error_type=exc.original_exception.__class__.__name__,
+                error_message=str(exc.original_exception),
+                original_exception=exc.original_exception,
+            )
+            return
+        except ToolExecutionError as exc:
+            state.failure_info = FailureInfo(
+                stage=str(stage),
+                plugin_name=exc.tool_name,
                 error_type=exc.original_exception.__class__.__name__,
                 error_message=str(exc.original_exception),
                 original_exception=exc.original_exception,

--- a/tests/test_tool_error_propagation.py
+++ b/tests/test_tool_error_propagation.py
@@ -1,0 +1,44 @@
+import asyncio
+
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
+from user_plugins.failure.basic_logger import BasicLogger
+from user_plugins.failure.error_formatter import ErrorFormatter
+
+
+class FailingTool(ToolPlugin):
+    async def execute_function(self, params):
+        raise RuntimeError("tool boom")
+
+
+class CallToolPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        context.execute_tool("fail", {})
+
+
+def make_registries():
+    plugins = PluginRegistry()
+    plugins.register_plugin_for_stage(CallToolPlugin({}), PipelineStage.DO)
+    plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR)
+    plugins.register_plugin_for_stage(ErrorFormatter({}), PipelineStage.ERROR)
+
+    tools = ToolRegistry()
+    tools.add("fail", FailingTool({"max_retries": 0}))
+
+    return SystemRegistries(ResourceRegistry(), tools, plugins)
+
+
+def test_tool_failure_propagates_to_error_stage():
+    registries = make_registries()
+    result = asyncio.run(execute_pipeline("hi", registries))
+    assert result == {"error": "fail failed (RuntimeError): tool boom"}


### PR DESCRIPTION
## Summary
- add `ToolExecutionError` for failed tool calls
- raise `ToolExecutionError` when tool execution fails and record `FailureInfo`
- capture `ToolExecutionError` in the pipeline
- test error propagation from tool failure

## Testing
- `black src/pipeline/exceptions.py src/pipeline/tools/execution.py src/pipeline/pipeline.py tests/test_tool_error_propagation.py`
- `isort src/pipeline/exceptions.py src/pipeline/tools/execution.py src/pipeline/pipeline.py tests/test_tool_error_propagation.py`
- `flake8 src/pipeline/exceptions.py src/pipeline/pipeline.py src/pipeline/tools/execution.py tests/test_tool_error_propagation.py` *(fails: command not found)*
- `mypy src` *(fails: plugins.resources is not a valid Python package name)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_6868b06383b8832284ac3382e2350758