### PR TITLE
[Pipeline] Resolve merge conflicts across resource modules

### DIFF
--- a/plugins/builtin/resources/llm/providers/base.py
+++ b/plugins/builtin/resources/llm/providers/base.py
@@ -9,12 +9,7 @@ import httpx
 from plugins.builtin.resources.http_llm_resource import HttpLLMResource
 from plugins.builtin.resources.llm_base import LLM
 
-from interfaces.resources import LLM
 from pipeline.validation import ValidationResult
-<<<<<<<< HEAD:plugins/llm/providers/base.py
-from plugins.resources.http_llm_resource import HttpLLMResource
-========
->>>>>>>> 94729e2a932fa4b63abaf4976b85727defa173ae:plugins/builtin/resources/llm/providers/base.py
 
 
 class BaseProvider(LLM):

--- a/plugins/llm/providers/base.py
+++ b/plugins/llm/providers/base.py
@@ -9,12 +9,7 @@ import httpx
 from plugins.builtin.resources.http_llm_resource import HttpLLMResource
 from plugins.builtin.resources.llm_base import LLM
 
-from interfaces.resources import LLM
 from pipeline.validation import ValidationResult
-<<<<<<<< HEAD:plugins/llm/providers/base.py
-from plugins.resources.http_llm_resource import HttpLLMResource
-========
->>>>>>>> 94729e2a932fa4b63abaf4976b85727defa173ae:plugins/builtin/resources/llm/providers/base.py
 
 
 class BaseProvider(LLM):

--- a/plugins/resources/cache.py
+++ b/plugins/resources/cache.py
@@ -1,5 +1,0 @@
-"""Compatibility shim for accessing :class:`CacheResource`."""
-
-from pipeline.user_plugins.resources.cache import CacheResource
-
-__all__ = ["CacheResource"]

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,8 +1,5 @@
-<<<<<<< HEAD
-=======
 from plugins.builtin.adapters.server import AgentServer
 
->>>>>>> 94729e2a932fa4b63abaf4976b85727defa173ae
 from .agent import Agent
 from .builder import AgentBuilder
 from .config_update import ConfigUpdateResult, update_plugin_configuration
@@ -38,14 +35,10 @@ from .runtime import AgentRuntime
 from .stages import PipelineStage
 from .state import FailureInfo, LLMResponse, PipelineState
 
-<<<<<<< HEAD
-=======
 # isort: off
 from plugins.builtin.adapters import CLIAdapter, HTTPAdapter, WebSocketAdapter
 
 # isort: on
-
->>>>>>> 94729e2a932fa4b63abaf4976b85727defa173ae
 __all__ = [
     "PipelineStage",
     "PipelineState",
@@ -86,7 +79,11 @@ __all__ = [
     "Agent",
     "AgentBuilder",
     "AgentRuntime",
+    "AgentServer",
     "PipelineManager",
     "ConversationManager",
+    "HTTPAdapter",
+    "WebSocketAdapter",
+    "CLIAdapter",
     "execute_with_observability",
 ]

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -8,15 +8,9 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, cast
 
 if TYPE_CHECKING:  # pragma: no cover
-<<<<<<< HEAD
     from interfaces.resources import LLM
 else:  # pragma: no cover - runtime type reference
     from interfaces.resources import LLM
-=======
-    from plugins.builtin.resources.llm_base import LLM
-else:  # pragma: no cover - runtime type reference
-    from plugins.builtin.resources.llm_base import LLM
->>>>>>> 94729e2a932fa4b63abaf4976b85727defa173ae
 
 from registry import SystemRegistries
 

--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,12 +1,5 @@
 """Public resource wrappers for pipeline consumers."""
 
-<<<<<<< HEAD
-from interfaces.resources import LLM, BaseResource, LLMResource, Resource
-
-from .container import ResourceContainer
-from .llm.unified import UnifiedLLMResource
-from .memory_resource import MemoryResource, SimpleMemoryResource
-=======
 from plugins.builtin.resources.base import BaseResource, Resource
 from plugins.builtin.resources.llm_base import LLM
 from plugins.builtin.resources.llm_resource import LLMResource
@@ -22,12 +15,19 @@ from .memory_resource import MemoryResource, SimpleMemoryResource
 from .pg_vector_store import PgVectorStore
 from .postgres import PostgresResource
 from .sqlite_storage import SQLiteStorageResource
->>>>>>> 94729e2a932fa4b63abaf4976b85727defa173ae
 
 __all__ = [
     "MemoryResource",
     "SimpleMemoryResource",
     "UnifiedLLMResource",
+    "DatabaseResource",
+    "DuckDBDatabaseResource",
+    "FileSystemResource",
+    "InMemoryStorageResource",
+    "Memory",
+    "PgVectorStore",
+    "PostgresResource",
+    "SQLiteStorageResource",
     "ResourceContainer",
     "LLM",
     "LLMResource",

--- a/src/pipeline/resources/container.py
+++ b/src/pipeline/resources/container.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
-<<<<<<< HEAD
 from pipeline.utils import DependencyGraph
 from registry.registries import ResourceRegistry
-=======
-from plugins.builtin.resources.container import ResourceContainer
->>>>>>> 94729e2a932fa4b63abaf4976b85727defa173ae
 
 
 @dataclass

--- a/src/pipeline/resources/llm_base.py
+++ b/src/pipeline/resources/llm_base.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 """Public re-export of :class:`LLM`."""
 
-<<<<<<< HEAD
-from interfaces.resources import LLM
-=======
 from plugins.builtin.resources.llm_base import LLM
->>>>>>> 94729e2a932fa4b63abaf4976b85727defa173ae
 
 __all__ = ["LLM"]

--- a/src/pipeline/resources/llm_resource.py
+++ b/src/pipeline/resources/llm_resource.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 """Public re-export of :class:`LLMResource`."""
 
-<<<<<<< HEAD
-from interfaces.resources import LLMResource
-=======
 from plugins.builtin.resources.llm_resource import LLMResource
->>>>>>> 94729e2a932fa4b63abaf4976b85727defa173ae
 
 __all__ = ["LLMResource"]

--- a/tests/integration/test_chat_history_backends.py
+++ b/tests/integration/test_chat_history_backends.py
@@ -21,7 +21,7 @@ from pipeline import (
 from pipeline.resources.duckdb_database import DuckDBDatabaseResource
 from pipeline.resources.in_memory_storage import InMemoryStorageResource
 from pipeline.resources.memory_resource import MemoryResource
-from plugins.resources.postgres import PostgresResource
+from pipeline.resources.postgres import PostgresResource
 from pipeline.resources.sqlite_storage import SQLiteStorageResource
 
 load_env(Path(__file__).resolve().parents[2] / ".env")

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -19,12 +19,7 @@ from pipeline import (
 )
 from pipeline.resources.llm import UnifiedLLMResource
 from pipeline.resources.pg_vector_store import PgVectorStore
-<<<<<<< HEAD
-from plugins.resources.postgres import PostgresResource
-from user_plugins.prompts.complex_prompt import ComplexPrompt
-=======
 from pipeline.resources.postgres import PostgresResource
->>>>>>> 94729e2a932fa4b63abaf4976b85727defa173ae
 
 load_env(Path(__file__).resolve().parents[2] / ".env")
 


### PR DESCRIPTION
## Summary
- clean up merge conflict markers
- align resource imports with `plugins.builtin` paths
- update tests to use new imports
- drop old `plugins/resources/cache.py`

## Testing
- `black src/pipeline/__init__.py src/pipeline/context.py src/pipeline/resources/__init__.py src/pipeline/resources/container.py src/pipeline/resources/llm/unified.py src/pipeline/resources/llm_base.py src/pipeline/resources/llm_resource.py plugins/builtin/resources/llm/providers/base.py plugins/llm/providers/base.py tests/integration/test_chat_history_backends.py tests/integration/test_vector_memory_integration.py`
- `isort src/pipeline/__init__.py src/pipeline/context.py src/pipeline/resources/__init__.py src/pipeline/resources/container.py src/pipeline/resources/llm/unified.py src/pipeline/resources/llm_base.py src/pipeline/resources/llm_resource.py plugins/builtin/resources/llm/providers/base.py plugins/llm/providers/base.py tests/integration/test_chat_history_backends.py tests/integration/test_vector_memory_integration.py`
- `flake8 src/ tests/`
- `mypy src/` *(fails: 114 errors)*
- `bandit -r src/`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'aioboto3')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'aioboto3')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'aioboto3')*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: No module named 'aioboto3')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'aioboto3')*


------
https://chatgpt.com/codex/tasks/task_e_686929815b108322af0b927f7b41a6c9