### PR TITLE
Fix merge conflicts in runtime and execution modules

### DIFF
--- a/src/interfaces/__init__.py
+++ b/src/interfaces/__init__.py
@@ -1,4 +1,5 @@
-<<<<<<< HEAD
+from .plugin import (ResourcePluginProtocol, ResourceT, ToolPluginProtocol,
+                     ToolResultT)
 from .plugins import PluginAutoClassifier, import_plugin_class
 from .resources import LLM, BaseResource, LLMResource, Resource
 
@@ -9,13 +10,8 @@ __all__ = [
     "BaseResource",
     "LLM",
     "LLMResource",
-=======
-from .plugin import ToolPluginProtocol, ToolResultT, ResourcePluginProtocol, ResourceT
-
-__all__ = [
     "ToolPluginProtocol",
     "ToolResultT",
     "ResourcePluginProtocol",
     "ResourceT",
->>>>>>> 7f065b1474162305cfdc41a24e318e660ad8a8dd
 ]

--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,35 +1,29 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, cast
+from typing import Any, Dict, cast
 
 from registry import SystemRegistries
 
-from .manager import PipelineManager, ResultT
+from .manager import PipelineManager
 
 
 @dataclass
-class AgentRuntime(Generic[ResultT]):
+class AgentRuntime:
     """Execute messages through the pipeline."""
 
     registries: SystemRegistries
 
     def __post_init__(self) -> None:
-        self.manager = PipelineManager[ResultT](self.registries)
+        self.manager = PipelineManager(self.registries)
 
-<<<<<<< HEAD
     async def run_pipeline(self, message: str) -> Dict[str, Any]:
         async with self.registries.resources:
             return await self.manager.run_pipeline(message)
-=======
-    async def run_pipeline(self, message: str) -> ResultT:
-        return await self.manager.run_pipeline(message)
->>>>>>> 7f065b1474162305cfdc41a24e318e660ad8a8dd
 
-    async def handle(self, message: str) -> ResultT:
+    async def handle(self, message: str) -> Dict[str, Any]:
         """Alias for :meth:`run_pipeline`."""
 
-<<<<<<< HEAD
         return cast(Dict[str, Any], await self.run_pipeline(message))
 
     async def __aenter__(self) -> "AgentRuntime":
@@ -38,6 +32,3 @@ class AgentRuntime(Generic[ResultT]):
     async def __aexit__(self, exc_type, exc, tb) -> None:
         if hasattr(self.registries.resources, "shutdown_all"):
             await self.registries.resources.shutdown_all()
-=======
-        return await self.run_pipeline(message)
->>>>>>> 7f065b1474162305cfdc41a24e318e660ad8a8dd

--- a/src/pipeline/tools/execution.py
+++ b/src/pipeline/tools/execution.py
@@ -1,16 +1,12 @@
-from __future__ import annotations
-
 import asyncio
 from typing import Any, Awaitable, Callable, Dict, TypeVar, cast
 
 from interfaces import ToolPluginProtocol
-
 from registry import SystemRegistries
 
 from ..errors import ToolExecutionError
 from ..state import PipelineState, ToolCall
 from .base import RetryOptions
-
 
 ResultT = TypeVar("ResultT")
 
@@ -54,15 +50,8 @@ async def execute_pending_tools(
     for call in list(state.pending_tool_calls):
         tool = registries.tools.get(call.name)
         if not tool:
-<<<<<<< HEAD
-            error_msg = f"Error: tool {call.name} not found"
-            state.stage_results[call.result_key] = error_msg
-            results[call.result_key] = cast(ResultT, error_msg)
-            continue
-        tool = cast(ToolPluginProtocol[ResultT], tool)
-=======
             raise ToolExecutionError(call.name)
->>>>>>> 6548efef9c31979c7c9316833be101808bace0c6
+        tool = cast(ToolPluginProtocol[ResultT], tool)
 
         options = RetryOptions(
             max_retries=getattr(tool, "max_retries", 1),
@@ -98,12 +87,6 @@ async def execute_pending_tools(
                 call.source,
             )
         except Exception as exc:
-<<<<<<< HEAD
-            err = f"Error: {exc}"
-            state.stage_results[call.result_key] = err
-            results[call.result_key] = cast(ResultT, err)
-=======
->>>>>>> 6548efef9c31979c7c9316833be101808bace0c6
             state.metrics.record_tool_error(
                 call.name,
                 cast(str, state.current_stage and str(state.current_stage)),


### PR DESCRIPTION
## Summary
- clean up leftover merge markers in `interfaces`, `runtime`, and `execution`
- ensure tool execution raises `ToolExecutionError`
- expose plugin utilities and protocols from `interfaces`

## Testing
- `poetry run black src/interfaces/__init__.py src/pipeline/runtime.py src/pipeline/tools/execution.py`
- `poetry run isort src/interfaces/__init__.py src/pipeline/runtime.py src/pipeline/tools/execution.py`
- `poetry run flake8 src/interfaces/__init__.py src/pipeline/runtime.py src/pipeline/tools/execution.py`
- `poetry run mypy src/interfaces/__init__.py src/pipeline/runtime.py src/pipeline/tools/execution.py`
- `bandit -r src/interfaces/__init__.py src/pipeline/runtime.py src/pipeline/tools/execution.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'psutil')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: 'psutil')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'pipeline')*
- `pytest tests/test_execute_pending_tools.py` *(fails: ModuleNotFoundError: 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68692d563a9883228eeb39f9f6c006ea