### PR TITLE
Add StorageResource implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
 - ``MemoryResource`` – unified interface that delegates to an in-memory backend by default.
+- ``StorageResource`` – composite layer combining database, vectors and files.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
 
@@ -283,6 +284,21 @@ memory = MemoryResource(
 ### S3 File Storage
 The `S3FileSystem` backend persists files in Amazon S3. Configure the
 `bucket` and optional `region` keys under `filesystem`.
+
+### StorageResource Example
+Combine chat history storage with local file persistence:
+```yaml
+plugins:
+  resources:
+    storage:
+      type: storage
+      database:
+        type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
+        path: ./agent.db
+      filesystem:
+        type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
+        base_path: ./files
+```
 
 ## Implementation Recommendations
 

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -44,6 +44,21 @@ plugins:
         path: ./agent.db
 ```
 
+You can also use `StorageResource` for a lighter setup:
+
+```yaml
+plugins:
+  resources:
+    storage:
+      type: storage
+      database:
+        type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
+        path: ./agent.db
+      filesystem:
+        type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
+        base_path: ./files
+```
+
 These configurations illustrate **Preserve All Power (7)** by enabling
 advanced storage without sacrificing the simple default setup.
 

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -103,6 +103,15 @@ memory = MemoryResource(
 )
 ```
 
+`StorageResource` offers the same interface when you only need history and file storage:
+
+```python
+storage = StorageResource(
+    database=SQLiteDatabaseResource({"path": "./agent.db"}),
+    filesystem=LocalFileSystemResource({"base_path": "./files"}),
+)
+```
+
 ### Vector Memory
 
 `examples/pipelines/vector_memory_pipeline.py` shows a custom `ResourcePlugin` that stores vectors in memory. A prompt plugin retrieves vectors and interacts with the LLM:

--- a/plugins/builtin/resources/storage_resource.py
+++ b/plugins/builtin/resources/storage_resource.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Composite storage resource for history, vectors and file data."""
+
+from typing import Dict, List
+
+from pipeline.base_plugins import ResourcePlugin, ValidationResult
+from pipeline.context import ConversationEntry
+from pipeline.stages import PipelineStage
+
+from .database import DatabaseResource
+from .filesystem import FileSystemResource
+from .vector_store import VectorStoreResource
+
+
+class StorageResource(ResourcePlugin):
+    """Combine database, vector store and filesystem into one resource."""
+
+    stages = [PipelineStage.PARSE]
+    name = "storage"
+    dependencies = ["database", "vector_store", "filesystem"]
+
+    def __init__(
+        self,
+        database: DatabaseResource | None = None,
+        vector_store: VectorStoreResource | None = None,
+        filesystem: FileSystemResource | None = None,
+        config: Dict | None = None,
+    ) -> None:
+        super().__init__(config or {})
+        self.database = database
+        self.vector_store = vector_store
+        self.filesystem = filesystem
+
+    @classmethod
+    def from_config(cls, config: Dict) -> "StorageResource":
+        return cls(config=config)
+
+    async def save_history(
+        self, conversation_id: str, history: List[ConversationEntry]
+    ) -> None:
+        if self.database:
+            await self.database.save_history(conversation_id, history)
+
+    async def load_history(self, conversation_id: str) -> List[ConversationEntry]:
+        if self.database:
+            return await self.database.load_history(conversation_id)
+        return []
+
+    async def search_similar(self, query: str, k: int = 5) -> List[str]:
+        if self.vector_store:
+            return await self.vector_store.query_similar(query, k)
+        return []
+
+    async def store_file(self, key: str, content: bytes) -> str:
+        if not self.filesystem:
+            raise ValueError("No filesystem backend configured")
+        return await self.filesystem.store(key, content)
+
+    async def load_file(self, key: str) -> bytes:
+        if not self.filesystem:
+            raise ValueError("No filesystem backend configured")
+        return await self.filesystem.load(key)
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        for name in ("database", "vector_store", "filesystem"):
+            sub = config.get(name)
+            if sub is not None and not isinstance(sub, dict):
+                return ValidationResult.error_result(f"'{name}' must be a mapping")
+        return ValidationResult.success_result()
+
+
+__all__ = ["StorageResource"]

--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -15,6 +15,7 @@ from .memory_resource import MemoryResource, SimpleMemoryResource
 from .pg_vector_store import PgVectorStore
 from .postgres import PostgresResource
 from .sqlite_storage import SQLiteStorageResource
+from .storage_resource import StorageResource
 
 __all__ = [
     "MemoryResource",
@@ -28,6 +29,7 @@ __all__ = [
     "PgVectorStore",
     "PostgresResource",
     "SQLiteStorageResource",
+    "StorageResource",
     "ResourceContainer",
     "LLM",
     "LLMResource",

--- a/src/pipeline/resources/storage_resource.py
+++ b/src/pipeline/resources/storage_resource.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Wrapper for StorageResource."""
+
+from plugins.builtin.resources.storage_resource import StorageResource
+
+__all__ = ["StorageResource"]

--- a/tests/test_storage_resource.py
+++ b/tests/test_storage_resource.py
@@ -1,0 +1,41 @@
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+from plugins.builtin.resources.in_memory_storage import InMemoryStorageResource
+from plugins.builtin.resources.local_filesystem import LocalFileSystemResource
+
+from pipeline.context import ConversationEntry
+from pipeline.resources.storage_resource import StorageResource
+
+
+async def make_resource(tmp_path: Path) -> StorageResource:
+    db = InMemoryStorageResource({})
+    fs = LocalFileSystemResource({"base_path": str(tmp_path)})
+    res = StorageResource(database=db, filesystem=fs)
+    return res
+
+
+def test_save_and_load_history(tmp_path):
+    async def run():
+        storage = await make_resource(tmp_path)
+        history = [
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        ]
+        await storage.save_history("1", history)
+        loaded = await storage.load_history("1")
+        return loaded
+
+    loaded = asyncio.run(run())
+    assert loaded and loaded[0].content == "hi"
+
+
+def test_store_and_load_file(tmp_path):
+    async def run():
+        storage = await make_resource(tmp_path)
+        await storage.store_file("foo.txt", b"data")
+        content = await storage.load_file("foo.txt")
+        return content
+
+    content = asyncio.run(run())
+    assert content == b"data"


### PR DESCRIPTION
## Summary
- implement new `StorageResource` plugin and wrapper
- document StorageResource usage in README and docs
- expose StorageResource from pipeline resources
- test save/load history and file operations via StorageResource

## Testing
- `poetry run black plugins/builtin/resources/storage_resource.py src/pipeline/resources/storage_resource.py src/pipeline/resources/__init__.py tests/test_storage_resource.py`
- `poetry run isort plugins/builtin/resources/storage_resource.py src/pipeline/resources/storage_resource.py src/pipeline/resources/__init__.py tests/test_storage_resource.py`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: missing dependencies)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686939a9f3008322993ff17b0f26de6b