### PR TITLE
Update docs for StorageResource

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -4,16 +4,16 @@
 :end-before: <!-- end advanced_usage -->
 ```
 
-### Composing Memory Backends
+### Composing Storage Backends
 
 PostgreSQL's `pgvector` extension allows vector similarity search for embeddings.
-Use `MemoryResource` with a Postgres database and optional S3 file storage:
+Use `StorageResource` with a Postgres database and optional S3 file storage:
 
 ```yaml
 plugins:
   resources:
-    memory:
-      type: memory
+    storage:
+      type: storage
       database:
         type: plugins.builtin.resources.postgres:PostgresResource
         host: localhost
@@ -37,8 +37,8 @@ For local experimentation you can swap the database section with SQLite:
 ```yaml
 plugins:
   resources:
-    memory:
-      type: memory
+    storage:
+      type: storage
       database:
         type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
         path: ./agent.db

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -91,12 +91,12 @@ methods, enabling a consistent storage interface across resources.
 
 Several example pipelines in the `examples/` directory showcase more advanced patterns.
 
-### Memory Composition
+### StorageResource Composition
 
-`examples/pipelines/memory_composition_pipeline.py` demonstrates how to combine SQLite, PGVector and a local file system into a single `MemoryResource`:
+`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface. The pipeline at `examples/pipelines/memory_composition_pipeline.py` demonstrates the same pattern using the older `MemoryResource`. With the new plugin the code looks like:
 
 ```python
-memory = MemoryResource(
+storage = StorageResource(
     database=SQLiteDatabaseResource({"path": "./agent.db"}),
     vector_store=PgVectorStore({"table": "embeddings"}),
     filesystem=LocalFileSystemResource({"base_path": "./files"}),


### PR DESCRIPTION
## Summary
- update README, ARCHITECTURE, advanced usage docs for `StorageResource`
- document StorageResource composition in plugin guide

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811 redefinition of unused 'Resource' from line 7)*
- `poetry run mypy src` *(fails: Module `resources.container` has no attribute `PoolConfig`)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686939ab6710832287d72158102d3c94