### PR TITLE
Add StorageResource configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ plugins:
         bucket: agent-files
         region: us-east-1
 ```
+Full examples live in [`config/dev.yaml`](config/dev.yaml) and
+[`config/prod.yaml`](config/prod.yaml). Each file includes a commented
+`storage:` block showing how to wire up `StorageResource` with sample database,
+vector store, and filesystem settings.
 
 ### Programmatic Configuration
 ```python

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -36,6 +36,23 @@ plugins:
         type: plugins.builtin.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
+#   storage:
+#     type: pipeline.resources.storage_resource:StorageResource
+#     database:
+#       type: plugins.builtin.resources.postgres:PostgresResource
+#       host: localhost
+#       port: 5432
+#       name: storage_db
+#       username: user
+#       password: pass
+#     vector_store:
+#       type: plugins.builtin.resources.pg_vector_store:PgVectorStore
+#       dimensions: 768
+#       table: embeddings
+#     filesystem:
+#       type: plugins.builtin.resources.s3_filesystem:S3FileSystem
+#       bucket: agent-files
+#       region: us-east-1
     cache:
       type: plugins.contrib.resources.cache:CacheResource
       backend:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -41,6 +41,23 @@ plugins:
         type: plugins.builtin.resources.s3_filesystem:S3FileSystem
         bucket: agent-files
         region: us-east-1
+#   storage:
+#     type: pipeline.resources.storage_resource:StorageResource
+#     database:
+#       type: plugins.builtin.resources.postgres:PostgresResource
+#       host: prod-db.example.com
+#       port: 5432
+#       name: prod_storage
+#       username: prod_user
+#       password: securepass
+#     vector_store:
+#       type: plugins.builtin.resources.pg_vector_store:PgVectorStore
+#       dimensions: 768
+#       table: embeddings
+#     filesystem:
+#       type: plugins.builtin.resources.s3_filesystem:S3FileSystem
+#       bucket: agent-files
+#       region: us-east-1
     cache:
       type: plugins.contrib.resources.cache:CacheResource
       backend:


### PR DESCRIPTION
## Summary
- show how to configure `StorageResource` in dev/prod YAML
- reference new examples from README

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811, E402, etc.)*
- `poetry run mypy src` *(fails: ModuleNotFoundError and many typing errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686939ac9f9c8322a7b568f473abde68