### PR TITLE
Add gRPC server example and adapter

### DIFF
--- a/docs/source/grpc_services.md
+++ b/docs/source/grpc_services.md
@@ -44,3 +44,15 @@ if __name__ == "__main__":
 
 ``src/grpc_services/llm.proto`` and ``llm_service.py`` act as references for
 future model services.
+
+### Demo Script
+
+Run the example server implemented with ``LLMGRPCAdapter`` and stream a short
+response:
+
+```bash
+python examples/servers/grpc_server.py
+```
+
+The adapter launches ``LLMService`` locally and prints each token generated for
+the sample prompt.

--- a/examples/servers/grpc_server.py
+++ b/examples/servers/grpc_server.py
@@ -1,0 +1,48 @@
+"""Demo gRPC server using :class:`LLMGRPCAdapter`."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+
+from utilities import enable_plugins_namespace
+
+enable_plugins_namespace()
+
+import grpc
+from plugins.builtin.adapters.grpc import LLMGRPCAdapter
+
+from grpc_services import llm_pb2, llm_pb2_grpc
+from pipeline.initializer import SystemInitializer
+
+
+async def stream_prompt() -> None:
+    """Connect to the server and print streamed tokens."""
+    async with grpc.aio.insecure_channel("localhost:50051") as channel:
+        stub = llm_pb2_grpc.LLMServiceStub(channel)
+        request = llm_pb2.GenerateRequest(prompt="Hello world")
+        async for resp in stub.Generate(request):
+            print(resp.token, end="", flush=True)
+    print()
+
+
+async def main() -> None:
+    initializer = SystemInitializer.from_yaml("config/dev.yaml")
+    registries = await initializer.initialize()
+    adapter = LLMGRPCAdapter({"host": "[::]", "port": 50051})
+
+    server_task = asyncio.create_task(adapter.serve(registries))
+    await asyncio.sleep(0.5)
+    await stream_prompt()
+    await adapter.shutdown()
+    server_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await server_task
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/plugins/builtin/adapters/__init__.py
+++ b/plugins/builtin/adapters/__init__.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 """Adapter implementations used to expose the pipeline externally."""
 
 from .cli import CLIAdapter
+from .grpc import LLMGRPCAdapter
 from .http import HTTPAdapter
 from .websocket import WebSocketAdapter
 
-__all__ = ["HTTPAdapter", "CLIAdapter", "WebSocketAdapter"]
+__all__ = ["HTTPAdapter", "CLIAdapter", "WebSocketAdapter", "LLMGRPCAdapter"]

--- a/plugins/builtin/adapters/grpc.py
+++ b/plugins/builtin/adapters/grpc.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""gRPC adapter exposing :class:`LLMService`."""
+
+import grpc
+
+from grpc_services import llm_pb2_grpc
+from grpc_services.llm_service import LLMService
+from pipeline.base_plugins import AdapterPlugin
+from pipeline.stages import PipelineStage
+from registry import SystemRegistries
+
+
+class LLMGRPCAdapter(AdapterPlugin):
+    """Serve :class:`LLMService` over gRPC."""
+
+    stages = [PipelineStage.DELIVER]
+
+    def __init__(self, config: dict | None = None) -> None:
+        super().__init__(config)
+        self._server: grpc.aio.Server | None = None
+
+    async def serve(self, registries: SystemRegistries) -> None:  # noqa: ARG002
+        """Start the gRPC server."""
+        self._server = grpc.aio.server()
+        llm_pb2_grpc.add_LLMServiceServicer_to_server(LLMService(), self._server)
+        host = self.config.get("host", "[::]")
+        port = int(self.config.get("port", 50051))
+        self._server.add_insecure_port(f"{host}:{port}")
+        await self._server.start()
+        await self._server.wait_for_termination()
+
+    async def shutdown(self) -> None:
+        """Stop the server if running."""
+        if self._server is not None:
+            await self._server.stop(0)
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - adapter
+        pass


### PR DESCRIPTION
## Summary
- add `LLMGRPCAdapter` plugin to serve `LLMService`
- demonstrate adapter usage in `examples/servers/grpc_server.py`
- document example in gRPC services guide

## Testing
- `poetry run black .`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811, E402, etc.)*
- `poetry run mypy src` *(fails: found 156 errors)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: psutil)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: psutil)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: pipeline)*
- `pytest` *(fails: ModuleNotFoundError: psutil)*

------
https://chatgpt.com/codex/tasks/task_e_68694647632c83228fb2c9e81dcf30a3