### PR TITLE
Add structured logging example

### DIFF
--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -28,6 +28,9 @@ and mental models stay easy to grasp.
 4. Clear stage boundaries and structured logging
 5. One canonical name per resource
 
+A small example of structured logging lives in `examples/structured_logging_example.py`.
+It configures the `StructuredLogging` resource and emits one log entry.
+
 ## Network Architecture
 All backend services communicate using gRPC streaming with Protobuf schemas.
 Web interfaces may use WebSockets, but model services must expose gRPC

--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -22,3 +22,13 @@ Example log output:
 ```
 
 Use the ID to trace a single request across plugins and stages.
+
+### Example Script
+
+The `examples/structured_logging_example.py` script configures the `StructuredLogging` resource and writes a single log entry.
+Run it with:
+
+```bash
+python examples/structured_logging_example.py
+```
+

--- a/examples/structured_logging_example.py
+++ b/examples/structured_logging_example.py
@@ -1,0 +1,30 @@
+"""Configure StructuredLogging and write a single log entry."""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from utilities import enable_plugins_namespace
+
+enable_plugins_namespace()
+
+from plugins.builtin.resources.structured_logging import StructuredLogging
+
+from pipeline.logging import get_logger
+
+
+async def main() -> None:
+    logging_cfg = {"level": "INFO", "json": True}
+    plugin = StructuredLogging(logging_cfg)
+    await plugin.initialize()
+
+    logger = get_logger("structured_logging_example")
+    logger.info("Logging configured successfully")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `examples/structured_logging_example.py`
- document how to run the script in `logging.md`
- reference the example in the architecture guide

## Testing
- `poetry run black examples/structured_logging_example.py`
- `poetry run isort examples/structured_logging_example.py`
- `poetry run mypy src`
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68694a62304483229f31c7f249d59d53