### PR TITLE
Add cache resource example

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -106,3 +106,7 @@ store backed by DuckDB:
 ```bash
 python examples/pipelines/duckdb_pipeline.py
 ```
+
+### Caching Pipeline Data
+
+`CacheResource` lets plugins store intermediate results between stages. Configure it with `InMemoryCache` or your own backend. Run `examples/cache_example.py` for a minimal setup.

--- a/examples/cache_example.py
+++ b/examples/cache_example.py
@@ -1,0 +1,27 @@
+"""Demonstrate CacheResource with an in-memory backend."""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from utilities import enable_plugins_namespace
+
+enable_plugins_namespace()
+
+from plugins.contrib.resources.cache import CacheResource
+from pipeline.cache import InMemoryCache
+
+
+async def main() -> None:
+    cache = CacheResource(InMemoryCache())
+    await cache.set("greeting", "hello world")
+    print("Cached value:", await cache.get("greeting"))
+    await cache.clear()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `examples/cache_example.py` to show setting up `CacheResource` with `InMemoryCache`
- document caching in advanced usage guide

## Testing
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F401, F811, etc.)*
- `poetry run mypy src` *(fails: many missing imports)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: pipeline)*
- `pytest` *(fails: ModuleNotFoundError: pipeline.user_plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68694a62546c8322a4cffeee3ba77896