### PR TITLE
Add storage resource example

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ plugins:
         type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
         base_path: ./files
 ```
+For a runnable demonstration see `examples/storage_resource_example.py`.
 
 ## Implementation Recommendations
 

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -111,6 +111,7 @@ storage = StorageResource(
     filesystem=LocalFileSystemResource({"base_path": "./files"}),
 )
 ```
+The script at `examples/storage_resource_example.py` demonstrates this setup.
 
 ### Vector Memory
 

--- a/examples/storage_resource_example.py
+++ b/examples/storage_resource_example.py
@@ -1,0 +1,59 @@
+"""Demonstrate StorageResource with SQLite and local files."""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+from datetime import datetime
+
+# Make the repository's ``src`` directory importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from utilities import enable_plugins_namespace
+
+enable_plugins_namespace()
+
+from plugins.builtin.resources.local_filesystem import LocalFileSystemResource
+from plugins.builtin.resources.sqlite_storage import (
+    SQLiteStorageResource as SQLiteDatabaseResource,
+)
+from plugins.builtin.resources.storage_resource import StorageResource
+from pipeline.context import PluginContext, ConversationEntry
+from pipeline import PipelineStage, PromptPlugin
+from entity import Agent
+
+
+class StorePrompt(PromptPlugin):
+    """Store message history and save the input to a file."""
+
+    dependencies = ["storage"]
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, ctx: PluginContext) -> None:
+        storage: StorageResource = ctx.get_resource("storage")
+        await storage.save_history(ctx.pipeline_id, ctx.get_conversation_history())
+        path = await storage.store_file("input.txt", ctx.message.encode())
+        ctx.add_conversation_entry(f"File stored at {path}", role="assistant")
+
+
+def main() -> None:
+    agent = Agent()
+
+    database = SQLiteDatabaseResource({"path": "./agent.db"})
+    filesystem = LocalFileSystemResource({"base_path": "./files"})
+    storage = StorageResource(database=database, filesystem=filesystem)
+
+    agent.builder.resource_registry.add("storage", storage)
+    agent.builder.plugin_registry.register_plugin_for_stage(
+        StorePrompt(), PipelineStage.THINK
+    )
+
+    async def run() -> None:
+        print(await agent.handle("remember this"))
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `examples/storage_resource_example.py` to show StorageResource setup
- reference example in README and plugin guide

## Testing
- `poetry run black src tests` *(fails: reformatted many files)*
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: various style issues)*
- `poetry run mypy src` *(fails: many errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: 72 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68694a5c335083228659abf61df40a56