### PR TITLE
Add Search and Weather tools example

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -126,6 +126,9 @@ class VectorMemoryResource(ResourcePlugin):
 ```
 
 These scripts are great starting points when designing your own plugins.
+The `examples/tools/search_weather_example.py` script demonstrates
+registering built-in tools directly with an `Agent` and combining their
+results.
 
 ### Adapter and Failure Examples
 


### PR DESCRIPTION
## Summary
- add `examples/tools/search_weather_example.py`
- reference the example in plugin guide documentation

## Testing
- `poetry run black examples/tools/search_weather_example.py`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811, E402, F401, F822, etc.)*
- `poetry run mypy src` *(fails: found 156 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `poetry run pytest` *(fails: 72 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68694a5c499c8322af8cdf8bda8e89e3