### PR TITLE
Add config reload example

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -74,6 +74,12 @@ The command waits for active pipelines to finish, then applies the new YAML
 configuration. This demonstrates **Dynamic Configuration Updates**, letting you
 tweak resources or tools at runtime while keeping the system responsive.
 
+For a hands-on demonstration, run `examples/config_reload_example.py`:
+
+```bash
+python examples/config_reload_example.py
+```
+
 ### Streaming and Function Calling
 
 UnifiedLLMResource now exposes streaming via Server-Sent Events and optional

--- a/examples/config_reload_example.py
+++ b/examples/config_reload_example.py
@@ -1,0 +1,79 @@
+"""Demonstrate runtime configuration reload using the CLI."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+
+import yaml
+
+# Allow importing from the repository's src directory
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+# Expose local plugins namespace
+from utilities import enable_plugins_namespace
+
+enable_plugins_namespace()
+
+# Make this module importable as "examples.config_reload_example" even when executed directly
+sys.modules.setdefault("examples.config_reload_example", sys.modules[__name__])
+
+from cli import CLI
+from entity import Agent
+from pipeline.base_plugins import PromptPlugin
+from pipeline.context import PluginContext
+from pipeline.stages import PipelineStage
+
+
+class GreetingPrompt(PromptPlugin):
+    """Simple prompt plugin that prints a greeting."""
+
+    stages = [PipelineStage.THINK]
+    name = "greeting"
+
+    async def _execute_impl(
+        self, context: PluginContext
+    ) -> None:  # pragma: no cover - example
+        message = self.config.get("message", "Hello")
+        print(f"GreetingPrompt: {message}")
+
+
+async def main() -> None:
+    base_config = pathlib.Path("config/dev.yaml")
+    agent = Agent(str(base_config))
+
+    def list_think_plugins() -> list[str]:
+        reg = agent.builder.plugin_registry
+        return [
+            reg.get_plugin_name(p)
+            for p in reg.get_plugins_for_stage(PipelineStage.THINK)
+        ]
+
+    print("THINK plugins before reload:", list_think_plugins())
+
+    updated = tempfile.NamedTemporaryFile(delete=False, suffix=".yaml")
+    updated_cfg = {
+        "plugins": {
+            "prompts": {
+                "greeting": {
+                    "type": "examples.config_reload_example:GreetingPrompt",
+                    "message": "Hi from the updated config!",
+                }
+            }
+        }
+    }
+    updated.write(yaml.dump(updated_cfg).encode())
+    updated.close()
+
+    cli = CLI.__new__(CLI)
+    result = cli._reload_config(agent, updated.name)
+    print("Reload exit code:", result)
+
+    print("THINK plugins after reload:", list_think_plugins())
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add example demonstrating CLI config reload
- reference the example in advanced usage docs

## Testing
- `poetry run black examples/config_reload_example.py`
- `poetry run isort examples/config_reload_example.py`
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811 redefinition etc.)*
- `poetry run mypy src` *(fails: Found 156 errors)*
- `bandit -r src` *(fails: command not found)*
- `PYTHONPATH=src poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `PYTHONPATH=src poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `PYTHONPATH=src poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `PYTHONPATH=src poetry run pytest` *(fails: 72 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68694a595ce88322b12477ff3ed0da58