### PR TITLE
Fix README conflict and import cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,7 @@ When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
-<<<<<< codex/update-docs-for-storageresource-plugin
 - ``StorageResource`` – unified interface that composes database, vector store, and file system backends.
-======
-- ``MemoryResource`` – unified interface that delegates to an in-memory backend by default.
-- ``StorageResource`` – composite layer combining database, vectors and files.
->>>>>> main
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -4,7 +4,6 @@ import shutil
 from pathlib import Path
 
 import yaml
-from plugins.builtin.resources.base import Resource
 
 from entity import Agent, AgentServer
 from interfaces import import_plugin_class

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -5,9 +5,6 @@ import json
 from contextlib import contextmanager
 from typing import Any, Dict, Iterable, List, Tuple
 
-from plugins.builtin.resources.base import Resource
-from plugins.builtin.resources.container import ResourceContainer
-
 from config.environment import load_env
 from interfaces.resources import Resource
 from pipeline.config.utils import interpolate_env_vars


### PR DESCRIPTION
## Summary
- resolve README merge conflict
- drop duplicate Resource imports
- clean up initializer imports

## Testing
- `poetry run black src/cli.py src/pipeline/initializer.py`
- `poetry run isort README.md src/cli.py src/pipeline/initializer.py`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: found 156 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686944e7a75c83228be1e6a127763aec