### PR TITLE
Add observability metrics example

### DIFF
--- a/docs/source/monitoring.md
+++ b/docs/source/monitoring.md
@@ -14,7 +14,8 @@ start_metrics_server(port=9001)
 ```
 
 The exporter provides LLM latency and failure counters along with CPU and memory
-usage. Point Prometheus at the server to scrape these metrics.
+usage. Point Prometheus at the server to scrape these metrics. See
+`examples/observability_metrics.py` for a minimal example.
 
 ## Grafana Dashboard
 

--- a/examples/observability_metrics.py
+++ b/examples/observability_metrics.py
@@ -1,0 +1,29 @@
+"""Start Prometheus metrics and trace a simple asynchronous task."""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from utilities import enable_plugins_namespace
+
+enable_plugins_namespace()
+
+from pipeline.observability import start_metrics_server, start_span
+
+
+async def sample_task() -> None:
+    async with start_span("sample_task"):
+        await asyncio.sleep(0.2)
+
+
+async def main() -> None:
+    start_metrics_server(port=9001)
+    await sample_task()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add an example script showing how to start the metrics server and trace a task
- reference the example in the monitoring docs

## Testing
- `poetry run black --check src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `bandit -r src` *(command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `pytest` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68694f434e6c83229c23c7de1d17b295