### PR TITLE
Update docs with grpc and cli server examples

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -104,6 +104,18 @@ For a WebSocket server use the CLI:
 python src/cli.py serve-websocket --config config/dev.yaml
 ```
 
+Run the gRPC server:
+
+```bash
+python examples/servers/grpc_server.py
+```
+
+Start the CLI adapter for a basic text interface:
+
+```bash
+python examples/servers/cli_adapter.py
+```
+
 ### DuckDB Pipeline Example
 
 The `examples/pipelines/duckdb_pipeline.py` script demonstrates a local vector


### PR DESCRIPTION
## Summary
- document running the gRPC and CLI example servers

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: pipeline.user_plugins)*
- `poetry run pytest` *(fails: 72 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68694f4125dc8322afbec987cc2786e9