### PR TITLE
Update plugin guide examples

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -133,14 +133,16 @@ results.
 
 ### Adapter and Failure Examples
 
-The repository also includes short examples for different adapters and basic
-failure handling. Use `src/cli.py` to run the agent interactively or over a
-WebSocket connection:
+The repository also includes short examples for adapter usage and basic
+failure handling. See [`examples/servers/cli_adapter.py`](../../examples/servers/cli_adapter.py)
+for how to expose an `Agent` through a command line interface. Use `src/cli.py`
+to run the agent interactively or over a WebSocket connection:
 
 ```bash
 python src/cli.py --config config/dev.yaml
 python src/cli.py serve-websocket --config config/dev.yaml
 ```
 
-When implementing custom error handling, refer to the failure plugin template at
-`src/cli/templates/failure.py`.
+When implementing custom error handling, refer to
+[`examples/failure_example.py`](../../examples/failure_example.py) and the
+failure plugin template at `src/cli/templates/failure.py`.


### PR DESCRIPTION
## Summary
- add links to adapter and error handling examples in plugin guide

## Testing
- `poetry run sphinx-build docs/source docs/build/html`
- `poetry run black --check src tests` *(fails: would reformat 57 files)*
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 156 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: 72 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68694f3e2da4832284f6e3f34158de0e