### PR TITLE
Update README memory resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
-- ``StorageResource`` – unified interface that composes database, vector store, and file system backends.
+- ``MemoryResource`` – composite memory combining optional database, vector store, and filesystem backends.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
 
+StorageResource is an advanced plugin for persistent storage. See [docs/source/plugin_guide.md](docs/source/plugin_guide.md) for details.
 These defaults allow ``Agent()`` to process messages without any external
 configuration.
 


### PR DESCRIPTION
## Summary
- clarify memory resource default plugin description
- add note about advanced StorageResource persistent storage

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: found 156 errors)*
- `bandit -r src` *(fails: Command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68699d8e0e9883229635d43f3792aadd