### PR TITLE
Update StorageResource docs

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -93,7 +93,7 @@ Several example pipelines in the `examples/` directory showcase more advanced pa
 
 ### StorageResource Composition
 
-`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface. The pipeline at `examples/pipelines/memory_composition_pipeline.py` demonstrates the same pattern using the older `MemoryResource`. With the new plugin the code looks like:
+`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface. The pipeline at `examples/pipelines/memory_composition_pipeline.py` demonstrates the same pattern using the older `MemoryResource`. `MemoryResource` remains the framework's default ephemeral memory, configured in [config/dev.yaml](../../config/dev.yaml). For persistent deployments, prefer `StorageResource` so history, vectors, and files survive restarts. With the new plugin the code looks like:
 
 ```python
 storage = StorageResource(


### PR DESCRIPTION
## Summary
- clarify default ephemeral memory in StorageResource docs
- mention StorageResource for persistent setups
- point users to `config/dev.yaml` for example configuration

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Function is missing a return type annotation)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run pytest` *(fails: 72 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68699e916df483228a3d937f2fed4895