### PR TITLE
Update docs with components overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
-- ``StorageResource`` – unified interface that composes database, vector store, and file system backends.
+- ``MemoryResource`` – composite memory combining optional database, vector store, and filesystem backends.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
 
+StorageResource is an advanced plugin for persistent storage. See [docs/source/plugin_guide.md](docs/source/plugin_guide.md) for details.
 These defaults allow ``Agent()`` to process messages without any external
 configuration.
 
@@ -21,7 +22,10 @@ poetry run python src/cli.py --config config.yaml
 ```
 This project relies on `httpx==0.27.*`, which Poetry will install automatically.
 <!-- end quick_start -->
+For a high-level look at how the pieces connect, see [components_overview.md](components_overview.md).
+
 ## Environment Setup
+
 
 1. Install Python 3.11+ and [Poetry](https://python-poetry.org/).
 2. Run `poetry install` to create the virtual environment. This installs all

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -21,6 +21,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 
 ### Architecture
 - [Architecture overview](architecture.md)
+- [Components overview](components_overview.md)
 
 ### Reference
 - [Context API](context.md)
@@ -59,5 +60,6 @@ principle_checklist
 apidocs/index
 api_reference
 architecture
+components_overview
 plugins
 ```


### PR DESCRIPTION
## Summary
- mention components overview in README
- reference components overview in index docs

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src`
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68699e939be483229bf7ae829e7097d1