### PR TITLE
Update docs to reference components overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ poetry run python src/cli.py --config config.yaml
 ```
 This project relies on `httpx==0.27.*`, which Poetry will install automatically.
 <!-- end quick_start -->
+
+For a deeper look at how the core pieces fit together, see the
+[components overview](docs/source/components_overview.md).
 ## Environment Setup
 
 1. Install Python 3.11+ and [Poetry](https://python-poetry.org/).

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -21,6 +21,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 
 ### Architecture
 - [Architecture overview](architecture.md)
+- [Components overview](components_overview.md)
 
 ### Reference
 - [Context API](context.md)
@@ -59,5 +60,6 @@ principle_checklist
 apidocs/index
 api_reference
 architecture
+components_overview
 plugins
 ```


### PR DESCRIPTION
## Summary
- point README readers to the new components overview
- link components overview in the architecture section

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: E402, F401, etc.)*
- `poetry run mypy src` *(fails: many errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: 72 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68699f80dadc832288d3aa6aca33906b