### PR TITLE
Remove filesystem from MemoryResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
-- ``MemoryResource`` – composite in-memory store with optional database, vector,
-  and file backends.
+- ``MemoryResource`` – composite in-memory store with optional SQL/NoSQL and vector backends.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
 

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -13,7 +13,6 @@ from utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 
-from plugins.contrib.local_filesystem import LocalFileSystemResource  # noqa: E402
 from plugins.contrib.memory_resource import MemoryResource  # noqa: E402
 from plugins.contrib.pg_vector_store import PgVectorStore  # noqa: E402
 from plugins.contrib.sqlite_storage import (
@@ -44,12 +43,10 @@ def main() -> None:
 
     database = SQLiteDatabaseResource({"path": "./agent.db"})
     vector_store = PgVectorStore({"table": "embeddings"})
-    filesystem = LocalFileSystemResource({"base_path": "./files"})
 
     memory = MemoryResource(
         database=database,
         vector_store=vector_store,
-        filesystem=filesystem,
     )
 
     agent.builder.resource_registry.add("memory", memory)

--- a/src/pipeline/resources/memory_resource.py
+++ b/src/pipeline/resources/memory_resource.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Memory resource combining storage and vector store plugins."""
+"""Memory resource supporting in-memory, SQL/NoSQL, and vector store backends."""
 
 
 from typing import Any, Dict, List
@@ -12,7 +12,6 @@ from pipeline.context import ConversationEntry
 from pipeline.stages import PipelineStage
 
 from .database import DatabaseResource
-from .filesystem import FileSystemResource
 from .memory import Memory
 
 
@@ -40,23 +39,21 @@ class SimpleMemoryResource(ResourcePlugin, Memory):
 
 
 class MemoryResource(ResourcePlugin, Memory):
-    """Composite memory resource composed of optional backends."""
+    """Combine in-memory storage with optional database and vector backends."""
 
     stages = [PipelineStage.PARSE]
     name = "memory"
-    dependencies = ["database", "vector_store", "filesystem"]
+    dependencies = ["database", "vector_store"]
 
     def __init__(
         self,
         database: DatabaseResource | None = None,
         vector_store: VectorStoreResource | None = None,
-        filesystem: FileSystemResource | None = None,
         config: Dict | None = None,
     ) -> None:
         super().__init__(config or {})
         self.database = database
         self.vector_store = vector_store
-        self.filesystem = filesystem
         self._kv: Dict[str, Any] = {}
 
     @classmethod
@@ -91,14 +88,9 @@ class MemoryResource(ResourcePlugin, Memory):
             return await self.vector_store.query_similar(query, k)
         return []
 
-    async def store_file(self, key: str, content: bytes) -> str:
-        if not self.filesystem:
-            raise ValueError("No filesystem backend configured")
-        return await self.filesystem.store(key, content)
-
     @classmethod
     def validate_config(cls, config: Dict) -> ValidationResult:
-        for name in ("database", "vector_store", "filesystem"):
+        for name in ("database", "vector_store"):
             sub = config.get(name)
             if sub is not None and not isinstance(sub, dict):
                 return ValidationResult.error_result(f"'{name}' must be a mapping")


### PR DESCRIPTION
## Summary
- drop filesystem support from `MemoryResource`
- update example script that composes memory backends
- clarify `MemoryResource` bullet in README

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: E402 and other errors)*
- `poetry run mypy src` *(fails: many missing stubs)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_6869a39e7418832292dd36eba2a2f3cd