### PR TITLE
Simplify StorageResource

### DIFF
--- a/plugins/builtin/resources/storage_resource.py
+++ b/plugins/builtin/resources/storage_resource.py
@@ -1,56 +1,33 @@
 from __future__ import annotations
 
-"""Composite storage resource for history, vectors and file data."""
+"""Simple filesystem backed storage resource."""
 
-from typing import Dict, List
+from typing import Dict
 
 from pipeline.base_plugins import ResourcePlugin, ValidationResult
-from pipeline.context import ConversationEntry
 from pipeline.stages import PipelineStage
 
-from .database import DatabaseResource
 from .filesystem import FileSystemResource
-from .vector_store import VectorStoreResource
 
 
 class StorageResource(ResourcePlugin):
-    """Combine database, vector store and filesystem into one resource."""
+    """Provide simple file CRUD operations through a filesystem backend."""
 
     stages = [PipelineStage.PARSE]
     name = "storage"
-    dependencies = ["database", "vector_store", "filesystem"]
+    dependencies = ["filesystem"]
 
     def __init__(
         self,
-        database: DatabaseResource | None = None,
-        vector_store: VectorStoreResource | None = None,
         filesystem: FileSystemResource | None = None,
         config: Dict | None = None,
     ) -> None:
         super().__init__(config or {})
-        self.database = database
-        self.vector_store = vector_store
         self.filesystem = filesystem
 
     @classmethod
     def from_config(cls, config: Dict) -> "StorageResource":
         return cls(config=config)
-
-    async def save_history(
-        self, conversation_id: str, history: List[ConversationEntry]
-    ) -> None:
-        if self.database:
-            await self.database.save_history(conversation_id, history)
-
-    async def load_history(self, conversation_id: str) -> List[ConversationEntry]:
-        if self.database:
-            return await self.database.load_history(conversation_id)
-        return []
-
-    async def search_similar(self, query: str, k: int = 5) -> List[str]:
-        if self.vector_store:
-            return await self.vector_store.query_similar(query, k)
-        return []
 
     async def store_file(self, key: str, content: bytes) -> str:
         if not self.filesystem:
@@ -64,7 +41,7 @@ class StorageResource(ResourcePlugin):
 
     @classmethod
     def validate_config(cls, config: Dict) -> ValidationResult:
-        for name in ("database", "vector_store", "filesystem"):
+        for name in ("filesystem",):
             sub = config.get(name)
             if sub is not None and not isinstance(sub, dict):
                 return ValidationResult.error_result(f"'{name}' must be a mapping")

--- a/src/pipeline/resources/storage_resource.py
+++ b/src/pipeline/resources/storage_resource.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Wrapper for StorageResource."""
+"""Thin wrapper exposing the built-in filesystem StorageResource."""
 
 from plugins.builtin.resources.storage_resource import StorageResource
 

--- a/tests/test_storage_resource.py
+++ b/tests/test_storage_resource.py
@@ -1,33 +1,14 @@
 import asyncio
-from datetime import datetime
 from pathlib import Path
 
-from plugins.builtin.resources.in_memory_storage import InMemoryStorageResource
 from plugins.builtin.resources.local_filesystem import LocalFileSystemResource
 
-from pipeline.context import ConversationEntry
 from pipeline.resources.storage_resource import StorageResource
 
 
 async def make_resource(tmp_path: Path) -> StorageResource:
-    db = InMemoryStorageResource({})
     fs = LocalFileSystemResource({"base_path": str(tmp_path)})
-    res = StorageResource(database=db, filesystem=fs)
-    return res
-
-
-def test_save_and_load_history(tmp_path):
-    async def run():
-        storage = await make_resource(tmp_path)
-        history = [
-            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
-        ]
-        await storage.save_history("1", history)
-        loaded = await storage.load_history("1")
-        return loaded
-
-    loaded = asyncio.run(run())
-    assert loaded and loaded[0].content == "hi"
+    return StorageResource(filesystem=fs)
 
 
 def test_store_and_load_file(tmp_path):


### PR DESCRIPTION
## Summary
- drop database and vector store logic from StorageResource
- refresh wrapper documentation
- adjust unit test

## Testing
- `poetry run black plugins/builtin/resources/storage_resource.py src/pipeline/resources/storage_resource.py tests/test_storage_resource.py`
- `poetry run isort plugins/builtin/resources/storage_resource.py src/pipeline/resources/storage_resource.py tests/test_storage_resource.py`
- `poetry run flake8 src tests` *(fails: E402, F401, etc.)*
- `poetry run mypy src` *(fails: Module not found and typing errors)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'pipeline')*
- `poetry run pytest` *(fails: ModuleNotFoundError: 'pipeline.user_plugins')*

------
https://chatgpt.com/codex/tasks/task_e_6869a39ffcf48322a5e06f2b90c995a8