### PR TITLE
Fix example memory and storage resources

### DIFF
--- a/examples/pipelines/duckdb_pipeline.py
+++ b/examples/pipelines/duckdb_pipeline.py
@@ -16,7 +16,7 @@ enable_plugins_namespace()
 
 from plugins.contrib.duckdb_database import DuckDBDatabaseResource
 from plugins.contrib.duckdb_vector_store import DuckDBVectorStore
-from plugins.contrib.memory_resource import MemoryResource
+from pipeline.resources import MemoryResource
 
 from entity import Agent
 from pipeline import PipelineStage, PromptPlugin

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -1,4 +1,4 @@
-"""Demonstrate composed memory resource using SQLite, PGVector and local files."""
+"""Demonstrate composed memory resource using SQLite and PGVector."""
 
 from __future__ import annotations
 
@@ -13,8 +13,7 @@ from utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 
-from plugins.contrib.local_filesystem import LocalFileSystemResource  # noqa: E402
-from plugins.contrib.memory_resource import MemoryResource  # noqa: E402
+from pipeline.resources import MemoryResource  # noqa: E402
 from plugins.contrib.pg_vector_store import PgVectorStore  # noqa: E402
 from plugins.contrib.sqlite_storage import (
     SQLiteStorageResource as SQLiteDatabaseResource,
@@ -44,12 +43,10 @@ def main() -> None:
 
     database = SQLiteDatabaseResource({"path": "./agent.db"})
     vector_store = PgVectorStore({"table": "embeddings"})
-    filesystem = LocalFileSystemResource({"base_path": "./files"})
 
     memory = MemoryResource(
         database=database,
         vector_store=vector_store,
-        filesystem=filesystem,
     )
 
     agent.builder.resource_registry.add("memory", memory)


### PR DESCRIPTION
## Summary
- use `MemoryResource` for conversation history and `StorageResource` for files in `storage_resource_example.py`
- drop filesystem usage from `memory_composition_pipeline.py`
- update imports for `MemoryResource` in pipelines

## Testing
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: E402, F401, E501, F822 ...)*
- `poetry run mypy src` *(fails: Module "resources.container" has no attribute "PoolConfig", etc.)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869a3a21ae88322a0aef677850aaac6