### PR TITLE
Introduce storage resource defaults

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -32,6 +32,8 @@ plugins:
       database:
         type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
         path: ./dev.db
+    storage:
+      type: pipeline.resources.storage_resource:StorageResource
       filesystem:
         type: plugins.builtin.resources.s3_filesystem:S3FileSystem
         bucket: agent-files

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -37,6 +37,8 @@ plugins:
         name: "${DB_NAME}"
         username: "${DB_USERNAME}"
         password: "${DB_PASSWORD}"
+    storage:
+      type: pipeline.resources.storage_resource:StorageResource
       filesystem:
         type: plugins.builtin.resources.s3_filesystem:S3FileSystem
         bucket: agent-files

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -27,6 +27,8 @@ plugins:
       database:
         type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
         path: ./agent.db
+    storage:
+      type: pipeline.resources.storage_resource:StorageResource
       filesystem:
         type: plugins.builtin.resources.s3_filesystem:S3FileSystem
         bucket: agent-files

--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -23,7 +23,18 @@ DEFAULT_RESOURCES: Dict[str, Dict[str, Any]] = {
     "llm": DEFAULT_LLM_CONFIG,
     "memory": {
         "type": "pipeline.resources.memory_resource:MemoryResource",
-        "backend": {"type": "pipeline.resources.memory_resource:SimpleMemoryResource"},
+        "database": {
+            "type": "pipeline.resources.duckdb_database:DuckDBDatabaseResource"
+        },
+        "vector_store": {
+            "type": "plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore"
+        },
+    },
+    "storage": {
+        "type": "pipeline.resources.storage_resource:StorageResource",
+        "filesystem": {
+            "type": "plugins.builtin.resources.local_filesystem:LocalFileSystemResource"
+        },
     },
     "cache": {
         "type": "plugins.contrib.resources.cache:CacheResource",


### PR DESCRIPTION
## Summary
- set `storage` default with local filesystem backend
- refactor `memory` defaults to use DuckDB database and vector store
- move file system config from `memory` block to new `storage` block in dev, prod, and template configurations

## Testing
- `poetry run black --check src tests`
- `poetry run isort --check src tests`
- `poetry run flake8 src tests` *(fails: command not found)*
- `poetry run mypy src` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869a3a3a71c8322a6c09d1ff57ba006