### PR TITLE
Update memory resource tests

### DIFF
--- a/tests/test_storage_resource.py
+++ b/tests/test_storage_resource.py
@@ -1,11 +1,9 @@
 import asyncio
-from datetime import datetime
 from pathlib import Path
 
 from plugins.builtin.resources.in_memory_storage import InMemoryStorageResource
 from plugins.builtin.resources.local_filesystem import LocalFileSystemResource
 
-from pipeline.context import ConversationEntry
 from pipeline.resources.storage_resource import StorageResource
 
 
@@ -14,20 +12,6 @@ async def make_resource(tmp_path: Path) -> StorageResource:
     fs = LocalFileSystemResource({"base_path": str(tmp_path)})
     res = StorageResource(database=db, filesystem=fs)
     return res
-
-
-def test_save_and_load_history(tmp_path):
-    async def run():
-        storage = await make_resource(tmp_path)
-        history = [
-            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
-        ]
-        await storage.save_history("1", history)
-        loaded = await storage.load_history("1")
-        return loaded
-
-    loaded = asyncio.run(run())
-    assert loaded and loaded[0].content == "hi"
 
 
 def test_store_and_load_file(tmp_path):


### PR DESCRIPTION
## Summary
- refactor `test_storage_resource` to only check file handling
- extend `test_memory_resource` with history persistence
- ensure history integration uses `MemoryResource` for Postgres and vectors

## Testing
- `poetry run isort tests/test_storage_resource.py tests/test_memory_resource.py tests/integration/test_postgres_history.py tests/integration/test_vector_memory_integration.py`
- `poetry run black tests/test_storage_resource.py tests/test_memory_resource.py tests/integration/test_postgres_history.py tests/integration/test_vector_memory_integration.py`
- `poetry run flake8 src tests` *(fails: module level import not at top of file, undefined names, etc.)*
- `poetry run mypy src` *(fails: many errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869a3a49cd483229a68a77503c4de78