### PR TITLE
Fix docs on MemoryResource persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@ When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
-- ``MemoryResource`` – composite in-memory store with optional database, vector,
-  and file backends.
+- ``MemoryResource`` – persists conversation history and vectors.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
 
-StorageResource is an advanced plugin for persistent storage. See [docs/source/plugin_guide.md](docs/source/plugin_guide.md) for details.
+StorageResource handles file CRUD and can combine multiple backends. See [docs/source/plugin_guide.md](docs/source/plugin_guide.md) for details.
 These defaults allow ``Agent()`` to process messages without any external
 configuration.
 
@@ -59,7 +58,7 @@ plugins:
       pool_max_size: 5
 ```
 
-For ephemeral sessions, an in-memory backend is available:
+For quick tests you can use an in-memory backend:
 
 ```yaml
 plugins:

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -32,6 +32,8 @@ plugins:
         region: us-east-1
 ```
 
+`MemoryResource` persists conversation history and vectors. `StorageResource` extends it with file CRUD across the configured backends.
+
 For local experimentation you can swap the database section with SQLite:
 
 ```yaml

--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -1,46 +1,10 @@
-<<<<<<< HEAD
 # Component Overview
 
-This page summarizes the core building blocks of Entity pipelines. For diagrams and a deeper discussion see [Architecture](architecture.md) and the [Plugin Guide](plugin_guide.md). A working configuration can be found in [`config/dev.yaml`](../../config/dev.yaml).
-
-## Pipelines
-
-A *pipeline* orchestrates execution across explicit stages like `parse`, `think` and `do`. Each stage runs its registered plugins in order. Pipelines enforce clear boundaries so behaviors remain predictable and easy to reason about.
-
-## Plugins
-
-Plugins implement the logic for each stage. They interact with the system through `PluginContext` and may use resources or tools. Refer to the [Plugin Guide](plugin_guide.md) for implementation details and examples.
-
-## Adapters
-
-Adapters expose a pipeline through some interface such as CLI, WebSocket or gRPC. They translate external requests into pipeline calls and return the responses.
-
-## Resources
-
-Resources provide shared functionality like databases, LLM access and file storage. They are registered by name in the configuration and retrieved in plugins via `context.get_resource()`.
-
-### LLM
-
-An LLM resource wraps a large language model provider. Plugins can call `context.ask_llm()` to generate text or embeddings without caring about the underlying API.
-
-### Memory vs Storage
-
-`MemoryResource` keeps conversation history in memory only. It is *ephemeral* and lost when the process stops. `StorageResource` persists history and files using databases, vector stores and file systems. It survives restarts and can combine several backends behind one interface.
-
-## Putting It Together
-
-Pipelines, plugins and adapters form the execution engine. Resources supply capabilities like LLMs, memory and long‑term storage. The [architecture document](architecture.md) shows how these pieces fit together.
-=======
-# Components Overview
-
-This page explains the main building blocks of the Entity Pipeline framework.
-Use it alongside the [architecture overview](architecture.md) and the
-[plugin cheat sheet](plugin_cheatsheet.md) for quick reference.
+This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](architecture.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](../../config/dev.yaml).
 
 ## Pipelines and Stages
 
-A pipeline is a fixed sequence of stages that an agent runs through on each
-request:
+A pipeline is a fixed sequence of stages that an agent runs on each request:
 
 1. **parse** – validate input and load context
 2. **think** – plan and reason about actions
@@ -49,11 +13,15 @@ request:
 5. **deliver** – send output back to the user
 6. **error** – handle failures gracefully
 
-Each stage is independent, making it easy to reason about the agent's behavior.
+Each stage is independent, making the agent's behavior easier to reason about.
+
+## Plugins
+
+Plugins implement the work at each stage. They interact with the system through `PluginContext` and may use resources or tools. See the [Plugin Guide](plugin_guide.md) for implementation details.
 
 ## Plugin Categories
 
-Plugins implement the work at each stage and fall into five categories:
+Plugins fall into five groups:
 
 - **Resource** – provide infrastructure like databases or LLMs
 - **Tool** – perform discrete actions such as search or calculations
@@ -61,25 +29,24 @@ Plugins implement the work at each stage and fall into five categories:
 - **Adapter** – expose the agent over interfaces like HTTP or CLI
 - **Failure** – format and log error messages
 
-You can mix and match plugins to create custom agents.
-See the [plugin cheat sheet](plugin_cheatsheet.md) for class names and examples.
+Mix and match plugins to create custom agents. See the [plugin cheat sheet](plugin_cheatsheet.md) for class names and examples.
 
-## Core Resources
+## Resources
 
-Resources are stateful services registered by name. The framework includes:
+Resources supply shared functionality and are registered by name. Retrieve them in plugins with `context.get_resource("name")`.
 
-- **`LLMResource`** – wraps a language model backend
-- **`MemoryResource`** – stores conversation history or embeddings
-- **`StorageResource`** – handles databases and file storage
+### LLM
 
-Resources are retrieved inside plugins via `context.get_resource("name")`.
+An LLM resource wraps a language model provider. Plugins can call `context.ask_llm()` to generate text or embeddings.
+
+### Memory vs Storage
+
+`MemoryResource` stores conversation history and vectors persistently. `StorageResource` handles file CRUD across databases, vector stores, and file systems.
 
 ## Adapters
 
-Adapters make the agent accessible to the outside world. For example,
-the HTTP adapter exposes REST endpoints, while the CLI adapter runs the
-agent interactively. Adapters are plugins that typically run during the
-`deliver` stage to send responses back to the caller.
+Adapters expose the agent to the outside world. The HTTP adapter provides REST endpoints while the CLI adapter runs the agent interactively. Adapters typically run during the `deliver` stage.
 
-Combining these components lets you build reusable and predictable agents.
->>>>>>> 8d0c270bb5e3d80688ec98972bcaf6729a41b4ce
+## Putting It Together
+
+Pipelines, plugins, and adapters form the execution engine. Resources supply capabilities like LLMs, memory, and storage. The [architecture document](architecture.md) shows how these pieces fit together.

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -93,7 +93,7 @@ Several example pipelines in the `examples/` directory showcase more advanced pa
 
 ### StorageResource Composition
 
-`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface. The pipeline at `examples/pipelines/memory_composition_pipeline.py` demonstrates the same pattern using the older `MemoryResource`. `MemoryResource` remains the framework's default ephemeral memory, configured in [config/dev.yaml](../../config/dev.yaml). For persistent deployments, prefer `StorageResource` so history, vectors, and files survive restarts. With the new plugin the code looks like:
+`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. The pipeline at `examples/pipelines/memory_composition_pipeline.py` demonstrates the same pattern using the older `MemoryResource`. `MemoryResource` now persists conversation history and vectors and is configured in [config/dev.yaml](../../config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. With the plugin configured the code looks like:
 
 ```python
 storage = StorageResource(


### PR DESCRIPTION
## Summary
- clean merge conflict markers in components_overview.md and clarify resource roles
- describe MemoryResource as persistent and StorageResource as file management in plugin_guide, advanced_usage, and README
- note in README that in-memory backend is for quick tests

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: found 156 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_6869a3a55fd08322b31992b78bb84fd0