### PR TITLE
Resolve merge conflict leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
-<<<<<<< HEAD
 - ``MemoryResource`` – composite in-memory store with optional SQL/NoSQL and vector backends.
-=======
-- ``MemoryResource`` – persists conversation history and vectors.
->>>>>>> 48b73b1081ae32bab181101b7e919c386421a22e
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
 

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -43,10 +43,6 @@ def main() -> None:
 
     database = SQLiteDatabaseResource({"path": "./agent.db"})
     vector_store = PgVectorStore({"table": "embeddings"})
-<<<<<<< HEAD
-=======
-
->>>>>>> ff38e02a16bc4c5714c4df24a08ca8a808fad97d
     memory = MemoryResource(
         database=database,
         vector_store=vector_store,

--- a/tests/test_storage_resource.py
+++ b/tests/test_storage_resource.py
@@ -8,12 +8,7 @@ from pipeline.resources.storage_resource import StorageResource
 
 async def make_resource(tmp_path: Path) -> StorageResource:
     fs = LocalFileSystemResource({"base_path": str(tmp_path)})
-<<<<<<< HEAD
     return StorageResource(filesystem=fs)
-=======
-    res = StorageResource(database=db, filesystem=fs)
-    return res
->>>>>>> a197b831e6d56ae87b057a10b87aef268617d579
 
 
 def test_store_and_load_file(tmp_path):


### PR DESCRIPTION
## Summary
- clean up residual merge conflict markers in README, storage resource test, and example

## Testing
- `poetry run black examples/pipelines/memory_composition_pipeline.py tests/test_storage_resource.py`
- `poetry run isort src tests` *(fails: reverted unrelated changes)*
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: various import errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869a78cde0c8322ae3f70002b590ffa