### PR TITLE
Resolve merge conflicts, apply formatting

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -7,15 +7,10 @@ if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
 from .builder import ConfigBuilder
-from .models import (
-    CONFIG_SCHEMA,
-    EntityConfig,
-    PluginConfig,
-    PluginsSection,
-    ServerConfig,
-    validate_config,
-)
-from .validators import _validate_cache, _validate_memory, _validate_vector_memory
+from .models import (CONFIG_SCHEMA, EntityConfig, PluginConfig, PluginsSection,
+                     ServerConfig, validate_config)
+from .validators import (_validate_cache, _validate_memory,
+                         _validate_vector_memory)
 
 __all__ = [
     "ConfigBuilder",

--- a/src/pipeline/cache/semantic.py
+++ b/src/pipeline/cache/semantic.py
@@ -18,7 +18,8 @@ def __getattr__(name: str):
     """Lazily import :class:`SemanticCache` when requested."""
 
     if name == "SemanticCache":
-        from plugins.contrib.resources.cache_backends.semantic import SemanticCache
+        from plugins.contrib.resources.cache_backends.semantic import \
+            SemanticCache
 
         return SemanticCache
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -7,16 +7,9 @@ import pytest
 from plugins.contrib.prompts.complex_prompt import ComplexPrompt
 
 from config.environment import load_env
-from pipeline import (
-    ConversationEntry,
-    MetricsCollector,
-    PipelineState,
-    PluginContext,
-    PluginRegistry,
-    ResourceRegistry,
-    SystemRegistries,
-    ToolRegistry,
-)
+from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
+                      PluginContext, PluginRegistry, ResourceRegistry,
+                      SystemRegistries, ToolRegistry)
 from pipeline.resources.llm import UnifiedLLMResource
 from pipeline.resources.memory_resource import MemoryResource
 from pipeline.resources.pg_vector_store import PgVectorStore

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -3,18 +3,13 @@ from datetime import datetime
 
 from plugins.builtin.resources.in_memory_storage import InMemoryStorageResource
 
-from pipeline import (
-    PipelineStage,
-    PluginRegistry,
-    PromptPlugin,
-    ResourceRegistry,
-    SystemRegistries,
-    ToolRegistry,
-    execute_pipeline,
-)
+from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
+                      ResourceRegistry, SystemRegistries, ToolRegistry,
+                      execute_pipeline)
 from pipeline.context import ConversationEntry
 from pipeline.resources.memory import Memory
-from pipeline.resources.memory_resource import MemoryResource, SimpleMemoryResource
+from pipeline.resources.memory_resource import (MemoryResource,
+                                                SimpleMemoryResource)
 
 
 class IncrementPlugin(PromptPlugin):


### PR DESCRIPTION
## Summary
- format imports in config package and tests
- reformat semantic cache loader
- clean up test memory resource and vector store integration imports

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Function is missing a return type annotation)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869accb9e3c83228ba8bba7949e4467