### PR TITLE
Fix README storage snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ plugins:
       pool_max_size: 5
 ```
 
-For quick tests you can use an in-memory backend:
+For quick tests you can use DuckDB's default in-memory mode:
 
 ```yaml
 plugins:
   resources:
     database:
-      type: plugins.builtin.resources.memory_storage:MemoryStorage
+      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
 ```
 
 HTTP adapter configuration with authentication and rate limiting:


### PR DESCRIPTION
## Summary
- remove MemoryStorage snippet
- document DuckDB's in-memory configuration
- build the docs to ensure README is rendered

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Module "resources.container" has no attribute "PoolConfig")*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run pytest -q` *(fails: 72 errors during collection)*
- `poetry run sphinx-build -b html docs/source docs/build`

------
https://chatgpt.com/codex/tasks/task_e_6869b0bba21c8322ac45c4794881874c