### PR TITLE
Update README memory resource note

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
-- ``MemoryResource`` – composite in-memory store with optional SQL/NoSQL and vector backends.
+- ``MemoryResource`` – composite store that defaults to a DuckDB-backed database in memory and supports optional SQL/NoSQL and vector backends.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
+MemoryResource uses an in-memory DuckDB database by default, so there is no separate ``InMemoryResource``.
 
 StorageResource handles file CRUD and can combine multiple backends. See [docs/source/plugin_guide.md](docs/source/plugin_guide.md) for details.
 These defaults allow ``Agent()`` to process messages without any external


### PR DESCRIPTION
## Summary
- clarify that `MemoryResource` stores everything in an in-memory DuckDB database
- mention that there is no longer an `InMemoryResource`

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: found errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869b0bdf4fc8322ba96e15dda35d5c3