### PR TITLE
Improve pipeline stage error handling

### DIFF
--- a/tests/test_execute_stage.py
+++ b/tests/test_execute_stage.py
@@ -1,0 +1,63 @@
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.pipeline import execute_stage
+
+
+class GenericFailPlugin:
+    stages = [PipelineStage.DO]
+
+    async def execute(self, context):
+        raise RuntimeError("boom")
+
+
+class PropagatePlugin:
+    stages = [PipelineStage.DO]
+
+    async def execute(self, context):
+        raise KeyError("oops")
+
+
+def make_state():
+    return PipelineState(
+        conversation=[
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id="123",
+        metrics=MetricsCollector(),
+    )
+
+
+def make_registries(plugin):
+    plugins = PluginRegistry()
+    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DO))
+    return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+
+
+def test_generic_error_sets_failure_info():
+    state = make_state()
+    registries = make_registries(GenericFailPlugin())
+    asyncio.run(execute_stage(PipelineStage.DO, state, registries))
+    assert state.failure_info is not None
+    assert state.failure_info.error_message == "boom"
+
+
+def test_unexpected_error_propagates():
+    state = make_state()
+    registries = make_registries(PropagatePlugin())
+    with pytest.raises(KeyError):
+        asyncio.run(execute_stage(PipelineStage.DO, state, registries))
+    assert state.failure_info is not None
+    assert state.failure_info.error_message == "oops"


### PR DESCRIPTION
## Summary
- add execute_stage tests
- log unexpected plugin exceptions and re-raise them

## Testing
- `poetry run black src/pipeline/pipeline.py tests/test_execute_stage.py`
- `poetry run isort src/pipeline/pipeline.py tests/test_execute_stage.py`
- `poetry run flake8 src/pipeline/pipeline.py tests/test_execute_stage.py`
- `poetry run mypy src`
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*

------
https://chatgpt.com/codex/tasks/task_e_6869b9169e648322b2b5fe7cfa46b2e5