### PR TITLE
Refactor pipeline docstring

### DIFF
--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -1,4 +1,8 @@
-"""Compatibility wrapper for renamed execution module."""
+"""Pipeline execution utilities.
+
+This module delegates tool execution to
+``pipeline.tools.execution`` to keep logic centralized.
+"""
 
 from __future__ import annotations
 
@@ -12,7 +16,8 @@ from registry import SystemRegistries
 
 from .context import ConversationEntry, PluginContext, SimpleContext
 from .errors import create_static_error_response
-from .exceptions import CircuitBreakerTripped, PluginExecutionError, ToolExecutionError
+from .exceptions import (CircuitBreakerTripped, PluginExecutionError,
+                         ToolExecutionError)
 from .logging import get_logger, reset_request_id, set_request_id
 from .manager import PipelineManager
 from .observability.metrics import get_metrics_server

--- a/tests/test_execute_stage.py
+++ b/tests/test_execute_stage.py
@@ -3,16 +3,9 @@ from datetime import datetime
 
 import pytest
 
-from pipeline import (
-    ConversationEntry,
-    MetricsCollector,
-    PipelineStage,
-    PipelineState,
-    PluginRegistry,
-    ResourceRegistry,
-    SystemRegistries,
-    ToolRegistry,
-)
+from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
+                      PipelineState, PluginRegistry, ResourceRegistry,
+                      SystemRegistries, ToolRegistry)
 from pipeline.pipeline import execute_stage
 
 


### PR DESCRIPTION
## Summary
- clarify module description in `pipeline.py`
- clean up `test_execute_stage` imports

## Testing
- `poetry run black src/pipeline/pipeline.py tests/test_execute_stage.py`
- `poetry run isort src/pipeline/pipeline.py tests/test_execute_stage.py`
- `poetry run flake8 src/pipeline/pipeline.py tests/test_execute_stage.py`
- `poetry run mypy src/pipeline/pipeline.py` *(fails: Module "pipeline.plugins.contrib" not found)*
- `bandit -r src/pipeline/pipeline.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'pipeline.user_plugins')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'pipeline.user_plugins')*
- `python -m src.registry.validator` *(fails: No module named 'pipeline')*
- `pytest -q` *(fails: No module named 'pipeline.user_plugins')*

------
https://chatgpt.com/codex/tasks/task_e_6869bec9d3bc832285bd1474c10afb2f