### PR TITLE
Add LoggingAdapter and update docs

### DIFF
--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -29,7 +29,7 @@ and mental models stay easy to grasp.
 5. One canonical name per resource
 
 A small example of structured logging lives in `examples/structured_logging_example.py`.
-It configures the `StructuredLogging` resource and emits one log entry.
+It initializes ``LoggingAdapter`` and emits one log entry.
 
 ## Network Architecture
 All backend services communicate using gRPC streaming with Protobuf schemas.

--- a/docs/source/config_cheatsheet.md
+++ b/docs/source/config_cheatsheet.md
@@ -24,6 +24,10 @@ plugins:
   adapters:
     http:
       type: plugins.builtin.adapters.http:HTTPAdapter
+    cli:
+      type: plugins.builtin.adapters.cli:CLIAdapter
+    logging:
+      type: plugins.builtin.adapters.logging:LoggingAdapter
 ```
 
 Use `entity src/cli.py --config config.yaml` to start the agent.

--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -1,16 +1,16 @@
 # Structured Logging
 
-The framework exposes a simple helper to enable JSON logs for any deployment.
-Enable logging at startup:
+The easiest way to capture structured logs is using ``LoggingAdapter``. Add it
+to your ``adapters`` configuration or initialize it directly:
 
 ```python
-from pipeline.logging import configure_logging
+from plugins.builtin.adapters.logging import LoggingAdapter
 
-configure_logging(level="INFO", json_enabled=True)
+adapter = LoggingAdapter()
 ```
 
 Every pipeline run generates a unique *request ID*. When using
-`configure_logging` or the `StructuredLogging` resource plugin, this ID is
+``LoggingAdapter`` this ID is
 attached to each log entry under the `request_id` field.
 
 Plugins can access the same value via `context.request_id`.
@@ -25,7 +25,7 @@ Use the ID to trace a single request across plugins and stages.
 
 ### Example Script
 
-The `examples/structured_logging_example.py` script configures the `StructuredLogging` resource and writes a single log entry.
+The `examples/structured_logging_example.py` script initializes ``LoggingAdapter`` and writes a single log entry.
 Run it with:
 
 ```bash

--- a/examples/structured_logging_example.py
+++ b/examples/structured_logging_example.py
@@ -1,4 +1,4 @@
-"""Configure StructuredLogging and write a single log entry."""
+"""Demonstrate LoggingAdapter and structured logging."""
 
 from __future__ import annotations
 
@@ -12,18 +12,23 @@ from utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 
-from plugins.builtin.resources.structured_logging import StructuredLogging
+from plugins.builtin.adapters.logging import LoggingAdapter
 
-from pipeline.logging import get_logger
+from pipeline.logging import configure_logging, get_logger
 
 
 async def main() -> None:
-    logging_cfg = {"level": "INFO", "json": True}
-    plugin = StructuredLogging(logging_cfg)
-    await plugin.initialize()
+    configure_logging(level="INFO", json_enabled=True)
+    adapter = LoggingAdapter()
 
     logger = get_logger("structured_logging_example")
     logger.info("Logging configured successfully")
+
+    class FakeContext:
+        def get_response(self):
+            return {"message": "hello"}
+
+    await adapter.execute(FakeContext())
 
 
 if __name__ == "__main__":

--- a/plugins/builtin/adapters/__init__.py
+++ b/plugins/builtin/adapters/__init__.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from .cli import CLIAdapter
 from .grpc import LLMGRPCAdapter
 from .http import HTTPAdapter
+from .logging import LoggingAdapter
 from .websocket import WebSocketAdapter
 
-__all__ = ["HTTPAdapter", "CLIAdapter", "WebSocketAdapter", "LLMGRPCAdapter"]
+__all__ = [
+    "HTTPAdapter",
+    "CLIAdapter",
+    "WebSocketAdapter",
+    "LLMGRPCAdapter",
+    "LoggingAdapter",
+]

--- a/plugins/builtin/adapters/logging.py
+++ b/plugins/builtin/adapters/logging.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Adapter that writes pipeline responses to the log."""
+
+import logging
+from typing import Any
+
+from pipeline.base_plugins import AdapterPlugin
+from pipeline.stages import PipelineStage
+
+
+class LoggingAdapter(AdapterPlugin):
+    """Log the final pipeline response during the deliver stage."""
+
+    stages = [PipelineStage.DELIVER]
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__(config)
+        self.logger = logging.getLogger("pipeline.output")
+
+    async def serve(self, registries) -> None:  # pragma: no cover - no server
+        pass
+
+    async def _execute_impl(self, context) -> None:
+        response = context.get_response()
+        if response is not None:
+            self.logger.info("response delivered", extra={"response": response})

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -26,7 +26,12 @@ from .stages import PipelineStage
 from .state import FailureInfo, LLMResponse, PipelineState
 
 # isort: off
-from plugins.builtin.adapters import CLIAdapter, HTTPAdapter, WebSocketAdapter
+from plugins.builtin.adapters import (
+    CLIAdapter,
+    HTTPAdapter,
+    LoggingAdapter,
+    WebSocketAdapter,
+)
 
 # isort: on
 __all__ = [
@@ -75,5 +80,6 @@ __all__ = [
     "HTTPAdapter",
     "WebSocketAdapter",
     "CLIAdapter",
+    "LoggingAdapter",
     "execute_with_observability",
 ]

--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -52,6 +52,7 @@ DEFAULT_ADAPTERS: Dict[str, Dict[str, Any]] = {
     "http": {"type": "plugins.builtin.adapters.http:HTTPAdapter"},
     "websocket": {"type": "plugins.builtin.adapters.websocket:WebSocketAdapter"},
     "cli": {"type": "plugins.builtin.adapters.cli:CLIAdapter"},
+    "logging": {"type": "plugins.builtin.adapters.logging:LoggingAdapter"},
 }
 
 DEFAULT_CONFIG: Dict[str, Any] = {


### PR DESCRIPTION
## Summary
- add `LoggingAdapter` output plugin
- document LoggingAdapter usage
- update default adapters
- show LoggingAdapter in example and docs

## Testing
- `poetry run black src tests plugins examples --quiet`
- `poetry run isort src tests plugins examples --quiet`
- `poetry run flake8 src tests`
- `poetry run mypy`
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(not run due to previous failure)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline.user_plugins')*
- `poetry run pytest` *(fails: 73 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6869e306631c832296f1c5708da41c80