### PR TITLE
Add deliver adapter overview

### DIFF
--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -47,6 +47,10 @@ An LLM resource wraps a language model provider. Plugins can call `context.ask_l
 
 Adapters expose the agent to the outside world. The HTTP adapter provides REST endpoints while the CLI adapter runs the agent interactively. Adapters typically run during the `deliver` stage.
 
+### Deliver-stage adapters
+
+Multiple adapters may run during the `deliver` stage. Each adapter receives the pipeline response sequentially, which allows combining behaviors. A common pattern is to send an HTTP reply while also logging the request using `LoggingAdapter`. Register every adapter in the configuration and they will be invoked one after another.
+
 ## Putting It Together
 
 Pipelines, plugins, and adapters form the execution engine. Resources supply capabilities like LLMs, memory, and storage. The [architecture document](architecture.md) shows how these pieces fit together.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -22,6 +22,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 ### Architecture
 - [Architecture overview](architecture.md)
 - [Components overview](components_overview.md)
+- [Deliver-stage adapters](components_overview.md#deliver-stage-adapters)
 
 ### Reference
 - [Context API](context.md)


### PR DESCRIPTION
## Summary
- explain how multiple deliver-stage adapters work
- link deliver adapters from the docs index

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: yaml)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: pipeline)*
- `pytest` *(fails: ModuleNotFoundError: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_6869e5736e98832296ac43c9628deb64