### PR TITLE
Shift logging configuration to adapter

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -22,11 +22,6 @@ plugins:
       model: "${OLLAMA_MODEL}"
       retries: 3
       backoff: 1.0
-    logging:
-      type: plugins.builtin.resources.structured_logging:StructuredLogging
-      level: "DEBUG"
-      file_enabled: true
-      file_path: "logs/entity.log"
     memory:
       type: pipeline.resources.memory_resource:MemoryResource
       database:
@@ -78,6 +73,8 @@ plugins:
       dashboard: true
     cli:
       type: plugins.builtin.adapters.cli:CLIAdapter
+    logging:
+      type: plugins.builtin.adapters.logging:LoggingAdapter
   prompts:
     chain_of_thought:
       type: plugins.contrib.prompts.chain_of_thought:ChainOfThoughtPrompt

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -23,11 +23,6 @@ plugins:
       temperature: 0.7
       retries: 5
       backoff: 2.0
-    logging:
-      type: plugins.builtin.resources.structured_logging:StructuredLogging
-      level: "INFO"
-      file_enabled: true
-      file_path: "logs/entity.log"
     memory:
       type: pipeline.resources.memory_resource:MemoryResource
       database:
@@ -85,6 +80,8 @@ plugins:
       dashboard: false
     cli:
       type: plugins.builtin.adapters.cli:CLIAdapter
+    logging:
+      type: plugins.builtin.adapters.logging:LoggingAdapter
   prompts:
     chain_of_thought:
       type: plugins.contrib.prompts.chain_of_thought:ChainOfThoughtPrompt

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -17,11 +17,6 @@ plugins:
       provider: ollama
       base_url: "${OLLAMA_BASE_URL}"
       model: "${OLLAMA_MODEL}"
-    logging:
-      type: plugins.builtin.resources.structured_logging:StructuredLogging
-      level: "INFO"
-      file_enabled: true
-      file_path: "logs/entity.log"
     memory:
       type: pipeline.resources.memory_resource:MemoryResource
       database:
@@ -55,6 +50,8 @@ plugins:
       audit_log_path: logs/audit.log
     cli:
       type: plugins.builtin.adapters.cli:CLIAdapter
+    logging:
+      type: plugins.builtin.adapters.logging:LoggingAdapter
   prompts:
     chain_of_thought:
       type: plugins.contrib.prompts.chain_of_thought:ChainOfThoughtPrompt

--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -8,10 +8,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
-    "type": "plugins.builtin.resources.structured_logging:StructuredLogging",
-    "level": "INFO",
-    "json": True,
-    "file_enabled": False,
+    "type": "plugins.builtin.adapters.logging:LoggingAdapter",
 }
 
 DEFAULT_LLM_CONFIG: Dict[str, Any] = {
@@ -40,7 +37,6 @@ DEFAULT_RESOURCES: Dict[str, Dict[str, Any]] = {
         "type": "plugins.contrib.resources.cache:CacheResource",
         "backend": {"type": "pipeline.cache.memory:InMemoryCache"},
     },
-    "logging": DEFAULT_LOGGING_CONFIG,
 }
 
 DEFAULT_TOOLS: Dict[str, Dict[str, Any]] = {
@@ -52,7 +48,7 @@ DEFAULT_ADAPTERS: Dict[str, Dict[str, Any]] = {
     "http": {"type": "plugins.builtin.adapters.http:HTTPAdapter"},
     "websocket": {"type": "plugins.builtin.adapters.websocket:WebSocketAdapter"},
     "cli": {"type": "plugins.builtin.adapters.cli:CLIAdapter"},
-    "logging": {"type": "plugins.builtin.adapters.logging:LoggingAdapter"},
+    "logging": DEFAULT_LOGGING_CONFIG,
 }
 
 DEFAULT_CONFIG: Dict[str, Any] = {

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -15,6 +15,7 @@ from registry import PluginRegistry, ToolRegistry
 from .base_plugins import BasePlugin, ResourcePlugin, ToolPlugin
 from .defaults import DEFAULT_CONFIG
 from .interfaces import import_plugin_class
+from .logging import configure_logging
 
 
 class ClassRegistry:
@@ -73,6 +74,7 @@ class SystemInitializer:
 
     def __init__(self, config: Dict | None = None, env_file: str = ".env") -> None:
         load_env(env_file)
+        configure_logging()
         self.config = config or copy.deepcopy(DEFAULT_CONFIG)
 
     @classmethod

--- a/src/registry/registries.py
+++ b/src/registry/registries.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
+from pipeline.base_plugins import BasePlugin
 from pipeline.stages import PipelineStage
-from pipeline.user_plugins import BasePlugin
 
 
 class ResourceRegistry:


### PR DESCRIPTION
## Summary
- use LoggingAdapter as the default logging plugin
- move logging defaults out of resources in YAML configs
- configure logging during SystemInitializer setup
- fix registry imports for BasePlugin

## Testing
- `poetry run black src/pipeline/defaults.py src/pipeline/initializer.py`
- `poetry run isort src/pipeline/defaults.py src/pipeline/initializer.py`
- `poetry run isort src/registry/registries.py`
- `poetry run flake8 src tests`
- `poetry run mypy src/pipeline/context.py src/pipeline/manager.py src/pipeline/runtime.py src/pipeline/tools/execution.py src/interfaces` *(fails: Missing type hints)*
- `bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `poetry run pytest -q` *(fails: 73 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6869e56f447883229d51aea6dc4612cf