### PR TITLE
Add pyproject plugin discovery

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -48,6 +48,31 @@ agent = Agent.from_directory("./plugins")
 
 Any import errors are logged and the remaining plugins continue to load.
 
+## Discovering Plugins from `pyproject.toml`
+
+`SystemInitializer` can scan arbitrary directories for `pyproject.toml` files
+containing plugin definitions. Add paths to the `plugin_dirs` list in your
+configuration:
+
+```yaml
+plugin_dirs:
+  - ./third_party_plugins
+```
+
+Each `pyproject.toml` should define plugins under `[tool.entity.plugins]`:
+
+```toml
+[tool.entity.plugins.prompts.example]
+class = "my_pkg.example:ExamplePrompt"
+dependencies = ["memory"]
+
+[tool.entity.plugins.tools.calc]
+class = "my_pkg.calc:CalculatorTool"
+```
+
+During initialization the discovered entries are merged into the config and
+their dependencies validated automatically.
+
 ## Implementing Storage Backends
 
 Storage resources persist conversation history and other agent data. To add a

--- a/tests/registry/test_plugin_discovery.py
+++ b/tests/registry/test_plugin_discovery.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from pipeline import PipelineStage, SystemInitializer
+
+
+async def _run_initializer(cfg):
+    initializer = SystemInitializer.from_dict(cfg)
+    return await initializer.initialize()
+
+
+def test_pyproject_discovery(tmp_path, monkeypatch):
+    plugin_module = tmp_path / "my_plugin.py"
+    plugin_module.write_text(
+        """
+from pipeline.base_plugins import PromptPlugin, ToolPlugin
+from pipeline.stages import PipelineStage
+
+class MyPrompt(PromptPlugin):
+    stages = [PipelineStage.THINK]
+    async def _execute_impl(self, context):
+        return None
+
+class MyTool(ToolPlugin):
+    async def execute_function(self, params):
+        return "ok"
+"""
+    )
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.entity.plugins.prompts.test]
+class = "my_plugin:MyPrompt"
+
+[tool.entity.plugins.tools.echo]
+class = "my_plugin:MyTool"
+"""
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    cfg = {
+        "plugin_dirs": [str(tmp_path)],
+        "plugins": {"resources": {}, "tools": {}, "adapters": {}, "prompts": {}},
+    }
+
+    plugins, _, tools = asyncio.run(_run_initializer(cfg))
+    think = plugins.get_plugins_for_stage(PipelineStage.THINK)
+    assert any(p.__class__.__name__ == "MyPrompt" for p in think)
+    assert tools.get("echo") is not None


### PR DESCRIPTION
## Summary
- discover plugins from `pyproject.toml` in `SystemInitializer`
- document new discovery mechanism
- test plugin discovery logic

## Testing
- `poetry run black src/pipeline/initializer.py tests/registry/test_plugin_discovery.py`
- `poetry run isort src/pipeline/initializer.py tests/registry/test_plugin_discovery.py`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: found errors)*
- `bandit -r src` *(fails: command not found)*
- `PYTHONPATH=src poetry run python -m src.config.validator --config config/dev.yaml` *(failed to run)*
- `PYTHONPATH=src poetry run python -m src.config.validator --config config/prod.yaml` *(failed to run)*
- `poetry run python -m src.registry.validator --config config/dev.yaml` *(failed to run)*
- `poetry run pytest` *(fails with import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869ed47267083228af950ab4f2b0dc2