### PR TITLE
Add async tool batching with caching

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -4,6 +4,10 @@ server:
   reload: true
   log_level: "debug"
 
+tool_registry:
+  concurrency_limit: 5
+  cache_ttl: 300
+
 plugins:
   resources:
     database:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -4,6 +4,10 @@ server:
   reload: false
   log_level: "info"
 
+tool_registry:
+  concurrency_limit: 10
+  cache_ttl: 600
+
 plugins:
   resources:
     database:

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -8,7 +8,7 @@ if str(SRC_PATH) not in sys.path:
 
 from .builder import ConfigBuilder
 from .models import (CONFIG_SCHEMA, EntityConfig, PluginConfig, PluginsSection,
-                     ServerConfig, validate_config)
+                     ServerConfig, ToolRegistryConfig, validate_config)
 from .validators import (_validate_cache, _validate_memory,
                          _validate_vector_memory)
 
@@ -20,6 +20,7 @@ __all__ = [
     "PluginConfig",
     "PluginsSection",
     "ServerConfig",
+    "ToolRegistryConfig",
     "EntityConfig",
     "CONFIG_SCHEMA",
     "validate_config",

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -49,15 +49,25 @@ class ServerConfig:
 
 
 @dataclass
+class ToolRegistryConfig:
+    """Options controlling tool execution."""
+
+    concurrency_limit: int = 5
+    cache_ttl: int | None = None
+
+
+@dataclass
 class EntityConfig:
     server: ServerConfig
     plugins: PluginsSection = field(default_factory=PluginsSection)
+    tool_registry: ToolRegistryConfig = field(default_factory=ToolRegistryConfig)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "EntityConfig":
         server = ServerConfig(**data.get("server", {}))
         plugins = PluginsSection.from_dict(data.get("plugins", {}))
-        return cls(server, plugins)
+        tool_reg_cfg = ToolRegistryConfig(**data.get("tool_registry", {}))
+        return cls(server, plugins, tool_reg_cfg)
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +122,7 @@ __all__ = [
     "PluginConfig",
     "PluginsSection",
     "ServerConfig",
+    "ToolRegistryConfig",
     "EntityConfig",
     "CONFIG_SCHEMA",
     "validate_config",

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -177,7 +177,11 @@ class SystemInitializer:
                 await resource_registry.remove(name)
 
         # Phase 3.5: register tools
-        tool_registry = ToolRegistry()
+        tr_cfg = self.config.get("tool_registry", {})
+        tool_registry = ToolRegistry(
+            concurrency_limit=tr_cfg.get("concurrency_limit", 5),
+            cache_ttl=tr_cfg.get("cache_ttl"),
+        )
         for cls, config in registry.tool_classes():
             if any(dep in degraded for dep in getattr(cls, "dependencies", [])):
                 continue

--- a/src/pipeline/metrics.py
+++ b/src/pipeline/metrics.py
@@ -12,6 +12,7 @@ class MetricsCollector:
     plugin_durations: dict[str, list[float]] = field(default_factory=dict)
     tool_execution_count: dict[str, int] = field(default_factory=dict)
     tool_error_count: dict[str, int] = field(default_factory=dict)
+    tool_durations: dict[str, list[float]] = field(default_factory=dict)
     llm_call_count: dict[str, int] = field(default_factory=dict)
     llm_durations: dict[str, list[float]] = field(default_factory=dict)
     llm_token_count: dict[str, int] = field(default_factory=dict)
@@ -36,6 +37,10 @@ class MetricsCollector:
         key = f"{stage}:{tool_name}"
         self.tool_error_count[key] = self.tool_error_count.get(key, 0) + 1
 
+    def record_tool_duration(self, tool_name: str, stage: str, duration: float) -> None:
+        key = f"{stage}:{tool_name}"
+        self.tool_durations.setdefault(key, []).append(duration)
+
     def record_llm_call(self, plugin: str, stage: str, purpose: str) -> None:
         key = f"{stage}:{plugin}:{purpose}"
         self.llm_call_count[key] = self.llm_call_count.get(key, 0) + 1
@@ -58,6 +63,7 @@ class MetricsCollector:
             "plugin_durations": self.plugin_durations,
             "tool_execution_count": self.tool_execution_count,
             "tool_error_count": self.tool_error_count,
+            "tool_durations": self.tool_durations,
             "llm_call_count": self.llm_call_count,
             "llm_durations": self.llm_durations,
             "llm_token_count": self.llm_token_count,

--- a/tests/test_tool_registry_options.py
+++ b/tests/test_tool_registry_options.py
@@ -1,0 +1,66 @@
+import asyncio
+import time
+from datetime import datetime
+
+from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
+                      PipelineState, PluginRegistry, ResourceRegistry,
+                      SystemRegistries, ToolCall, ToolRegistry)
+from pipeline.tools.execution import execute_pending_tools
+
+
+class SleepTool:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def execute_function(self, params):
+        self.calls += 1
+        await asyncio.sleep(params.get("delay", 0))
+        return params.get("delay", 0)
+
+
+def _make_state() -> PipelineState:
+    return PipelineState(
+        conversation=[
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now()),
+        ],
+        pipeline_id="1",
+        metrics=MetricsCollector(),
+        current_stage=PipelineStage.DO,
+    )
+
+
+def test_concurrency_limit():
+    state = _make_state()
+    tool = SleepTool()
+    tools = ToolRegistry(concurrency_limit=2)
+    asyncio.run(tools.add("sleep", tool))
+    registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
+    for i in range(4):
+        state.pending_tool_calls.append(
+            ToolCall(name="sleep", params={"delay": 0.1}, result_key=f"r{i}")
+        )
+    start = time.time()
+    asyncio.run(execute_pending_tools(state, registries))
+    duration = time.time() - start
+    assert tool.calls == 4
+    assert duration >= 0.2
+
+
+def test_cache_ttl():
+    state = _make_state()
+    tool = SleepTool()
+    tools = ToolRegistry(cache_ttl=5)
+    asyncio.run(tools.add("sleep", tool))
+    registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
+    state.pending_tool_calls.append(
+        ToolCall(name="sleep", params={"delay": 0}, result_key="a")
+    )
+    asyncio.run(execute_pending_tools(state, registries))
+    state.pending_tool_calls.append(
+        ToolCall(name="sleep", params={"delay": 0}, result_key="b")
+    )
+    asyncio.run(execute_pending_tools(state, registries))
+    assert tool.calls == 1
+    assert state.stage_results["b"] == 0
+    key = f"{PipelineStage.DO}:sleep"
+    assert key in state.metrics.tool_durations


### PR DESCRIPTION
## Summary
- implement concurrency limit and optional TTL caching in `ToolRegistry`
- add async batching in `execute_pending_tools` and record durations
- support registry config in initializer
- expose new configuration options in dev and prod YAML
- provide tests for cache TTL and concurrency

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: missing stubs & dependencies)*
- `bandit -r src` *(fails: Command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869ed43ea508322a5061941d7d6a32e