### PR TITLE
Add plugin config validation

### DIFF
--- a/docs/source/schemas/BedrockResource.json
+++ b/docs/source/schemas/BedrockResource.json
@@ -1,0 +1,14 @@
+{
+  "title": "BedrockResourceConfig",
+  "type": "object",
+  "properties": {
+    "region": {
+      "title": "Region",
+      "type": "string"
+    },
+    "model_id": {
+      "title": "Model Id",
+      "type": "string"
+    }
+  }
+}

--- a/docs/source/schemas/CLIAdapter.json
+++ b/docs/source/schemas/CLIAdapter.json
@@ -1,0 +1,5 @@
+{
+  "title": "CLIAdapterConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/CalculatorTool.json
+++ b/docs/source/schemas/CalculatorTool.json
@@ -1,0 +1,5 @@
+{
+  "title": "CalculatorToolConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/ChatHistory.json
+++ b/docs/source/schemas/ChatHistory.json
@@ -1,0 +1,5 @@
+{
+  "title": "ChatHistoryConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/ClaudeResource.json
+++ b/docs/source/schemas/ClaudeResource.json
@@ -1,0 +1,5 @@
+{
+  "title": "ClaudeResourceConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/ComplexPrompt.json
+++ b/docs/source/schemas/ComplexPrompt.json
@@ -1,0 +1,10 @@
+{
+  "title": "ComplexPromptConfig",
+  "type": "object",
+  "properties": {
+    "k": {
+      "title": "K",
+      "type": "integer"
+    }
+  }
+}

--- a/docs/source/schemas/ConversationHistory.json
+++ b/docs/source/schemas/ConversationHistory.json
@@ -1,0 +1,5 @@
+{
+  "title": "ConversationHistoryConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/DuckDBDatabaseResource.json
+++ b/docs/source/schemas/DuckDBDatabaseResource.json
@@ -1,0 +1,14 @@
+{
+  "title": "DuckDBDatabaseResourceConfig",
+  "type": "object",
+  "properties": {
+    "path": {
+      "title": "Path",
+      "type": "string"
+    },
+    "history_table": {
+      "title": "History Table",
+      "type": "string"
+    }
+  }
+}

--- a/docs/source/schemas/DuckDBVectorStore.json
+++ b/docs/source/schemas/DuckDBVectorStore.json
@@ -1,0 +1,10 @@
+{
+  "title": "DuckDBVectorStoreConfig",
+  "type": "object",
+  "properties": {
+    "path": {
+      "title": "Path",
+      "type": "string"
+    }
+  }
+}

--- a/docs/source/schemas/EchoLLMResource.json
+++ b/docs/source/schemas/EchoLLMResource.json
@@ -1,0 +1,5 @@
+{
+  "title": "EchoLLMResourceConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/GeminiResource.json
+++ b/docs/source/schemas/GeminiResource.json
@@ -1,0 +1,5 @@
+{
+  "title": "GeminiResourceConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/HTTPAdapter.json
+++ b/docs/source/schemas/HTTPAdapter.json
@@ -1,0 +1,18 @@
+{
+  "title": "HTTPAdapterConfig",
+  "type": "object",
+  "properties": {
+    "host": {
+      "title": "Host",
+      "type": "string"
+    },
+    "port": {
+      "title": "Port",
+      "type": "integer"
+    },
+    "dashboard": {
+      "title": "Dashboard",
+      "type": "boolean"
+    }
+  }
+}

--- a/docs/source/schemas/InMemoryStorageResource.json
+++ b/docs/source/schemas/InMemoryStorageResource.json
@@ -1,0 +1,10 @@
+{
+  "title": "InMemoryStorageResourceConfig",
+  "type": "object",
+  "properties": {
+    "history_table": {
+      "title": "History Table",
+      "type": "string"
+    }
+  }
+}

--- a/docs/source/schemas/LLMGRPCAdapter.json
+++ b/docs/source/schemas/LLMGRPCAdapter.json
@@ -1,0 +1,14 @@
+{
+  "title": "LLMGRPCAdapterConfig",
+  "type": "object",
+  "properties": {
+    "host": {
+      "title": "Host",
+      "type": "string"
+    },
+    "port": {
+      "title": "Port",
+      "type": "integer"
+    }
+  }
+}

--- a/docs/source/schemas/LocalFileSystemResource.json
+++ b/docs/source/schemas/LocalFileSystemResource.json
@@ -1,0 +1,10 @@
+{
+  "title": "LocalFileSystemResourceConfig",
+  "type": "object",
+  "properties": {
+    "base_path": {
+      "title": "Base Path",
+      "type": "string"
+    }
+  }
+}

--- a/docs/source/schemas/LoggingAdapter.json
+++ b/docs/source/schemas/LoggingAdapter.json
@@ -1,0 +1,5 @@
+{
+  "title": "LoggingAdapterConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/MemoryPlugin.json
+++ b/docs/source/schemas/MemoryPlugin.json
@@ -1,0 +1,5 @@
+{
+  "title": "MemoryPluginConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/MemoryRetrievalPrompt.json
+++ b/docs/source/schemas/MemoryRetrievalPrompt.json
@@ -1,0 +1,5 @@
+{
+  "title": "MemoryRetrievalPromptConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/OllamaLLMResource.json
+++ b/docs/source/schemas/OllamaLLMResource.json
@@ -1,0 +1,5 @@
+{
+  "title": "OllamaLLMResourceConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/OpenAIResource.json
+++ b/docs/source/schemas/OpenAIResource.json
@@ -1,0 +1,5 @@
+{
+  "title": "OpenAIResourceConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/PgVectorStore.json
+++ b/docs/source/schemas/PgVectorStore.json
@@ -1,0 +1,10 @@
+{
+  "title": "PgVectorStoreConfig",
+  "type": "object",
+  "properties": {
+    "table_name": {
+      "title": "Table Name",
+      "type": "string"
+    }
+  }
+}

--- a/docs/source/schemas/PostgresResource.json
+++ b/docs/source/schemas/PostgresResource.json
@@ -1,0 +1,22 @@
+{
+  "title": "PostgresResourceConfig",
+  "type": "object",
+  "properties": {
+    "pool_min_size": {
+      "title": "Pool Min Size",
+      "type": "integer"
+    },
+    "pool_max_size": {
+      "title": "Pool Max Size",
+      "type": "integer"
+    },
+    "db_schema": {
+      "title": "Db Schema",
+      "type": "string"
+    },
+    "history_table": {
+      "title": "History Table",
+      "type": "string"
+    }
+  }
+}

--- a/docs/source/schemas/S3FileSystem.json
+++ b/docs/source/schemas/S3FileSystem.json
@@ -1,0 +1,14 @@
+{
+  "title": "S3FileSystemConfig",
+  "type": "object",
+  "properties": {
+    "bucket": {
+      "title": "Bucket",
+      "type": "string"
+    },
+    "base_path": {
+      "title": "Base Path",
+      "type": "string"
+    }
+  }
+}

--- a/docs/source/schemas/SQLiteStorageResource.json
+++ b/docs/source/schemas/SQLiteStorageResource.json
@@ -1,0 +1,14 @@
+{
+  "title": "SQLiteStorageResourceConfig",
+  "type": "object",
+  "properties": {
+    "path": {
+      "title": "Path",
+      "type": "string"
+    },
+    "history_table": {
+      "title": "History Table",
+      "type": "string"
+    }
+  }
+}

--- a/docs/source/schemas/SearchTool.json
+++ b/docs/source/schemas/SearchTool.json
@@ -1,0 +1,5 @@
+{
+  "title": "SearchToolConfig",
+  "type": "object",
+  "properties": {}
+}

--- a/docs/source/schemas/StorageResource.json
+++ b/docs/source/schemas/StorageResource.json
@@ -1,0 +1,10 @@
+{
+  "title": "StorageResourceConfig",
+  "type": "object",
+  "properties": {
+    "filesystem": {
+      "title": "Filesystem",
+      "type": "object"
+    }
+  }
+}

--- a/docs/source/schemas/StructuredLogging.json
+++ b/docs/source/schemas/StructuredLogging.json
@@ -1,0 +1,26 @@
+{
+  "title": "StructuredLoggingConfig",
+  "type": "object",
+  "properties": {
+    "level": {
+      "title": "Level",
+      "type": "string"
+    },
+    "file_enabled": {
+      "title": "File Enabled",
+      "type": "boolean"
+    },
+    "file_path": {
+      "title": "File Path",
+      "type": "string"
+    },
+    "max_file_size": {
+      "title": "Max File Size",
+      "type": "integer"
+    },
+    "backup_count": {
+      "title": "Backup Count",
+      "type": "integer"
+    }
+  }
+}

--- a/docs/source/schemas/WeatherApiTool.json
+++ b/docs/source/schemas/WeatherApiTool.json
@@ -1,0 +1,18 @@
+{
+  "title": "WeatherApiToolConfig",
+  "type": "object",
+  "properties": {
+    "base_url": {
+      "title": "Base Url",
+      "type": "string"
+    },
+    "api_key": {
+      "title": "Api Key",
+      "type": "string"
+    },
+    "timeout": {
+      "title": "Timeout",
+      "type": "integer"
+    }
+  }
+}

--- a/docs/source/schemas/WebSocketAdapter.json
+++ b/docs/source/schemas/WebSocketAdapter.json
@@ -1,0 +1,14 @@
+{
+  "title": "WebSocketAdapterConfig",
+  "type": "object",
+  "properties": {
+    "host": {
+      "title": "Host",
+      "type": "string"
+    },
+    "port": {
+      "title": "Port",
+      "type": "integer"
+    }
+  }
+}

--- a/plugins/builtin/config_models.py
+++ b/plugins/builtin/config_models.py
@@ -1,0 +1,212 @@
+from pydantic import BaseModel
+
+
+class DefaultConfigModel(BaseModel):
+    class Config:
+        extra = "allow"
+
+
+__all__ = ["DefaultConfigModel"]
+
+
+# Adapter configs
+class CLIAdapterConfig(DefaultConfigModel):
+    pass
+
+
+class LLMGRPCAdapterConfig(DefaultConfigModel):
+    host: str | None = None
+    port: int | None = None
+
+
+class HTTPAdapterConfig(DefaultConfigModel):
+    host: str | None = None
+    port: int | None = None
+    dashboard: bool | None = None
+
+
+class LoggingAdapterConfig(DefaultConfigModel):
+    pass
+
+
+class WebSocketAdapterConfig(DefaultConfigModel):
+    host: str | None = None
+    port: int | None = None
+
+
+# Prompt configs
+class MemoryPluginConfig(DefaultConfigModel):
+    pass
+
+
+class ComplexPromptConfig(DefaultConfigModel):
+    k: int | None = None
+
+
+class ConversationHistoryConfig(DefaultConfigModel):
+    pass
+
+
+class MemoryRetrievalPromptConfig(DefaultConfigModel):
+    pass
+
+
+class ChatHistoryConfig(DefaultConfigModel):
+    pass
+
+
+# Tool configs
+class WeatherApiToolConfig(DefaultConfigModel):
+    base_url: str | None = None
+    api_key: str | None = None
+    timeout: int | None = None
+
+
+class CalculatorToolConfig(DefaultConfigModel):
+    pass
+
+
+class SearchToolConfig(DefaultConfigModel):
+    pass
+
+
+# Resource configs
+class BedrockResourceConfig(DefaultConfigModel):
+    region: str | None = None
+    model_id: str | None = None
+
+
+class ClaudeResourceConfig(DefaultConfigModel):
+    pass
+
+
+class DuckDBDatabaseResourceConfig(DefaultConfigModel):
+    path: str | None = None
+    history_table: str | None = None
+
+
+class DuckDBVectorStoreConfig(DefaultConfigModel):
+    path: str | None = None
+
+
+class EchoLLMResourceConfig(DefaultConfigModel):
+    pass
+
+
+class GeminiResourceConfig(DefaultConfigModel):
+    pass
+
+
+class InMemoryStorageResourceConfig(DefaultConfigModel):
+    history_table: str | None = None
+
+
+class LocalFileSystemResourceConfig(DefaultConfigModel):
+    base_path: str | None = None
+
+
+class OllamaLLMResourceConfig(DefaultConfigModel):
+    pass
+
+
+class OpenAIResourceConfig(DefaultConfigModel):
+    pass
+
+
+class PgVectorStoreConfig(DefaultConfigModel):
+    table_name: str | None = None
+
+
+class PostgresResourceConfig(DefaultConfigModel):
+    pool_min_size: int | None = None
+    pool_max_size: int | None = None
+    db_schema: str | None = None
+    history_table: str | None = None
+
+
+class SQLiteStorageResourceConfig(DefaultConfigModel):
+    path: str | None = None
+    history_table: str | None = None
+
+
+class StorageResourceConfig(DefaultConfigModel):
+    filesystem: dict | None = None
+
+
+class StructuredLoggingConfig(DefaultConfigModel):
+    level: str | None = None
+    file_enabled: bool | None = None
+    file_path: str | None = None
+    max_file_size: int | None = None
+    backup_count: int | None = None
+
+
+class S3FileSystemConfig(DefaultConfigModel):
+    bucket: str | None = None
+    base_path: str | None = None
+
+
+__all__ += [
+    "CLIAdapterConfig",
+    "LLMGRPCAdapterConfig",
+    "HTTPAdapterConfig",
+    "LoggingAdapterConfig",
+    "WebSocketAdapterConfig",
+    "MemoryPluginConfig",
+    "ComplexPromptConfig",
+    "ConversationHistoryConfig",
+    "MemoryRetrievalPromptConfig",
+    "ChatHistoryConfig",
+    "WeatherApiToolConfig",
+    "CalculatorToolConfig",
+    "SearchToolConfig",
+    "BedrockResourceConfig",
+    "ClaudeResourceConfig",
+    "DuckDBDatabaseResourceConfig",
+    "DuckDBVectorStoreConfig",
+    "EchoLLMResourceConfig",
+    "GeminiResourceConfig",
+    "InMemoryStorageResourceConfig",
+    "LocalFileSystemResourceConfig",
+    "OllamaLLMResourceConfig",
+    "OpenAIResourceConfig",
+    "PgVectorStoreConfig",
+    "PostgresResourceConfig",
+    "SQLiteStorageResourceConfig",
+    "StorageResourceConfig",
+    "StructuredLoggingConfig",
+    "S3FileSystemConfig",
+]
+
+# Map plugin class names to config models
+PLUGIN_CONFIG_MODELS = {
+    "CLIAdapter": CLIAdapterConfig,
+    "LLMGRPCAdapter": LLMGRPCAdapterConfig,
+    "HTTPAdapter": HTTPAdapterConfig,
+    "LoggingAdapter": LoggingAdapterConfig,
+    "WebSocketAdapter": WebSocketAdapterConfig,
+    "MemoryPlugin": MemoryPluginConfig,
+    "ComplexPrompt": ComplexPromptConfig,
+    "ConversationHistory": ConversationHistoryConfig,
+    "MemoryRetrievalPrompt": MemoryRetrievalPromptConfig,
+    "ChatHistory": ChatHistoryConfig,
+    "WeatherApiTool": WeatherApiToolConfig,
+    "CalculatorTool": CalculatorToolConfig,
+    "SearchTool": SearchToolConfig,
+    "BedrockResource": BedrockResourceConfig,
+    "ClaudeResource": ClaudeResourceConfig,
+    "DuckDBDatabaseResource": DuckDBDatabaseResourceConfig,
+    "DuckDBVectorStore": DuckDBVectorStoreConfig,
+    "EchoLLMResource": EchoLLMResourceConfig,
+    "GeminiResource": GeminiResourceConfig,
+    "InMemoryStorageResource": InMemoryStorageResourceConfig,
+    "LocalFileSystemResource": LocalFileSystemResourceConfig,
+    "OllamaLLMResource": OllamaLLMResourceConfig,
+    "OpenAIResource": OpenAIResourceConfig,
+    "PgVectorStore": PgVectorStoreConfig,
+    "PostgresResource": PostgresResourceConfig,
+    "SQLiteStorageResource": SQLiteStorageResourceConfig,
+    "StorageResource": StorageResourceConfig,
+    "StructuredLogging": StructuredLoggingConfig,
+    "S3FileSystem": S3FileSystemConfig,
+}

--- a/tools/generate_plugin_schemas.py
+++ b/tools/generate_plugin_schemas.py
@@ -1,0 +1,18 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from plugins.builtin.config_models import PLUGIN_CONFIG_MODELS
+
+SCHEMA_DIR = Path("docs/source/schemas")
+SCHEMA_DIR.mkdir(exist_ok=True)
+
+for name, model in PLUGIN_CONFIG_MODELS.items():
+    schema_path = SCHEMA_DIR / f"{name}.json"
+    schema_path.write_text(json.dumps(model.schema(), indent=2))
+
+print(f"Wrote {len(PLUGIN_CONFIG_MODELS)} schemas to {SCHEMA_DIR}")


### PR DESCRIPTION
## Summary
- add Pydantic config models for builtin plugins
- validate configs using these models
- generate JSON schemas for docs

## Testing
- `poetry run black src/pipeline/base_plugins.py plugins/builtin/config_models.py tools/generate_plugin_schemas.py`
- `poetry run isort src tests plugins/builtin/config_models.py tools/generate_plugin_schemas.py`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: found 166 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869ed3e2f748322b6c18790ff2e92be