### PR TITLE
Refactor memory resource backends

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -24,7 +24,7 @@ plugins:
       backoff: 1.0
     memory:
       type: pipeline.resources.memory_resource:MemoryResource
-      database:
+      storage:
         type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
         path: ./dev.db
     storage:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -25,7 +25,7 @@ plugins:
       backoff: 2.0
     memory:
       type: pipeline.resources.memory_resource:MemoryResource
-      database:
+      storage:
         type: plugins.builtin.resources.postgres:PostgresResource
         host: "${DB_HOST}"
         port: 5432

--- a/plugins/builtin/resources/__init__.py
+++ b/plugins/builtin/resources/__init__.py
@@ -13,10 +13,13 @@ from .llm_base import LLM
 from .llm_resource import LLMResource
 from .local_filesystem import LocalFileSystemResource
 from .memory import Memory
+from .memory_filesystem import MemoryFileSystem
+from .memory_storage import MemoryStorage
+from .memory_vector_store import MemoryVectorStore
+from .metrics import MetricsResource
 from .pg_vector_store import PgVectorStore
 from .s3_filesystem import S3FileSystem
 from .structured_logging import StructuredLogging
-from .metrics import MetricsResource
 from .vector_store import VectorStore, VectorStoreResource
 
 __all__ = [
@@ -35,6 +38,9 @@ __all__ = [
     "MetricsResource",
     "DuckDBDatabaseResource",
     "PgVectorStore",
+    "MemoryStorage",
+    "MemoryVectorStore",
+    "MemoryFileSystem",
     "DuckDBVectorStore",
     "LocalFileSystemResource",
     "S3FileSystem",

--- a/plugins/builtin/resources/memory_filesystem.py
+++ b/plugins/builtin/resources/memory_filesystem.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""In-memory file system resource."""
+
+from typing import Dict
+
+from plugins.builtin.resources.base import BaseResource
+from plugins.builtin.resources.filesystem import FileSystemResource
+
+
+class MemoryFileSystem(BaseResource, FileSystemResource):
+    """Store files in an in-memory dictionary."""
+
+    name = "filesystem"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self._files: Dict[str, bytes] = {}
+
+    async def store(self, key: str, content: bytes) -> str:
+        self._files[key] = content
+        return key
+
+    async def load(self, key: str) -> bytes:
+        return self._files[key]

--- a/plugins/builtin/resources/memory_storage.py
+++ b/plugins/builtin/resources/memory_storage.py
@@ -1,121 +1,32 @@
 from __future__ import annotations
 
-"""Persistent memory storage implementation."""
-import json
-from collections import defaultdict
-from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, DefaultDict, Dict, List
+"""In-memory database resource for conversation history."""
 
+from typing import Dict, List
+
+from plugins.builtin.resources.database import DatabaseResource
 from pipeline.context import ConversationEntry
 
-from .storage_backend import StorageBackend
 
+class MemoryStorage(DatabaseResource):
+    """Store conversation history purely in memory."""
 
-class MemoryStorage(StorageBackend):
-    """In-memory storage backend for testing and ephemeral runs."""
+    name = "database"
 
-    def __init__(
-        self, config: Dict | None = None, *, history_table: str | None = None
-    ) -> None:
-        self.config = config or {}
-        self._history_table = history_table or self.config.get("history_table")
-        self._data: DefaultDict[str, List[Dict[str, Any]]] = defaultdict(list)
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self._data: Dict[str, List[ConversationEntry]] = {}
 
-    def _table_name(self) -> str:
-        return self._history_table or "chat_history"
-
-    async def initialize(self) -> None:  # pragma: no cover - no setup needed
+    async def _do_health_check(self, connection: None) -> None:  # pragma: no cover
         return None
 
-    @asynccontextmanager
-    async def connection(self) -> AsyncIterator["MemoryStorage"]:
-        yield self
-
-    async def acquire(self) -> "MemoryStorage":  # pragma: no cover - not used
-        return self
-
-    async def release(self, connection: Any) -> None:  # pragma: no cover - no-op
-        return None
-
-    async def execute(self, query: str, *args: Any) -> Any:
-        if self._history_table and query.lower().startswith("insert into"):
-            self._data[self._table_name()].append(
-                {
-                    "conversation_id": args[0],
-                    "role": args[1],
-                    "content": args[2],
-                    "metadata": (
-                        json.loads(args[3]) if isinstance(args[3], str) else args[3]
-                    ),
-                    "timestamp": args[4],
-                }
-            )
-
-    async def fetch(self, query: str, *args: Any) -> Any:
-        if self._history_table and query.lower().startswith("select"):
-            convo_id = args[0]
-            rows = [
-                {
-                    "role": r["role"],
-                    "content": r["content"],
-                    "metadata": r["metadata"],
-                    "timestamp": r["timestamp"],
-                }
-                for r in self._data[self._table_name()]
-                if r["conversation_id"] == convo_id
-            ]
-            return rows
-        return []
-
-    async def fetchrow(self, query: str, *args: Any) -> Any:
-        rows = await self.fetch(query, *args)
-        return rows[0] if rows else None
-
-    async def fetchval(self, query: str, *args: Any) -> Any:
-        row = await self.fetchrow(query, *args)
-        if row is None:
-            return None
-        if isinstance(row, dict):
-            return next(iter(row.values()))
-        return row[0]
+    async def health_check(self) -> bool:  # pragma: no cover - trivial
+        return True
 
     async def save_history(
         self, conversation_id: str, history: List[ConversationEntry]
     ) -> None:
-        for entry in history:
-            await self.execute(
-                (
-                    f"INSERT INTO {self._table_name()} "
-                    "(conversation_id, role, content, metadata, timestamp) "
-                    "VALUES (?, ?, ?, ?, ?)"
-                ),
-                conversation_id,
-                entry.role,
-                entry.content,
-                json.dumps(entry.metadata),
-                entry.timestamp,
-            )
+        self._data[conversation_id] = list(history)
 
     async def load_history(self, conversation_id: str) -> List[ConversationEntry]:
-        rows = await self.fetch(
-            (
-                f"SELECT role, content, metadata, timestamp FROM {self._table_name()} "
-                "WHERE conversation_id=? ORDER BY timestamp"
-            ),
-            conversation_id,
-        )
-        history: List[ConversationEntry] = []
-        for row in rows:
-            metadata = row["metadata"]
-            history.append(
-                ConversationEntry(
-                    content=row["content"],
-                    role=row["role"],
-                    timestamp=row["timestamp"],
-                    metadata=metadata,
-                )
-            )
-        return history
-
-    async def health_check(self) -> bool:
-        return True
+        return list(self._data.get(conversation_id, []))

--- a/plugins/builtin/resources/memory_vector_store.py
+++ b/plugins/builtin/resources/memory_vector_store.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""In-memory vector store resource."""
+
+from typing import Dict, List, Tuple
+
+from plugins.builtin.resources.vector_store import VectorStoreResource
+
+
+class MemoryVectorStore(VectorStoreResource):
+    """Persist embeddings in memory and provide similarity search."""
+
+    name = "vector_memory"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config)
+        self._dim = int(self.config.get("dimensions", 3))
+        self._items: List[Tuple[str, List[float]]] = []
+
+    def _embed(self, text: str) -> List[float]:
+        values = [0.0] * self._dim
+        for i, byte in enumerate(text.encode("utf-8")):
+            values[i % self._dim] += float(byte)
+        return [v / 255.0 for v in values]
+
+    async def add_embedding(self, text: str, metadata: Dict | None = None) -> None:
+        self._items.append((text, self._embed(text)))
+
+    async def query_similar(self, query: str, k: int) -> List[str]:
+        if not self._items:
+            return []
+        target = self._embed(query)
+
+        def sim(a: List[float], b: List[float]) -> float:
+            dot = sum(x * y for x, y in zip(a, b))
+            norm_a = sum(x * x for x in a) ** 0.5
+            norm_b = sum(y * y for y in b) ** 0.5
+            return dot / (norm_a * norm_b + 1e-9)
+
+        scored = sorted(
+            self._items,
+            key=lambda item: sim(item[1], target),
+            reverse=True,
+        )
+        return [text for text, _ in scored[:k]]

--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -11,7 +11,10 @@ from .filesystem import FileSystemResource
 from .in_memory_storage import InMemoryStorageResource
 from .llm.unified import UnifiedLLMResource
 from .memory import Memory
+from .memory_filesystem import MemoryFileSystem
 from .memory_resource import MemoryResource, SimpleMemoryResource
+from .memory_storage import MemoryStorage
+from .memory_vector_store import MemoryVectorStore
 from .pg_vector_store import PgVectorStore
 from .postgres import PostgresResource
 from .sqlite_storage import SQLiteStorageResource
@@ -25,6 +28,9 @@ __all__ = [
     "DuckDBDatabaseResource",
     "FileSystemResource",
     "InMemoryStorageResource",
+    "MemoryStorage",
+    "MemoryVectorStore",
+    "MemoryFileSystem",
     "Memory",
     "PgVectorStore",
     "PostgresResource",

--- a/src/pipeline/resources/memory_filesystem.py
+++ b/src/pipeline/resources/memory_filesystem.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Wrapper for MemoryFileSystem."""
+
+from plugins.builtin.resources.memory_filesystem import MemoryFileSystem
+
+__all__ = ["MemoryFileSystem"]

--- a/src/pipeline/resources/memory_resource.py
+++ b/src/pipeline/resources/memory_resource.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from plugins.builtin.resources.vector_store import VectorStoreResource
+from plugins.builtin.resources.memory_filesystem import MemoryFileSystem
+from plugins.builtin.resources.memory_storage import MemoryStorage
+from plugins.builtin.resources.memory_vector_store import MemoryVectorStore
 
 from pipeline.base_plugins import ResourcePlugin, ValidationResult
 from pipeline.context import ConversationEntry
 from pipeline.stages import PipelineStage
 
-from .database import DatabaseResource
 from .memory import Memory
 
 
@@ -43,17 +44,19 @@ class MemoryResource(ResourcePlugin, Memory):
 
     stages = [PipelineStage.PARSE]
     name = "memory"
-    dependencies = ["database", "vector_store"]
+    dependencies = ["storage", "vector", "filesystem"]
 
     def __init__(
         self,
-        database: DatabaseResource | None = None,
-        vector_store: VectorStoreResource | None = None,
+        storage: MemoryStorage | None = None,
+        vector: MemoryVectorStore | None = None,
+        filesystem: MemoryFileSystem | None = None,
         config: Dict | None = None,
     ) -> None:
         super().__init__(config or {})
-        self.database = database
-        self.vector_store = vector_store
+        self.storage = storage
+        self.vector = vector
+        self.filesystem = filesystem
         self._kv: Dict[str, Any] = {}
 
     @classmethod
@@ -75,22 +78,32 @@ class MemoryResource(ResourcePlugin, Memory):
     async def save_conversation(
         self, conversation_id: str, history: List[ConversationEntry]
     ) -> None:
-        if self.database:
-            await self.database.save_history(conversation_id, history)
+        if self.storage:
+            await self.storage.save_history(conversation_id, history)
 
     async def load_conversation(self, conversation_id: str) -> List[ConversationEntry]:
-        if self.database:
-            return await self.database.load_history(conversation_id)
+        if self.storage:
+            return await self.storage.load_history(conversation_id)
         return []
 
     async def search_similar(self, query: str, k: int = 5) -> List[str]:
-        if self.vector_store:
-            return await self.vector_store.query_similar(query, k)
+        if self.vector:
+            return await self.vector.query_similar(query, k)
         return []
+
+    async def store_file(self, key: str, content: bytes) -> str:
+        if not self.filesystem:
+            raise ValueError("No filesystem backend configured")
+        return await self.filesystem.store(key, content)
+
+    async def load_file(self, key: str) -> bytes:
+        if not self.filesystem:
+            raise ValueError("No filesystem backend configured")
+        return await self.filesystem.load(key)
 
     @classmethod
     def validate_config(cls, config: Dict) -> ValidationResult:
-        for name in ("database", "vector_store"):
+        for name in ("storage", "vector", "filesystem"):
             sub = config.get(name)
             if sub is not None and not isinstance(sub, dict):
                 return ValidationResult.error_result(f"'{name}' must be a mapping")

--- a/src/pipeline/resources/memory_storage.py
+++ b/src/pipeline/resources/memory_storage.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Wrapper for MemoryStorage."""
+
+from plugins.builtin.resources.memory_storage import MemoryStorage
+
+__all__ = ["MemoryStorage"]

--- a/src/pipeline/resources/memory_vector_store.py
+++ b/src/pipeline/resources/memory_vector_store.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Wrapper for MemoryVectorStore."""
+
+from plugins.builtin.resources.memory_vector_store import MemoryVectorStore
+
+__all__ = ["MemoryVectorStore"]

--- a/tests/integration/test_chat_history_backends.py
+++ b/tests/integration/test_chat_history_backends.py
@@ -11,8 +11,8 @@ from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
                       PipelineState, PluginContext, PluginRegistry,
                       ResourceRegistry, SystemRegistries, ToolRegistry)
 from pipeline.resources.duckdb_database import DuckDBDatabaseResource
-from pipeline.resources.in_memory_storage import InMemoryStorageResource
 from pipeline.resources.memory_resource import MemoryResource
+from pipeline.resources.memory_storage import MemoryStorage
 from pipeline.resources.postgres import PostgresResource
 from pipeline.resources.sqlite_storage import SQLiteStorageResource
 
@@ -36,7 +36,7 @@ async def run_history_test(resource):
         resource._history_table = "test_history"
         await resource.initialize()
 
-    memory = MemoryResource(resource)
+    memory = MemoryResource(storage=resource)
     resources = ResourceRegistry()
     await resources.add("memory", memory)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
@@ -64,7 +64,7 @@ async def run_history_test(resource):
 
 @pytest.mark.integration
 def test_in_memory_history():
-    history = asyncio.run(run_history_test(InMemoryStorageResource({})))
+    history = asyncio.run(run_history_test(MemoryStorage({})))
     assert history and history[0].content == "hi"
 
 

--- a/tests/integration/test_postgres_history.py
+++ b/tests/integration/test_postgres_history.py
@@ -28,7 +28,7 @@ CONN = {
 def test_save_and_load_history():
     async def run():
         db = PostgresResource(CONN)
-        memory = MemoryResource(database=db)
+        memory = MemoryResource(storage=db)
         try:
             await db.initialize()
         except OSError as exc:

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -42,7 +42,7 @@ def test_vector_memory_integration():
         }
         db = PostgresResource(db_cfg)
         vm = PgVectorStore(vm_cfg)
-        memory = MemoryResource(database=db, vector_store=vm)
+        memory = MemoryResource(storage=db, vector=vm)
         llm = UnifiedLLMResource(
             {"provider": "echo", "base_url": "http://localhost", "model": "none"}
         )

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import datetime
 
-from plugins.builtin.resources.in_memory_storage import InMemoryStorageResource
+from plugins.builtin.resources.memory_storage import MemoryStorage
 
 from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
                       ResourceRegistry, SystemRegistries, ToolRegistry,
@@ -43,8 +43,8 @@ def test_memory_persists_between_runs():
 
 def test_save_and_load_history():
     async def run():
-        db = InMemoryStorageResource({})
-        memory = MemoryResource(database=db)
+        storage = MemoryStorage({})
+        memory = MemoryResource(storage=storage)
         history = [
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ]

--- a/tests/test_memory_storage.py
+++ b/tests/test_memory_storage.py
@@ -8,7 +8,7 @@ from pipeline.context import ConversationEntry
 
 def test_save_and_load_history():
     async def run():
-        storage = MemoryStorage({"history_table": "tbl"})
+        storage = MemoryStorage({})
         await storage.initialize()
         history = [
             ConversationEntry(


### PR DESCRIPTION
## Summary
- break out memory storage helpers into dedicated resource classes
- compose MemoryResource from storage, vector, and filesystem backends
- switch tests and configs to the new API

## Testing
- `poetry run black plugins/builtin/resources/memory_storage.py plugins/builtin/resources/memory_vector_store.py plugins/builtin/resources/memory_filesystem.py src/pipeline/resources/memory_resource.py src/pipeline/resources/__init__.py src/pipeline/resources/memory_vector_store.py src/pipeline/resources/memory_filesystem.py src/pipeline/resources/memory_storage.py tests/test_memory_resource.py tests/test_memory_storage.py tests/integration/test_chat_history_backends.py tests/integration/test_postgres_history.py tests/integration/test_vector_memory_integration.py plugins/builtin/resources/__init__.py`
- `poetry run isort plugins/builtin/resources/memory_storage.py plugins/builtin/resources/memory_vector_store.py plugins/builtin/resources/memory_filesystem.py src/pipeline/resources/memory_resource.py src/pipeline/resources/__init__.py src/pipeline/resources/memory_vector_store.py src/pipeline/resources/memory_filesystem.py src/pipeline/resources/memory_storage.py tests/test_memory_resource.py tests/test_memory_storage.py tests/integration/test_chat_history_backends.py tests/integration/test_postgres_history.py tests/integration/test_vector_memory_integration.py plugins/builtin/resources/__init__.py`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails with missing types)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869ed3fbbd48322bb77d68632e401bc