### PR TITLE
Refactor plugin stage handling

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -62,8 +62,9 @@ plugins:
     calculator:
       type: plugins.builtin.tools.calculator_tool:CalculatorTool
   adapters:
-    http:
-      type: plugins.builtin.adapters.http:HTTPAdapter
+  http:
+    type: plugins.builtin.adapters.http:HTTPAdapter
+    stages: [parse, deliver]
       auth_tokens:
         - dev-secret
       rate_limit:
@@ -71,20 +72,24 @@ plugins:
         interval: 60
       audit_log_path: logs/audit.log
       dashboard: true
-    cli:
-      type: plugins.builtin.adapters.cli:CLIAdapter
-    logging:
-      type: plugins.builtin.adapters.logging:LoggingAdapter
+  cli:
+    type: plugins.builtin.adapters.cli:CLIAdapter
+    stages: [deliver]
+  logging:
+    type: plugins.builtin.adapters.logging:LoggingAdapter
+    stages: [deliver]
   prompts:
     chain_of_thought:
       type: plugins.contrib.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
-    conversation_history:
-      type: plugins.builtin.prompts.conversation_history:ConversationHistory
-      history_table: chat_history
-    memory_retrieval:
-      type: plugins.builtin.prompts.memory_retrieval:MemoryRetrievalPrompt
-      max_context_length: 4000
-    intent_classifier:
-      type: plugins.contrib.prompts.intent_classifier:IntentClassifierPrompt
-      confidence_threshold: 0.8
+  conversation_history:
+    type: plugins.builtin.prompts.conversation_history:ConversationHistory
+    history_table: chat_history
+    stages: [parse, deliver]
+  memory_retrieval:
+    type: plugins.builtin.prompts.memory_retrieval:MemoryRetrievalPrompt
+    max_context_length: 4000
+    stages: [think]
+  intent_classifier:
+    type: plugins.contrib.prompts.intent_classifier:IntentClassifierPrompt
+    confidence_threshold: 0.8

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -69,32 +69,37 @@ plugins:
       type: plugins.builtin.tools.calculator_tool:CalculatorTool
       precision: 10
   adapters:
-    http:
-      type: plugins.builtin.adapters.http:HTTPAdapter
-      auth_tokens:
-        - ${HTTP_TOKEN}
+  http:
+    type: plugins.builtin.adapters.http:HTTPAdapter
+    stages: [parse, deliver]
+    auth_tokens:
+      - ${HTTP_TOKEN}
       rate_limit:
         requests: 100
         interval: 60
       audit_log_path: logs/audit.log
       dashboard: false
-    cli:
-      type: plugins.builtin.adapters.cli:CLIAdapter
-    logging:
-      type: plugins.builtin.adapters.logging:LoggingAdapter
+  cli:
+    type: plugins.builtin.adapters.cli:CLIAdapter
+    stages: [deliver]
+  logging:
+    type: plugins.builtin.adapters.logging:LoggingAdapter
+    stages: [deliver]
   prompts:
     chain_of_thought:
       type: plugins.contrib.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
       max_steps: 5
-    conversation_history:
-      type: plugins.builtin.prompts.conversation_history:ConversationHistory
-      db_schema: public
-      history_table: chat_history
-    memory_retrieval:
-      type: plugins.builtin.prompts.memory_retrieval:MemoryRetrievalPrompt
-      max_context_length: 4000
-      similarity_threshold: 0.7
-    intent_classifier:
-      type: plugins.contrib.prompts.intent_classifier:IntentClassifierPrompt
-      confidence_threshold: 0.8
+  conversation_history:
+    type: plugins.builtin.prompts.conversation_history:ConversationHistory
+    db_schema: public
+    history_table: chat_history
+    stages: [parse, deliver]
+  memory_retrieval:
+    type: plugins.builtin.prompts.memory_retrieval:MemoryRetrievalPrompt
+    max_context_length: 4000
+    similarity_threshold: 0.7
+    stages: [think]
+  intent_classifier:
+    type: plugins.contrib.prompts.intent_classifier:IntentClassifierPrompt
+    confidence_threshold: 0.8

--- a/plugins/builtin/adapters/cli.py
+++ b/plugins/builtin/adapters/cli.py
@@ -14,14 +14,11 @@ from typing import Any, cast
 from pipeline.base_plugins import AdapterPlugin
 from pipeline.manager import PipelineManager
 from pipeline.pipeline import execute_pipeline
-from pipeline.stages import PipelineStage
 from registry import SystemRegistries
 
 
 class CLIAdapter(AdapterPlugin):
     """Interactive command line adapter."""
-
-    stages = [PipelineStage.DELIVER]
 
     def __init__(
         self,

--- a/plugins/builtin/adapters/grpc.py
+++ b/plugins/builtin/adapters/grpc.py
@@ -7,14 +7,11 @@ import grpc
 from grpc_services import llm_pb2_grpc
 from grpc_services.llm_service import LLMService
 from pipeline.base_plugins import AdapterPlugin
-from pipeline.stages import PipelineStage
 from registry import SystemRegistries
 
 
 class LLMGRPCAdapter(AdapterPlugin):
     """Serve :class:`LLMService` over gRPC."""
-
-    stages = [PipelineStage.DELIVER]
 
     def __init__(self, config: dict | None = None) -> None:
         super().__init__(config)

--- a/plugins/builtin/adapters/http.py
+++ b/plugins/builtin/adapters/http.py
@@ -21,7 +21,6 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from pipeline.base_plugins import AdapterPlugin
 from pipeline.manager import PipelineManager
 from pipeline.pipeline import execute_pipeline
-from pipeline.stages import PipelineStage
 from registry import SystemRegistries
 
 
@@ -86,8 +85,6 @@ class MessageRequest(BaseModel):
 
 class HTTPAdapter(AdapterPlugin):
     """FastAPI based HTTP adapter for request/response handling."""
-
-    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
 
     def __init__(
         self,

--- a/plugins/builtin/adapters/logging.py
+++ b/plugins/builtin/adapters/logging.py
@@ -6,13 +6,10 @@ import logging
 from typing import Any
 
 from pipeline.base_plugins import AdapterPlugin
-from pipeline.stages import PipelineStage
 
 
 class LoggingAdapter(AdapterPlugin):
     """Log the final pipeline response during the deliver stage."""
-
-    stages = [PipelineStage.DELIVER]
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         super().__init__(config)

--- a/plugins/builtin/adapters/logging_adapter.py
+++ b/plugins/builtin/adapters/logging_adapter.py
@@ -10,7 +10,6 @@ from logging.handlers import RotatingFileHandler
 from typing import Optional
 
 from pipeline.base_plugins import AdapterPlugin
-from pipeline.stages import PipelineStage
 
 _request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "request_id", default=None
@@ -121,8 +120,6 @@ def get_logger(name: str) -> logging.Logger:
 
 class LoggingAdapter(AdapterPlugin):
     """Adapter placeholder for logging setup."""
-
-    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - adapter
         pass

--- a/plugins/builtin/adapters/websocket.py
+++ b/plugins/builtin/adapters/websocket.py
@@ -16,14 +16,11 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from pipeline.base_plugins import AdapterPlugin
 from pipeline.manager import PipelineManager
 from pipeline.pipeline import execute_pipeline
-from pipeline.stages import PipelineStage
 from registry import SystemRegistries
 
 
 class WebSocketAdapter(AdapterPlugin):
     """WebSocket adapter using FastAPI."""
-
-    stages = [PipelineStage.DELIVER]
 
     def __init__(
         self, manager: PipelineManager | None = None, config: dict | None = None

--- a/plugins/builtin/prompts/complex_prompt.py
+++ b/plugins/builtin/prompts/complex_prompt.py
@@ -19,7 +19,6 @@ class ComplexPrompt(PromptPlugin):
     """
 
     dependencies = ["llm", "memory"]
-    stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         """Compose a context-aware reply.

--- a/plugins/builtin/prompts/conversation_history.py
+++ b/plugins/builtin/prompts/conversation_history.py
@@ -15,7 +15,6 @@ class ConversationHistory(PromptPlugin):
     """Load and persist conversation history using the ``memory`` resource."""
 
     dependencies = ["memory"]
-    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/plugins/builtin/prompts/memory.py
+++ b/plugins/builtin/prompts/memory.py
@@ -15,7 +15,6 @@ class MemoryPlugin(PromptPlugin):
     """Persist conversation history using the ``memory`` resource."""
 
     dependencies = ["memory"]
-    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/plugins/builtin/prompts/memory_retrieval.py
+++ b/plugins/builtin/prompts/memory_retrieval.py
@@ -15,7 +15,6 @@ class MemoryRetrievalPrompt(PromptPlugin):
     """Fetch past conversation from memory and append it to the context."""
 
     dependencies = ["memory", "llm"]
-    stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         memory: MemoryResource = context.get_resource("memory")

--- a/plugins/builtin/resources/storage_resource.py
+++ b/plugins/builtin/resources/storage_resource.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Dict
 
 from pipeline.base_plugins import ResourcePlugin, ValidationResult
-from pipeline.stages import PipelineStage
 
 from .filesystem import FileSystemResource
 
@@ -13,7 +12,6 @@ from .filesystem import FileSystemResource
 class StorageResource(ResourcePlugin):
     """Provide simple file CRUD operations through a filesystem backend."""
 
-    stages = [PipelineStage.PARSE]
     name = "storage"
     dependencies = ["filesystem"]
 

--- a/plugins/builtin/tools/calculator_tool.py
+++ b/plugins/builtin/tools/calculator_tool.py
@@ -79,7 +79,6 @@ class CalculatorTool(ToolPlugin):
     any stage.
     """
 
-    stages = [PipelineStage.DO]
     _evaluator = SafeEvaluator()
 
     class Params(BaseModel):

--- a/plugins/builtin/tools/search_tool.py
+++ b/plugins/builtin/tools/search_tool.py
@@ -19,7 +19,6 @@ class SearchTool(ToolPlugin):
     stage.
     """
 
-    stages = [PipelineStage.DO]
     required_params = ["query"]
 
     class Params(BaseModel):

--- a/plugins/builtin/tools/weather_api_tool.py
+++ b/plugins/builtin/tools/weather_api_tool.py
@@ -19,7 +19,6 @@ class WeatherApiTool(ToolPlugin):
     needed and results are logged centrally.
     """
 
-    stages = [PipelineStage.DO]
     required_params = ["location"]
 
     def __init__(self, config: Dict | None = None) -> None:

--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -9,6 +9,7 @@ import httpx
 
 DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
     "type": "plugins.builtin.adapters.logging:LoggingAdapter",
+    "stages": ["deliver"],
 }
 
 DEFAULT_LLM_CONFIG: Dict[str, Any] = {
@@ -45,9 +46,15 @@ DEFAULT_TOOLS: Dict[str, Dict[str, Any]] = {
 }
 
 DEFAULT_ADAPTERS: Dict[str, Dict[str, Any]] = {
-    "http": {"type": "plugins.builtin.adapters.http:HTTPAdapter"},
-    "websocket": {"type": "plugins.builtin.adapters.websocket:WebSocketAdapter"},
-    "cli": {"type": "plugins.builtin.adapters.cli:CLIAdapter"},
+    "http": {
+        "type": "plugins.builtin.adapters.http:HTTPAdapter",
+        "stages": ["parse", "deliver"],
+    },
+    "websocket": {
+        "type": "plugins.builtin.adapters.websocket:WebSocketAdapter",
+        "stages": ["deliver"],
+    },
+    "cli": {"type": "plugins.builtin.adapters.cli:CLIAdapter", "stages": ["deliver"]},
     "logging": DEFAULT_LOGGING_CONFIG,
 }
 

--- a/src/pipeline/logging.py
+++ b/src/pipeline/logging.py
@@ -8,10 +8,10 @@ from importlib import import_module
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
-    from plugins.builtin.adapters.logging_adapter import JsonFormatter as _JsonFormatter
     from plugins.builtin.adapters.logging_adapter import (
+        JsonFormatter as _JsonFormatter,
         RequestIdFilter as _RequestIdFilter,
-    )
+    )  # noqa: F401
 
 
 def _adapter():

--- a/tests/test_stage_checks.py
+++ b/tests/test_stage_checks.py
@@ -12,11 +12,12 @@ class GoodPlugin(PromptPlugin):
         pass
 
 
-def test_plugin_requires_stages():
-    with pytest.raises(ValueError):
-
-        class NoStages(PromptPlugin):
+def test_plugin_without_stages_allowed():
+    class NoStages(PromptPlugin):
+        async def _execute_impl(self, context):
             pass
+
+    NoStages()
 
 
 def test_plugin_invalid_stage():


### PR DESCRIPTION
## Summary
- adjust BasePlugin stage checks to allow unspecified stages
- register plugin stages via SystemInitializer
- update defaults and configs with stage assignments
- remove stage attributes from built-in plugins
- update tests for new behavior

## Testing
- `poetry run black src/pipeline/logging.py tests/test_stage_checks.py src/pipeline/base_plugins.py src/pipeline/initializer.py src/pipeline/defaults.py plugins/builtin/adapters/cli.py plugins/builtin/adapters/grpc.py plugins/builtin/adapters/http.py plugins/builtin/adapters/logging.py plugins/builtin/adapters/logging_adapter.py plugins/builtin/adapters/websocket.py plugins/builtin/prompts/complex_prompt.py plugins/builtin/prompts/conversation_history.py plugins/builtin/prompts/memory.py plugins/builtin/prompts/memory_retrieval.py plugins/builtin/resources/storage_resource.py plugins/builtin/tools/calculator_tool.py plugins/builtin/tools/search_tool.py plugins/builtin/tools/weather_api_tool.py > /tmp/black.log && tail -n 20 /tmp/black.log`
- `poetry run flake8 src tests > /tmp/flake8.log && tail -n 20 /tmp/flake8.log`
- `poetry run mypy src > /tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `bandit -r src > /tmp/bandit.log && tail -n 20 /tmp/bandit.log`
- `poetry run python -m src.config.validator --config config/dev.yaml > /tmp/confdev.log && tail -n 20 /tmp/confdev.log`
- `poetry run python -m src.config.validator --config config/prod.yaml > /tmp/confprod.log && tail -n 20 /tmp/confprod.log`
- `poetry run python -m src.registry.validator > /tmp/regval.log && tail -n 20 /tmp/regval.log`
- `poetry run pytest -q > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6869ed3acff4832296ae3badbf9ee646