### PR TITLE
Introduce pipeline error hierarchy

### DIFF
--- a/plugins/builtin/adapters/cli.py
+++ b/plugins/builtin/adapters/cli.py
@@ -12,6 +12,7 @@ import asyncio
 from typing import Any, cast
 
 from pipeline.base_plugins import AdapterPlugin
+from pipeline.exceptions import ResourceError
 from pipeline.manager import PipelineManager
 from pipeline.pipeline import execute_pipeline
 from pipeline.stages import PipelineStage
@@ -55,7 +56,7 @@ class CLIAdapter(AdapterPlugin):
                 response = await self.manager.run_pipeline(message)
             else:
                 if self._registries is None:
-                    raise RuntimeError("Adapter not initialized")
+                    raise ResourceError("Adapter not initialized")
                 response = cast(
                     dict[str, Any],
                     await execute_pipeline(message, self._registries),

--- a/plugins/builtin/adapters/http.py
+++ b/plugins/builtin/adapters/http.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from pipeline.base_plugins import AdapterPlugin
+from pipeline.exceptions import ResourceError
 from pipeline.manager import PipelineManager
 from pipeline.pipeline import execute_pipeline
 from pipeline.stages import PipelineStage
@@ -152,7 +153,7 @@ class HTTPAdapter(AdapterPlugin):
                 result = await self.manager.run_pipeline(message)
             else:
                 if self._registries is None:
-                    raise RuntimeError("Adapter not initialized")
+                    raise ResourceError("Adapter not initialized")
                 result = cast(
                     dict[str, Any],
                     await execute_pipeline(message, self._registries),

--- a/plugins/builtin/adapters/websocket.py
+++ b/plugins/builtin/adapters/websocket.py
@@ -14,6 +14,7 @@ import uvicorn
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 from pipeline.base_plugins import AdapterPlugin
+from pipeline.exceptions import ResourceError
 from pipeline.manager import PipelineManager
 from pipeline.pipeline import execute_pipeline
 from pipeline.stages import PipelineStage
@@ -38,7 +39,7 @@ class WebSocketAdapter(AdapterPlugin):
         if self.manager is not None:
             return await self.manager.run_pipeline(message)
         if self._registries is None:
-            raise RuntimeError("Adapter not initialized")
+            raise ResourceError("Adapter not initialized")
         return cast(dict[str, Any], await execute_pipeline(message, self._registries))
 
     async def _connection_handler(self, websocket: WebSocket) -> None:

--- a/plugins/builtin/resources/bedrock.py
+++ b/plugins/builtin/resources/bedrock.py
@@ -7,6 +7,7 @@ from typing import Dict
 import aioboto3
 from plugins.builtin.resources.llm_resource import LLMResource
 
+from pipeline.exceptions import ResourceError
 from pipeline.validation import ValidationResult
 
 
@@ -29,7 +30,7 @@ class BedrockResource(LLMResource):
 
     async def generate(self, prompt: str) -> str:
         if not self.validate_config(self.config).valid:
-            raise RuntimeError("Bedrock resource not properly configured")
+            raise ResourceError("Bedrock resource not properly configured")
         payload = {"prompt": prompt, **self.params}
         async with aioboto3.client(
             "bedrock-runtime", region_name=self.region

--- a/plugins/builtin/resources/duckdb_vector_store.py
+++ b/plugins/builtin/resources/duckdb_vector_store.py
@@ -7,6 +7,8 @@ import duckdb
 from plugins.builtin.resources.duckdb_database import DuckDBDatabaseResource
 from plugins.builtin.resources.vector_store import VectorStoreResource
 
+from pipeline.exceptions import ResourceError
+
 
 class DuckDBVectorStore(VectorStoreResource):
     """Simple DuckDB-backed vector store."""
@@ -45,7 +47,7 @@ class DuckDBVectorStore(VectorStoreResource):
     async def add_embedding(self, text: str, metadata: Dict | None = None) -> None:
         embedding = self._embed(text)
         if self._connection is None:
-            raise RuntimeError("Resource not initialized")
+            raise ResourceError("Resource not initialized")
         await asyncio.to_thread(
             self._connection.execute,
             f"INSERT INTO {self._table} (text, embedding) VALUES (?, ?)",

--- a/plugins/builtin/resources/http_llm_resource.py
+++ b/plugins/builtin/resources/http_llm_resource.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from pipeline.base_plugins import ValidationResult
+from pipeline.exceptions import ResourceError
 from pipeline.reliability import CircuitBreaker, RetryPolicy
 
 
@@ -54,4 +55,4 @@ class HttpLLMResource:
         try:
             return await self._breaker.call(send)
         except Exception as exc:  # pragma: no cover
-            raise RuntimeError(f"HTTP request failed: {exc}") from exc
+            raise ResourceError(f"HTTP request failed: {exc}") from exc

--- a/plugins/builtin/resources/llm/providers/base.py
+++ b/plugins/builtin/resources/llm/providers/base.py
@@ -9,6 +9,7 @@ import httpx
 from plugins.builtin.resources.http_llm_resource import HttpLLMResource
 from plugins.builtin.resources.llm_base import LLM
 
+from pipeline.exceptions import ResourceError
 from pipeline.validation import ValidationResult
 
 
@@ -64,4 +65,4 @@ class BaseProvider(LLM):
             except Exception as exc:  # noqa: BLE001 - retry
                 last_exc = exc
                 await asyncio.sleep(2**attempt)
-        raise RuntimeError(f"{self.name} provider request failed") from last_exc
+        raise ResourceError(f"{self.name} provider request failed") from last_exc

--- a/plugins/builtin/resources/llm/providers/bedrock.py
+++ b/plugins/builtin/resources/llm/providers/bedrock.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncIterator, Dict, List
 
 import aioboto3
 
+from pipeline.exceptions import ResourceError
 from pipeline.state import LLMResponse
 from pipeline.validation import ValidationResult
 
@@ -60,7 +61,7 @@ class BedrockProvider(BaseProvider):
         try:
             return await self.http._breaker.call(call)
         except Exception as exc:  # pragma: no cover - bubble up
-            raise RuntimeError("bedrock provider request failed") from exc
+            raise ResourceError("bedrock provider request failed") from exc
 
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None

--- a/plugins/builtin/resources/llm/providers/claude.py
+++ b/plugins/builtin/resources/llm/providers/claude.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Adapter for Anthropic Claude API."""
 from typing import Any, AsyncIterator, Dict, List
 
+from pipeline.exceptions import ResourceError
 from pipeline.state import LLMResponse
 
 from .base import BaseProvider
@@ -18,7 +19,7 @@ class ClaudeProvider(BaseProvider):
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
         if not self.http.validate_config().valid:
-            raise RuntimeError("Claude provider not properly configured")
+            raise ResourceError("Claude provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/messages"
         headers = {
@@ -40,7 +41,7 @@ class ClaudeProvider(BaseProvider):
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
         if not self.http.validate_config().valid:
-            raise RuntimeError("Claude provider not properly configured")
+            raise ResourceError("Claude provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/messages"
         headers = {

--- a/plugins/builtin/resources/llm/providers/gemini.py
+++ b/plugins/builtin/resources/llm/providers/gemini.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Adapter for Google's Gemini API."""
 from typing import Any, AsyncIterator, Dict, List
 
+from pipeline.exceptions import ResourceError
 from pipeline.state import LLMResponse
 
 from .base import BaseProvider
@@ -18,7 +19,7 @@ class GeminiProvider(BaseProvider):
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
         if not self.http.validate_config().valid:
-            raise RuntimeError("Gemini provider not properly configured")
+            raise ResourceError("Gemini provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1beta/models/{self.http.model}:generateContent"
         headers = {"Content-Type": "application/json"}
@@ -39,7 +40,7 @@ class GeminiProvider(BaseProvider):
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
         if not self.http.validate_config().valid:
-            raise RuntimeError("Gemini provider not properly configured")
+            raise ResourceError("Gemini provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1beta/models/{self.http.model}:generateContent"
         headers = {"Content-Type": "application/json"}

--- a/plugins/builtin/resources/llm/providers/ollama.py
+++ b/plugins/builtin/resources/llm/providers/ollama.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Adapter for a running Ollama server."""
 from typing import Any, AsyncIterator, Dict, List
 
+from pipeline.exceptions import ResourceError
 from pipeline.state import LLMResponse
 
 from .base import BaseProvider
@@ -17,7 +18,7 @@ class OllamaProvider(BaseProvider):
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
         if not self.http.validate_config().valid:
-            raise RuntimeError("Ollama provider not properly configured")
+            raise ResourceError("Ollama provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/api/generate"
         payload = {"model": self.http.model, "prompt": prompt, **self.http.params}
@@ -31,7 +32,7 @@ class OllamaProvider(BaseProvider):
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
         if not self.http.validate_config().valid:
-            raise RuntimeError("Ollama provider not properly configured")
+            raise ResourceError("Ollama provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/api/generate"
         payload = {

--- a/plugins/builtin/resources/llm/providers/openai.py
+++ b/plugins/builtin/resources/llm/providers/openai.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """LLM resource for OpenAI's API."""
 from typing import Any, AsyncIterator, Dict, List
 
+from pipeline.exceptions import ResourceError
 from pipeline.state import LLMResponse
 
 from .base import BaseProvider
@@ -18,7 +19,7 @@ class OpenAIProvider(BaseProvider):
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
         if not self.http.validate_config().valid:
-            raise RuntimeError("OpenAI provider not properly configured")
+            raise ResourceError("OpenAI provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/chat/completions"
         headers = {"Authorization": f"Bearer {self.http.api_key}"}
@@ -43,7 +44,7 @@ class OpenAIProvider(BaseProvider):
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
         if not self.http.validate_config().valid:
-            raise RuntimeError("OpenAI provider not properly configured")
+            raise ResourceError("OpenAI provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/chat/completions"
         headers = {"Authorization": f"Bearer {self.http.api_key}"}

--- a/plugins/builtin/resources/ollama_llm.py
+++ b/plugins/builtin/resources/ollama_llm.py
@@ -6,6 +6,7 @@ from typing import Dict
 from plugins.builtin.resources.http_llm_resource import HttpLLMResource
 from plugins.builtin.resources.llm_resource import LLMResource
 
+from pipeline.exceptions import ResourceError
 from pipeline.validation import ValidationResult
 
 
@@ -28,7 +29,7 @@ class OllamaLLMResource(LLMResource):
 
     async def generate(self, prompt: str) -> str:
         if not self.http.validate_config().valid:
-            raise RuntimeError("Ollama resource not properly configured")
+            raise ResourceError("Ollama resource not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/api/generate"
         payload = {"model": self.http.model, "prompt": prompt, **self.http.params}

--- a/plugins/builtin/resources/openai.py
+++ b/plugins/builtin/resources/openai.py
@@ -6,6 +6,7 @@ from typing import Dict
 from plugins.builtin.resources.http_llm_resource import HttpLLMResource
 from plugins.builtin.resources.llm_resource import LLMResource
 
+from pipeline.exceptions import ResourceError
 from pipeline.validation import ValidationResult
 
 
@@ -24,7 +25,7 @@ class OpenAIResource(LLMResource):
 
     async def generate(self, prompt: str) -> str:
         if not self.http.validate_config().valid:
-            raise RuntimeError("OpenAI resource not properly configured")
+            raise ResourceError("OpenAI resource not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/chat/completions"
         headers = {"Authorization": f"Bearer {self.http.api_key}"}

--- a/plugins/builtin/resources/storage_resource.py
+++ b/plugins/builtin/resources/storage_resource.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Dict
 
 from pipeline.base_plugins import ResourcePlugin, ValidationResult
+from pipeline.exceptions import ResourceError
 from pipeline.stages import PipelineStage
 
 from .filesystem import FileSystemResource
@@ -31,12 +32,12 @@ class StorageResource(ResourcePlugin):
 
     async def store_file(self, key: str, content: bytes) -> str:
         if not self.filesystem:
-            raise ValueError("No filesystem backend configured")
+            raise ResourceError("No filesystem backend configured")
         return await self.filesystem.store(key, content)
 
     async def load_file(self, key: str) -> bytes:
         if not self.filesystem:
-            raise ValueError("No filesystem backend configured")
+            raise ResourceError("No filesystem backend configured")
         return await self.filesystem.load(key)
 
     @classmethod

--- a/plugins/builtin/tools/search_tool.py
+++ b/plugins/builtin/tools/search_tool.py
@@ -8,6 +8,7 @@ import httpx
 from pydantic import BaseModel
 
 from pipeline.base_plugins import ToolPlugin
+from pipeline.exceptions import ResourceError
 from pipeline.stages import PipelineStage
 from pipeline.validation.input import validate_params
 
@@ -43,7 +44,7 @@ class SearchTool(ToolPlugin):
                 )
                 response.raise_for_status()
         except httpx.HTTPError as exc:  # pragma: no cover - network error path
-            raise RuntimeError(f"Search request failed: {exc}") from exc
+            raise ResourceError(f"Search request failed: {exc}") from exc
 
         data = response.json()
         topics = data.get("RelatedTopics")

--- a/plugins/builtin/tools/weather_api_tool.py
+++ b/plugins/builtin/tools/weather_api_tool.py
@@ -8,6 +8,7 @@ import httpx
 from pydantic import BaseModel
 
 from pipeline.base_plugins import ToolPlugin
+from pipeline.exceptions import ResourceError
 from pipeline.stages import PipelineStage
 from pipeline.validation.input import validate_params
 
@@ -43,7 +44,7 @@ class WeatherApiTool(ToolPlugin):
                 )
                 response.raise_for_status()
         except httpx.HTTPError as exc:  # pragma: no cover - network error path
-            raise RuntimeError(f"Weather request failed: {exc}") from exc
+            raise ResourceError(f"Weather request failed: {exc}") from exc
 
         return response.json()
 

--- a/src/pipeline/agent.py
+++ b/src/pipeline/agent.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Optional
 from registry import SystemRegistries
 
 from .builder import AgentBuilder
+from .exceptions import PipelineError
 from .runtime import AgentRuntime
 
 
@@ -65,7 +66,7 @@ class Agent:
     @property
     def runtime(self) -> AgentRuntime:
         if self._runtime is None:
-            raise RuntimeError("Agent not initialized; call an async method")
+            raise PipelineError("Agent not initialized; call an async method")
         return self._runtime
 
     async def run_message(self, message: str) -> Dict[str, Any]:
@@ -78,7 +79,7 @@ class Agent:
 
     def get_registries(self) -> SystemRegistries:
         if self._runtime is None:
-            raise RuntimeError("Agent not initialized")
+            raise PipelineError("Agent not initialized")
         return self._runtime.registries
 
     # ------------------------------------------------------------------

--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -18,8 +18,7 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints only
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .initializer import ClassRegistry
 
-from .exceptions import (CircuitBreakerTripped, PluginError,
-                         PluginExecutionError)
+from .exceptions import CircuitBreakerTripped, PipelineError, PluginExecutionError
 from .logging import get_logger
 from .observability.utils import execute_with_observability
 from .stages import PipelineStage
@@ -102,7 +101,7 @@ class BasePlugin(ABC):
             )
             self._failure_count = 0
             return result
-        except PluginError:
+        except PipelineError:
             self._failure_count += 1
             self._last_failure = time.time()
             raise

--- a/src/pipeline/config/utils.py
+++ b/src/pipeline/config/utils.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from ..exceptions import ResourceError
+
 
 def interpolate_env_vars(config: Any) -> Any:
     """Recursively replace ``${VAR}`` strings with environment variables."""
@@ -14,6 +16,6 @@ def interpolate_env_vars(config: Any) -> Any:
         key = config[2:-1]
         value = os.environ.get(key)
         if value is None:
-            raise EnvironmentError(f"Required environment variable {key} not found")
+            raise ResourceError(f"Required environment variable {key} not found")
         return value
     return config

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from datetime import datetime
-from typing import (TYPE_CHECKING, Any, AsyncIterator, Callable, Dict, List,
-                    Optional, TypeVar, cast)
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypeVar,
+    cast,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from interfaces.resources import LLM
@@ -17,8 +26,7 @@ from registry import SystemRegistries
 
 from .metrics import MetricsCollector
 from .stages import PipelineStage
-from .state import (ConversationEntry, FailureInfo, LLMResponse, PipelineState,
-                    ToolCall)
+from .state import ConversationEntry, FailureInfo, LLMResponse, PipelineState, ToolCall
 from .tools.base import RetryOptions
 from .tools.execution import execute_tool
 
@@ -108,11 +116,11 @@ class PluginContext:
         """Return the configured LLM resource.
 
         Raises:
-            RuntimeError: If no ``"llm"`` resource is found.
+            ResourceError: If no ``"llm"`` resource is found.
         """
         llm = self.get_resource("llm")
         if llm is None:
-            raise RuntimeError(
+            raise ResourceError(
                 "No LLM resource configured. Add 'llm' to resources section."
             )
         return cast(LLM, llm)
@@ -302,7 +310,7 @@ class PluginContext:
         """Send ``prompt`` to the configured LLM and return its reply."""
         llm = self.get_llm()
         if llm is None:
-            raise RuntimeError("LLM resource not available")
+            raise ResourceError("LLM resource not available")
 
         self.record_llm_call("PluginContext", "ask_llm")
         start = asyncio.get_event_loop().time()
@@ -312,7 +320,7 @@ class PluginContext:
         else:
             func = getattr(llm, "__call__", None)
             if func is None:
-                raise RuntimeError("LLM resource is not callable")
+                raise ResourceError("LLM resource is not callable")
             if asyncio.iscoroutinefunction(func):
                 response = await func(prompt)
             else:

--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -3,11 +3,17 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict
 
-from .exceptions import PipelineError, ResourceError, ToolExecutionError
+from .exceptions import (
+    PipelineError,
+    PluginExecutionError,
+    ResourceError,
+    ToolExecutionError,
+)
 
 __all__ = [
     "create_static_error_response",
     "PipelineError",
+    "PluginExecutionError",
     "ResourceError",
     "ToolExecutionError",
 ]

--- a/src/pipeline/errors/exceptions.py
+++ b/src/pipeline/errors/exceptions.py
@@ -9,18 +9,34 @@ class PipelineError(Exception):
     """Base class for pipeline errors."""
 
 
+class PluginExecutionError(PipelineError):
+    """Raised when execution of a plugin fails."""
+
+    def __init__(self, plugin_name: str, original_exception: Exception) -> None:
+        self.plugin_name = plugin_name
+        self.original_exception = original_exception
+        super().__init__(f"{plugin_name} failed: {original_exception}")
+
+
 class ResourceError(PipelineError):
     """Raised when a required resource is unavailable or fails."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
 
 
 class ToolExecutionError(PipelineError):
     """Raised when execution of a tool fails."""
 
     def __init__(
-        self, tool_name: str, original_exception: Optional[Exception] = None
+        self,
+        tool_name: str,
+        original_exception: Optional[Exception] = None,
+        result_key: str | None = None,
     ) -> None:
         self.tool_name = tool_name
         self.original_exception = original_exception
+        self.result_key = result_key
         message = f"Tool '{tool_name}' execution failed"
         if original_exception:
             message += f": {original_exception}"

--- a/src/pipeline/exceptions.py
+++ b/src/pipeline/exceptions.py
@@ -1,45 +1,27 @@
-"""Custom exceptions used across the pipeline."""
-
 from __future__ import annotations
 
+"""Compatibility exceptions for pipeline modules."""
 
-class PluginError(Exception):
-    """Base class for plugin related errors."""
-
-
-class PluginExecutionError(PluginError):
-    """Exception raised when a plugin fails during execution.
-
-    Args:
-        plugin_name: Name of the plugin that failed.
-        original_exception: The underlying exception that triggered this error.
-    """
-
-    def __init__(self, plugin_name: str, original_exception: Exception) -> None:
-        self.plugin_name = plugin_name
-        self.original_exception = original_exception
-        super().__init__(str(original_exception))
+from .errors import (
+    PipelineError,
+    PluginExecutionError,
+    ResourceError,
+    ToolExecutionError,
+)
 
 
-class ToolExecutionError(PluginError):
-    """Exception raised when a tool fails during execution."""
-
-    def __init__(
-        self, tool_name: str, original_exception: Exception, result_key: str
-    ) -> None:
-        self.tool_name = tool_name
-        self.original_exception = original_exception
-        self.result_key = result_key
-        super().__init__(str(original_exception))
-
-
-class CircuitBreakerTripped(PluginError):
-    """Raised when repeated plugin failures prevent execution.
-
-    Args:
-        plugin_name: Name of the plugin whose circuit breaker tripped.
-    """
+class CircuitBreakerTripped(PipelineError):
+    """Raised when repeated plugin failures prevent execution."""
 
     def __init__(self, plugin_name: str) -> None:
         self.plugin_name = plugin_name
         super().__init__(f"Circuit breaker tripped for {plugin_name}")
+
+
+__all__ = [
+    "PipelineError",
+    "PluginExecutionError",
+    "ToolExecutionError",
+    "ResourceError",
+    "CircuitBreakerTripped",
+]

--- a/src/pipeline/resources/llm/unified.py
+++ b/src/pipeline/resources/llm/unified.py
@@ -7,16 +7,20 @@ from typing import Any, AsyncIterator, Dict, List, Type
 
 # Import provider implementations from the public plugin package. Using the
 # fully qualified path avoids ambiguity if this module is restructured.
-from plugins.builtin.resources.llm.providers import (BedrockProvider,
-                                                     ClaudeProvider,
-                                                     EchoProvider,
-                                                     GeminiProvider,
-                                                     OllamaProvider,
-                                                     OpenAIProvider)
+from plugins.builtin.resources.llm.providers import (
+    BedrockProvider,
+    ClaudeProvider,
+    EchoProvider,
+    GeminiProvider,
+    OllamaProvider,
+    OpenAIProvider,
+)
 from plugins.builtin.resources.llm_resource import LLMResource
 
 from pipeline.base_plugins import ValidationResult
 from pipeline.state import LLMResponse
+
+from ...exceptions import ResourceError
 
 
 class UnifiedLLMResource(LLMResource):
@@ -100,7 +104,7 @@ class UnifiedLLMResource(LLMResource):
                 continue
         if last_exc:
             raise last_exc
-        raise RuntimeError("No provider available")
+        raise ResourceError("No provider available")
 
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None

--- a/src/pipeline/tools/builtin.py
+++ b/src/pipeline/tools/builtin.py
@@ -7,6 +7,8 @@ from typing import Any
 import httpx
 from plugins.contrib.tools.calculator_tool import SafeEvaluator
 
+from ..exceptions import ResourceError
+
 
 def calculator(expression: str) -> Any:
     """Evaluate an arithmetic expression."""
@@ -23,7 +25,7 @@ def search(query: str) -> str:
         resp.raise_for_status()
         data = resp.json()
     except Exception as exc:  # noqa: BLE001 - network errors
-        raise RuntimeError(f"Search request failed: {exc}") from exc
+        raise ResourceError(f"Search request failed: {exc}") from exc
 
     topics = data.get("RelatedTopics")
     if topics and isinstance(topics, list):

--- a/src/pipeline/tools/execution.py
+++ b/src/pipeline/tools/execution.py
@@ -27,7 +27,11 @@ async def execute_tool(
                 return await tool.execute_function(call.params)
             func = getattr(tool, "run", None)
             if func is None:
-                raise RuntimeError("Tool lacks execution method")
+                raise ToolExecutionError(
+                    call.name,
+                    RuntimeError("Tool lacks execution method"),
+                    call.result_key,
+                )
             if asyncio.iscoroutinefunction(func):
                 async_func = cast(Callable[[Dict[str, Any]], Awaitable[ResultT]], func)
                 return await async_func(call.params)
@@ -37,7 +41,9 @@ async def execute_tool(
             if attempt == options.max_retries:
                 raise
             await asyncio.sleep(options.delay)
-    raise RuntimeError("Tool execution failed")
+    raise ToolExecutionError(
+        call.name, RuntimeError("Tool execution failed"), call.result_key
+    )
 
 
 async def execute_pending_tools(

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -2,17 +2,37 @@ import asyncio
 
 from plugins.contrib.failure.basic_logger import BasicLogger
 
-from pipeline import (FailurePlugin, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry, execute_pipeline)
-from pipeline.errors import create_static_error_response
+from pipeline import (
+    FailurePlugin,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.errors import (
+    PipelineError,
+    PluginExecutionError,
+    ResourceError,
+    ToolExecutionError,
+    create_static_error_response,
+)
 
 
 class BoomPlugin(PromptPlugin):
     stages = [PipelineStage.DO]
 
     async def _execute_impl(self, context):
-        raise RuntimeError("boom")
+        raise PluginExecutionError("BoomPlugin", RuntimeError("boom"))
+
+
+class ResourceFailPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        raise ResourceError("missing resource")
 
 
 class FallbackPlugin(FailurePlugin):
@@ -23,9 +43,9 @@ class FallbackPlugin(FailurePlugin):
         context.set_response({"error": info.error_message})
 
 
-def make_registries(error_plugin):
+def make_registries(error_plugin, main_plugin=BoomPlugin):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(BoomPlugin({}), PipelineStage.DO))
+    asyncio.run(plugins.register_plugin_for_stage(main_plugin({}), PipelineStage.DO))
     asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
     asyncio.run(
         plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
@@ -44,3 +64,15 @@ def test_static_error_response():
     resp = create_static_error_response(pipeline_id)
     assert resp["error_id"] == pipeline_id
     assert resp["type"] == "static_fallback"
+
+
+def test_error_hierarchy():
+    assert issubclass(PluginExecutionError, PipelineError)
+    assert issubclass(ToolExecutionError, PipelineError)
+    assert issubclass(ResourceError, PipelineError)
+
+
+def test_resource_error_propagation():
+    registries = make_registries(FallbackPlugin, main_plugin=ResourceFailPlugin)
+    result = asyncio.run(execute_pipeline("hi", registries))
+    assert result == {"error": "missing resource"}


### PR DESCRIPTION
## Summary
- define `PipelineError` and subclasses for plugin, tool, and resource failures
- catch new errors in the pipeline execution path
- convert builtin plugins to raise structured errors
- update tests to cover the new error hierarchy

## Testing
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: found errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6869ed3c8ff48322a7bf70bd0bc83e36