### PR TITLE
Implement tool parameter models and validation

### DIFF
--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar
 
 import yaml
+from pydantic import BaseModel, ValidationError
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .context import PluginContext
@@ -18,12 +19,15 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints only
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .initializer import ClassRegistry
 
-from .exceptions import (CircuitBreakerTripped, PluginError,
-                         PluginExecutionError)
+# isort: off
+from .errors import ToolExecutionError
+from .exceptions import CircuitBreakerTripped, PluginError, PluginExecutionError
 from .logging import get_logger
 from .observability.utils import execute_with_observability
 from .stages import PipelineStage
 from .validation import ValidationResult
+
+# isort: on
 
 logger = logging.getLogger(__name__)
 
@@ -313,11 +317,21 @@ class ToolPlugin(BasePlugin):
         """Ensure all :attr:`required_params` are present in ``params``."""
         missing = [p for p in self.required_params if params.get(p) is None]
         if missing:
-            raise ValueError(f"Missing required parameters: {', '.join(missing)}")
+            raise ToolExecutionError(
+                self.__class__.__name__,
+                ValueError(f"Missing required parameters: {', '.join(missing)}"),
+            )
         return True
 
     def validate_tool_params(self, params: Dict[str, Any]) -> bool:
-        """Public hook for validating tool parameters."""
+        """Validate ``params`` using a :class:`pydantic.BaseModel` if provided."""
+        model_cls: Type[BaseModel] | None = getattr(self, "Params", None)
+        if model_cls is not None and issubclass(model_cls, BaseModel):
+            try:
+                model_cls(**params)
+            except ValidationError as exc:
+                raise ToolExecutionError(self.__class__.__name__, exc) from exc
+            return True
         return self._validate_required_params(params)
 
     def __init__(self, config: Dict | None = None) -> None:

--- a/src/pipeline/logging.py
+++ b/src/pipeline/logging.py
@@ -8,8 +8,8 @@ from importlib import import_module
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
-    from plugins.builtin.adapters.logging_adapter import JsonFormatter as _JsonFormatter
-    from plugins.builtin.adapters.logging_adapter import (
+    from plugins.builtin.adapters.logging_adapter import (  # noqa: F401, isort: skip
+        JsonFormatter as _JsonFormatter,
         RequestIdFilter as _RequestIdFilter,
     )
 

--- a/tests/test_tool_parameter_validation.py
+++ b/tests/test_tool_parameter_validation.py
@@ -1,0 +1,38 @@
+import asyncio
+
+import pytest
+from plugins.builtin.tools.search_tool import SearchTool
+from pydantic import BaseModel
+
+from pipeline.base_plugins import ToolPlugin
+from pipeline.errors import ToolExecutionError
+
+
+class EchoTool(ToolPlugin):
+    class Params(BaseModel):
+        text: str
+
+    async def execute_function(self, params: Params):
+        return params.text
+
+
+async def run(tool, params):
+    return await tool.execute_function_with_retry(params)
+
+
+def test_builtin_tool_invalid_params():
+    tool = SearchTool()
+    with pytest.raises(ToolExecutionError):
+        asyncio.run(run(tool, {}))
+
+
+def test_custom_tool_param_validation():
+    tool = EchoTool({})
+    result = asyncio.run(run(tool, {"text": "hi"}))
+    assert result == "hi"
+
+
+def test_custom_tool_invalid_param():
+    tool = EchoTool({})
+    with pytest.raises(ToolExecutionError):
+        asyncio.run(run(tool, {}))

--- a/tests/test_tool_plugin.py
+++ b/tests/test_tool_plugin.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from pipeline.base_plugins import ToolPlugin
+from pipeline.errors import ToolExecutionError
 
 
 class EchoTool(ToolPlugin):
@@ -24,5 +25,5 @@ def test_tool_plugin_valid_params():
 
 def test_tool_plugin_missing_param():
     tool = EchoTool({})
-    with pytest.raises(ValueError):
+    with pytest.raises(ToolExecutionError):
         asyncio.run(run_tool(tool, {}))


### PR DESCRIPTION
## Summary
- use pydantic models for validating ToolPlugin parameters
- raise ToolExecutionError when validation fails
- fix logging imports
- test parameter validation behaviour

## Testing
- `poetry run flake8 src/pipeline/base_plugins.py src/pipeline/logging.py tests/test_tool_plugin.py tests/test_tool_parameter_validation.py`
- `poetry run mypy src/pipeline/base_plugins.py src/pipeline/logging.py` *(fails: Function is missing a return type annotation)*
- `bandit -r src/pipeline/base_plugins.py src/pipeline/logging.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ImportError: cannot import name 'llm_pb2_grpc')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ImportError: cannot import name 'llm_pb2_grpc')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ImportError: cannot import name 'llm_pb2_grpc')*

------
https://chatgpt.com/codex/tasks/task_e_6869ed5018c48322bbb563fe13a3d4a9