### PR TITLE
Replace ResourceRegistry exports with ResourceContainer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,10 +53,11 @@ The pipeline follows a **single-execution pattern** optimized for reconfigurable
 **Why Single Execution for Agents**: Predictable execution patterns make behavior changes more reliable and easier to debug. Plugin swaps produce consistent results because the execution flow remains stable.
 
 ```python
-from enum import Enum, auto
 from dataclasses import dataclass, field
-from typing import Dict, List, Any, Optional
 from datetime import datetime
+from enum import Enum, auto
+from typing import Any, Dict, List, Optional
+
 
 async def execute_pipeline(request):
     """Main pipeline execution with layered context"""
@@ -73,7 +74,7 @@ async def execute_pipeline(request):
     )
     
     registries = SystemRegistries(
-        resources=resource_registry,
+        resources=resource_container,
         tools=tool_registry,
         plugins=plugin_registry
     )
@@ -959,7 +960,7 @@ class PluginContext:
 @dataclass
 class SystemRegistries:
     """Container for all system registries"""
-    resources: ResourceRegistry
+    resources: ResourceContainer
     tools: ToolRegistry
     plugins: PluginRegistry
 ```
@@ -1183,13 +1184,13 @@ class SystemInitializer:
                     raise SystemError(f"Config validation failed for {plugin_class.__name__}: {config_result.error_message}")
             
             # Phase 3: Initialize resources and tools
-            resource_registry = ResourceRegistry()
+            resource_container = ResourceContainer()
             tool_registry = ToolRegistry()
             
             for resource_class, config in registry.resource_classes():
                 instance = resource_class(config)
                 await instance.initialize()
-                resource_registry.add_resource(instance)
+                resource_container.add_resource(instance)
             
             for tool_class, config in registry.tool_classes():
                 instance = tool_class(config)
@@ -1201,7 +1202,7 @@ class SystemInitializer:
                 instance = plugin_class(config)
                 plugin_registry.add_plugin(instance)
             
-            return plugin_registry, resource_registry, tool_registry
+            return plugin_registry, resource_container, tool_registry
 
     def _validate_dependency_graph(self, registry, dep_graph: Dict[str, List[str]]):
         """Validate dependency graph: check existence and detect circular dependencies"""

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -28,7 +28,7 @@ from .plugins.contrib import (
     ValidationResult,
 )
 from .registries import PluginRegistry, ResourceRegistry, SystemRegistries, ToolRegistry
-from .resources import LLM, BaseResource, Resource
+from .resources import LLM, BaseResource, Resource, ResourceContainer
 from .runtime import AgentRuntime
 from .stages import PipelineStage
 from .state import FailureInfo, LLMResponse, PipelineState
@@ -62,7 +62,7 @@ __all__ = [
     "ReconfigResult",
     "ConfigurationError",
     "PluginRegistry",
-    "ResourceRegistry",
+    "ResourceContainer",
     "ToolRegistry",
     "ClassRegistry",
     "SystemInitializer",

--- a/src/pipeline/registries.py
+++ b/src/pipeline/registries.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from pipeline.initializer import ClassRegistry
-from registry.registries import (PluginRegistry, ResourceRegistry,
-                                 SystemRegistries, ToolRegistry)
+from pipeline.resources import ResourceContainer
+from registry.registries import (
+    PluginRegistry,
+    ResourceRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 
 __all__ = [
     "PluginRegistry",
-    "ResourceRegistry",
+    "ResourceContainer",
     "SystemRegistries",
     "ToolRegistry",
     "ClassRegistry",

--- a/src/registry/__init__.py
+++ b/src/registry/__init__.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from .registries import (PluginRegistry, ResourceRegistry, SystemRegistries,
-                         ToolRegistry)
+from pipeline.resources import ResourceContainer
+
+from .registries import PluginRegistry, ResourceRegistry, SystemRegistries, ToolRegistry
 from .validator import RegistryValidator
 
 __all__ = [
     "PluginRegistry",
-    "ResourceRegistry",
+    "ResourceContainer",
     "ToolRegistry",
     "SystemRegistries",
     "RegistryValidator",


### PR DESCRIPTION
## Summary
- swap `ResourceRegistry` references in the architecture guide with `ResourceContainer`
- expose `ResourceContainer` from `registry` and `pipeline` packages
- export `ResourceContainer` via `pipeline.registries`

## Testing
- `poetry run black src/registry/__init__.py src/pipeline/__init__.py src/pipeline/registries.py`
- `poetry run isort src/registry/__init__.py src/pipeline/__init__.py src/pipeline/registries.py ARCHITECTURE.md`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: invalid syntax in memory_resource.py)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: SyntaxError in base_plugins.py)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: SyntaxError in base_plugins.py)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: SyntaxError in base_plugins.py)*

------
https://chatgpt.com/codex/tasks/task_e_6869f2bf99448322a57a723ceb529a78