### PR TITLE
Update tests to use ResourceContainer

### DIFF
--- a/tests/integration/test_chaos.py
+++ b/tests/integration/test_chaos.py
@@ -5,8 +5,8 @@ import pytest
 
 from pipeline import PipelineStage, execute_pipeline
 from pipeline.reliability.queue import PersistentQueue
-from registry import (PluginRegistry, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline.resources import ResourceContainer
+from registry import PluginRegistry, SystemRegistries, ToolRegistry
 
 
 class CrashPlugin:
@@ -25,7 +25,7 @@ def test_pipeline_resume_after_crash(tmp_path: Path):
         state_file = tmp_path / "state.json"
         plugins = PluginRegistry()
         await plugins.register_plugin_for_stage(CrashPlugin(), PipelineStage.PARSE)
-        registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+        registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
         try:
             await execute_pipeline("hi", registries, state_file=str(state_file))
         except RuntimeError:

--- a/tests/integration/test_chat_history_backends.py
+++ b/tests/integration/test_chat_history_backends.py
@@ -7,9 +7,17 @@ import pytest
 from plugins.contrib.prompts.chat_history import ChatHistory
 
 from config.environment import load_env
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginContext, PluginRegistry,
-                      ResourceRegistry, SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 from pipeline.resources.duckdb_database import DuckDBDatabaseResource
 from pipeline.resources.memory_resource import MemoryResource
 from pipeline.resources.memory_storage import MemoryStorage
@@ -37,7 +45,7 @@ async def run_history_test(resource):
         await resource.initialize()
 
     memory = MemoryResource(storage=resource)
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     await resources.add("memory", memory)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     state = PipelineState(

--- a/tests/integration/test_stage_failures.py
+++ b/tests/integration/test_stage_failures.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import pytest
 
 from pipeline import PipelineStage, execute_pipeline
-from registry import (PluginRegistry, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline.resources import ResourceContainer
+from registry import PluginRegistry, SystemRegistries, ToolRegistry
 
 
 class RespondPlugin:
@@ -47,7 +47,7 @@ def test_pipeline_recovers_from_stage_failure(
         plugins = PluginRegistry()
         plugins.register_plugin_for_stage(make_failing_plugin(stage), stage)
         plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DO)
-        registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+        registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
         try:
             await execute_pipeline("hi", registries, state_file=str(state_file))
         except RuntimeError:

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -7,9 +7,16 @@ import pytest
 from plugins.contrib.prompts.complex_prompt import ComplexPrompt
 
 from config.environment import load_env
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 from pipeline.resources.llm import UnifiedLLMResource
 from pipeline.resources.memory_resource import MemoryResource
 from pipeline.resources.pg_vector_store import PgVectorStore
@@ -69,7 +76,7 @@ def test_vector_memory_integration():
         )
         await memory.save_conversation("conv1", [history_entry])
         await vm.add_embedding("previous")
-        resources = ResourceRegistry()
+        resources = ResourceContainer()
         await resources.add("memory", memory)
         await resources.add("llm", llm)
         registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())

--- a/tests/performance/test_full_pipeline_benchmark.py
+++ b/tests/performance/test_full_pipeline_benchmark.py
@@ -2,8 +2,14 @@ import asyncio
 
 import pytest
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      ResourceRegistry, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class RespondPlugin:
@@ -17,7 +23,7 @@ class RespondPlugin:
 def test_full_pipeline_benchmark(benchmark):
     plugins = PluginRegistry()
     plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DO)
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
 
     def run():

--- a/tests/performance/test_pipeline_benchmark.py
+++ b/tests/performance/test_pipeline_benchmark.py
@@ -2,9 +2,15 @@ import asyncio
 
 import pytest
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class NoOpPlugin(PromptPlugin):
@@ -17,7 +23,7 @@ class NoOpPlugin(PromptPlugin):
 def _make_manager():
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DO))
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 
 

--- a/tests/registry/test_thread_safety.py
+++ b/tests/registry/test_thread_safety.py
@@ -1,8 +1,9 @@
 import asyncio
 
+from pipeline.resources import ResourceContainer
 from pipeline.stages import PipelineStage
 from pipeline.user_plugins import PromptPlugin
-from registry.registries import PluginRegistry, ResourceRegistry, ToolRegistry
+from registry.registries import PluginRegistry, ToolRegistry
 
 
 class DummyPlugin(PromptPlugin):
@@ -24,7 +25,7 @@ async def test_plugin_registry_thread_safety():
 
 
 async def test_resource_and_tool_registry_thread_safety():
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     tools = ToolRegistry()
 
     async def add_resource(i):

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -1,11 +1,17 @@
 import asyncio
 import time
 
-from pipeline import (PipelineStage, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolPlugin, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.base_plugins import PluginAutoClassifier
 from pipeline.context import PluginContext
+from pipeline.resources import ResourceContainer
 
 
 class SleepTool(ToolPlugin):
@@ -20,7 +26,7 @@ async def use_tool_plugin(ctx: PluginContext) -> None:
 
 
 def make_registries() -> SystemRegistries:
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     tools = ToolRegistry()
     asyncio.run(tools.add("sleep", SleepTool({})))
     plugins = PluginRegistry()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,11 +3,19 @@ from datetime import datetime
 from plugins.contrib.resources.cache import CacheResource
 
 import pipeline.context as context_module
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginContext, PluginRegistry,
-                      ResourceRegistry, SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.base_plugins import PromptPlugin
 from pipeline.cache import InMemoryCache
+from pipeline.resources import ResourceContainer
 from pipeline.resources.llm_base import LLM
 from pipeline.state import ToolCall
 from pipeline.tools.execution import execute_pending_tools
@@ -49,7 +57,7 @@ async def make_context(cache: CacheResource, llm: FakeLLM):
         metrics=MetricsCollector(),
         current_stage=PipelineStage.THINK,
     )
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     await resources.add("llm", llm)
     await resources.add("cache", cache)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())

--- a/tests/test_call_llm_logging.py
+++ b/tests/test_call_llm_logging.py
@@ -1,10 +1,18 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginContext, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class FakeLLM:
@@ -30,7 +38,7 @@ def make_context(llm: FakeLLM) -> PluginContext:
         metrics=MetricsCollector(),
         current_stage=PipelineStage.THINK,
     )
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     asyncio.run(resources.add("llm", llm))
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return PluginContext(state, registries)

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -3,9 +3,16 @@ from datetime import datetime
 
 from plugins.contrib.prompts.chain_of_thought import ChainOfThoughtPrompt
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class FakeLLM:
@@ -33,7 +40,7 @@ def make_context(llm: FakeLLM):
         pipeline_id="1",
         metrics=MetricsCollector(),
     )
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     tools = ToolRegistry()
     plugins = PluginRegistry()
     asyncio.run(resources.add("llm", llm))

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -3,9 +3,15 @@ import asyncio
 from plugins.contrib.failure.basic_logger import BasicLogger
 from plugins.contrib.failure.error_formatter import ErrorFormatter
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      ResourceRegistry, SystemRegistries, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.resources import ResourceContainer
 
 
 class UnstablePlugin(PromptPlugin):
@@ -27,7 +33,7 @@ def make_registries():
     asyncio.run(
         plugins.register_plugin_for_stage(ErrorFormatter({}), PipelineStage.ERROR)
     )
-    return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 
 def test_circuit_breaker_trips():

--- a/tests/test_cli_adapter.py
+++ b/tests/test_cli_adapter.py
@@ -4,9 +4,15 @@ from typing import Any
 
 from plugins.builtin.adapters.cli import CLIAdapter
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class EchoPlugin(PromptPlugin):
@@ -20,7 +26,7 @@ class EchoPlugin(PromptPlugin):
 def make_adapter() -> tuple[CLIAdapter, SystemRegistries]:
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO))
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return CLIAdapter(manager), registries
 

--- a/tests/test_complex_prompt.py
+++ b/tests/test_complex_prompt.py
@@ -4,9 +4,16 @@ from unittest.mock import AsyncMock
 
 from plugins.contrib.prompts.complex_prompt import ComplexPrompt
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 from pipeline.resources.memory_resource import MemoryResource
 
 
@@ -40,7 +47,7 @@ def make_context(llm, memory):
         pipeline_id="1",
         metrics=MetricsCollector(),
     )
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     asyncio.run(resources.add("llm", llm))
     asyncio.run(resources.add("memory", memory))
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())

--- a/tests/test_config_update.py
+++ b/tests/test_config_update.py
@@ -1,9 +1,17 @@
 import asyncio
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry, ValidationResult, execute_pipeline,
-                      update_plugin_configuration)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    ValidationResult,
+    execute_pipeline,
+    update_plugin_configuration,
+)
+from pipeline.resources import ResourceContainer
 
 
 class TestReconfigPlugin(PromptPlugin):
@@ -66,7 +74,7 @@ def test_update_plugin_configuration_restart_required():
 def test_update_waits_for_running_pipeline():
     async def run_test():
         reg, plugin = make_registry(add_slow=True)
-        registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), reg)
+        registries = SystemRegistries(ResourceContainer(), ToolRegistry(), reg)
         manager = PipelineManager()
         task = asyncio.create_task(
             execute_pipeline("hello", registries, pipeline_manager=manager)

--- a/tests/test_conversation_history_plugin.py
+++ b/tests/test_conversation_history_plugin.py
@@ -4,9 +4,16 @@ from unittest.mock import AsyncMock
 
 from plugins.contrib.prompts.conversation_history import ConversationHistory
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 from pipeline.resources.memory_resource import MemoryResource
 from pipeline.stages import PipelineStage
 
@@ -33,7 +40,7 @@ def make_context(db: FakeMemory):
         pipeline_id="1",
         metrics=MetricsCollector(),
     )
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     asyncio.run(resources.add("memory", db))
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return state, PluginContext(state, registries)

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1,8 +1,15 @@
 import asyncio
 
-from pipeline import (ConversationManager, PipelineManager, PipelineStage,
-                      PluginRegistry, PromptPlugin, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationManager,
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class ContinuePlugin(PromptPlugin):
@@ -25,7 +32,7 @@ def make_manager():
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DO))
     asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     conv = ConversationManager(registries, manager)
     return conv, manager

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -7,7 +7,6 @@ from pipeline import (
     PipelineStage,
     PluginRegistry,
     PromptPlugin,
-    ResourceRegistry,
     SystemRegistries,
     ToolRegistry,
     execute_pipeline,
@@ -19,6 +18,7 @@ from pipeline.errors import (
     ToolExecutionError,
     create_static_error_response,
 )
+from pipeline.resources import ResourceContainer
 
 
 class BoomPlugin(PromptPlugin):
@@ -50,7 +50,7 @@ def make_registries(error_plugin, main_plugin=BoomPlugin):
     asyncio.run(
         plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
     )
-    return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 
 def test_error_plugin_runs():

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -1,3 +1,5 @@
+from pipeline.resources import ResourceContainer
+
 # isort: off
 import asyncio
 import logging
@@ -7,7 +9,6 @@ from pipeline import (
     PipelineStage,
     PluginRegistry,
     PromptPlugin,
-    ResourceRegistry,
     SystemRegistries,
     ToolRegistry,
     execute_pipeline,
@@ -48,7 +49,7 @@ def make_registries(error_plugin):
     asyncio.run(
         plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
     )
-    return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 
 def test_error_stage_execution(caplog):

--- a/tests/test_execute_pending_tools.py
+++ b/tests/test_execute_pending_tools.py
@@ -1,9 +1,16 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginRegistry, ResourceRegistry, SystemRegistries,
-                      ToolCall, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginRegistry,
+    SystemRegistries,
+    ToolCall,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 from pipeline.tools.execution import execute_pending_tools
 
 
@@ -28,7 +35,7 @@ def make_state():
 
 def test_execute_pending_tools_returns_mapping_by_result_key():
     state = make_state()
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), PluginRegistry())
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), PluginRegistry())
     asyncio.run(registries.tools.add("echo", EchoTool()))
 
     results = asyncio.run(execute_pending_tools(state, registries))

--- a/tests/test_execute_stage.py
+++ b/tests/test_execute_stage.py
@@ -3,10 +3,17 @@ from datetime import datetime
 
 import pytest
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.pipeline import execute_stage
+from pipeline.resources import ResourceContainer
 
 
 class GenericFailPlugin:
@@ -36,7 +43,7 @@ def make_state():
 def make_registries(plugin):
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DO))
-    return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 
 def test_generic_error_sets_failure_info():

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -3,9 +3,15 @@ import asyncio
 import httpx
 from plugins.builtin.adapters import HTTPAdapter
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class RespPlugin(PromptPlugin):
@@ -19,7 +25,7 @@ class RespPlugin(PromptPlugin):
 def make_adapter(config=None):
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return HTTPAdapter(manager, config)
 

--- a/tests/test_intent_classifier_prompt.py
+++ b/tests/test_intent_classifier_prompt.py
@@ -3,9 +3,16 @@ from datetime import datetime
 
 from plugins.contrib.prompts.intent_classifier import IntentClassifierPrompt
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class FakeLLM:
@@ -21,7 +28,7 @@ def make_context(llm: FakeLLM):
         pipeline_id="1",
         metrics=MetricsCollector(),
     )
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     asyncio.run(resources.add("llm", llm))
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())
     return state, PluginContext(state, registries)

--- a/tests/test_llm_helpers.py
+++ b/tests/test_llm_helpers.py
@@ -3,10 +3,18 @@ from datetime import datetime
 
 import pytest
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginContext, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class StubLLM:
@@ -22,7 +30,7 @@ def make_context(llm=None) -> PluginContext:
         pipeline_id="1",
         metrics=MetricsCollector(),
     )
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     if llm is not None:
         asyncio.run(resources.add("llm", llm))
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())

--- a/tests/test_logging_adapter.py
+++ b/tests/test_logging_adapter.py
@@ -8,10 +8,10 @@ from pipeline import (
     PipelineStage,
     PluginRegistry,
     PromptPlugin,
-    ResourceRegistry,
     SystemRegistries,
     ToolRegistry,
 )
+from pipeline.resources import ResourceContainer
 
 
 class EchoPlugin(PromptPlugin):
@@ -28,7 +28,7 @@ def make_manager() -> PipelineManager:
     asyncio.run(
         plugins.register_plugin_for_stage(LoggingAdapter({}), PipelineStage.DELIVER)
     )
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 
 

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -3,13 +3,18 @@ from datetime import datetime
 
 from plugins.builtin.resources.memory_storage import MemoryStorage
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      ResourceRegistry, SystemRegistries, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.context import ConversationEntry
+from pipeline.resources import ResourceContainer
 from pipeline.resources.memory import Memory
-from pipeline.resources.memory_resource import (MemoryResource,
-                                                SimpleMemoryResource)
+from pipeline.resources.memory_resource import MemoryResource, SimpleMemoryResource
 
 
 class IncrementPlugin(PromptPlugin):
@@ -28,7 +33,7 @@ def make_registries():
     asyncio.run(
         plugins.register_plugin_for_stage(IncrementPlugin({}), PipelineStage.DO)
     )
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     asyncio.run(resources.add("memory", SimpleMemoryResource()))
     return SystemRegistries(resources, ToolRegistry(), plugins)
 

--- a/tests/test_memory_retrieval_prompt.py
+++ b/tests/test_memory_retrieval_prompt.py
@@ -3,11 +3,17 @@ from datetime import datetime
 
 from plugins.contrib.prompts.memory_retrieval import MemoryRetrievalPrompt
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
-from pipeline.resources.memory_resource import (MemoryResource,
-                                                SimpleMemoryResource)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
+from pipeline.resources.memory_resource import MemoryResource, SimpleMemoryResource
 
 
 class DummyMemory(MemoryResource):
@@ -30,7 +36,7 @@ def make_context(memory: MemoryResource | None = None):
     ]
     memory = memory or SimpleMemoryResource()
     asyncio.run(memory.save_conversation("1", past))
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     asyncio.run(resources.add("memory", memory))
 
     state = PipelineState(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,8 +1,16 @@
 import asyncio
 
-from pipeline import (LLMResponse, PipelineStage, PluginRegistry, PromptPlugin,
-                      ResourceRegistry, SystemRegistries, ToolPlugin,
-                      ToolRegistry, execute_pipeline)
+from pipeline import (
+    LLMResponse,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.resources import ResourceContainer
 
 
 class EchoLLM:
@@ -29,7 +37,7 @@ class MetricsPlugin(PromptPlugin):
 def make_registries():
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DO))
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     asyncio.run(resources.add("llm", EchoLLM()))
     tools = ToolRegistry()
     asyncio.run(tools.add("echo", EchoTool({})))

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,9 +1,15 @@
 import asyncio
 import time
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      ResourceRegistry, SystemRegistries, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.resources import ResourceContainer
 
 
 class TimedPlugin(PromptPlugin):
@@ -17,7 +23,7 @@ class TimedPlugin(PromptPlugin):
 def make_registries():
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(TimedPlugin({}), PipelineStage.DO))
-    return SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 
 def test_metrics_overhead():

--- a/tests/test_pii_scrubber_plugin.py
+++ b/tests/test_pii_scrubber_plugin.py
@@ -3,9 +3,16 @@ from datetime import datetime
 
 from plugins.contrib.prompts.pii_scrubber import PIIScrubberPrompt
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 def make_context():
@@ -21,7 +28,7 @@ def make_context():
         metrics=MetricsCollector(),
     )
     state.response = "Contact admin@example.com at (123) 456-7890"
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), PluginRegistry())
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), PluginRegistry())
     return state, PluginContext(state, registries)
 
 

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -1,8 +1,14 @@
 import asyncio
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class WaitPlugin(PromptPlugin):
@@ -16,7 +22,7 @@ class WaitPlugin(PromptPlugin):
 def make_manager():
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(WaitPlugin({}), PipelineStage.DO))
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 
 

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -9,11 +9,11 @@ from pipeline import (
     PipelineState,
     PluginRegistry,
     PromptPlugin,
-    ResourceRegistry,
     SystemRegistries,
     ToolRegistry,
 )
 from pipeline.pipeline import execute_pipeline
+from pipeline.resources import ResourceContainer
 
 
 class RespondPlugin(PromptPlugin):
@@ -52,7 +52,7 @@ def test_restore_replaces_state():
 def test_execute_pipeline_persists_snapshots(tmp_path: Path):
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     snap_dir = tmp_path / "snaps"
     result = asyncio.run(
         execute_pipeline("hello", registries, snapshots_dir=str(snap_dir))

--- a/tests/test_plugin_layers.py
+++ b/tests/test_plugin_layers.py
@@ -1,10 +1,17 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, ResourcePlugin,
-                      ResourceRegistry, SystemRegistries, ToolPlugin,
-                      ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    ResourcePlugin,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.base_plugins import PluginAutoClassifier
 from pipeline.context import PluginContext
+from pipeline.resources import ResourceContainer
 
 
 class MyResource(ResourcePlugin):
@@ -27,7 +34,7 @@ async def my_prompt(ctx: PluginContext) -> None:
 
 
 def make_registries() -> SystemRegistries:
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     asyncio.run(resources.add("resource", MyResource({})))
     tools = ToolRegistry()
     asyncio.run(tools.add("tool", MyTool({})))

--- a/tests/test_plugin_registry_order.py
+++ b/tests/test_plugin_registry_order.py
@@ -2,9 +2,16 @@ import asyncio
 
 import yaml
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      ResourceRegistry, SystemInitializer, SystemRegistries,
-                      ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemInitializer,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.resources import ResourceContainer
 
 
 class First(PromptPlugin):
@@ -48,7 +55,7 @@ def test_plugin_priority_order_matches_execution():
     asyncio.run(registry.register_plugin_for_stage(First({}), PipelineStage.DO))
     asyncio.run(registry.register_plugin_for_stage(Third({}), PipelineStage.DO))
     asyncio.run(registry.register_plugin_for_stage(Second({}), PipelineStage.DO))
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), registry)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), registry)
     result = asyncio.run(execute_pipeline("hi", registries))
     assert result == ["third", "second", "first"]
 

--- a/tests/test_react_prompt.py
+++ b/tests/test_react_prompt.py
@@ -4,9 +4,16 @@ from datetime import datetime
 from plugins.contrib.prompts.react_prompt import ReActPrompt
 from plugins.contrib.tools.calculator_tool import CalculatorTool
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class FakeLLM:
@@ -29,7 +36,7 @@ def make_context(llm: FakeLLM):
         pipeline_id="1",
         metrics=MetricsCollector(),
     )
-    resources = ResourceRegistry()
+    resources = ResourceContainer()
     tools = ToolRegistry()
     plugins = PluginRegistry()
     asyncio.run(resources.add("llm", llm))

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -4,9 +4,16 @@ from unittest.mock import AsyncMock, patch
 
 from plugins.contrib.tools.search_tool import SearchTool
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 from pipeline.tools.execution import execute_pending_tools
 
 
@@ -30,7 +37,7 @@ async def run_search():
     )
     tools = ToolRegistry()
     await tools.add("search", SearchTool())
-    registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
+    registries = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
     ctx = PluginContext(state, registries)
     with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=FakeResponse())):
         key = ctx.execute_tool("search", {"query": "test"})

--- a/tests/test_tool_error_propagation.py
+++ b/tests/test_tool_error_propagation.py
@@ -3,9 +3,16 @@ import asyncio
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      ResourceRegistry, SystemRegistries, ToolPlugin,
-                      ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.resources import ResourceContainer
 
 
 class FailingTool(ToolPlugin):
@@ -29,7 +36,7 @@ def make_registries():
     tools = ToolRegistry()
     tools.add("fail", FailingTool({"max_retries": 0}))
 
-    return SystemRegistries(ResourceRegistry(), tools, plugins)
+    return SystemRegistries(ResourceContainer(), tools, plugins)
 
 
 def test_tool_failure_propagates_to_error_stage():

--- a/tests/test_tool_registry_options.py
+++ b/tests/test_tool_registry_options.py
@@ -2,9 +2,17 @@ import asyncio
 import time
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolCall, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginRegistry,
+    SystemRegistries,
+    ToolCall,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 from pipeline.tools.execution import execute_pending_tools
 
 
@@ -34,7 +42,7 @@ def test_concurrency_limit():
     tool = SleepTool()
     tools = ToolRegistry(concurrency_limit=2)
     asyncio.run(tools.add("sleep", tool))
-    registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
+    registries = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
     for i in range(4):
         state.pending_tool_calls.append(
             ToolCall(name="sleep", params={"delay": 0.1}, result_key=f"r{i}")
@@ -51,7 +59,7 @@ def test_cache_ttl():
     tool = SleepTool()
     tools = ToolRegistry(cache_ttl=5)
     asyncio.run(tools.add("sleep", tool))
-    registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
+    registries = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
     state.pending_tool_calls.append(
         ToolCall(name="sleep", params={"delay": 0}, result_key="a")
     )

--- a/tests/test_weather_api_tool.py
+++ b/tests/test_weather_api_tool.py
@@ -7,9 +7,16 @@ from unittest.mock import AsyncMock, patch
 from plugins.contrib.tools.weather_api_tool import WeatherApiTool
 
 from config.environment import load_env
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, ResourceRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 from pipeline.tools.execution import execute_pending_tools
 
 load_env(Path(__file__).resolve().parents[1] / ".env")
@@ -38,7 +45,7 @@ async def run_weather():
         {"base_url": "http://test/weather", "api_key": os.environ["WEATHER_API_KEY"]}
     )
     await tools.add("weather", tool)
-    registries = SystemRegistries(ResourceRegistry(), tools, PluginRegistry())
+    registries = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
     ctx = PluginContext(state, registries)
     with patch(
         "httpx.AsyncClient.get", new=AsyncMock(return_value=FakeResponse())

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -3,9 +3,15 @@ import asyncio
 from fastapi.testclient import TestClient
 from plugins.builtin.adapters import WebSocketAdapter
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, ResourceRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
 
 
 class RespPlugin(PromptPlugin):
@@ -19,7 +25,7 @@ class RespPlugin(PromptPlugin):
 def make_adapter():
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
-    registries = SystemRegistries(ResourceRegistry(), ToolRegistry(), plugins)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return WebSocketAdapter(manager)
 


### PR DESCRIPTION
## Summary
- replace `ResourceRegistry()` with `ResourceContainer()` throughout tests
- import `ResourceContainer` from `pipeline.resources`

## Testing
- `poetry run black tests/test_observability.py tests/test_tool_registry_options.py tests/performance/test_pipeline_benchmark.py tests/performance/test_full_pipeline_benchmark.py tests/registry/test_thread_safety.py tests/test_llm_helpers.py tests/test_execute_stage.py tests/test_logging_adapter.py tests/integration/test_chat_history_backends.py tests/integration/test_chaos.py tests/integration/test_stage_failures.py tests/integration/test_vector_memory_integration.py tests/test_metrics.py tests/test_async_patterns.py tests/test_complex_prompt.py tests/test_circuit_breaker.py tests/test_pipeline_manager.py tests/test_cache.py tests/test_tool_error_propagation.py tests/test_conversation_manager.py tests/test_memory_retrieval_prompt.py tests/test_chain_of_thought_prompt.py tests/test_weather_api_tool.py tests/test_react_prompt.py tests/test_plugin_registry_order.py tests/test_intent_classifier_prompt.py tests/test_error_stage.py tests/test_websocket_adapter.py tests/test_cli_adapter.py tests/test_config_update.py tests/test_plugin_layers.py tests/test_pipeline_state.py tests/test_http_adapter.py tests/test_pii_scrubber_plugin.py tests/test_conversation_history_plugin.py tests/test_execute_pending_tools.py tests/test_error_handling.py tests/test_search_tool.py tests/test_call_llm_logging.py tests/test_memory_resource.py`
- `poetry run isort tests/test_observability.py tests/test_tool_registry_options.py tests/performance/test_pipeline_benchmark.py tests/performance/test_full_pipeline_benchmark.py tests/registry/test_thread_safety.py tests/test_llm_helpers.py tests/test_execute_stage.py tests/test_logging_adapter.py tests/integration/test_chat_history_backends.py tests/integration/test_chaos.py tests/integration/test_stage_failures.py tests/integration/test_vector_memory_integration.py tests/test_metrics.py tests/test_async_patterns.py tests/test_complex_prompt.py tests/test_circuit_breaker.py tests/test_pipeline_manager.py tests/test_cache.py tests/test_tool_error_propagation.py tests/test_conversation_manager.py tests/test_memory_retrieval_prompt.py tests/test_chain_of_thought_prompt.py tests/test_weather_api_tool.py tests/test_react_prompt.py tests/test_plugin_registry_order.py tests/test_intent_classifier_prompt.py tests/test_error_stage.py tests/test_websocket_adapter.py tests/test_cli_adapter.py tests/test_config_update.py tests/test_plugin_layers.py tests/test_pipeline_state.py tests/test_http_adapter.py tests/test_pii_scrubber_plugin.py tests/test_conversation_history_plugin.py tests/test_execute_pending_tools.py tests/test_error_handling.py tests/test_search_tool.py tests/test_call_llm_logging.py tests/test_memory_resource.py`
- `poetry run flake8 src tests` *(fails: Command not found: flake8)*
- `poetry run mypy src` *(fails: syntax error in memory_resource.py)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: SyntaxError in base_plugins.py)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: SyntaxError in base_plugins.py)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest -q` *(fails: SyntaxError in base_plugins.py)*


------
https://chatgpt.com/codex/tasks/task_e_6869f2bcab448322a110db4dbbbb84be