### PR TITLE
Fix ConversationEntry imports in builtin resources

### DIFF
--- a/plugins/builtin/resources/database.py
+++ b/plugins/builtin/resources/database.py
@@ -7,7 +7,7 @@ from typing import Any, AsyncIterator, List, Optional, Protocol
 
 from plugins.builtin.resources.base import BaseResource
 
-from pipeline.context import ConversationEntry
+from pipeline.state import ConversationEntry
 
 
 class StorageBackend(Protocol):

--- a/plugins/builtin/resources/duckdb_database.py
+++ b/plugins/builtin/resources/duckdb_database.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 import duckdb
 from plugins.builtin.resources.database import DatabaseResource
 
-from pipeline.context import ConversationEntry
+from pipeline.state import ConversationEntry
 
 
 class DuckDBDatabaseResource(DatabaseResource):

--- a/plugins/builtin/resources/in_memory_storage.py
+++ b/plugins/builtin/resources/in_memory_storage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from plugins.builtin.resources.database import DatabaseResource
 
-from pipeline.context import ConversationEntry
+from pipeline.state import ConversationEntry
 
 
 class InMemoryStorageResource(DatabaseResource):

--- a/plugins/builtin/resources/memory.py
+++ b/plugins/builtin/resources/memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, List
 
-from pipeline.context import ConversationEntry
+from pipeline.state import ConversationEntry
 
 
 class Memory(ABC):

--- a/plugins/builtin/resources/memory_storage.py
+++ b/plugins/builtin/resources/memory_storage.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import Dict, List
 
 from plugins.builtin.resources.database import DatabaseResource
-from pipeline.context import ConversationEntry
+
+from pipeline.state import ConversationEntry
 
 
 class MemoryStorage(DatabaseResource):

--- a/plugins/builtin/resources/postgres.py
+++ b/plugins/builtin/resources/postgres.py
@@ -8,9 +8,9 @@ from typing import AsyncIterator, Dict, List, Optional
 import asyncpg
 from plugins.builtin.resources.database import DatabaseResource
 
-from pipeline.context import ConversationEntry
 from pipeline.observability.tracing import start_span
 from pipeline.reliability import CircuitBreaker, RetryPolicy
+from pipeline.state import ConversationEntry
 
 
 class PostgresResource(DatabaseResource):

--- a/plugins/builtin/resources/sqlite_storage.py
+++ b/plugins/builtin/resources/sqlite_storage.py
@@ -8,8 +8,8 @@ from typing import Dict, List, Optional
 import aiosqlite
 from plugins.builtin.resources.database import DatabaseResource
 
-from pipeline.context import ConversationEntry
 from pipeline.observability.tracing import start_span
+from pipeline.state import ConversationEntry
 
 
 class SQLiteStorageResource(DatabaseResource):


### PR DESCRIPTION
## Summary
- import `ConversationEntry` from `pipeline.state`

## Testing
- `poetry run black src tests -q`
- `poetry run isort src tests` *(fails: `Fixing` output indicates reformatting)*
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: found 204 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'aioboto3')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: 'aioboto3')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'pipeline')*
- `pytest -q` *(fails: ModuleNotFoundError: 'aioboto3')*

------
https://chatgpt.com/codex/tasks/task_e_6869fc32e6cc83228eccfd205417eda5