### PR TITLE
Improve type hints for lazy resources

### DIFF
--- a/src/pipeline/cache/redis.py
+++ b/src/pipeline/cache/redis.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
 warnings.warn(
     (
@@ -10,6 +11,10 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.contrib.resources.cache_backends.redis import RedisCache
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,5 +1,28 @@
 """Public resource wrappers for pipeline consumers."""
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.base import BaseResource, Resource
+    from plugins.builtin.resources.llm_base import LLM
+    from plugins.builtin.resources.llm_resource import LLMResource
+
+    from .container import ResourceContainer
+    from .database import DatabaseResource
+    from .duckdb_database import DuckDBDatabaseResource
+    from .filesystem import FileSystemResource
+    from .in_memory_storage import InMemoryStorageResource
+    from .llm.unified import UnifiedLLMResource
+    from .memory import Memory
+    from .memory_filesystem import MemoryFileSystem
+    from .memory_resource import MemoryResource, SimpleMemoryResource
+    from .memory_storage import MemoryStorage
+    from .memory_vector_store import MemoryVectorStore
+    from .pg_vector_store import PgVectorStore
+    from .postgres import PostgresResource
+    from .sqlite_storage import SQLiteStorageResource
+    from .storage_resource import StorageResource
+
 
 def __getattr__(name: str):
     if name in {"BaseResource", "Resource"}:
@@ -14,24 +37,72 @@ def __getattr__(name: str):
         from plugins.builtin.resources.llm_resource import LLMResource
 
         return LLMResource
+    if name == "ResourceContainer":
+        from .container import ResourceContainer
+
+        return ResourceContainer
+    if name == "DatabaseResource":
+        from .database import DatabaseResource
+
+        return DatabaseResource
+    if name == "DuckDBDatabaseResource":
+        from .duckdb_database import DuckDBDatabaseResource
+
+        return DuckDBDatabaseResource
+    if name == "FileSystemResource":
+        from .filesystem import FileSystemResource
+
+        return FileSystemResource
+    if name == "InMemoryStorageResource":
+        from .in_memory_storage import InMemoryStorageResource
+
+        return InMemoryStorageResource
+    if name == "UnifiedLLMResource":
+        from .llm.unified import UnifiedLLMResource
+
+        return UnifiedLLMResource
+    if name == "Memory":
+        from .memory import Memory
+
+        return Memory
+    if name == "MemoryFileSystem":
+        from .memory_filesystem import MemoryFileSystem
+
+        return MemoryFileSystem
+    if name == "MemoryResource":
+        from .memory_resource import MemoryResource
+
+        return MemoryResource
+    if name == "SimpleMemoryResource":
+        from .memory_resource import SimpleMemoryResource
+
+        return SimpleMemoryResource
+    if name == "MemoryStorage":
+        from .memory_storage import MemoryStorage
+
+        return MemoryStorage
+    if name == "MemoryVectorStore":
+        from .memory_vector_store import MemoryVectorStore
+
+        return MemoryVectorStore
+    if name == "PgVectorStore":
+        from .pg_vector_store import PgVectorStore
+
+        return PgVectorStore
+    if name == "PostgresResource":
+        from .postgres import PostgresResource
+
+        return PostgresResource
+    if name == "SQLiteStorageResource":
+        from .sqlite_storage import SQLiteStorageResource
+
+        return SQLiteStorageResource
+    if name == "StorageResource":
+        from .storage_resource import StorageResource
+
+        return StorageResource
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
-
-from .container import ResourceContainer
-from .database import DatabaseResource
-from .duckdb_database import DuckDBDatabaseResource
-from .filesystem import FileSystemResource
-from .in_memory_storage import InMemoryStorageResource
-from .llm.unified import UnifiedLLMResource
-from .memory import Memory
-from .memory_filesystem import MemoryFileSystem
-from .memory_resource import MemoryResource, SimpleMemoryResource
-from .memory_storage import MemoryStorage
-from .memory_vector_store import MemoryVectorStore
-from .pg_vector_store import PgVectorStore
-from .postgres import PostgresResource
-from .sqlite_storage import SQLiteStorageResource
-from .storage_resource import StorageResource
 
 __all__ = [
     "MemoryResource",

--- a/src/pipeline/resources/database.py
+++ b/src/pipeline/resources/database.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Database resource wrapper used by tests."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.database import DatabaseResource
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/duckdb_database.py
+++ b/src/pipeline/resources/duckdb_database.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Wrapper for DuckDBDatabaseResource."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.duckdb_database import DuckDBDatabaseResource
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/filesystem.py
+++ b/src/pipeline/resources/filesystem.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Filesystem resource wrapper used by pipeline components."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.filesystem import FileSystemResource
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/in_memory_storage.py
+++ b/src/pipeline/resources/in_memory_storage.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Wrapper for InMemoryStorageResource."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.in_memory_storage import InMemoryStorageResource
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/llm_base.py
+++ b/src/pipeline/resources/llm_base.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Public re-export of :class:`LLM`."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.llm_base import LLM
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/llm_resource.py
+++ b/src/pipeline/resources/llm_resource.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Public re-export of :class:`LLMResource`."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.llm_resource import LLMResource
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/memory.py
+++ b/src/pipeline/resources/memory.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Memory resource interface wrapper."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.memory import Memory
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/pg_vector_store.py
+++ b/src/pipeline/resources/pg_vector_store.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Wrapper for PgVectorStore."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.pg_vector_store import PgVectorStore
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/postgres.py
+++ b/src/pipeline/resources/postgres.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Wrapper for PostgresResource."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.postgres import PostgresResource
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/sqlite_storage.py
+++ b/src/pipeline/resources/sqlite_storage.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Wrapper for SQLiteStorageResource."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.sqlite_storage import SQLiteStorageResource
 
 
 def __getattr__(name: str):

--- a/src/pipeline/resources/storage_resource.py
+++ b/src/pipeline/resources/storage_resource.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 """Thin wrapper exposing the built-in filesystem StorageResource."""
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.builtin.resources.storage_resource import StorageResource
 
 
 def __getattr__(name: str):

--- a/src/pipeline/sandbox/__init__.py
+++ b/src/pipeline/sandbox/__init__.py
@@ -1,12 +1,17 @@
 """Sandbox utilities for running and auditing contrib plugins."""
 
 import warnings
+from typing import TYPE_CHECKING
 
 warnings.warn(
     "pipeline.sandbox is deprecated; use plugins.contrib.infrastructure.sandbox instead",
     DeprecationWarning,
     stacklevel=2,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.contrib.infrastructure.sandbox.audit import PluginAuditor
+    from plugins.contrib.infrastructure.sandbox.runner import DockerSandboxRunner
 
 
 def __getattr__(name: str):

--- a/src/pipeline/sandbox/audit.py
+++ b/src/pipeline/sandbox/audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
 warnings.warn(
     (
@@ -10,6 +11,9 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.contrib.infrastructure.sandbox.audit import PluginAuditor
 
 
 def __getattr__(name: str):

--- a/src/pipeline/sandbox/runner.py
+++ b/src/pipeline/sandbox/runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
 warnings.warn(
     (
@@ -10,6 +11,9 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.contrib.infrastructure.sandbox.runner import DockerSandboxRunner
 
 
 def __getattr__(name: str):

--- a/src/pipeline/user_plugins/resources/cache.py
+++ b/src/pipeline/user_plugins/resources/cache.py
@@ -1,3 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from plugins.contrib.resources.cache import CacheResource
+
+
 def __getattr__(name: str):
     if name == "CacheResource":
         from plugins.contrib.resources.cache import CacheResource


### PR DESCRIPTION
## Summary
- make lazy resource modules visible to type checkers using TYPE_CHECKING imports
- update sandbox wrappers to match the pattern
- fix flake8 F822 redefinition warning

## Testing
- `poetry run black src/pipeline/cache/redis.py src/pipeline/resources/__init__.py src/pipeline/resources/database.py src/pipeline/resources/duckdb_database.py src/pipeline/resources/filesystem.py src/pipeline/resources/in_memory_storage.py src/pipeline/resources/llm_base.py src/pipeline/resources/llm_resource.py src/pipeline/resources/memory.py src/pipeline/resources/pg_vector_store.py src/pipeline/resources/postgres.py src/pipeline/resources/sqlite_storage.py src/pipeline/resources/storage_resource.py src/pipeline/sandbox/__init__.py src/pipeline/sandbox/audit.py src/pipeline/sandbox/runner.py src/pipeline/user_plugins/resources/cache.py`
- `poetry run isort src/pipeline/cache/redis.py src/pipeline/resources/__init__.py src/pipeline/resources/database.py src/pipeline/resources/duckdb_database.py src/pipeline/resources/filesystem.py src/pipeline/resources/in_memory_storage.py src/pipeline/resources/llm_base.py src/pipeline/resources/llm_resource.py src/pipeline/resources/memory.py src/pipeline/resources/pg_vector_store.py src/pipeline/resources/postgres.py src/pipeline/resources/sqlite_storage.py src/pipeline/resources/storage_resource.py src/pipeline/sandbox/__init__.py src/pipeline/sandbox/audit.py src/pipeline/sandbox/runner.py src/pipeline/user_plugins/resources/cache.py`
- `poetry run flake8 src/pipeline/cache/redis.py src/pipeline/resources src/pipeline/sandbox src/pipeline/user_plugins/resources/cache.py`
- `poetry run mypy src` *(fails: 204 errors)*
- `bandit -r src` *(passes with issues)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `python -m src.registry.validator` *(fails: No module named 'pipeline')*
- `pytest -q` *(fails: CLIAdapter must define a non-empty 'stages' list)*

------
https://chatgpt.com/codex/tasks/task_e_6869fc345b108322b4b8d8e78ebdb5a4