### PR TITLE
Add websockets dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,18 @@ plugins:
 ```
 For a runnable demonstration see `examples/storage_resource_example.py`.
 
+## Server Examples
+
+A set of demo servers lives in `examples/servers`. The WebSocket example
+requires the `websockets` package, which is now listed in `pyproject.toml`.
+
+```bash
+python examples/servers/http_server.py
+python src/cli.py serve-websocket --config config/dev.yaml
+python examples/servers/grpc_server.py
+python examples/servers/cli_adapter.py
+```
+
 ## Implementation Recommendations
 
 1. **Create Abstract Base Classes**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ psutil = "^5.9.8"
 opentelemetry-api = "^1.24.0"
 opentelemetry-sdk = "^1.24.0"
 tenacity = "^8.2.3"
+websockets = "^15.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"


### PR DESCRIPTION
## Summary
- add websockets to project dependencies
- clarify WebSocket server requirement in README

## Testing
- `poetry run black .`
- `poetry run isort .`
- `poetry run flake8` *(fails: F821 undefined name 'asyncio', etc.)*
- `poetry run mypy src` *(fails: found 201 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'config.models')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'config.models')*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'config.models')*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'config.models')*

------
https://chatgpt.com/codex/tasks/task_e_686a0339d9f4832283852a01ce6f7cd2