### PR TITLE
Document env vars for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ For a high-level look at how the pieces connect, see [components_overview.md](co
 2. Run `poetry install` to create the virtual environment. This installs all
    dependencies, including `httpx==0.27.*`.
 3. Start the agent with your desired configuration file.
+4. Copy `.env.example` to `.env` and fill in the values if you want to run the example scripts. See [examples/README.md](examples/README.md) for what each example expects.
 
 For an infrastructure walkthrough on Amazon Web Services, see the [AWS deployment guide](docs/source/deploy_aws.md).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,14 @@
+# Example Scripts
+
+This folder contains small programs that showcase different features of the Entity pipeline framework.
+Many of them read credentials from environment variables. Copy `.env.example` to `.env` and fill in the values before running the scripts.
+
+## Variables by Example
+
+| Example | Required Variables |
+|---------|-------------------|
+| `pipelines/pipeline_example.py` | `OLLAMA_BASE_URL`, `OLLAMA_MODEL` |
+| `pipelines/vector_memory_pipeline.py` | `DB_HOST`, `DB_USERNAME`, `DB_PASSWORD`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL` |
+| `tools/search_weather_example.py` | `WEATHER_API_KEY` |
+
+All other examples work without additional configuration.

--- a/src/pipeline/cache/semantic.py
+++ b/src/pipeline/cache/semantic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import Any
 
 warnings.warn(
     (
@@ -16,10 +17,12 @@ def __getattr__(name: str):
     """Lazily import :class:`SemanticCache` when requested."""
 
     if name == "SemanticCache":
-        from plugins.contrib.resources.cache_backends.semantic import SemanticCache
+        from plugins.contrib.resources.cache_backends.semantic import \
+            SemanticCache
 
         return SemanticCache
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
+SemanticCache: Any
 __all__ = ["SemanticCache"]


### PR DESCRIPTION
## Summary
- note example environment variables in the main README
- add an examples/README listing vars for each example
- stub out `SemanticCache` to satisfy flake8

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy`
- `poetry run bandit -r src`
- `poetry run pytest` *(fails: 77 errors during collection)*
- `poetry run python -m config.validator --config ../config/dev.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `poetry run python -m config.validator --config ../config/prod.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `poetry run python -m src.registry.validator` *(fails: CLIAdapter must define a non-empty 'stages' list)*

------
https://chatgpt.com/codex/tasks/task_e_686a033a553c83229d02e32660924c07