### PR TITLE
Update gRPC docs

### DIFF
--- a/docs/source/grpc_services.md
+++ b/docs/source/grpc_services.md
@@ -56,3 +56,16 @@ python examples/servers/grpc_server.py
 
 The adapter launches ``LLMService`` locally and prints each token generated for
 the sample prompt.
+
+### Generating Python Stubs
+
+Regenerate ``llm_pb2.py`` and ``llm_pb2_grpc.py`` whenever ``llm.proto``
+changes. Execute the following command from the project root:
+
+```bash
+python -m grpc_tools.protoc \
+    -I src/grpc_services \
+    --python_out=src/grpc_services \
+    --grpc_python_out=src/grpc_services \
+    src/grpc_services/llm.proto
+```

--- a/examples/servers/grpc_server.py
+++ b/examples/servers/grpc_server.py
@@ -1,4 +1,9 @@
-"""Demo gRPC server using :class:`LLMGRPCAdapter`."""
+"""Demo gRPC server using :class:`LLMGRPCAdapter`.
+
+Refer to the "Generating Python Stubs" section in
+``docs/source/grpc_services.md`` for instructions on rebuilding the gRPC
+stubs.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document how to generate gRPC stubs
- link from the example server to the new documentation

## Testing
- `poetry run black examples/servers/grpc_server.py`
- `poetry run isort src tests --check` *(fails: Imports are incorrectly sorted)*
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: found 201 errors)*
- `bandit -r src` *(fails: Command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686a033d59cc832292624d4ed1079e7c