### PR TITLE
Add dev install instructions and Poe tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Get started quickly by installing dependencies with Poetry and running an agent
 with a YAML file:
 
 ```bash
-poetry install
+poetry install --with dev
 poetry run python src/cli.py --config config.yaml
 ```
 This project relies on `httpx==0.27.*`, which Poetry will install automatically.
@@ -29,8 +29,8 @@ For a high-level look at how the pieces connect, see [components_overview.md](co
 
 
 1. Install Python 3.11+ and [Poetry](https://python-poetry.org/).
-2. Run `poetry install` to create the virtual environment. This installs all
-   dependencies, including `httpx==0.27.*`.
+2. Run `poetry install --with dev` to create the virtual environment and install
+   development tools.
 3. Start the agent with your desired configuration file.
 
 For an infrastructure walkthrough on Amazon Web Services, see the [AWS deployment guide](docs/source/deploy_aws.md).

--- a/docs/source/deploy_local.md
+++ b/docs/source/deploy_local.md
@@ -4,7 +4,7 @@ Run the agent directly on your machine during development.
 
 1. Install dependencies with Poetry (ensures `httpx==0.27.*`):
    ```bash
-   poetry install
+   poetry install --with dev
    ```
 2. Start the HTTP adapter:
    ```bash

--- a/docs/source/tutorial_setup.md
+++ b/docs/source/tutorial_setup.md
@@ -3,8 +3,8 @@
 Follow these steps to install dependencies and scaffold a new project.
 
 1. Install Python 3.11+ and [Poetry](https://python-poetry.org/).
-2. Run `poetry install` to create the virtual environment. This installs
-   all dependencies, including the required `httpx==0.27.*`.
+2. Run `poetry install --with dev` to create the virtual environment with all
+   development tools.
 3. Copy `.env.example` to `.env` and provide any required credentials.
 4. Generate a starter project:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,27 @@ release = ["docs", "patch", "_publish"]
 test = "pytest"
 test-verbose = "pytest -v"
 test-coverage = "pytest --cov=src --cov-report=html --cov-report=term-missing"
+setup-dev = "poetry install --with dev"
+[tool.poe.tasks.lint]
+sequence = [
+    "poetry run black src tests",
+    "poetry run isort src tests",
+    "poetry run flake8 src tests",
+]
+[tool.poe.tasks.validate]
+sequence = [
+    "python -m src.config.validator --config config/dev.yaml",
+    "python -m src.config.validator --config config/prod.yaml",
+    "python -m src.registry.validator",
+]
+[tool.poe.tasks.check]
+sequence = [
+    "poe lint",
+    "poetry run mypy src",
+    "bandit -r src",
+    "poe validate",
+    "pytest",
+]
 
 
 [tool.pytest.ini_options]

--- a/src/pipeline/cache/semantic.py
+++ b/src/pipeline/cache/semantic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
 warnings.warn(
     (
@@ -16,10 +17,14 @@ def __getattr__(name: str):
     """Lazily import :class:`SemanticCache` when requested."""
 
     if name == "SemanticCache":
-        from plugins.contrib.resources.cache_backends.semantic import SemanticCache
+        from plugins.contrib.resources.cache_backends.semantic import \
+            SemanticCache
 
         return SemanticCache
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
+    from plugins.contrib.resources.cache_backends.semantic import SemanticCache
 
 __all__ = ["SemanticCache"]


### PR DESCRIPTION
## Summary
- instruct to use `poetry install --with dev`
- add `setup-dev`, `lint`, `validate`, and `check` poe tasks
- tweak `SemanticCache` module for flake8

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `flake8 src tests` *(fails: command not found without manual install)*
- `poetry run mypy src` *(fails: 201 errors)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `python -m src.registry.validator` *(fails: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686a033f07408322aed94cb0c6af9c98