### PR TITLE
Update contribution docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ git branch --set-upstream-to=origin/main work
   backward compatibility.
 - Prefer adding `TODO:` comments when scope is unclear.
 - Always use the Poetry environment for development.
+- Run `poetry install` before executing any quality checks.
 
 ## Programmatic Checks
 Run the following commands before opening a pull request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for helping improve Entity Pipeline Framework! Please follow the project guidelines and run all checks before opening a pull request.
+Thank you for helping improve Entity Pipeline Framework! Always start with `poetry install` to create the virtual environment and install dependencies. After that, follow the project guidelines and run all checks before opening a pull request.
 
 ## Code Review Expectations
 
@@ -25,6 +25,15 @@ python -m src.registry.validator
 pytest tests/integration/ -v
 pytest tests/infrastructure/ -v
 pytest tests/performance/ -m benchmark
+```
+
+## Optional Dependencies for Examples
+
+The examples under `examples/` rely on packages such as `websockets` and `grpcio-tools`.
+Install them all at once with:
+
+```bash
+poetry install --with examples
 ```
 
 CI will also check docstrings with `pydocstyle`. Core modules may import plugins, but plugins must not import core modules directly.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3813,7 +3813,10 @@ enabler = ["pytest-enabler (>=2.2)"]
 test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
+[extras]
+examples = []
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "47a35aeb4040229006963d2c71228afee8f6544477217f102e726e19321b2c92"
+content-hash = "d63f0f28777bd5e02a8f50843b75fe9b0c49ff0aa1f54f1ddc6370993f46195f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,13 @@ opentelemetry-api = "^1.24.0"
 opentelemetry-sdk = "^1.24.0"
 tenacity = "^8.2.3"
 
+[tool.poetry.extras]
+examples = [
+    "websockets",
+    "grpcio",
+    "grpcio-tools",
+]
+
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"
 sphinx = "^8.1.3"

--- a/src/pipeline/cache/semantic.py
+++ b/src/pipeline/cache/semantic.py
@@ -22,4 +22,4 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
-__all__ = ["SemanticCache"]
+__all__ = ["SemanticCache"]  # noqa: F822


### PR DESCRIPTION
## Summary
- emphasize installing with poetry
- add optional example deps group
- silence flake8 warning for deferred import
- mention running `poetry install` in AGENTS.md

## Testing
- `poetry install`
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run black src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing type annotations and missing stubs)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'config.models')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'config.models')*
- `poetry run python -m src.registry.validator` *(fails: No module named 'config.models')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686a0336c6948322b84cb36fc2f118b9