### PR TITLE
Update deprecated imports to user_plugins

### DIFF
--- a/src/pipeline/cache/__init__.py
+++ b/src/pipeline/cache/__init__.py
@@ -7,7 +7,7 @@ from .memory import InMemoryCache
 def get_redis_cache() -> type[CacheBackend]:
     """Return the :class:`RedisCache` class with a lazy import."""
 
-    from plugins.contrib.resources.cache_backends.redis import RedisCache
+    from user_plugins.resources.cache_backends.redis import RedisCache
 
     return RedisCache
 
@@ -15,7 +15,7 @@ def get_redis_cache() -> type[CacheBackend]:
 def get_semantic_cache() -> type[CacheBackend]:
     """Return the :class:`SemanticCache` class with a lazy import."""
 
-    from plugins.contrib.resources.cache_backends.semantic import SemanticCache
+    from user_plugins.resources.cache_backends.semantic import SemanticCache
 
     return SemanticCache
 

--- a/src/pipeline/cache/redis.py
+++ b/src/pipeline/cache/redis.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 warnings.warn(
     (
         "pipeline.cache.redis is deprecated; use "
-        "plugins.contrib.resources.cache_backends.redis instead"
+        "user_plugins.resources.cache_backends.redis instead"
     ),
     DeprecationWarning,
     stacklevel=2,
@@ -14,14 +14,14 @@ warnings.warn(
 
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
-    from plugins.contrib.resources.cache_backends.redis import RedisCache
+    from user_plugins.resources.cache_backends.redis import RedisCache
 
 
 def __getattr__(name: str):
     """Lazily import :class:`RedisCache` when requested."""
 
     if name == "RedisCache":
-        from plugins.contrib.resources.cache_backends.redis import RedisCache
+        from user_plugins.resources.cache_backends.redis import RedisCache
 
         return RedisCache
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/pipeline/cache/semantic.py
+++ b/src/pipeline/cache/semantic.py
@@ -5,7 +5,7 @@ import warnings
 warnings.warn(
     (
         "pipeline.cache.semantic is deprecated; "
-        "use plugins.contrib.resources.cache_backends.semantic instead"
+        "use user_plugins.resources.cache_backends.semantic instead"
     ),
     DeprecationWarning,
     stacklevel=2,
@@ -16,7 +16,7 @@ def __getattr__(name: str):
     """Lazily import :class:`SemanticCache` when requested."""
 
     if name == "SemanticCache":
-        from plugins.contrib.resources.cache_backends.semantic import SemanticCache
+        from user_plugins.resources.cache_backends.semantic import SemanticCache
 
         return SemanticCache
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/pipeline/sandbox/__init__.py
+++ b/src/pipeline/sandbox/__init__.py
@@ -4,23 +4,23 @@ import warnings
 from typing import TYPE_CHECKING
 
 warnings.warn(
-    "pipeline.sandbox is deprecated; use plugins.contrib.infrastructure.sandbox instead",
+    "pipeline.sandbox is deprecated; use user_plugins.infrastructure.sandbox instead",
     DeprecationWarning,
     stacklevel=2,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
-    from plugins.contrib.infrastructure.sandbox.audit import PluginAuditor
-    from plugins.contrib.infrastructure.sandbox.runner import DockerSandboxRunner
+    from user_plugins.infrastructure.sandbox.audit import PluginAuditor
+    from user_plugins.infrastructure.sandbox.runner import DockerSandboxRunner
 
 
 def __getattr__(name: str):
     if name == "DockerSandboxRunner":
-        from plugins.contrib.infrastructure.sandbox.runner import DockerSandboxRunner
+        from user_plugins.infrastructure.sandbox.runner import DockerSandboxRunner
 
         return DockerSandboxRunner
     if name == "PluginAuditor":
-        from plugins.contrib.infrastructure.sandbox.audit import PluginAuditor
+        from user_plugins.infrastructure.sandbox.audit import PluginAuditor
 
         return PluginAuditor
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/pipeline/sandbox/audit.py
+++ b/src/pipeline/sandbox/audit.py
@@ -6,19 +6,19 @@ from typing import TYPE_CHECKING
 warnings.warn(
     (
         "pipeline.sandbox.audit is deprecated; "
-        "use plugins.contrib.infrastructure.sandbox.audit instead"
+        "use user_plugins.infrastructure.sandbox.audit instead"
     ),
     DeprecationWarning,
     stacklevel=2,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
-    from plugins.contrib.infrastructure.sandbox.audit import PluginAuditor
+    from user_plugins.infrastructure.sandbox.audit import PluginAuditor
 
 
 def __getattr__(name: str):
     if name == "PluginAuditor":
-        from plugins.contrib.infrastructure.sandbox.audit import PluginAuditor
+        from user_plugins.infrastructure.sandbox.audit import PluginAuditor
 
         return PluginAuditor
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/pipeline/sandbox/runner.py
+++ b/src/pipeline/sandbox/runner.py
@@ -6,19 +6,19 @@ from typing import TYPE_CHECKING
 warnings.warn(
     (
         "pipeline.sandbox.runner is deprecated; "
-        "use plugins.contrib.infrastructure.sandbox.runner instead"
+        "use user_plugins.infrastructure.sandbox.runner instead"
     ),
     DeprecationWarning,
     stacklevel=2,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
-    from plugins.contrib.infrastructure.sandbox.runner import DockerSandboxRunner
+    from user_plugins.infrastructure.sandbox.runner import DockerSandboxRunner
 
 
 def __getattr__(name: str):
     if name == "DockerSandboxRunner":
-        from plugins.contrib.infrastructure.sandbox.runner import DockerSandboxRunner
+        from user_plugins.infrastructure.sandbox.runner import DockerSandboxRunner
 
         return DockerSandboxRunner
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/pipeline/user_plugins/resources/__init__.py
+++ b/src/pipeline/user_plugins/resources/__init__.py
@@ -1,6 +1,6 @@
 def __getattr__(name: str):
     if name == "CacheResource":
-        from plugins.contrib.resources import CacheResource
+        from user_plugins.resources import CacheResource
 
         return CacheResource
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/pipeline/user_plugins/resources/cache.py
+++ b/src/pipeline/user_plugins/resources/cache.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
-    from plugins.contrib.resources.cache import CacheResource
+    from user_plugins.resources.cache import CacheResource
 
 
 def __getattr__(name: str):
     if name == "CacheResource":
-        from plugins.contrib.resources.cache import CacheResource
+        from user_plugins.resources.cache import CacheResource
 
         return CacheResource
     raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Summary
- switch resource wrappers to pull from `user_plugins.resources`
- redirect deprecated cache and sandbox modules to `user_plugins`

## Testing
- `poetry run black src/pipeline/cache/__init__.py src/pipeline/cache/redis.py src/pipeline/cache/semantic.py src/pipeline/sandbox/__init__.py src/pipeline/sandbox/audit.py src/pipeline/sandbox/runner.py src/pipeline/user_plugins/resources/__init__.py src/pipeline/user_plugins/resources/cache.py`
- `poetry run isort src/pipeline/cache/__init__.py src/pipeline/cache/redis.py src/pipeline/cache/semantic.py src/pipeline/sandbox/__init__.py src/pipeline/sandbox/audit.py src/pipeline/sandbox/runner.py src/pipeline/user_plugins/resources/__init__.py src/pipeline/user_plugins/resources/cache.py`
- `poetry run flake8 src tests` *(fails: src/pipeline/cache/semantic.py:26:1: F822)*
- `poetry run mypy src` *(fails: Found 211 errors)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `poetry run pytest` *(fails: 77 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686a034d0b0483228672451b55150782