### PR TITLE
Update docs on plugin directories

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,10 +20,9 @@ The framework's core value is **making agent behavior adjustable** without code 
 
 The codebase now consolidates the core engine under `src/pipeline`. This module
 contains the context system, execution logic and shared abstractions. Plugins
-now live under the `plugins` package with two subpackages:
-`plugins/builtin` for the framework plugins and `plugins/contrib` for example
-implementations. The previous `src/pipeline/user_plugins` wrappers were
-removed. Plugin modules are grouped by type:
+live under `src/plugins` for built-in functionality. Optional example
+implementations reside in the `user_plugins` package. Plugin modules are grouped
+by type:
 
 - `resources` for databases, LLM providers and storage backends
 - `tools` for user-facing functions

--- a/docs/source/config_cheatsheet.md
+++ b/docs/source/config_cheatsheet.md
@@ -20,7 +20,7 @@ plugins:
       type: plugins.builtin.tools.search:SearchTool
   prompts:
     main:
-      type: plugins.contrib.prompts.simple:SimplePrompt
+      type: user_plugins.prompts.simple:SimplePrompt
   adapters:
     http:
       type: plugins.builtin.adapters.http:HTTPAdapter
@@ -31,3 +31,5 @@ plugins:
 ```
 
 Use `entity src/cli.py --config config.yaml` to start the agent.
+This example references a plugin under the `user_plugins` package to
+demonstrate how custom modules can be loaded.


### PR DESCRIPTION
## Summary
- show `user_plugins` in config cheat sheet
- clarify plugin directory locations in the architecture doc

## Testing
- `poetry run black --check src tests` *(fails: would reformat files)*
- `poetry run isort --check src tests` *(fails to import sorted files)*
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError and other errors)*
- `bandit -r src` *(command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: errors during collection)*
- `poetry run make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_686a0350fb008322bb1444ab97e76c21