### PR TITLE
Remove unused LoggingAdapter stub

### DIFF
--- a/src/pipeline/logging.py
+++ b/src/pipeline/logging.py
@@ -1,4 +1,4 @@
-"""Re-export logging helpers from :class:`LoggingAdapter`."""
+"""Expose logging helpers from the builtin ``LoggingAdapter`` plugin."""
 
 import contextvars
 import logging
@@ -40,10 +40,6 @@ def JsonFormatter(*args, **kwargs):  # type: ignore[override]
     return _adapter().JsonFormatter(*args, **kwargs)
 
 
-class LoggingAdapter:  # pragma: no cover - compatibility stub
-    pass
-
-
 __all__ = [
     "RequestIdFilter",
     "JsonFormatter",
@@ -51,5 +47,4 @@ __all__ = [
     "get_logger",
     "set_request_id",
     "reset_request_id",
-    "LoggingAdapter",
 ]


### PR DESCRIPTION
## Summary
- simplify logging re-exports and remove stub `LoggingAdapter`

## Testing
- `poetry run black src tests`
- `poetry run isort --check src tests` *(fails: imports not sorted)*
- `poetry run flake8 src tests` *(fails: various F errors)*
- `poetry run mypy src` *(fails: many type errors)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: CLIAdapter must define stages)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: CLIAdapter must define stages)*
- `python -m src.registry.validator` *(fails: cannot import config.models)*
- `pytest` *(fails: CLIAdapter must define stages)*

------
https://chatgpt.com/codex/tasks/task_e_686aa1f585988322ab6622b2b5f5c4a1