### PR TITLE
Remove optional gRPC stubs

### DIFF
--- a/docs/source/grpc_services.md
+++ b/docs/source/grpc_services.md
@@ -43,7 +43,9 @@ if __name__ == "__main__":
 ```
 
 ``src/grpc_services/llm.proto`` and ``llm_service.py`` act as references for
-future model services.
+future model services. The service requires the generated modules
+``llm_pb2`` and ``llm_pb2_grpc`` to be present. If they are missing the import
+will fail with an error directing you to regenerate them.
 
 ### Demo Script
 

--- a/src/grpc_services/llm_service.py
+++ b/src/grpc_services/llm_service.py
@@ -1,4 +1,4 @@
-"""Minimal gRPC service stub for model components."""
+"""Minimal gRPC service for model components."""
 
 # mypy: ignore-errors
 
@@ -16,16 +16,16 @@ from pipeline.resources.llm.unified import UnifiedLLMResource
 # These modules are generated from ``llm.proto`` using ``grpcio-tools``.
 # They are intentionally excluded from version control and should be
 # regenerated when the protocol changes.
-try:  # pragma: no cover - stubs for illustration
+try:
     from . import llm_pb2, llm_pb2_grpc  # type: ignore
-except Exception:  # pragma: no cover - stub fallback
-    llm_pb2 = None
-    llm_pb2_grpc = None
+except ImportError as exc:  # pragma: no cover - manual repair
+    raise ImportError(
+        "Generated gRPC modules not found. Run 'python -m grpc_tools.protoc' "
+        "from the project root to create llm_pb2.py and llm_pb2_grpc.py."
+    ) from exc
 
 
-class LLMService(
-    llm_pb2_grpc.LLMServiceServicer if llm_pb2_grpc else object
-):  # type: ignore[misc]
+class LLMService(llm_pb2_grpc.LLMServiceServicer):  # type: ignore[misc]
     """Text generation service using :class:`UnifiedLLMResource`."""
 
     def __init__(self, llm: Any | None = None) -> None:
@@ -53,8 +53,7 @@ class LLMService(
 async def serve(port: int = 50051) -> None:
     """Run the example service."""
     server = grpc.aio.server()
-    if llm_pb2_grpc:
-        llm_pb2_grpc.add_LLMServiceServicer_to_server(LLMService(), server)
+    llm_pb2_grpc.add_LLMServiceServicer_to_server(LLMService(), server)
     server.add_insecure_port(f"[::]:{port}")
     await server.start()
     await server.wait_for_termination()


### PR DESCRIPTION
## Summary
- remove fallback imports for gRPC service
- ensure `llm_pb2` and `llm_pb2_grpc` must exist
- update grpc services documentation

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F821 undefined names)*
- `poetry run mypy src` *(fails: found 426 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `poetry run pytest` *(fails: ValueError: CLIAdapter must define a non-empty 'stages' list)*

------
https://chatgpt.com/codex/tasks/task_e_686aa1fe78748322999a7b07c5602164