### PR TITLE
Remove unused plugin shim

### DIFF
--- a/src/pipeline/plugins/__init__.py
+++ b/src/pipeline/plugins/__init__.py
@@ -1,5 +1,0 @@
-"""Backward compatibility shims for plugin imports."""
-
-from . import contrib
-
-__all__ = ["contrib"]


### PR DESCRIPTION
## Summary
- drop `pipeline.plugins` shim

## Testing
- `poetry run black src tests`
- `poetry run isort src tests` *(produced formatting changes which were reverted)*
- `poetry run flake8 src tests` *(fails: undefined names and unused imports)*
- `poetry run mypy src` *(fails: found 412 errors)*
- `poetry run bandit -r src`
- `PYTHONPATH=src poetry run python src/config/validator.py --config config/dev.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `PYTHONPATH=src poetry run python src/config/validator.py --config config/prod.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `PYTHONPATH=src poetry run python src/registry/validator.py` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `poetry run pytest` *(fails: 77 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686aa1fb084c83229f9e2579033b8b3d