### PR TITLE
Update gRPC service docs

### DIFF
--- a/docs/source/grpc_services.md
+++ b/docs/source/grpc_services.md
@@ -1,7 +1,7 @@
-# gRPC Service Stubs
+# gRPC Services
 
 Entity uses gRPC for all backend model communication. The `src/grpc_services`
-package contains protocol definitions and stub implementations. Below is a
+package contains protocol definitions and service implementations. Below is a
 minimal example for text generation services.
 
 ```proto
@@ -57,7 +57,7 @@ python examples/servers/grpc_server.py
 The adapter launches ``LLMService`` locally and prints each token generated for
 the sample prompt.
 
-### Generating Python Stubs
+### Regenerating gRPC Code
 
 Regenerate ``llm_pb2.py`` and ``llm_pb2_grpc.py`` whenever ``llm.proto``
 changes. Execute the following command from the project root:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -29,7 +29,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [API reference](api_reference.md)
 - [Advanced usage](advanced_usage.md)
 - [Module map](module_map.md)
-- [gRPC service stubs](grpc_services.md)
+- [gRPC services](grpc_services.md)
 - [Troubleshooting](troubleshooting.md)
 
 ### Deployment

--- a/examples/servers/grpc_server.py
+++ b/examples/servers/grpc_server.py
@@ -1,8 +1,8 @@
 """Demo gRPC server using :class:`LLMGRPCAdapter`.
 
-Refer to the "Generating Python Stubs" section in
+Refer to the "Regenerating gRPC Code" section in
 ``docs/source/grpc_services.md`` for instructions on rebuilding the gRPC
-stubs.
+bindings.
 """
 
 from __future__ import annotations
@@ -19,10 +19,10 @@ from utilities import enable_plugins_namespace
 enable_plugins_namespace()
 
 import grpc
-from plugins.builtin.adapters.grpc import LLMGRPCAdapter
 
 from grpc_services import llm_pb2, llm_pb2_grpc
 from pipeline.initializer import SystemInitializer
+from plugins.builtin.adapters.grpc import LLMGRPCAdapter
 
 
 async def stream_prompt() -> None:


### PR DESCRIPTION
## Summary
- clarify gRPC service docs
- adjust index link
- update example comment

## Testing
- `poetry run make -C docs html`
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F821 undefined name)*
- `poetry run mypy src` *(fails: found 412 errors)*
- `poetry run bandit -r src`
- `poetry run python src/config/validator.py --config config/dev.yaml` *(fails: ValueError: CLIAdapter must define a non-empty 'stages' list)*
- `poetry run python src/config/validator.py --config config/prod.yaml` *(fails: ValueError: CLIAdapter must define a non-empty 'stages' list)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'config.models')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686aa20955a08322b42563a271609dc8