### PR TITLE
Simplify gRPC LLM service

### DIFF
--- a/docs/source/grpc_services.md
+++ b/docs/source/grpc_services.md
@@ -42,10 +42,10 @@ if __name__ == "__main__":
     asyncio.run(serve())
 ```
 
-``src/grpc_services/llm.proto`` and ``llm_service.py`` act as references for
-future model services. The service requires the generated modules
-``llm_pb2`` and ``llm_pb2_grpc`` to be present. If they are missing the import
-will fail with an error directing you to regenerate them.
+``src/grpc_services/llm.proto`` and ``llm_service.py`` serve as references for
+future model services. ``llm_service.py`` imports the generated modules
+``llm_pb2`` and ``llm_pb2_grpc`` directly. If those files are missing,
+rebuild them using the command below.
 
 ### Demo Script
 


### PR DESCRIPTION
## Summary
- require generated gRPC bindings in llm_service
- run llm via UnifiedLLMResource
- clarify docs about importing generated modules

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F821 undefined name 'asyncio', etc.)*
- `poetry run mypy src` *(fails: found 413 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ValueError: CLIAdapter must define a non-empty 'stages' list)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ValueError: CLIAdapter must define a non-empty 'stages' list)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686aa5c5be388322998465f283984aa6