### PR TITLE
Remove deprecated ValidationResult property

### DIFF
--- a/src/pipeline/validation/__init__.py
+++ b/src/pipeline/validation/__init__.py
@@ -12,11 +12,6 @@ class ValidationResult:
     error_message: Optional[str] = None
     warnings: List[str] = field(default_factory=list)
 
-    @property
-    def valid(self) -> bool:
-        """Backwards compatibility alias for :attr:`success`."""
-        return self.success
-
     @classmethod
     def success_result(cls) -> "ValidationResult":
         """Create a successful validation result."""

--- a/src/plugins/builtin/resources/bedrock.py
+++ b/src/plugins/builtin/resources/bedrock.py
@@ -29,7 +29,7 @@ class BedrockResource(LLMResource):
         return ValidationResult.success_result()
 
     async def generate(self, prompt: str) -> str:
-        if not self.validate_config(self.config).valid:
+        if not self.validate_config(self.config).success:
             raise ResourceError("Bedrock resource not properly configured")
         payload = {"prompt": prompt, **self.params}
         async with aioboto3.client(

--- a/src/plugins/builtin/resources/claude.py
+++ b/src/plugins/builtin/resources/claude.py
@@ -22,7 +22,7 @@ class ClaudeResource(LLMResource):
         return HttpLLMResource(config, require_api_key=True).validate_config()
 
     async def generate(self, prompt: str) -> str:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise RuntimeError("Claude resource not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/messages"

--- a/src/plugins/builtin/resources/gemini.py
+++ b/src/plugins/builtin/resources/gemini.py
@@ -22,7 +22,7 @@ class GeminiResource(LLMResource):
         return HttpLLMResource(config, require_api_key=True).validate_config()
 
     async def generate(self, prompt: str) -> str:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise RuntimeError("Gemini resource not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1beta/models/{self.http.model}:generateContent"

--- a/src/plugins/builtin/resources/llm/providers/claude.py
+++ b/src/plugins/builtin/resources/llm/providers/claude.py
@@ -18,7 +18,7 @@ class ClaudeProvider(BaseProvider):
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise ResourceError("Claude provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/messages"
@@ -40,7 +40,7 @@ class ClaudeProvider(BaseProvider):
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise ResourceError("Claude provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/messages"

--- a/src/plugins/builtin/resources/llm/providers/gemini.py
+++ b/src/plugins/builtin/resources/llm/providers/gemini.py
@@ -18,7 +18,7 @@ class GeminiProvider(BaseProvider):
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise ResourceError("Gemini provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1beta/models/{self.http.model}:generateContent"
@@ -39,7 +39,7 @@ class GeminiProvider(BaseProvider):
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise ResourceError("Gemini provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1beta/models/{self.http.model}:generateContent"

--- a/src/plugins/builtin/resources/llm/providers/ollama.py
+++ b/src/plugins/builtin/resources/llm/providers/ollama.py
@@ -17,7 +17,7 @@ class OllamaProvider(BaseProvider):
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise ResourceError("Ollama provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/api/generate"
@@ -31,7 +31,7 @@ class OllamaProvider(BaseProvider):
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise ResourceError("Ollama provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/api/generate"

--- a/src/plugins/builtin/resources/llm/providers/openai.py
+++ b/src/plugins/builtin/resources/llm/providers/openai.py
@@ -18,7 +18,7 @@ class OpenAIProvider(BaseProvider):
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise ResourceError("OpenAI provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/chat/completions"
@@ -43,7 +43,7 @@ class OpenAIProvider(BaseProvider):
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise ResourceError("OpenAI provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/chat/completions"

--- a/src/plugins/builtin/resources/ollama_llm.py
+++ b/src/plugins/builtin/resources/ollama_llm.py
@@ -27,7 +27,7 @@ class OllamaLLMResource(LLMResource):
         return HttpLLMResource(config).validate_config()
 
     async def generate(self, prompt: str) -> str:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise ResourceError("Ollama resource not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/api/generate"

--- a/src/plugins/builtin/resources/openai.py
+++ b/src/plugins/builtin/resources/openai.py
@@ -23,7 +23,7 @@ class OpenAIResource(LLMResource):
         return HttpLLMResource(config, require_api_key=True).validate_config()
 
     async def generate(self, prompt: str) -> str:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise ResourceError("OpenAI resource not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/chat/completions"

--- a/src/plugins/llm/providers/claude.py
+++ b/src/plugins/llm/providers/claude.py
@@ -17,7 +17,7 @@ class ClaudeProvider(BaseProvider):
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise RuntimeError("Claude provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/messages"
@@ -39,7 +39,7 @@ class ClaudeProvider(BaseProvider):
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise RuntimeError("Claude provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/messages"

--- a/src/plugins/llm/providers/gemini.py
+++ b/src/plugins/llm/providers/gemini.py
@@ -17,7 +17,7 @@ class GeminiProvider(BaseProvider):
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise RuntimeError("Gemini provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1beta/models/{self.http.model}:generateContent"
@@ -38,7 +38,7 @@ class GeminiProvider(BaseProvider):
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise RuntimeError("Gemini provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1beta/models/{self.http.model}:generateContent"

--- a/src/plugins/llm/providers/ollama.py
+++ b/src/plugins/llm/providers/ollama.py
@@ -16,7 +16,7 @@ class OllamaProvider(BaseProvider):
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise RuntimeError("Ollama provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/api/generate"
@@ -30,7 +30,7 @@ class OllamaProvider(BaseProvider):
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise RuntimeError("Ollama provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/api/generate"

--- a/src/plugins/llm/providers/openai.py
+++ b/src/plugins/llm/providers/openai.py
@@ -17,7 +17,7 @@ class OpenAIProvider(BaseProvider):
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> LLMResponse:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise RuntimeError("OpenAI provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/chat/completions"
@@ -42,7 +42,7 @@ class OpenAIProvider(BaseProvider):
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
-        if not self.http.validate_config().valid:
+        if not self.http.validate_config().success:
             raise RuntimeError("OpenAI provider not properly configured")
 
         url = f"{self.http.base_url.rstrip('/')}/v1/chat/completions"


### PR DESCRIPTION
## Summary
- drop `ValidationResult.valid`
- update plugin code to check `success` instead

## Testing
- `poetry run isort src/pipeline/validation/__init__.py src/plugins/llm/providers/claude.py src/plugins/llm/providers/gemini.py src/plugins/llm/providers/openai.py src/plugins/llm/providers/ollama.py src/plugins/builtin/resources/llm/providers/claude.py src/plugins/builtin/resources/llm/providers/gemini.py src/plugins/builtin/resources/llm/providers/openai.py src/plugins/builtin/resources/llm/providers/ollama.py src/plugins/builtin/resources/claude.py src/plugins/builtin/resources/gemini.py src/plugins/builtin/resources/bedrock.py src/plugins/builtin/resources/openai.py src/plugins/builtin/resources/ollama_llm.py`
- `poetry run flake8 src tests` *(fails: Command not found: flake8)*
- `poetry run mypy src` *(fails: 409 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_686aa5c6a2fc83228e4117c2a53ca1f6