### PR TITLE
Run quality checks and update dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3814,9 +3814,9 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_it
 type = ["pytest-mypy"]
 
 [extras]
-examples = []
+examples = ["websockets"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "d63f0f28777bd5e02a8f50843b75fe9b0c49ff0aa1f54f1ddc6370993f46195f"
+content-hash = "6bdffef297ab66d10d0d9955c97952a195132ca9f05de2217f888ede6a6e7d5c"

--- a/src/plugins/builtin/adapters/__init__.py
+++ b/src/plugins/builtin/adapters/__init__.py
@@ -6,7 +6,7 @@ from .cli import CLIAdapter
 from .grpc import LLMGRPCAdapter
 from .http import HTTPAdapter
 from .logging import LoggingAdapter
-from .logging_adapter import LoggingAdapter
+from .logging_adapter import LoggingAdapter as LoggingAdapterWrapper
 from .websocket import WebSocketAdapter
 
 __all__ = [
@@ -15,4 +15,5 @@ __all__ = [
     "WebSocketAdapter",
     "LLMGRPCAdapter",
     "LoggingAdapter",
+    "LoggingAdapterWrapper",
 ]

--- a/src/plugins/builtin/prompts/complex_prompt.py
+++ b/src/plugins/builtin/prompts/complex_prompt.py
@@ -8,7 +8,6 @@ from typing import List
 from pipeline.base_plugins import PromptPlugin
 from pipeline.context import ConversationEntry, PluginContext
 from pipeline.resources.memory_resource import MemoryResource
-from pipeline.stages import PipelineStage
 
 
 class ComplexPrompt(PromptPlugin):

--- a/src/plugins/builtin/prompts/memory_retrieval.py
+++ b/src/plugins/builtin/prompts/memory_retrieval.py
@@ -8,7 +8,6 @@ from typing import List
 from pipeline.base_plugins import PromptPlugin
 from pipeline.context import ConversationEntry, PluginContext
 from pipeline.resources.memory_resource import MemoryResource
-from pipeline.stages import PipelineStage
 
 
 class MemoryRetrievalPrompt(PromptPlugin):

--- a/src/plugins/builtin/resources/duckdb_database.py
+++ b/src/plugins/builtin/resources/duckdb_database.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 """DuckDB-based conversation history storage."""
+import asyncio
 import json
 from typing import Dict, List, Optional
 

--- a/src/plugins/builtin/resources/duckdb_vector_store.py
+++ b/src/plugins/builtin/resources/duckdb_vector_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 """DuckDB-backed vector store resource."""
+import asyncio
 from typing import Dict, List, Optional
 
 import duckdb

--- a/src/plugins/builtin/resources/in_memory_storage.py
+++ b/src/plugins/builtin/resources/in_memory_storage.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 """In-memory conversation history storage."""
 
+from typing import Dict, List
+
 from pipeline.state import ConversationEntry
 from plugins.builtin.resources.database import DatabaseResource
 

--- a/src/plugins/builtin/resources/pg_vector_store.py
+++ b/src/plugins/builtin/resources/pg_vector_store.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 """Postgres-backed vector store resource."""
 
+from typing import Dict, List
+
 from pgvector import Vector
 from pgvector.asyncpg import register_vector
 

--- a/src/plugins/builtin/tools/calculator_tool.py
+++ b/src/plugins/builtin/tools/calculator_tool.py
@@ -9,7 +9,6 @@ from typing import Any, Dict
 from pydantic import BaseModel
 
 from pipeline.base_plugins import ToolPlugin
-from pipeline.stages import PipelineStage
 from pipeline.validation.input import validate_params
 
 

--- a/src/plugins/builtin/tools/search_tool.py
+++ b/src/plugins/builtin/tools/search_tool.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 
 from pipeline.base_plugins import ToolPlugin
 from pipeline.exceptions import ResourceError
-from pipeline.stages import PipelineStage
 from pipeline.validation.input import validate_params
 
 

--- a/src/plugins/builtin/tools/weather_api_tool.py
+++ b/src/plugins/builtin/tools/weather_api_tool.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 
 from pipeline.base_plugins import ToolPlugin
 from pipeline.exceptions import ResourceError
-from pipeline.stages import PipelineStage
 from pipeline.validation.input import validate_params
 
 

--- a/src/plugins/resources/container.py
+++ b/src/plugins/resources/container.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 """Asynchronous resource container."""
+import asyncio
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 

--- a/tests/test_conversation_history_plugin.py
+++ b/tests/test_conversation_history_plugin.py
@@ -45,5 +45,7 @@ def test_history_plugin_saves_conversation(tmp_path):
     expected = ctx.get_conversation_history()
     asyncio.run(plugin.execute(ctx))
 
-    saved = asyncio.run(memory.database.load_history(state.pipeline_id))  # type: ignore[attr-defined]
+    saved = asyncio.run(
+        memory.database.load_history(state.pipeline_id)  # type: ignore[attr-defined]
+    )
     assert saved and saved[0].content == expected[0].content


### PR DESCRIPTION
## Summary
- regenerate Poetry lock file and install dev dependencies
- fix flake8 errors in adapters and resources
- alias LoggingAdapter import to avoid name clash
- clean up unused imports and add missing typing
- format codebase with isort and black

## Testing
- `poetry run python -m pip check`
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: No module named 'pipeline.logging')*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'pipeline.logging')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'pipeline.logging')*
- `poetry run python -m src.registry.validator` *(fails: No module named 'pipeline.logging')*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pipeline.logging')*

------
https://chatgpt.com/codex/tasks/task_e_686aab76ec9483228365b2b45b4da822