### PR TITLE
Add pipeline logging wrapper

### DIFF
--- a/src/pipeline/logging.py
+++ b/src/pipeline/logging.py
@@ -1,0 +1,35 @@
+"""Logging utilities for the pipeline."""
+
+from __future__ import annotations
+
+
+def configure_logging(*args, **kwargs):
+    from plugins.builtin.adapters.logging_adapter import configure_logging
+
+    return configure_logging(*args, **kwargs)
+
+
+def get_logger(name: str):
+    from plugins.builtin.adapters.logging_adapter import get_logger
+
+    return get_logger(name)
+
+
+def set_request_id(request_id: str):
+    from plugins.builtin.adapters.logging_adapter import set_request_id
+
+    return set_request_id(request_id)
+
+
+def reset_request_id(token):
+    from plugins.builtin.adapters.logging_adapter import reset_request_id
+
+    return reset_request_id(token)
+
+
+__all__ = [
+    "configure_logging",
+    "get_logger",
+    "set_request_id",
+    "reset_request_id",
+]


### PR DESCRIPTION
## Summary
- implement lazy re-exports for pipeline logging utilities
- ensure imports are available

## Testing
- `poetry run python -m pip check`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686aab6e63008322aaa7f1f3fcb56471