### PR TITLE
refactor registry imports

### DIFF
--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -15,12 +15,10 @@ from .manager import PipelineManager
 from .metrics import MetricsCollector
 from .observability import execute_with_observability
 from .pipeline import create_default_response, execute_pipeline
-from .registries import (
-    PluginRegistry,
-    ResourceContainer,
-    SystemRegistries,
-    ToolRegistry,
-)
+
+# Registry classes are no longer imported eagerly.
+# Access ``PluginRegistry`` and related classes via ``registry`` or
+# rely on this module's ``__getattr__`` for lazy loading.
 from .resources import LLM, BaseResource, Resource
 from .runtime import AgentRuntime
 from .stages import PipelineStage
@@ -66,14 +64,10 @@ __all__ = [
     "ValidationResult",
     "ReconfigResult",
     "ConfigurationError",
-    "PluginRegistry",
-    "ResourceContainer",
-    "ToolRegistry",
     "ClassRegistry",
     "SystemInitializer",
     "import_plugin_class",
     "initialization_cleanup_context",
-    "SystemRegistries",
     "execute_pipeline",
     "create_default_response",
     "create_static_error_response",
@@ -86,3 +80,28 @@ __all__ = [
     "ConversationManager",
     "execute_with_observability",
 ]
+
+
+def __getattr__(name: str):
+    """Lazily expose registry classes."""
+
+    if name in {
+        "PluginRegistry",
+        "ResourceContainer",
+        "SystemRegistries",
+        "ToolRegistry",
+    }:
+        from registry import (
+            PluginRegistry,
+            ResourceContainer,
+            SystemRegistries,
+            ToolRegistry,
+        )
+
+        return {
+            "PluginRegistry": PluginRegistry,
+            "ResourceContainer": ResourceContainer,
+            "SystemRegistries": SystemRegistries,
+            "ToolRegistry": ToolRegistry,
+        }[name]
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/registry/__init__.py
+++ b/src/registry/__init__.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
-from pipeline.resources import ResourceContainer
-
 from .registries import PluginRegistry, SystemRegistries, ToolRegistry
 from .validator import RegistryValidator
 
 __all__ = [
     "PluginRegistry",
-    "ResourceContainer",
     "ToolRegistry",
     "SystemRegistries",
     "RegistryValidator",
 ]
+
+
+def __getattr__(name: str):
+    """Lazily load pipeline dependencies."""
+
+    if name == "ResourceContainer":
+        from pipeline.resources import ResourceContainer
+
+        return ResourceContainer
+    raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Summary
- avoid importing registries in `pipeline.__init__`
- lazily provide registry classes in `pipeline` and `registry`

## Testing
- `poetry run black src/pipeline/__init__.py src/registry/__init__.py`
- `poetry run isort src/pipeline/__init__.py src/registry/__init__.py`
- `poetry run flake8 src tests` *(fails: redefinition, unused imports, undefined names)*
- `poetry run mypy src` *(fails: many errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.registry.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686aab706f7c8322b282dac6d783495f