### PR TITLE
Fix context exports

### DIFF
--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -24,6 +24,8 @@ else:  # pragma: no cover - runtime type reference
 
 from registry import SystemRegistries
 
+__all__ = ["PluginContext", "ConversationEntry", "ToolCall"]
+
 from .errors import ResourceError
 from .metrics import MetricsCollector
 from .stages import PipelineStage


### PR DESCRIPTION
## Summary
- make `PluginContext`, `ConversationEntry`, and `ToolCall` explicit exports in `context.py`

## Testing
- `poetry run black src/pipeline/context.py`
- `poetry run black src tests` *(fails: Cannot parse builtin adapters/__init__.py)*
- `poetry run isort src/pipeline/context.py`
- `poetry run flake8 src/pipeline/context.py`
- `poetry run mypy src/pipeline/context.py`
- `bandit -r src/pipeline/context.py` *(fails: command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: SyntaxError in builtin adapters)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: SyntaxError in builtin adapters)*
- `poetry run python -m src.registry.validator` *(fails: SyntaxError in builtin adapters)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686ab29b6040832281fe089b6dc69ce7