### PR TITLE
Switch to logging instead of prints

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -117,7 +117,7 @@ class CLI:
             "    main()\n"
         )
 
-        print(f"Created project at {target}")
+        logger.info("Created project at %s", target)
         return 0
 
     def _reload_config(self, agent: Agent, file_path: str) -> int:

--- a/src/config/generate_template.py
+++ b/src/config/generate_template.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from plugins.builtin.adapters.logging_adapter import configure_logging, get_logger
+
+logger = get_logger(__name__)
+
 
 def main() -> int:
+    configure_logging()
+
     parser = argparse.ArgumentParser(description="Generate a starter configuration")
     parser.add_argument(
         "path", nargs="?", default="-", help="Output path or '-' for stdout"
@@ -17,12 +23,12 @@ def main() -> int:
     content = template.read_text()
 
     if args.path == "-":
-        print(content)
+        logger.info(content)
     else:
         dest = Path(args.path)
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(content)
-        print(f"Wrote template to {dest}")
+        logger.info("Wrote template to %s", dest)
     return 0
 
 

--- a/src/config/migrate.py
+++ b/src/config/migrate.py
@@ -7,6 +7,9 @@ import yaml
 
 from config.models import EntityConfig, asdict
 from pipeline.config import ConfigLoader
+from plugins.builtin.adapters.logging_adapter import configure_logging, get_logger
+
+logger = get_logger(__name__)
 
 
 class ConfigMigrator:
@@ -29,15 +32,17 @@ class ConfigMigrator:
         return parser.parse_args()
 
     def run(self) -> int:
+        configure_logging()
+
         data = ConfigLoader.from_yaml(self.args.src)
         config = EntityConfig.from_dict(data)
         text = yaml.safe_dump(asdict(config), sort_keys=False)
         if self.args.dest == "-":
-            print(text)
+            logger.info(text)
         else:
             out = Path(self.args.dest)
             out.write_text(text)
-            print(f"Wrote migrated config to {out}")
+            logger.info("Wrote migrated config to %s", out)
         return 0
 
 

--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -82,10 +82,8 @@ class ConfigValidator:
                 initializer = SystemInitializer(config)
                 asyncio.run(initializer.initialize())
             except (ValidationError, Exception) as exc:  # pragma: no cover - error path
-                print(f"Configuration invalid: {exc}")
                 logger.error("Configuration invalid: %s", exc)
                 return False
-            print("Configuration valid")
             logger.info("Configuration valid.")
             return True
 
@@ -127,7 +125,7 @@ class ConfigValidator:
             else:
                 if last_good is not None:
                     cfg_path.write_text(last_good)
-                    print("Rolled back to last valid configuration")
+                    logger.error("Rolled back to last valid configuration")
 
         return 0
 

--- a/src/plugins/builtin/adapters/__init__.py
+++ b/src/plugins/builtin/adapters/__init__.py
@@ -6,11 +6,7 @@ from .cli import CLIAdapter
 from .grpc import LLMGRPCAdapter
 from .http import HTTPAdapter
 from .logging import LoggingAdapter
-<<<<<< codex/refactor-test-modules-and-improve-fixtures
-from .logging_adapter import LoggingAdapter as FileLoggingAdapter
-======
 from .logging_adapter import LoggingAdapter as LoggingAdapterWrapper
->>>>>> main
 from .websocket import WebSocketAdapter
 
 __all__ = [
@@ -19,9 +15,5 @@ __all__ = [
     "WebSocketAdapter",
     "LLMGRPCAdapter",
     "LoggingAdapter",
-<<<<<< codex/refactor-test-modules-and-improve-fixtures
-    "FileLoggingAdapter",
-======
     "LoggingAdapterWrapper",
->>>>>> main
 ]

--- a/src/plugins/builtin/adapters/cli.py
+++ b/src/plugins/builtin/adapters/cli.py
@@ -59,7 +59,6 @@ class CLIAdapter(AdapterPlugin):
                     await execute_pipeline(message, self._registries),
                 )
             self.logger.info("%s", response)
-            print(response)
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - adapter
         pass


### PR DESCRIPTION
## Summary
- replace leftover `print` calls with logger usage
- clean up adapter package init file

## Testing
- `poetry run isort --check --profile black src/config/generate_template.py src/config/migrate.py src/config/validator.py src/cli.py src/plugins/builtin/adapters/__init__.py src/plugins/builtin/adapters/cli.py`
- `poetry run flake8 src/cli.py src/config/generate_template.py src/config/migrate.py src/config/validator.py src/plugins/builtin/adapters/__init__.py src/plugins/builtin/adapters/cli.py`
- `poetry run mypy src/cli.py src/config/generate_template.py src/config/migrate.py src/config/validator.py src/plugins/builtin/adapters/__init__.py src/plugins/builtin/adapters/cli.py` *(fails: Class cannot subclass `AdapterPlugin`, missing stubs)*
- `poetry run bandit -r src/cli.py src/config/generate_template.py src/config/migrate.py src/config/validator.py src/plugins/builtin/adapters/__init__.py src/plugins/builtin/adapters/cli.py`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: circular import)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: circular import)*
- `poetry run pytest` *(fails: 74 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ab29d220883229deaa8c29afec549