### PR TITLE
Fix typing for agent

### DIFF
--- a/src/pipeline/agent.py
+++ b/src/pipeline/agent.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, cast
 
-from registry import SystemRegistries
+from registry import PluginRegistry, SystemRegistries
 
 from .builder import AgentBuilder
 from .exceptions import PipelineError
@@ -21,22 +21,32 @@ class Agent:
     # ------------------------------------------------------------------
     # Delegated plugin helpers
     # ------------------------------------------------------------------
-    async def add_plugin(self, plugin: Any) -> None:  # pragma: no cover - delegation
-        await self.builder.add_plugin(plugin)
+    def add_plugin(self, plugin: Any) -> None:  # pragma: no cover - delegation
+        """Register a plugin on the underlying builder."""
+
+        self.builder.add_plugin(plugin)
 
     def plugin(
-        self, func: Optional[Callable] = None, **hints
-    ):  # pragma: no cover - delegation
+        self,
+        func: Optional[Callable[..., Any]] = None,
+        **hints: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]] | Callable[..., Any]:
+        """Decorator for registering ``func`` as a plugin."""
+
         return self.builder.plugin(func, **hints)
 
     def load_plugins_from_directory(
         self, directory: str
     ) -> None:  # pragma: no cover - delegation
+        """Load and register all plugins from ``directory``."""
+
         self.builder.load_plugins_from_directory(directory)
 
     def load_plugins_from_package(
         self, package_name: str
     ) -> None:  # pragma: no cover - delegation
+        """Import a package and register any plugins it contains."""
+
         self.builder.load_plugins_from_package(package_name)
 
     @classmethod
@@ -70,11 +80,16 @@ class Agent:
         return self._runtime
 
     async def run_message(self, message: str) -> Dict[str, Any]:
+        """Run ``message`` through the runtime pipeline and return results."""
+
         await self._ensure_runtime()
         assert self._runtime is not None
-        return await self._runtime.run_pipeline(message)
+        runtime = cast(AgentRuntime, self._runtime)
+        return cast(Dict[str, Any], await runtime.run_pipeline(message))
 
     async def handle(self, message: str) -> Dict[str, Any]:
+        """Public alias for :meth:`run_message`."""
+
         return await self.run_message(message)
 
     def get_registries(self) -> SystemRegistries:
@@ -86,13 +101,13 @@ class Agent:
     # Compatibility helpers
     # ------------------------------------------------------------------
     @property
-    def plugin_registry(self):  # pragma: no cover - passthrough
+    def plugin_registry(self) -> "PluginRegistry":  # pragma: no cover - passthrough
         if self._runtime is not None:
             return self._runtime.registries.plugins
         return self.builder.plugin_registry
 
     @property
-    def plugins(self):  # pragma: no cover - passthrough
+    def plugins(self) -> "PluginRegistry":  # pragma: no cover - passthrough
         if self._runtime is not None:
             return self._runtime.registries.plugins
         return self.builder.plugin_registry

--- a/src/pipeline/builder.py
+++ b/src/pipeline/builder.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
-from registry import PluginRegistry, ResourceContainer, SystemRegistries, ToolRegistry
+from registry import (PluginRegistry, ResourceContainer, SystemRegistries,
+                      ToolRegistry)
 
 from .interfaces import PluginAutoClassifier
 from .logging import get_logger
@@ -25,6 +26,8 @@ class AgentBuilder:
 
     # ------------------------------ plugin utils ------------------------------
     def add_plugin(self, plugin: BasePlugin) -> None:
+        """Validate and register ``plugin`` for its declared stages."""
+
         if not hasattr(plugin, "_execute_impl") or not callable(
             getattr(plugin, "_execute_impl")
         ):
@@ -34,10 +37,14 @@ class AgentBuilder:
             name = getattr(plugin, "name", plugin.__class__.__name__)
             self.plugin_registry.register_plugin_for_stage(plugin, stage, name)
 
-    def plugin(self, func: Optional[Callable] = None, **hints):
+    def plugin(
+        self,
+        func: Optional[Callable[..., Any]] = None,
+        **hints: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]] | Callable[..., Any]:
         """Decorator registering ``func`` as a plugin."""
 
-        def decorator(f: Callable) -> Callable:
+        def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
             plugin = PluginAutoClassifier.classify(f, hints)
             self.add_plugin(plugin)
             return f

--- a/src/plugins/builtin/adapters/__init__.py
+++ b/src/plugins/builtin/adapters/__init__.py
@@ -6,11 +6,7 @@ from .cli import CLIAdapter
 from .grpc import LLMGRPCAdapter
 from .http import HTTPAdapter
 from .logging import LoggingAdapter
-<<<<<< codex/refactor-test-modules-and-improve-fixtures
-from .logging_adapter import LoggingAdapter as FileLoggingAdapter
-======
 from .logging_adapter import LoggingAdapter as LoggingAdapterWrapper
->>>>>> main
 from .websocket import WebSocketAdapter
 
 __all__ = [
@@ -19,9 +15,5 @@ __all__ = [
     "WebSocketAdapter",
     "LLMGRPCAdapter",
     "LoggingAdapter",
-<<<<<< codex/refactor-test-modules-and-improve-fixtures
-    "FileLoggingAdapter",
-======
     "LoggingAdapterWrapper",
->>>>>> main
 ]


### PR DESCRIPTION
## Summary
- expand agent plugin loading method hints
- add runtime cast helpers
- clean up adapter imports

## Testing
- `poetry run black src/pipeline/agent.py src/pipeline/builder.py src/plugins/builtin/adapters/__init__.py`
- `poetry run isort src/pipeline/agent.py src/pipeline/builder.py src/plugins/builtin/adapters/__init__.py`
- `poetry run flake8 src/pipeline/agent.py src/pipeline/builder.py src/plugins/builtin/adapters/__init__.py`
- `poetry run mypy src/pipeline/agent.py src/pipeline/builder.py src/plugins/builtin/adapters/__init__.py`
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ImportError: cannot import name 'SystemRegistries')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ImportError: cannot import name 'SystemRegistries')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ImportError: cannot import name 'SystemRegistries')*

------
https://chatgpt.com/codex/tasks/task_e_686ab29c3cd88322984cb3795ad2e8fc