### PR TITLE
Add async resource manager prototype

### DIFF
--- a/experiments/unified_registry/README.md
+++ b/experiments/unified_registry/README.md
@@ -1,0 +1,14 @@
+# Unified Registry Prototype
+
+This directory contains a prototype `AsyncResourceManager` designed for small
+experiments with dependency injection frameworks like FastAPI and Django.
+
+Key features:
+
+- Asynchronous resource registration and initialization
+- Health checks for all managed resources
+- Simple metrics collection
+- Example FastAPI integration in `di_demo.py`
+
+The same manager can be integrated with Django by creating the instance inside
+`apps.py` and exposing resources through dependency injection utilities.

--- a/experiments/unified_registry/di_demo.py
+++ b/experiments/unified_registry/di_demo.py
@@ -1,0 +1,48 @@
+"""Demonstrates using AsyncResourceManager with different DI frameworks."""
+
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI
+
+from experiments.unified_registry.resource_manager import (
+    AsyncResourceManager,
+    BaseResource,
+)
+
+app = FastAPI()
+manager = AsyncResourceManager()
+
+
+def get_resource(name: str) -> BaseResource:
+    resource = manager.get(name)
+    if resource is None:
+        raise RuntimeError(f"Resource '{name}' not registered")
+    return resource
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    await manager.initialize_all()
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await manager.shutdown_all()
+
+
+@app.get("/health")
+async def health() -> dict[str, bool]:
+    return await manager.health_report()
+
+
+# Dependency example using FastAPI's Depends
+@app.get("/items/{item_id}")
+async def read_item(
+    item_id: int,
+    db: BaseResource = Depends(lambda: get_resource("db")),
+) -> dict[str, int]:
+    return {"item_id": item_id}
+
+
+# Django integration would typically use the manager in middleware or apps.py.
+# For brevity this example focuses on FastAPI.

--- a/experiments/unified_registry/resource_manager.py
+++ b/experiments/unified_registry/resource_manager.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict
+
+
+@dataclass
+class ManagerMetrics:
+    """Simple metrics for the resource manager."""
+
+    resources_registered: int = 0
+    resources_initialized: int = 0
+    health_checks: int = 0
+    health_failures: int = 0
+    init_durations: Dict[str, float] = field(default_factory=dict)
+
+
+class BaseResource:
+    """Base class for managed resources."""
+
+    async def initialize(self) -> None:  # pragma: no cover - optional
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - optional
+        pass
+
+    async def health_check(self) -> bool:  # pragma: no cover - optional
+        return True
+
+
+class AsyncResourceManager:
+    """Asynchronous registry and lifecycle manager for resources."""
+
+    def __init__(self) -> None:
+        self._resources: Dict[str, BaseResource] = {}
+        self.metrics = ManagerMetrics()
+        self._lock = asyncio.Lock()
+
+    async def register(self, name: str, resource: BaseResource) -> None:
+        async with self._lock:
+            self._resources[name] = resource
+            self.metrics.resources_registered += 1
+
+    def get(self, name: str) -> BaseResource | None:
+        return self._resources.get(name)
+
+    async def initialize_all(self) -> None:
+        for name, resource in self._resources.items():
+            start = time.perf_counter()
+            await resource.initialize()
+            duration = time.perf_counter() - start
+            self.metrics.resources_initialized += 1
+            self.metrics.init_durations[name] = duration
+
+    async def shutdown_all(self) -> None:
+        for resource in self._resources.values():
+            await resource.shutdown()
+
+    async def health_report(self) -> Dict[str, bool]:
+        report: Dict[str, bool] = {}
+        for name, resource in self._resources.items():
+            try:
+                healthy = await resource.health_check()
+            except Exception:
+                healthy = False
+            if not healthy:
+                self.metrics.health_failures += 1
+            self.metrics.health_checks += 1
+            report[name] = healthy
+        return report

--- a/tests/experiments/test_resource_manager.py
+++ b/tests/experiments/test_resource_manager.py
@@ -1,0 +1,30 @@
+from experiments.unified_registry.resource_manager import (
+    AsyncResourceManager,
+    BaseResource,
+)
+
+
+class DummyResource(BaseResource):
+    def __init__(self) -> None:
+        self.initialized = False
+        self.closed = False
+
+    async def initialize(self) -> None:
+        self.initialized = True
+
+    async def shutdown(self) -> None:
+        self.closed = True
+
+    async def health_check(self) -> bool:
+        return self.initialized and not self.closed
+
+
+async def test_manager_lifecycle():
+    manager = AsyncResourceManager()
+    await manager.register("dummy", DummyResource())
+    await manager.initialize_all()
+    report = await manager.health_report()
+    assert report == {"dummy": True}
+    await manager.shutdown_all()
+    assert manager.get("dummy").closed
+    assert manager.metrics.resources_initialized == 1


### PR DESCRIPTION
## Summary
- prototype `AsyncResourceManager` for experiments
- example FastAPI integration demo
- add basic tests for the new manager

## Testing
- `poetry run black src tests experiments`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 369 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ImportError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ImportError)*
- `poetry run python -m src.registry.validator` *(fails: ImportError)*
- `poetry run pytest` *(fails: 74 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ad5bdca7883228ddbeee0a42b0671