### PR TITLE
Add simple composition-based plugins

### DIFF
--- a/experiments/simple_plugins/__init__.py
+++ b/experiments/simple_plugins/__init__.py
@@ -1,0 +1,7 @@
+"""Simplified plugin examples using composition."""
+
+from .prompt import ComposedPrompt
+from .resource import ComposedResource
+from .tool import ComposedTool
+
+__all__ = ["ComposedPrompt", "ComposedResource", "ComposedTool"]

--- a/experiments/simple_plugins/prompt.py
+++ b/experiments/simple_plugins/prompt.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from pipeline.base_plugins import PromptPlugin
+from pipeline.context import PluginContext
+from pipeline.stages import PipelineStage
+
+PromptBehavior = Callable[[PluginContext], Awaitable[None]]
+
+
+async def default_behavior(context: PluginContext) -> None:
+    context.set_response("Hello from simple prompt")
+
+
+class ComposedPrompt(PromptPlugin):
+    """Prompt plugin composed with a behavior callable."""
+
+    stages = [PipelineStage.THINK]
+    name = "composed_prompt"
+
+    def __init__(
+        self, behavior: PromptBehavior | None = None, config: dict | None = None
+    ) -> None:
+        super().__init__(config)
+        self._behavior = behavior or default_behavior
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        await self._behavior(context)

--- a/experiments/simple_plugins/resource.py
+++ b/experiments/simple_plugins/resource.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Protocol
+
+from pipeline.base_plugins import ResourcePlugin
+
+
+class StorageBackend(Protocol):
+    async def add(self, item: Any) -> None: ...
+    async def get_all(self) -> list[Any]: ...
+    async def initialize(self) -> None: ...
+    async def health_check(self) -> bool: ...
+    def get_metrics(self) -> Dict[str, Any]: ...
+
+
+class InMemoryBackend:
+    """Simple in-memory backend implementing ``StorageBackend``."""
+
+    def __init__(self) -> None:
+        self.items: list[Any] = []
+
+    async def add(self, item: Any) -> None:
+        self.items.append(item)
+
+    async def get_all(self) -> list[Any]:
+        return list(self.items)
+
+    async def initialize(self) -> None:
+        return None
+
+    async def health_check(self) -> bool:
+        return True
+
+    def get_metrics(self) -> Dict[str, Any]:
+        return {"items": len(self.items)}
+
+
+class ComposedResource(ResourcePlugin):
+    """Resource plugin delegating behavior to a backend."""
+
+    name = "composed_memory"
+
+    def __init__(
+        self, backend: StorageBackend | None = None, config: Dict | None = None
+    ) -> None:
+        super().__init__(config)
+        self._backend: StorageBackend = backend or InMemoryBackend()
+
+    async def initialize(self) -> None:
+        await self._backend.initialize()
+
+    async def health_check(self) -> bool:
+        return await self._backend.health_check()
+
+    def get_metrics(self) -> Dict[str, Any]:
+        return self._backend.get_metrics()
+
+    async def add_item(self, item: Any) -> None:
+        await self._backend.add(item)
+
+    async def items(self) -> list[Any]:
+        return await self._backend.get_all()

--- a/experiments/simple_plugins/tool.py
+++ b/experiments/simple_plugins/tool.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Protocol
+
+from pipeline.base_plugins import ToolPlugin
+
+
+class ToolBehavior(Protocol):
+    async def run(self, params: Dict[str, Any]) -> Any: ...
+
+
+class EchoBehavior:
+    async def run(self, params: Dict[str, Any]) -> str:
+        return str(params.get("text", ""))
+
+
+class ComposedTool(ToolPlugin):
+    """Tool plugin that delegates execution to a behavior object."""
+
+    name = "composed_echo"
+
+    def __init__(
+        self, behavior: ToolBehavior | None = None, config: Dict | None = None
+    ) -> None:
+        super().__init__(config)
+        self._behavior: ToolBehavior = behavior or EchoBehavior()
+
+    async def execute_function(self, params: Dict[str, Any]) -> Any:
+        return await self._behavior.run(params)


### PR DESCRIPTION
## Summary
- add flattened `experiments/simple_plugins` with prompt, resource and tool examples

## Testing
- `bandit -r src`
- `poetry run pytest` *(fails: 74 errors during collection)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ImportError for circular import)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ImportError for circular import)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError for 'common_interfaces')*

------
https://chatgpt.com/codex/tasks/task_e_686ad5c1d5a08322b7361cbb0f7880f7