### PR TITLE
Add contextual errors and rollback example

### DIFF
--- a/experiments/error_handling/README.md
+++ b/experiments/error_handling/README.md
@@ -1,0 +1,7 @@
+# Error Handling Experiments
+
+This folder contains small programs exploring error handling techniques.
+
+Run `state_machine_example.py` to see a tiny state machine that rolls back
+its state when a plugin error occurs.
+

--- a/experiments/error_handling/state_machine_example.py
+++ b/experiments/error_handling/state_machine_example.py
@@ -1,0 +1,43 @@
+"""Demonstrate simple rollback logic using the new error classes."""
+
+from __future__ import annotations
+
+from pipeline.errors import PluginContextError
+from pipeline.stages import PipelineStage
+
+
+class SimpleStateMachine:
+    """Tiny state machine that can roll back when processing fails."""
+
+    def __init__(self) -> None:
+        self.state = "idle"
+        self.history = []
+
+    def transition(self, new_state: str) -> None:
+        self.history.append(self.state)
+        self.state = new_state
+        print(f"-> {self.state}")
+
+    def rollback(self) -> None:
+        if self.history:
+            self.state = self.history.pop()
+            print(f"rollback to {self.state}")
+
+    def do_work(self) -> None:
+        raise PluginContextError(PipelineStage.DO, "Worker", "failure", {"step": 1})
+
+    def run(self) -> None:
+        try:
+            self.transition("processing")
+            self.do_work()
+            self.transition("done")
+        except PluginContextError as exc:
+            print(f"caught: {exc}")
+            self.rollback()
+            self.transition("recovered")
+
+
+if __name__ == "__main__":
+    machine = SimpleStateMachine()
+    machine.run()
+    print(f"final: {machine.state}")

--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict
 
-from .exceptions import (PipelineError, PluginExecutionError, ResourceError,
-                         ToolExecutionError)
+from .context import PipelineContextError, PluginContextError, StageExecutionError
+from .exceptions import (
+    PipelineError,
+    PluginExecutionError,
+    ResourceError,
+    ToolExecutionError,
+)
 
 __all__ = [
     "create_static_error_response",
@@ -12,6 +17,9 @@ __all__ = [
     "PluginExecutionError",
     "ResourceError",
     "ToolExecutionError",
+    "PipelineContextError",
+    "StageExecutionError",
+    "PluginContextError",
 ]
 
 # Generic fallback returned when even error handling fails

--- a/src/pipeline/errors/context.py
+++ b/src/pipeline/errors/context.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Error classes that include execution context information."""
+
+from typing import Any, Dict
+
+from ..stages import PipelineStage
+from .exceptions import PipelineError
+
+
+class PipelineContextError(PipelineError):
+    """Base error carrying additional context."""
+
+    def __init__(self, message: str, context: Dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.context: Dict[str, Any] = context or {}
+
+
+class StageExecutionError(PipelineContextError):
+    """Raised when a pipeline stage fails."""
+
+    def __init__(
+        self,
+        stage: PipelineStage,
+        message: str,
+        context: Dict[str, Any] | None = None,
+    ) -> None:
+        self.stage = stage
+        super().__init__(f"{stage.name} stage failed: {message}", context)
+
+
+class PluginContextError(StageExecutionError):
+    """Raised when a plugin within a stage fails."""
+
+    def __init__(
+        self,
+        stage: PipelineStage,
+        plugin_name: str,
+        message: str,
+        context: Dict[str, Any] | None = None,
+    ) -> None:
+        self.plugin_name = plugin_name
+        super().__init__(stage, f"Plugin '{plugin_name}' error: {message}", context)


### PR DESCRIPTION
## Summary
- add error classes with context support
- export context errors in error package
- test contextual errors
- show simple rollback demo with state machine

## Testing
- `poetry run black src/pipeline/errors/context.py src/pipeline/errors/__init__.py tests/test_error_handling.py experiments/error_handling/state_machine_example.py`
- `poetry run isort src/pipeline/errors/context.py src/pipeline/errors/__init__.py tests/test_error_handling.py experiments/error_handling/state_machine_example.py`
- `poetry run flake8 src tests`
- `poetry run mypy src/pipeline/context.py src/pipeline/manager.py src/pipeline/runtime.py src/pipeline/tools/execution.py` *(fails: Need type annotation for "manager" among other errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(failed to run: ImportError due to circular import)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(failed to run: ImportError due to circular import)*
- `poetry run python -m src.registry.validator` *(failed to run: ModuleNotFoundError)*
- `pytest` *(failed to run: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_686ad5c4edd08322a1f66040b1072beb