### PR TITLE
Add config loader hot reload experiment

### DIFF
--- a/experiments/config_loader/__init__.py
+++ b/experiments/config_loader/__init__.py
@@ -1,0 +1,1 @@
+"""Example configuration hot reload."""

--- a/experiments/config_loader/config.yaml
+++ b/experiments/config_loader/config.yaml
@@ -1,0 +1,1 @@
+greeting: ${GREETING}

--- a/experiments/config_loader/demo.py
+++ b/experiments/config_loader/demo.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any
+
+from .loader import ConfigWatcher
+
+
+async def main() -> None:
+    os.environ.setdefault("GREETING", "Hello, world!")
+    cfg_file = Path(__file__).with_name("config.yaml")
+
+    def on_update(cfg: dict[str, Any]) -> None:
+        print("Config reloaded:", cfg)
+
+    watcher = ConfigWatcher(cfg_file)
+    watcher.start(on_update)
+
+    try:
+        while True:
+            await asyncio.sleep(1)
+    except KeyboardInterrupt:
+        watcher.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/experiments/config_loader/loader.py
+++ b/experiments/config_loader/loader.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Callable
+
+from pipeline.config import ConfigLoader
+
+
+class ConfigWatcher:
+    """Load a config file and watch for changes."""
+
+    def __init__(self, path: str | Path, env_file: str = ".env") -> None:
+        self.path = Path(path)
+        self.env_file = env_file
+        self.config: dict[str, Any] = ConfigLoader.from_yaml(self.path, env_file)
+        self._mtime = self.path.stat().st_mtime
+        self._task: asyncio.Task[None] | None = None
+
+    def start(
+        self,
+        callback: Callable[[dict[str, Any]], None] | None = None,
+        interval: float = 1.0,
+    ) -> None:
+        """Begin watching ``path`` for modifications."""
+
+        async def watch() -> None:
+            while True:
+                await asyncio.sleep(interval)
+                mtime = self.path.stat().st_mtime
+                if mtime != self._mtime:
+                    self._mtime = mtime
+                    self.config = ConfigLoader.from_yaml(self.path, self.env_file)
+                    if callback:
+                        callback(self.config)
+
+        self._task = asyncio.create_task(watch())
+
+    def stop(self) -> None:
+        """Stop watching the file."""
+        if self._task:
+            self._task.cancel()


### PR DESCRIPTION
## Summary
- add experiment demo for watching config changes
- show environment variable interpolation via ConfigLoader

## Testing
- `poetry run black src tests experiments/config_loader`
- `poetry run isort src tests experiments/config_loader`
- `poetry run flake8 src tests experiments/config_loader`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml`
- `poetry run python -m src.config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ad5c935148322910a8844535de781