### PR TITLE
Add spike doc for performance strategies

### DIFF
--- a/docs/spikes/SPIKE-PERF-001/strategies.md
+++ b/docs/spikes/SPIKE-PERF-001/strategies.md
@@ -1,0 +1,25 @@
+# SPIKE-PERF-001: Performance Techniques
+
+## Summary
+This spike explores ways to improve throughput when calling external LLM services. We reviewed async batching, Redis caching, concurrency patterns, and retry strategies.
+
+## Async Batching
+- Group multiple prompts into a single request when the backend supports it.
+- Use `asyncio.gather` to send batches concurrently.
+- Monitor response times to find an optimal batch size.
+
+## Redis Caching
+- Store past prompt/response pairs in Redis using a short TTL.
+- Key format: hash of the prompt and parameters.
+- Check cache before invoking the LLM to avoid repeated work.
+
+## Concurrency Patterns
+- Use `asyncio` tasks for I/O bound work.
+- Leverage `asyncio.Semaphore` to limit in-flight requests.
+- For CPU-bound tasks, delegate to a thread or process pool.
+
+## Retry and Backoff
+- Use exponential backoff with jitter to avoid thundering herd issues.
+- The `tenacity` library provides convenient decorators for retry policies.
+- Limit the total number of retries to keep failure handling predictable.
+


### PR DESCRIPTION
## Summary
- document async batching, Redis caching, concurrency, and retry strategies

## Testing
- `poetry run black --check src tests` *(fails: would reformat files)*
- `poetry run isort --check src tests` *(fails: imports unsorted)*
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: many errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686ae46005d083229edb0f70d5b1463a