### PR TITLE
Add documentation on validation and hot reload

### DIFF
--- a/docs/spikes/SPIKE-CFG-001.md
+++ b/docs/spikes/SPIKE-CFG-001.md
@@ -1,0 +1,19 @@
+# SPIKE-CFG-001: Validation and Hot Reload Overview
+
+## Summary
+This document summarizes how the Entity Pipeline handles configuration validation, security, and runtime hot reloading. It draws from the existing architecture guides and troubleshooting notes.
+
+## Validation Strategy
+- **Fail-fast validation** ensures initialization stops if any plugin dependencies are missing. Each plugin class implements `validate_config` and `validate_dependencies`, returning `ValidationResult` objects.
+- Configuration files can be checked with `python -m src.config.validator --config your.yaml` to see detailed messages before starting the agent.
+- Plugins declare required stages and dependencies, and the initializer verifies them up front so execution order is safe.
+
+## Security Considerations
+- The review stage performs privacy protection, content filtering, and a final security review to ensure responses meet policy requirements.
+- Networking best practices include using VPCs and security groups when deploying on AWS. IAM roles restrict access to databases and S3 buckets.
+- Bandit static analysis runs in CI to catch common Python security issues.
+
+## Hot-Reload Options
+- The architecture supports **dynamic configuration updates**. Plugins expose a `reconfigure()` method that validates new settings and applies them without restarting the application.
+- The CLI provides `reload-config updated.yaml` to load new YAML at runtime, waiting for active pipelines to finish before applying the changes.
+


### PR DESCRIPTION
## Summary
- document validation strategy, security checks, and hot reload

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 369 errors)*
- `bandit -r src` *(command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(failed to run due to ImportError)*
- `python -m src.config.validator --config config/prod.yaml` *(failed to run due to ImportError)*
- `python -m src.registry.validator` *(failed to run due to ImportError)*
- `pytest` *(failed: 74 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ae459b070832295d236481ca3dd88