### PR TITLE
Add storage backend spike

### DIFF
--- a/docs/spikes/SPIKE-MEM-001/backends.md
+++ b/docs/spikes/SPIKE-MEM-001/backends.md
@@ -1,0 +1,34 @@
+# SPIKE-MEM-001: Storage and Vector Backends
+
+## Summary
+This spike documents the available database, vector store, and filesystem backends
+found in `src/plugins/builtin/resources`. It also notes missing integrations such
+as Pinecone and Google Cloud Storage.
+
+## Database Resources
+- `MemoryStorage` – in-memory conversation history.
+- `SQLiteStorageResource` – SQLite persistence with async `aiosqlite`.
+- `DuckDBDatabaseResource` – DuckDB backend with optional history table.
+- `PostgresResource` – async Postgres with connection pooling and circuit breaker.
+
+## Vector Store Resources
+- `MemoryVectorStore` – keeps embeddings in a Python list.
+- `DuckDBVectorStore` – uses DuckDB and `list_cosine_similarity` for queries.
+- `PgVectorStore` – leverages `pgvector` extension in Postgres.
+
+No Pinecone integration exists yet. `PgVectorStore` depends on the `vector` extension
+being installed. The base interface is `VectorStoreResource` with `add_embedding`
+and `query_similar` methods.
+
+## Filesystem Resources
+- `MemoryFileSystem` – simple in-memory dict for unit tests.
+- `LocalFileSystemResource` – stores files under a configurable base path.
+- `S3FileSystem` – uploads and retrieves objects via `aioboto3`.
+
+The project lacks a Google Cloud Storage implementation, though one could mirror
+the S3 approach using `google-cloud-storage`.
+
+## Conclusions
+Entity already includes local and cloud options for databases, vector stores, and
+file storage. Adding Pinecone or GCS would require new resources adhering to the
+existing `VectorStoreResource` or `FileSystemResource` contracts.


### PR DESCRIPTION
## Summary
- document database, vector store and filesystem resources

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: cannot import name 'Resource')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: cannot import name 'Resource')*
- `poetry run python -m src.registry.validator` *(fails: cannot import name 'BasePlugin')*
- `poetry run pytest` *(fails: 74 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ae45cd1908322bf7c869e2ab48705