### PR TITLE
Add experimental StorageResource prototype

### DIFF
--- a/experiments/storage/__init__.py
+++ b/experiments/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Storage resource prototype."""
+
+from .resource import StorageResource
+
+__all__ = ["StorageResource"]

--- a/experiments/storage/resource.py
+++ b/experiments/storage/resource.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+"""Experimental StorageResource supporting composable backends."""
+
+from contextlib import asynccontextmanager
+from typing import Dict, List
+
+from pipeline.base_plugins import ResourcePlugin, ValidationResult
+from pipeline.context import ConversationEntry
+from pipeline.exceptions import ResourceError
+from pipeline.stages import PipelineStage
+from plugins.builtin.resources.database import DatabaseResource
+from plugins.builtin.resources.filesystem import FileSystemResource
+from plugins.builtin.resources.vector_store import VectorStoreResource
+
+
+class StorageResource(ResourcePlugin):
+    """Compose database, vector store, and filesystem backends."""
+
+    stages = [PipelineStage.PARSE]
+    name = "storage"
+    dependencies = ["database", "vector_store", "filesystem"]
+
+    def __init__(
+        self,
+        database: DatabaseResource | None = None,
+        vector_store: VectorStoreResource | None = None,
+        filesystem: FileSystemResource | None = None,
+        config: Dict | None = None,
+    ) -> None:
+        super().__init__(config or {})
+        self.database = database
+        self.vector_store = vector_store
+        self.filesystem = filesystem
+
+    @classmethod
+    def from_config(cls, config: Dict) -> "StorageResource":
+        return cls(config=config)
+
+    async def initialize(self) -> None:  # pragma: no cover - simple passthrough
+        for backend in (self.database, self.vector_store, self.filesystem):
+            if hasattr(backend, "initialize") and callable(backend.initialize):
+                await backend.initialize()
+
+    async def shutdown(self) -> None:  # pragma: no cover - simple passthrough
+        for backend in (self.database, self.vector_store, self.filesystem):
+            if hasattr(backend, "shutdown") and callable(backend.shutdown):
+                await backend.shutdown()
+
+    @asynccontextmanager
+    async def connection(self):
+        """Yield a pooled database connection if available."""
+
+        if self.database is None:
+            raise ResourceError("No database backend configured")
+        async with self.database.connection() as conn:
+            yield conn
+
+    async def save_conversation(
+        self, conversation_id: str, history: List[ConversationEntry]
+    ) -> None:
+        if self.database:
+            await self.database.save_history(conversation_id, history)
+
+    async def load_conversation(self, conversation_id: str) -> List[ConversationEntry]:
+        if self.database:
+            return await self.database.load_history(conversation_id)
+        return []
+
+    async def search_similar(self, query: str, k: int = 5) -> List[str]:
+        if self.vector_store:
+            return await self.vector_store.query_similar(query, k)
+        return []
+
+    async def store_file(self, key: str, content: bytes) -> str:
+        if not self.filesystem:
+            raise ResourceError("No filesystem backend configured")
+        return await self.filesystem.store(key, content)
+
+    async def load_file(self, key: str) -> bytes:
+        if not self.filesystem:
+            raise ResourceError("No filesystem backend configured")
+        return await self.filesystem.load(key)
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        for name in ("database", "vector_store", "filesystem"):
+            sub = config.get(name)
+            if sub is not None and not isinstance(sub, dict):
+                return ValidationResult.error_result(f"'{name}' must be a mapping")
+        return ValidationResult.success_result()
+
+
+__all__ = ["StorageResource"]

--- a/tests/experiments/test_experiment_storage_resource.py
+++ b/tests/experiments/test_experiment_storage_resource.py
@@ -1,0 +1,42 @@
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+from experiments.storage import StorageResource
+from pipeline.context import ConversationEntry
+from plugins.builtin.resources.in_memory_storage import InMemoryStorageResource
+from plugins.builtin.resources.local_filesystem import LocalFileSystemResource
+
+
+async def make_storage(tmp_path: Path) -> StorageResource:
+    fs = LocalFileSystemResource({"base_path": str(tmp_path)})
+    db = InMemoryStorageResource({})
+    storage = StorageResource(database=db, filesystem=fs)
+    await storage.initialize()
+    return storage
+
+
+def test_store_and_load_file(tmp_path: Path) -> None:
+    async def run() -> bytes:
+        storage = await make_storage(tmp_path)
+        await storage.store_file("foo.txt", b"bar")
+        content = await storage.load_file("foo.txt")
+        await storage.shutdown()
+        return content
+
+    assert asyncio.run(run()) == b"bar"
+
+
+def test_save_and_load_history(tmp_path: Path) -> None:
+    async def run() -> list[ConversationEntry]:
+        storage = await make_storage(tmp_path)
+        entry = ConversationEntry(
+            content="hi", role="user", timestamp=datetime.now(), metadata={}
+        )
+        await storage.save_conversation("1", [entry])
+        history = await storage.load_conversation("1")
+        await storage.shutdown()
+        return history
+
+    history = asyncio.run(run())
+    assert history and history[0].content == "hi"


### PR DESCRIPTION
## Summary
- prototype StorageResource in `experiments/storage`
- support database, vector store, and filesystem pieces
- basic tests for file and conversation storage

## Testing
- `poetry run black experiments/storage/resource.py experiments/storage/__init__.py tests/experiments/test_experiment_storage_resource.py`
- `poetry run isort experiments/storage/resource.py tests/experiments/test_experiment_storage_resource.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing dependencies)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: cannot import 'Resource')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: cannot import 'Resource')*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/experiments/test_experiment_storage_resource.py` *(fails: ImportError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ae45d3e308322a349fbd45f9152ed