### PR TITLE
Add diagrams and resource sharing spike

### DIFF
--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -37,3 +37,24 @@ Web interfaces may use WebSockets, but model services must expose gRPC
 endpoints.
 
 For additional diagrams and examples see the ADRs in `docs/adr/`.
+
+## Framework Overview Diagram
+```mermaid
+flowchart LR
+    A[User Input] --> B[Input Adapter]
+    B --> C[Processing Pipeline]
+    C --> D[Resource Container]
+    C --> E[Tool Registry]
+    C --> F[Plugins]
+    C --> G[Response]
+```
+
+## Benchmark Results
+The performance suite currently fails to run due to circular import errors.
+Example output:
+```
+ImportError: cannot import name 'Resource' from partially initialized module 'common_interfaces.resources'
+```
+
+Once the imports are resolved, the `pytest-benchmark` plugin can capture
+timing metrics for each pipeline stage.

--- a/docs/spikes/SPIKE-MEM-001.md
+++ b/docs/spikes/SPIKE-MEM-001.md
@@ -1,0 +1,24 @@
+# SPIKE-MEM-001: Shared Memory Strategy
+
+## Summary
+This spike explores how multiple plugins can share the same memory resources without
+introducing locking overhead. The goal is to keep mental models simple while
+allowing different pipelines to reuse common state.
+
+## Recommendation
+Use a single `MemoryResource` instance stored in the `ResourceContainer` and pass
+references to it during plugin initialization. Each plugin should hold only a
+weak reference and access the resource through the container. This approach avoids
+copying data and keeps lifetime management centralized.
+
+```mermaid
+graph TD
+    ResourceContainer --> MemoryResource
+    MemoryResource -->|provides| Parser
+    MemoryResource -->|provides| Thinker
+    MemoryResource -->|provides| Doer
+```
+
+The container is responsible for cleanup and can swap implementations (DuckDB,
+SQLite, Redis) as needed. Plugins simply ask for `resource_container["memory"]`
+when they run.


### PR DESCRIPTION
## Summary
- document shared memory strategy
- show a basic architecture diagram
- note that benchmark suite fails to run

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing stubs and import errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `pytest` *(fails: ModuleNotFoundError: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_686ae45e898c83228489173ccb4dfa98