### PR TITLE
Implement experimental StateManager

### DIFF
--- a/experiments/state_manager/__init__.py
+++ b/experiments/state_manager/__init__.py
@@ -1,0 +1,5 @@
+"""Simple in-memory persistence for pipeline states."""
+
+from .state_manager import StateManager, StateManagerMetrics
+
+__all__ = ["StateManager", "StateManagerMetrics"]

--- a/experiments/state_manager/state_manager.py
+++ b/experiments/state_manager/state_manager.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, List
+
+from pipeline.state import PipelineState
+
+
+@dataclass
+class StateManagerMetrics:
+    """Simple metrics collected by :class:`StateManager`."""
+
+    states_saved: int = 0
+    states_loaded: int = 0
+    states_evicted: int = 0
+
+
+class StateManager:
+    """Persist pipeline states with a fixed maximum size."""
+
+    def __init__(self, max_states: int = 100) -> None:
+        self._max_states = max_states
+        self._states: Dict[str, PipelineState] = {}
+        self._order: List[str] = []
+        self.metrics = StateManagerMetrics()
+        self._lock = asyncio.Lock()
+
+    async def save_state(self, state: PipelineState) -> None:
+        """Store a snapshot of ``state`` and enforce the size limit."""
+
+        async with self._lock:
+            snapshot = state.snapshot()
+            pipeline_id = snapshot.pipeline_id
+            self._states[pipeline_id] = snapshot
+            if pipeline_id in self._order:
+                self._order.remove(pipeline_id)
+            self._order.append(pipeline_id)
+            self.metrics.states_saved += 1
+            if len(self._order) > self._max_states:
+                oldest = self._order.pop(0)
+                if oldest in self._states:
+                    del self._states[oldest]
+                    self.metrics.states_evicted += 1
+
+    async def load_state(self, pipeline_id: str) -> PipelineState | None:
+        """Retrieve a saved state by ``pipeline_id``."""
+
+        async with self._lock:
+            state = self._states.get(pipeline_id)
+            if state is not None:
+                self.metrics.states_loaded += 1
+                return state.snapshot()
+            return None
+
+    async def pipeline_ids(self) -> List[str]:
+        async with self._lock:
+            return list(self._order)
+
+    async def count(self) -> int:
+        async with self._lock:
+            return len(self._states)

--- a/experiments/unified_registry/resource_manager.py
+++ b/experiments/unified_registry/resource_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Dict
+from typing import Dict
 
 
 @dataclass

--- a/tests/experiments/test_state_manager.py
+++ b/tests/experiments/test_state_manager.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from experiments.state_manager import StateManager
+from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
+                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline.resources import ResourceContainer
+
+
+class SavePlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    def __init__(self, manager: StateManager) -> None:
+        super().__init__({})
+        self.manager = manager
+
+    async def _execute_impl(self, context):
+        await self.manager.save_state(context.state)
+        context.set_response(context.state.pipeline_id)
+
+
+def make_manager(manager: StateManager) -> PipelineManager:
+    plugins = PluginRegistry()
+    asyncio.run(
+        plugins.register_plugin_for_stage(SavePlugin(manager), PipelineStage.DO)
+    )
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
+    return PipelineManager(registries)
+
+
+def test_state_manager_concurrent_limit():
+    state_manager = StateManager(max_states=2)
+    manager = make_manager(state_manager)
+
+    async def run_tasks():
+        tasks = [manager.start_pipeline(str(i)) for i in range(3)]
+        return await asyncio.gather(*tasks)
+
+    ids = asyncio.run(run_tasks())
+    stored_ids = asyncio.run(state_manager.pipeline_ids())
+    assert len(stored_ids) == 2
+    assert len(set(ids) - set(stored_ids)) >= 1


### PR DESCRIPTION
## Summary
- add a simple size-limited `StateManager` experiment
- test concurrent use with multiple pipelines
- fix unused imports in `resource_manager`

## Testing
- `poetry run black src tests experiments`
- `poetry run isort src tests experiments`
- `poetry run flake8 src tests experiments`
- `poetry run mypy src` *(fails: Found 364 errors)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: cannot import 'Resource')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: cannot import 'Resource')*
- `python -m src.registry.validator` *(fails: No module named 'common_interfaces')*
- `pytest` *(fails: ImportError: cannot import name 'Resource')*

------
https://chatgpt.com/codex/tasks/task_e_686ae46529dc832287e1b23d4ce556c1