### PR TITLE
Add tooling evaluation spike

### DIFF
--- a/docs/spikes/SPIKE-DX-002/tooling.md
+++ b/docs/spikes/SPIKE-DX-002/tooling.md
@@ -1,0 +1,38 @@
+# SPIKE-DX-002: Developer Tooling Evaluation
+
+## Summary
+This spike assesses tools that streamline project setup and improve daily development. The focus areas are scaffolding, type checking, test isolation, and documentation generation.
+
+## Scaffolding Options
+### 1. Cookiecutter
+- Widely adopted for templated project generation.
+- Uses simple Jinja templates; easy for newcomers.
+- Limited interactive features.
+
+### 2. Copier
+- Supports template updates after a project is created.
+- More configuration flexibility than Cookiecutter.
+- Slightly steeper learning curve.
+
+**Recommendation**: Copier offers better long–term maintainability because templates can be reapplied when shared tooling evolves.
+
+## Type Checking
+- **Mypy** provides mature support and integrates with existing CI.
+- **Pyright** offers faster checking and good VS Code integration.
+
+Either tool can enforce strict typing. Mypy is already in use, so adoption requires no migration.
+
+## Testing Isolation
+- **Pytest** fixtures combined with `tmp_path` handle most isolation needs.
+- For more complex environments, **Nox** can orchestrate disposable virtualenvs per session.
+
+## Documentation Generation
+- **Sphinx** is currently used for API docs and architecture guides.
+- **MkDocs** has a simpler theme system but less powerful extensibility.
+
+Sticking with Sphinx keeps consistency and leverages existing extensions.
+
+## Next Steps
+1. Prototype a Copier template for new plugins.
+2. Consider running Pyright in addition to Mypy for editor feedback.
+3. Evaluate Nox for integration tests that need dedicated environments.


### PR DESCRIPTION
## Summary
- draft developer tooling spike
- evaluate scaffolding, type checking, testing isolation and docs tools

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: many import and type errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: circular import)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: circular import)*
- `poetry run python -m src.registry.validator` *(fails: circular import)*
- `poetry run pytest -q` *(fails: 76 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_686ae706e95c832282b0fe01ddcc7535