### PR TITLE
Add visualization dashboard spike

### DIFF
--- a/docs/spikes/SPIKE-OBS-002.md
+++ b/docs/spikes/SPIKE-OBS-002.md
@@ -1,0 +1,53 @@
+# SPIKE-OBS-002: Visualization Comparisons and Dashboard Options
+
+## Summary
+This spike reviews several visualization libraries and dashboard frameworks to determine the best fit for monitoring the Entity Pipeline. The goal is a clear display of pipeline health without excessive overhead.
+
+## Visualization Libraries
+### 1. Matplotlib
+- Mature and highly configurable.
+- Handles static charts well.
+- **Pros**: Wide adoption, extensive tutorials.
+- **Cons**: Styling can be verbose for simple plots.
+
+### 2. Plotly
+- Interactive plots rendered in the browser.
+- Supports zooming and tooltips.
+- **Pros**: Great for exploratory dashboards.
+- **Cons**: Adds JavaScript dependencies and larger bundle size.
+
+### 3. Altair
+- Declarative syntax using the Vega-Lite grammar.
+- Generates JSON specs consumed by front‑end libraries.
+- **Pros**: Concise, expressive, and integrates with Jupyter easily.
+- **Cons**: Limited low-level control compared to Matplotlib.
+
+## Dashboard Frameworks
+### 1. Streamlit
+- Python-based with minimal boilerplate.
+- Live reload during development.
+- **Pros**: Quick to build prototypes.
+- **Cons**: Less suited for complex layouts.
+
+### 2. Dash
+- Built on top of Flask and Plotly.
+- Highly customizable callbacks.
+- **Pros**: Works well for interactive data apps.
+- **Cons**: Slightly heavier setup and more code than Streamlit.
+
+### 3. Grafana
+- Focuses on operational metrics and time series.
+- Integrates with Prometheus and other data sources.
+- **Pros**: Robust alerting and user management.
+- **Cons**: Requires external server and configuration.
+
+## Recommendation
+Use **Grafana** for monitoring production metrics because it excels at alerting and integrates with existing Prometheus exporters. For ad-hoc analysis and demos, prefer **Streamlit** with **Altair** charts for rapid iteration.
+
+## Risks
+- Running Grafana adds another service to maintain.
+- Interactive dashboards can bloat dependencies if not scoped carefully.
+
+## Next Steps
+1. Document a basic Grafana setup using Docker.
+2. Provide Streamlit examples in the `experiments` directory.


### PR DESCRIPTION
## Summary
- document comparison of visualization libraries and dashboard frameworks
- recommend Grafana with Prometheus and Streamlit/Altair for experiments

## Testing
- `poetry run black --check src tests` *(fails: would reformat 69 files)*
- `poetry run isort --check-only src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 369 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_686ae71ad2e08322abe8fb6d839132f6