### PR TITLE
Add security spike on sandboxing

### DIFF
--- a/docs/spikes/SPIKE-SEC-001.md
+++ b/docs/spikes/SPIKE-SEC-001.md
@@ -1,0 +1,19 @@
+# SPIKE-SEC-001: Sandboxing and Permission Recommendations
+
+## Summary
+This spike outlines strategies for isolating plugins and restricting their permissions. The goal is to prevent a compromised plugin from affecting the host system or accessing data beyond its scope.
+
+## Sandboxing Approaches
+- **Process isolation** using containers such as Docker or Podman. Each plugin runs in a minimal image with only the libraries it requires.
+- **Seccomp and AppArmor** profiles to limit system calls and filesystem access. Use permissive defaults during development, then tighten them for production.
+- **Resource limits** enforced through cgroups to prevent runaway CPU or memory usage.
+
+## Permission Model
+- Assign each plugin an identity with the minimum privileges needed. In Kubernetes this maps to a dedicated ServiceAccount with scoped RBAC rules.
+- Keep secrets out of images and inject them at runtime through environment variables or a secrets manager like AWS Secrets Manager.
+- Prefer read-only mounts for shared volumes and never mount host devices unless necessary.
+
+## Recommendations
+1. Develop plugins so they can run without root privileges.
+2. Use a layered defense: containerize plugins, restrict syscalls, and monitor resource usage.
+3. Automate policy testing with tools such as `docker scan` or `kube-bench` to validate that containers comply with security guidelines.


### PR DESCRIPTION
## Summary
- document sandboxing and permission best practices

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 369 errors)*
- `bandit -r src` *(command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(failed: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(failed: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(failed: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(failed: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686ae71c5e248322848143bbd5b43e39