### PR TITLE
Add observability experiment

### DIFF
--- a/experiments/observability/README.md
+++ b/experiments/observability/README.md
@@ -1,0 +1,13 @@
+# Observability Experiment
+
+This example shows how to expose Prometheus metrics and export OpenTelemetry
+traces for a minimal pipeline.
+
+Run the demo:
+
+```bash
+poetry run python experiments/observability/simple_pipeline.py
+```
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` before running to send spans to a collector.
+Prometheus can scrape metrics from `http://localhost:9001/metrics`.

--- a/experiments/observability/simple_pipeline.py
+++ b/experiments/observability/simple_pipeline.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Minimal pipeline emitting Prometheus metrics and OpenTelemetry traces."""
+
+import asyncio
+from typing import Any, Dict
+
+from pipeline import (
+    PluginRegistry,
+    PromptPlugin,
+    ResourceContainer,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.logging import configure_logging
+from pipeline.observability import start_metrics_server, start_span
+from pipeline.stages import PipelineStage
+
+
+class GreeterPrompt(PromptPlugin):
+    """Create a greeting based on the incoming message."""
+
+    stages = [PipelineStage.DO]
+    name = "greeter_prompt"
+
+    async def _execute_impl(self, context) -> None:
+        message = context.message
+        context.set_response(f"Hello, {message}")
+
+
+class UpperTool(ToolPlugin):
+    """Return an upper-case version of ``text``."""
+
+    stages = [PipelineStage.DO]
+    name = "upper_tool"
+
+    async def execute_function(self, params: Dict[str, Any]) -> str:
+        return str(params.get("text", "")).upper()
+
+    async def execute(self, params: Dict[str, Any]) -> str:
+        return await self.execute_function_with_retry(params)
+
+
+def build_registries() -> SystemRegistries:
+    plugins = PluginRegistry()
+    resources = ResourceContainer()
+    tools = ToolRegistry()
+
+    plugins.register_plugin_for_stage(GreeterPrompt(), PipelineStage.DO)
+    tools.add("upper", UpperTool())
+
+    return SystemRegistries(resources=resources, tools=tools, plugins=plugins)
+
+
+async def main() -> None:
+    configure_logging(level="INFO")
+    start_metrics_server(port=9001)
+
+    registries = build_registries()
+    async with start_span("observability_pipeline"):
+        result = await execute_pipeline("world", registries)
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- create observability experiment
- demonstrate Prometheus metrics and OpenTelemetry tracing

## Testing
- `poetry run black src tests --check` *(fails: would reformat many files)*
- `poetry run isort src tests --check-only`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: found 369 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(failed: ImportError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(failed: ImportError)*
- `poetry run python -m src.registry.validator` *(failed: ImportError)*
- `poetry run pytest` *(fails: 76 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ae712b6308322b9291c0098028b1b