### PR TITLE
Add debug dashboard prototype

### DIFF
--- a/experiments/debug_dashboard/__init__.py
+++ b/experiments/debug_dashboard/__init__.py
@@ -1,0 +1,5 @@
+"""Debug dashboard prototype."""
+
+from .logger import StateLogger, LogReplayer, StateTransition
+
+__all__ = ["StateLogger", "LogReplayer", "StateTransition"]

--- a/experiments/debug_dashboard/cli.py
+++ b/experiments/debug_dashboard/cli.py
@@ -1,0 +1,30 @@
+"""Command line interface for the debug dashboard."""
+
+from __future__ import annotations
+
+import argparse
+
+from .logger import LogReplayer
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Debug dashboard prototype")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    replay_p = subparsers.add_parser("replay", help="Replay a state log")
+    replay_p.add_argument("file", help="Log file to replay")
+    replay_p.add_argument(
+        "--delay", type=float, default=0.5, help="Delay between steps"
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.command == "replay":
+        LogReplayer(args.file).replay(args.delay)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/experiments/debug_dashboard/logger.py
+++ b/experiments/debug_dashboard/logger.py
@@ -1,0 +1,68 @@
+"""State transition logging and replay utilities."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Generator, Iterable
+
+from pipeline.state import PipelineState
+from pipeline.stages import PipelineStage
+
+
+@dataclass
+class StateTransition:
+    """Recorded pipeline state at a specific stage."""
+
+    timestamp: str
+    pipeline_id: str
+    stage: str
+    state: dict
+
+
+class StateLogger:
+    """Append state transitions to a JSON Lines log file."""
+
+    def __init__(self, file_path: str | Path) -> None:
+        self.path = Path(file_path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self.path.open("a", encoding="utf-8")
+
+    def log(self, state: PipelineState, stage: PipelineStage | str) -> None:
+        """Record ``state`` at ``stage`` to the log file."""
+
+        transition = StateTransition(
+            timestamp=datetime.utcnow().isoformat(),
+            pipeline_id=state.pipeline_id,
+            stage=str(stage),
+            state=state.to_dict(),
+        )
+        self._handle.write(json.dumps(asdict(transition)) + "\n")
+        self._handle.flush()
+
+    def close(self) -> None:
+        self._handle.close()
+
+
+class LogReplayer:
+    """Iterate over transitions saved by :class:`StateLogger`."""
+
+    def __init__(self, file_path: str | Path) -> None:
+        self.path = Path(file_path)
+
+    def transitions(self) -> Generator[StateTransition, None, None]:
+        with self.path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                data = json.loads(line)
+                yield StateTransition(**data)
+
+    def replay(self, delay: float = 0.5) -> None:
+        """Print transitions sequentially with ``delay`` seconds between."""
+
+        for t in self.transitions():
+            print(f"[{t.timestamp}] {t.stage} -> {t.pipeline_id}")
+            print(json.dumps(t.state, indent=2))
+            time.sleep(delay)

--- a/tests/experiments/test_debug_dashboard.py
+++ b/tests/experiments/test_debug_dashboard.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from experiments.debug_dashboard import LogReplayer, StateLogger
+from pipeline.stages import PipelineStage
+from pipeline.state import ConversationEntry, PipelineState
+
+
+def _make_state(pid: str) -> PipelineState:
+    return PipelineState(
+        conversation=[
+            ConversationEntry(
+                content="hi",
+                role="user",
+                timestamp=datetime.now(),
+            )
+        ],
+        pipeline_id=pid,
+    )
+
+
+def test_logger_and_replay(tmp_path):
+    log_file = tmp_path / "log.jsonl"
+    logger = StateLogger(log_file)
+
+    state = _make_state("123")
+    logger.log(state, PipelineStage.PARSE)
+    state.prompt = "next"
+    logger.log(state, PipelineStage.DO)
+    logger.close()
+
+    replayer = LogReplayer(log_file)
+    transitions = list(replayer.transitions())
+
+    assert len(transitions) == 2
+    assert transitions[0].pipeline_id == "123"
+    assert transitions[0].stage == "parse"
+    assert transitions[1].stage == "do"


### PR DESCRIPTION
## Summary
- prototype debug dashboard utilities
- allow state transition logging and replay
- provide basic CLI interface
- test logger and replay mechanics

## Testing
- `poetry run mypy src` *(fails: missing stubs)*
- `bandit -r src` *(command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_686ae718f6f483228de15cfb1db215f8