### PR TITLE
Add plugin security wrapper experiment

### DIFF
--- a/experiments/plugin_security/__init__.py
+++ b/experiments/plugin_security/__init__.py
@@ -1,0 +1,6 @@
+"""Experimental plugin security utilities."""
+
+from .validation import InputValidator, sanitize_text
+from .wrapper import SecureToolWrapper
+
+__all__ = ["SecureToolWrapper", "InputValidator", "sanitize_text"]

--- a/experiments/plugin_security/wrapper.py
+++ b/experiments/plugin_security/wrapper.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Security wrapper for tool plugins."""
+
+from typing import Any, Dict
+
+from pipeline.base_plugins import ToolPlugin
+
+from .validation import InputValidator
+
+
+class SecureToolWrapper(ToolPlugin):
+    """Wrap another :class:`ToolPlugin` to enforce input validation."""
+
+    def __init__(self, plugin: ToolPlugin, validator: InputValidator) -> None:
+        super().__init__(plugin.config)
+        self._plugin = plugin
+        self._validator = validator
+        self.stages = getattr(plugin, "stages", [])
+        self.priority = getattr(plugin, "priority", 50)
+
+    async def execute_function(self, params: Dict[str, Any]) -> Any:
+        validated = self._validator(params)
+        sanitized = validated.model_dump()
+        return await self._plugin.execute(sanitized)

--- a/tests/experiments/test_plugin_security_wrapper.py
+++ b/tests/experiments/test_plugin_security_wrapper.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from experiments.plugin_security import InputValidator, SecureToolWrapper
+from pipeline.base_plugins import ToolPlugin
+
+
+class EchoTool(ToolPlugin):
+    name = "echo"
+
+    class Params(BaseModel):
+        text: str
+
+    async def execute_function(self, params: dict) -> str:  # type: ignore[override]
+        return params["text"]
+
+
+@pytest.mark.asyncio
+async def test_secure_wrapper_validates_and_sanitizes():
+    plugin = EchoTool({})
+    validator = InputValidator(EchoTool.Params)
+    secure = SecureToolWrapper(plugin, validator)
+
+    result = await secure.execute({"text": "hello"})
+    assert result == "hello"
+
+
+@pytest.mark.asyncio
+async def test_secure_wrapper_rejects_sql_injection():
+    plugin = EchoTool({})
+    validator = InputValidator(EchoTool.Params)
+    secure = SecureToolWrapper(plugin, validator)
+
+    with pytest.raises(ValueError):
+        await secure.execute({"text": "DROP TABLE users;"})


### PR DESCRIPTION
## Summary
- add input validation helper with sanitization
- implement SecureToolWrapper to validate inputs before plugin execution
- expose utilities via package init
- test validation behavior

## Testing
- `poetry run black experiments/plugin_security tests/experiments/test_plugin_security_wrapper.py`
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: many errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: circular import)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: circular import)*
- `poetry run python -m src.registry.validator` *(fails: circular import)*
- `pytest -q` *(fails: ModuleNotFoundError 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686ae71ba5ac8322a9fb79d8b4e9a2ec