### PR TITLE
Add plugin scaffolding wrapper

### DIFF
--- a/tests/tools/test_plugin_cli.py
+++ b/tests/tools/test_plugin_cli.py
@@ -1,0 +1,43 @@
+import subprocess
+import sys
+
+
+def test_scaffold_plugin(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tools.plugin_cli",
+            "example_plugin",
+            "--type",
+            "prompt",
+            "--out",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    path = tmp_path / "example_plugin.py"
+    assert path.exists()
+    content = path.read_text()
+    assert "class ExamplePlugin" in content
+
+
+def test_scaffold_invalid_type(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tools.plugin_cli",
+            "bad_plugin",
+            "--type",
+            "unknown",
+            "--out",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert not (tmp_path / "bad_plugin.py").exists()

--- a/tools/plugin_cli/__init__.py
+++ b/tools/plugin_cli/__init__.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""CLI wrapper around :class:`PluginToolCLI` for quick scaffolding."""
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from cli.plugin_tool import PLUGIN_TYPES, PluginToolCLI  # type: ignore
+
+
+class PluginCLI:
+    """Create plugin modules from predefined templates."""
+
+    def __init__(self) -> None:
+        self.args = self._parse_args()
+
+    def _parse_args(self) -> argparse.Namespace:
+        parser = argparse.ArgumentParser(description="Scaffold a new plugin")
+        parser.add_argument("name", help="Plugin module name")
+        parser.add_argument("--type", choices=list(PLUGIN_TYPES), default="tool")
+        parser.add_argument("--out", default="user_plugins")
+        parser.add_argument("--docs-dir", default="docs/source")
+        return parser.parse_args()
+
+    def run(self) -> int:
+        tool_cli = PluginToolCLI.__new__(PluginToolCLI)
+        tool_cli.args = argparse.Namespace(
+            name=self.args.name,
+            type=self.args.type,
+            out=self.args.out,
+            docs_dir=self.args.docs_dir,
+        )
+        try:
+            return tool_cli._generate()
+        except Exception as exc:  # pragma: no cover - CLI error path
+            print(f"Error: {exc}")
+            return 1
+
+
+def main() -> None:
+    cli = PluginCLI()
+    raise SystemExit(cli.run())
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/tools/plugin_cli/__main__.py
+++ b/tools/plugin_cli/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()


### PR DESCRIPTION
## Summary
- wrap existing PluginTool CLI to generate plugin skeletons under `tools.plugin_cli`

## Testing
- `poetry run black tools/plugin_cli/__init__.py tests/tools/test_plugin_cli.py`
- `poetry run isort tools/plugin_cli/__init__.py tests/tools/test_plugin_cli.py`
- `poetry run flake8 tools/plugin_cli/__init__.py tests/tools/test_plugin_cli.py` *(fails: command not found)*
- `poetry run mypy src` *(fails: many errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686ae707dd308322b060bbd13831a191