### PR TITLE
Add observability spike

### DIFF
--- a/docs/spikes/SPIKE-OBS-001.md
+++ b/docs/spikes/SPIKE-OBS-001.md
@@ -1,0 +1,21 @@
+# SPIKE-OBS-001: Observability Stack and Monitoring Plan
+
+## Summary
+This spike outlines recommended observability tooling for the Entity Pipeline and lists key metrics to monitor.
+
+## Stack Recommendations
+- **Prometheus** for time-series metrics collection using exporters for Python and system statistics.
+- **Grafana** to visualize metrics and configure alerts.
+- **OpenTelemetry** instrumentation within the pipeline to capture traces, metrics, and logs.
+- **Loki** as a centralized log store for searchable, aggregated logs.
+
+## Monitoring Requirements
+- Track pipeline throughput, error counts, and stage latency.
+- Monitor CPU, memory, and disk I/O on worker nodes.
+- Alert on failed pipeline runs, plugin exceptions, and long queue times.
+- Visualize user-facing latency and API rate limits from LLM providers.
+
+## Next Steps
+- Integrate OpenTelemetry spans in core classes.
+- Provide a default Grafana dashboard showing throughput, latency, and failures.
+- Document Prometheus scraping and Loki log shipping configuration.


### PR DESCRIPTION
## Summary
- document stack recommendations and monitoring requirements

## Testing
- `poetry run black src tests`
- `poetry run isort --profile black src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 369 errors)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: circular import)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: circular import)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_686ae713da88832287513157a2ecf9ba