### PR TITLE
Fix architecture doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Update plugin settings without restarting the agent.
 python src/cli.py reload-config updated.yaml
 ```
 
-See [ARCHITECTURE.md](ARCHITECTURE.md#%F0%9F%94%84-reconfigurable-agent-infrastructure) for details on dynamic reconfiguration.
+See [the architecture overview](architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure) for details on dynamic reconfiguration.
 
 ### Using the "llm" Resource Key
 Define your LLM once and share it across plugins:

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -54,7 +54,7 @@ Reload plugin definitions while the agent is running:
 python src/cli.py reload-config updated.yaml
 ```
 
-For more on dynamic configuration, see [ARCHITECTURE.md](../../ARCHITECTURE.md#%F0%9F%94%84-reconfigurable-agent-infrastructure).
+For more on dynamic configuration, see [the architecture overview](../../architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure).
 
 ### Using the "llm" Resource Key
 Configure a shared LLM resource in YAML:


### PR DESCRIPTION
## Summary
- remove references to missing `ARCHITECTURE.md`
- point docs at `architecture/general.md`

## Testing
- `poetry run black .`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: Command not found)*
- `poetry run mypy src` *(fails: 369 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686aeeebf5ec8322814afa0cfc617c68