### PR TITLE
Add architecture file list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,14 @@ git branch --set-upstream-to=origin/main work
 - `/tests` – unit and integration tests
 - `/docs` – documentation and architecture guides
 
+## Architecture Directory
+
+The `/architecture` folder contains the following documents:
+
+- `architecture/`
+  - `general.md`
+  - `models.md`
+
 ## Important Notes
 - The project is pre-alpha; remove unused code rather than keeping
   backward compatibility.
@@ -48,5 +56,5 @@ pytest
 4. Verify plugin stage assignments and error handling.
 
 ## Further Reading
-See `docs/source/architecture.md` for a full architecture overview and
+See the **Architecture Directory** section for a full architecture overview and
 `CONTRIBUTING.md` for detailed contribution instructions.


### PR DESCRIPTION
## Summary
- enumerate architecture docs in AGENTS.md
- reference new list rather than architecture.md

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 369 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686aeef08edc8322a9d320192f709b65