### PR TITLE
Refactor architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,8 @@ git pull origin main
 git branch --set-upstream-to=origin/main work
 ```
 
-## Project Structure
-- `/architecture/*` – architecture overview and design documents
+- `/architecture/*` – architecture overview and design documents. Start with
+  [`architecture/overview.md`](architecture/overview.md).
 - `/src/pipeline` – core engine and shared abstractions
 - `/plugins` – concrete plugin implementations grouped by type
 - `/config` – YAML configuration files
@@ -48,5 +48,5 @@ pytest
 4. Verify plugin stage assignments and error handling.
 
 ## Further Reading
-See `docs/source/architecture.md` for a full architecture overview and
+See `architecture/overview.md` for a full architecture overview and
 `CONTRIBUTING.md` for detailed contribution instructions.

--- a/architecture/design_principles.md
+++ b/architecture/design_principles.md
@@ -1,0 +1,9 @@
+# Design Principles
+
+The framework follows a few simple rules so agents remain easy to reason about:
+
+1. **Progressive disclosure** – simple tasks stay simple, complex ones remain possible.
+2. **Async-first** – predictable ordering with nonblocking execution.
+3. **Runtime reconfiguration** – validate and apply changes without restarts.
+4. **Clear stage boundaries** – structured logs around each phase.
+5. **Single-name resources** – one canonical name per capability.

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -1,0 +1,8 @@
+# Architecture Overview
+
+This directory collects design documents for the Entity Pipeline Framework.
+
+- [Pipeline overview](pipeline_overview.md)
+- [Design principles](design_principles.md)
+- [General guide](general.md)
+- [Model comparisons](models.md)

--- a/architecture/pipeline_overview.md
+++ b/architecture/pipeline_overview.md
@@ -1,0 +1,11 @@
+# Pipeline Overview
+
+The Entity Pipeline Framework executes a single pass through a series of stages. Plugins implement each stage to keep responsibilities clear.
+
+## Stages
+- **parse** – validate input and load context
+- **think** – reason and plan
+- **do** – execute tools and actions
+- **review** – format and validate responses
+- **deliver** – send output to the user
+- **error** – handle failures gracefully

--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -1,6 +1,6 @@
 # Component Overview
 
-This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](architecture.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](../../config/dev.yaml).
+This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](../../architecture/overview.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](../../config/dev.yaml).
 
 ## Pipelines and Stages
 
@@ -53,4 +53,4 @@ Multiple adapters may run during the `deliver` stage. Each adapter receives the 
 
 ## Putting It Together
 
-Pipelines, plugins, and adapters form the execution engine. Resources supply capabilities like LLMs, memory, and storage. The [architecture document](architecture.md) shows how these pieces fit together.
+Pipelines, plugins, and adapters form the execution engine. Resources supply capabilities like LLMs, memory, and storage. The [architecture document](../../architecture/overview.md) shows how these pieces fit together.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -19,8 +19,8 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [Detailed guide](plugin_guide.md)
 - [Naming conventions](plugins.md)
 
-### Architecture
-- [Architecture overview](architecture.md)
+-### Architecture
+- [Architecture overview](../../architecture/overview.md)
 - [Components overview](components_overview.md)
 - [Deliver-stage adapters](components_overview.md#deliver-stage-adapters)
 


### PR DESCRIPTION
## Summary
- add architecture overview docs
- link docs to new overview
- point contributors to new docs

## Testing
- `poetry run black --check src tests`
- `poetry run isort --check-only src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml`
- `poetry run python -m src.config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686aeef2b0388322880d9fcbeecfcc33