### PR TITLE
Fix optional CDKTF handling

### DIFF
--- a/docs/source/deploy_docker.md
+++ b/docs/source/deploy_docker.md
@@ -11,3 +11,5 @@ Containerize the system to run anywhere Docker is available.
    docker run -p 8000:8000 entity-agent
    ```
 3. Connect to `http://localhost:8000` just as you would locally.
+4. *(Optional)* Install **Node.js** in the container if you plan to use the
+   Terraform CDK-based infrastructure plugin.

--- a/src/plugins/builtin/infrastructure/infrastructure.py
+++ b/src/plugins/builtin/infrastructure/infrastructure.py
@@ -6,7 +6,12 @@ from __future__ import annotations
 import subprocess
 from typing import Type
 
-from cdktf import App, TerraformStack
+try:
+    from cdktf import App, TerraformStack
+except (ImportError, FileNotFoundError) as exc:  # noqa: WPS440
+    raise ImportError(
+        "cdktf and Node.js are required for infrastructure features"
+    ) from exc
 
 
 class Infrastructure:


### PR DESCRIPTION
## Summary
- make `cdktf` dependency optional in infrastructure
- document optional Node.js requirement for Docker deployment

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing stubs)*
- `poetry run bandit -r src`
- `PYTHONPATH=src poetry run python -m src.config.validator --config config/dev.yaml` *(fails: circular import)*
- `PYTHONPATH=src poetry run python -m src.config.validator --config config/prod.yaml` *(fails: circular import)*
- `PYTHONPATH=src poetry run python -m src.registry.validator` *(fails: circular import)*
- `poetry run pytest -q` *(fails: import errors)*

------
https://chatgpt.com/codex/tasks/task_e_686af592cd9483228073d46426a5e53b