### PR TITLE
Fix relative imports for builtin tools

### DIFF
--- a/src/plugins/builtin/tools/__init__.py
+++ b/src/plugins/builtin/tools/__init__.py
@@ -1,6 +1,8 @@
 """Convenience re-exports for built-in tool plugins."""
 
-from plugins.builtin.tools import CalculatorTool, SearchTool, WeatherApiTool
+from .calculator_tool import CalculatorTool
+from .search_tool import SearchTool
+from .weather_api_tool import WeatherApiTool
 
 __all__ = [
     "CalculatorTool",


### PR DESCRIPTION
## Summary
- adjust builtin tools' package imports to use relative paths

## Testing
- `poetry run black src/plugins/builtin/tools/__init__.py`
- `poetry run isort src/plugins/builtin/tools/__init__.py`
- `poetry run flake8 src/plugins/builtin/tools/__init__.py`
- `poetry run mypy src/plugins/builtin/tools/__init__.py`
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686af593c24c8322b5d0cebbf6e977d8