### PR TITLE
Add alias for llm providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ packages = [
     { include = "config", from = "src" },
     { include = "registry", from = "src" },
     { include = "plugins", from = "src" },
+    { include = "plugins.resources.llm.providers", from = "src" },
     { include = "common_interfaces", from = "src" },
     { include = "user_plugins" },
 ]

--- a/src/plugins/resources/llm/providers/__init__.py
+++ b/src/plugins/resources/llm/providers/__init__.py
@@ -1,0 +1,4 @@
+"""Backward compatibility alias for LLM providers."""
+
+# Re-export providers for older import paths
+from plugins.llm.providers import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- expose `plugins.resources.llm.providers` as an alias of `plugins.llm.providers`
- include new alias package path in `pyproject.toml`

## Testing
- `poetry run black src/plugins/resources/llm/providers/__init__.py`
- `poetry run isort src/plugins/resources/llm/providers/__init__.py`
- `poetry run flake8 src/plugins/resources/llm/providers/__init__.py`
- `poetry run mypy src/plugins/resources/llm/providers/__init__.py`
- `poetry run bandit -r src/plugins/resources/llm/providers`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `poetry run pytest` *(fails: 76 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686af595298083229e005d74b608d097