### PR TITLE
Add Docker setup with programmatic checks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.12-slim
+
+# Install dependencies and node.js
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git curl nodejs npm && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install poetry
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python3 - && \
+    ln -s /opt/poetry/bin/poetry /usr/local/bin/poetry
+
+WORKDIR /app
+
+# Copy project metadata and install dependencies
+COPY pyproject.toml poetry.lock* ./
+RUN poetry install --no-interaction --no-root
+
+# Copy the rest of the code
+COPY . .
+
+# Run programmatic checks during build
+RUN poetry run black src tests && \
+    poetry run isort src tests && \
+    poetry run flake8 src tests && \
+    poetry run mypy src && \
+    bandit -r src && \
+    python -m src.config.validator --config config/dev.yaml && \
+    python -m src.config.validator --config config/prod.yaml && \
+    python -m src.registry.validator && \
+    pytest
+
+CMD ["poetry", "run", "pytest"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,15 @@
+# Docker Setup
+
+This image installs Python 3.12, Poetry, all project dependencies and Node.js. It runs all programmatic checks during the build.
+
+Build the image:
+
+```bash
+docker build -t entity-test docker
+```
+
+Run the tests in the container:
+
+```bash
+docker run --rm entity-test
+```


### PR DESCRIPTION
## Summary
- add Dockerfile with Python 3.12, Poetry, Node.js
- install project dependencies and run checks during build
- document image usage

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: No module named 'constructs', etc.)*
- `bandit -r src` *(fails: command not found, then installed)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: psutil)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: psutil)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `pytest` *(fails: ModuleNotFoundError: psutil)*

------
https://chatgpt.com/codex/tasks/task_e_686af59627908322bd84b74e29778a93