### PR TITLE
Replace logging_adapter imports

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -11,7 +11,7 @@ from entity import Agent, AgentServer
 from pipeline import update_plugin_configuration
 from pipeline.base_plugins import ResourcePlugin, ToolPlugin
 from pipeline.initializer import ClassRegistry
-from plugins.builtin.adapters.logging_adapter import get_logger
+from pipeline.logging import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/cli/plugin_tool.py
+++ b/src/cli/plugin_tool.py
@@ -6,10 +6,16 @@ import inspect
 from pathlib import Path
 from typing import Any, Dict, List, Type
 
-from pipeline.base_plugins import (AdapterPlugin, BasePlugin, FailurePlugin,
-                                   PromptPlugin, ResourcePlugin, ToolPlugin,
-                                   ValidationResult)
-from plugins.builtin.adapters.logging_adapter import get_logger
+from pipeline.base_plugins import (
+    AdapterPlugin,
+    BasePlugin,
+    FailurePlugin,
+    PromptPlugin,
+    ResourcePlugin,
+    ToolPlugin,
+    ValidationResult,
+)
+from pipeline.logging import get_logger
 
 TEMPLATE_DIR = Path(__file__).parent / "templates"
 

--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import (TYPE_CHECKING, Any, AsyncIterator, Dict, Protocol,
-                    runtime_checkable)
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Protocol, runtime_checkable
 
 if TYPE_CHECKING:  # pragma: no cover
     from registry import ClassRegistry
 
+from pipeline.logging import get_logger
 from pipeline.state import LLMResponse
 from pipeline.validation import ValidationResult
-from plugins.builtin.adapters.logging_adapter import get_logger
 
 
 @runtime_checkable

--- a/src/config/generate_template.py
+++ b/src/config/generate_template.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from plugins.builtin.adapters.logging_adapter import (configure_logging,
-                                                      get_logger)
+from pipeline.logging import get_logger
+from plugins.builtin.adapters.logging_adapter import configure_logging
 
 logger = get_logger(__name__)
 

--- a/src/config/migrate.py
+++ b/src/config/migrate.py
@@ -7,8 +7,8 @@ import yaml
 
 from config.models import EntityConfig, asdict
 from pipeline.config import ConfigLoader
-from plugins.builtin.adapters.logging_adapter import (configure_logging,
-                                                      get_logger)
+from pipeline.logging import get_logger
+from plugins.builtin.adapters.logging_adapter import configure_logging
 
 logger = get_logger(__name__)
 

--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -16,8 +16,8 @@ from jsonschema import RefResolver, ValidationError, validate  # noqa: E402
 from config.environment import load_env  # noqa: E402
 from pipeline import SystemInitializer  # noqa: E402
 from pipeline.config import ConfigLoader  # noqa: E402
-from plugins.builtin.adapters.logging_adapter import (  # noqa: E402
-    configure_logging, get_logger)
+from pipeline.logging import get_logger  # noqa: E402
+from plugins.builtin.adapters.logging_adapter import configure_logging  # noqa: E402
 
 from .validators import _validate_memory  # noqa: E402
 from .validators import _validate_cache, _validate_vector_memory  # noqa: E402

--- a/src/pipeline/validation/input.py
+++ b/src/pipeline/validation/input.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, Type
 
 from pydantic import BaseModel, ValidationError
 
-from plugins.builtin.adapters.logging_adapter import get_logger
+from pipeline.logging import get_logger
 
 SQL_PATTERN = re.compile(r"(;|--|/\*|\b(drop|delete|insert|update)\b)", re.IGNORECASE)
 

--- a/src/plugins/resources/base.py
+++ b/src/plugins/resources/base.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Any, Dict, Protocol, runtime_checkable
 if TYPE_CHECKING:  # pragma: no cover
     from registry import ClassRegistry
 
+from pipeline.logging import get_logger
 from pipeline.validation import ValidationResult
-from plugins.builtin.adapters.logging_adapter import get_logger
 
 
 @runtime_checkable

--- a/src/registry/validator.py
+++ b/src/registry/validator.py
@@ -16,9 +16,9 @@ if str(SRC_PATH) not in sys.path:
 from pipeline.initializer import ClassRegistry  # noqa: E402
 from pipeline.initializer import SystemInitializer  # noqa: E402
 from pipeline.initializer import import_plugin_class  # noqa: E402
+from pipeline.logging import get_logger  # noqa: E402
 from pipeline.stages import PipelineStage  # noqa: E402
 from pipeline.validation import ValidationResult  # noqa: E402
-from plugins.builtin.adapters.logging_adapter import get_logger  # noqa: E402
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- use `get_logger` from `pipeline.logging` throughout `src/`

## Testing
- `poetry run black src/cli.py src/cli/plugin_tool.py src/common_interfaces/resources.py src/config/generate_template.py src/config/migrate.py src/config/validator.py src/pipeline/validation/input.py src/plugins/resources/base.py src/registry/validator.py`
- `poetry run isort src/cli.py src/cli/plugin_tool.py src/common_interfaces/resources.py src/config/generate_template.py src/config/migrate.py src/config/validator.py src/pipeline/validation/input.py src/plugins/resources/base.py src/registry/validator.py`
- `poetry run flake8 src/cli.py src/cli/plugin_tool.py src/common_interfaces/resources.py src/config/generate_template.py src/config/migrate.py src/config/validator.py src/pipeline/validation/input.py src/plugins/resources/base.py src/registry/validator.py`
- `poetry run mypy src/cli.py src/cli/plugin_tool.py src/common_interfaces/resources.py src/config/generate_template.py src/config/migrate.py src/config/validator.py src/pipeline/validation/input.py src/plugins/resources/base.py src/registry/validator.py` *(fails: Missing type parameters for generic type "Dict")*
- `bandit -r src/cli.py src/cli/plugin_tool.py src/common_interfaces/resources.py src/config/generate_template.py src/config/migrate.py src/config/validator.py src/pipeline/validation/input.py src/plugins/resources/base.py src/registry/validator.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*
- `python -m src.registry.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_686af5917a5c8322b270519956cea922