### PR TITLE
Fix plugin loader path

### DIFF
--- a/examples/utilities/plugin_loader.py
+++ b/examples/utilities/plugin_loader.py
@@ -11,13 +11,14 @@ from utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 
-from plugins.builtin.adapters.server import AgentServer  # noqa: E402
-
 from entity import Agent  # noqa: E402
+from plugins.builtin.adapters.server import AgentServer  # noqa: E402
 
 
 def main() -> None:
-    agent = Agent.from_directory("../plugins")
+    base_path = pathlib.Path(__file__).resolve().parents[2]
+    plugins_dir = base_path / "src" / "plugins"
+    agent = Agent.from_directory(str(plugins_dir))
     runtime = agent.builder.build_runtime()
     server = AgentServer(runtime)
     server.run_http()


### PR DESCRIPTION
## Summary
- adjust plugin loader example path for relative execution

## Testing
- `poetry run black examples/utilities/plugin_loader.py`
- `poetry run isort examples/utilities/plugin_loader.py`
- `poetry run flake8 examples/utilities/plugin_loader.py`
- `poetry run mypy src` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `bandit -r examples/utilities/plugin_loader.py` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686af75e1a388322b8126cd35ad4d012