### PR TITLE
Update plugin doc paths

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -40,10 +40,10 @@ async def weather_plugin(ctx):
 
 ## Loading Plugins Automatically
 
-Place plugin modules inside a directory and load them with `Agent.from_directory(path)` or `Agent.from_package(package)`.
+Built-in plugins ship with the framework under `src/plugins`. Place your own plugin modules inside a directory and load them with `Agent.from_directory(path)` or `Agent.from_package(package)`.
 
 ```
-agent = Agent.from_directory("./plugins")
+agent = Agent.from_directory("./user_plugins")
 ```
 
 Any import errors are logged and the remaining plugins continue to load.

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -4,7 +4,7 @@ Plugins provide all extendable behavior in the framework. They are grouped by
 function and registered through configuration or the `Agent` API.
 
 ## Naming Conventions
-- Modules live under the `plugins` package
+- Built-in plugins live under the `src/plugins` package
 - Class names end with `Plugin`, e.g. `WeatherToolPlugin`
 - Each resource exposes one canonical registry name
 - Keep names short and descriptive


### PR DESCRIPTION
## Summary
- document that built-in plugins live under `src/plugins`
- clarify plugin loading example

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing stubs)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `poetry run sphinx-build docs/source docs/build/html`

------
https://chatgpt.com/codex/tasks/task_e_686af777e244832297ecb90d0074d204