### PR TITLE
Clarify path for built‑in plugins

### DIFF
--- a/docs/adr/0002-module-layout.md
+++ b/docs/adr/0002-module-layout.md
@@ -10,9 +10,9 @@ This split caused confusion about where base classes were defined and how
 framework code should be imported.
 
 ## Decision
-All engine functionality now resides under `src/pipeline` while concrete plugins
-live in the top-level `plugins` package. The `user_plugins` directory remains but
-only re-exports symbols from `plugins` for backward compatibility. This layout
+All engine functionality now resides under `src/pipeline` while built-in plugins
+live in `src/plugins`. The `user_plugins` directory remains but only re-exports
+symbols from `plugins` for backward compatibility. This layout
 clarifies imports and keeps plugin code clearly separated from the core engine.
 
 ## Consequences

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -40,7 +40,7 @@ async def weather_plugin(ctx):
 
 ## Loading Plugins Automatically
 
-Built-in plugins ship with the framework under `src/plugins`. Place your own plugin modules inside a directory and load them with `Agent.from_directory(path)` or `Agent.from_package(package)`.
+Built-in plugin modules live in `src/plugins`. Place your own plugins inside any directory and load them with `Agent.from_directory(path)` or `Agent.from_package(package)`.
 
 ```
 agent = Agent.from_directory("./user_plugins")

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -4,7 +4,7 @@ Plugins provide all extendable behavior in the framework. They are grouped by
 function and registered through configuration or the `Agent` API.
 
 ## Naming Conventions
-- Built-in plugins live under the `src/plugins` package
+- Built-in plugins live in the `src/plugins` directory
 - Class names end with `Plugin`, e.g. `WeatherToolPlugin`
 - Each resource exposes one canonical registry name
 - Keep names short and descriptive


### PR DESCRIPTION
## Summary
- clarify that core plugins live inside `src/plugins`
- update plugin docs and ADR with the correct path

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing stubs and type errors)*
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: CLIAdapter must define a non-empty 'stages' list)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `make html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afb2669648322ac2ba0b447d1f267