### PR TITLE
Clarify built-in plugin path

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -1,6 +1,6 @@
 # Writing Plugins
 
-The Entity framework is built around extensible plugins. Plugins run during specific pipeline stages and interact with the system through `PluginContext`.
+The Entity framework is built around extensible plugins. Plugins run during specific pipeline stages and interact with the system through `PluginContext`. Built-in plugin modules live under the `src/plugins` directory.
 
 ## Basic Class Plugin
 

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -4,7 +4,7 @@ Plugins provide all extendable behavior in the framework. They are grouped by
 function and registered through configuration or the `Agent` API.
 
 ## Naming Conventions
-- Built-in plugins live under the `src/plugins` package
+- Built-in plugin modules reside under the `src/plugins` directory
 - Class names end with `Plugin`, e.g. `WeatherToolPlugin`
 - Each resource exposes one canonical registry name
 - Keep names short and descriptive


### PR DESCRIPTION
## Summary
- note that built-in plugin modules live under `src/plugins`
- mention the `src/plugins` directory in plugin guide

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: many missing stubs)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `poetry run sphinx-build -b html docs/source docs/build/html`

------
https://chatgpt.com/codex/tasks/task_e_686afb889c0883229c23aa5d0df20132