### PR TITLE
Fix failure re-export modules

### DIFF
--- a/src/plugins/builtin/failure/basic_logger.py
+++ b/src/plugins/builtin/failure/basic_logger.py
@@ -1,5 +1,5 @@
-"""Public re-export of :class:`BasicLogger`."""
+"""Public re-export of :class:`BasicLogger` from :mod:`user_plugins`."""
 
-from plugins.builtin.failure.basic_logger import BasicLogger
+from user_plugins.failure.basic_logger import BasicLogger
 
 __all__ = ["BasicLogger"]

--- a/src/plugins/builtin/failure/error_formatter.py
+++ b/src/plugins/builtin/failure/error_formatter.py
@@ -1,5 +1,5 @@
-"""Public re-export of :class:`ErrorFormatter`."""
+"""Public re-export of :class:`ErrorFormatter` from :mod:`user_plugins`."""
 
-from plugins.builtin.failure.error_formatter import ErrorFormatter
+from user_plugins.failure.error_formatter import ErrorFormatter
 
 __all__ = ["ErrorFormatter"]


### PR DESCRIPTION
## Summary
- avoid circular imports in failure plugin wrappers

## Testing
- `poetry run black src/plugins/builtin/failure/basic_logger.py src/plugins/builtin/failure/error_formatter.py`
- `poetry run isort src/plugins/builtin/failure/basic_logger.py src/plugins/builtin/failure/error_formatter.py`
- `poetry run flake8 src/plugins/builtin/failure/basic_logger.py src/plugins/builtin/failure/error_formatter.py`
- `poetry run mypy src/plugins/builtin/failure/basic_logger.py src/plugins/builtin/failure/error_formatter.py`
- `poetry run bandit -r src/plugins/builtin/failure/basic_logger.py src/plugins/builtin/failure/error_formatter.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `poetry run pytest` *(fails: ImportError: cannot import name 'AdapterPlugin')*

------
https://chatgpt.com/codex/tasks/task_e_686b010805b88322b7741519710b663a