### PR TITLE
Add explicit stages to builtin prompts

### DIFF
--- a/src/plugins/builtin/prompts/chat_history.py
+++ b/src/plugins/builtin/prompts/chat_history.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 """Legacy alias plugin exposing conversation history."""
 
 
+from pipeline.stages import PipelineStage
+
 from .memory import MemoryPlugin
 
 
 class ChatHistory(MemoryPlugin):
     """Alias for ``MemoryPlugin`` for backward compatibility."""
 
-    pass
+    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
 
 
 __all__ = ["ChatHistory"]

--- a/src/plugins/builtin/prompts/complex_prompt.py
+++ b/src/plugins/builtin/prompts/complex_prompt.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
 from pipeline.base_plugins import PromptPlugin
+from pipeline.stages import PipelineStage
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from pipeline.context import ConversationEntry, PluginContext
@@ -20,6 +21,7 @@ class ComplexPrompt(PromptPlugin):
     """
 
     dependencies = ["llm", "memory"]
+    stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         """Compose a context-aware reply.

--- a/src/plugins/builtin/prompts/conversation_history.py
+++ b/src/plugins/builtin/prompts/conversation_history.py
@@ -18,6 +18,7 @@ class ConversationHistory(PromptPlugin):
     """Load and persist conversation history using the ``memory`` resource."""
 
     dependencies = ["memory"]
+    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/src/plugins/builtin/prompts/memory.py
+++ b/src/plugins/builtin/prompts/memory.py
@@ -18,6 +18,7 @@ class MemoryPlugin(PromptPlugin):
     """Persist conversation history using the ``memory`` resource."""
 
     dependencies = ["memory"]
+    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)

--- a/src/plugins/builtin/prompts/memory_retrieval.py
+++ b/src/plugins/builtin/prompts/memory_retrieval.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
 from pipeline.base_plugins import PromptPlugin
+from pipeline.stages import PipelineStage
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from pipeline.context import ConversationEntry, PluginContext
@@ -16,6 +17,7 @@ class MemoryRetrievalPrompt(PromptPlugin):
     """Fetch past conversation from memory and append it to the context."""
 
     dependencies = ["memory", "llm"]
+    stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         memory: MemoryResource = context.get_resource("memory")


### PR DESCRIPTION
## Summary
- set `stages` on builtin prompt plugins

## Testing
- `poetry run black src/plugins/builtin/prompts/chat_history.py src/plugins/builtin/prompts/complex_prompt.py src/plugins/builtin/prompts/conversation_history.py src/plugins/builtin/prompts/memory.py src/plugins/builtin/prompts/memory_retrieval.py`
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Missing type parameters, etc.)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686b0128a17483228343341f4cde77ac