### PR TITLE
Add LLM gRPC audit doc

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -30,6 +30,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [Advanced usage](advanced_usage.md)
 - [Module map](module_map.md)
 - [gRPC services](grpc_services.md)
+- [LLM gRPC audit](llm_grpc_audit.md)
 - [Troubleshooting](troubleshooting.md)
 
 ### Deployment
@@ -52,6 +53,7 @@ logging
 advanced_usage
 module_map
 grpc_services
+llm_grpc_audit
 troubleshooting
 deploy_aws
 deploy_local

--- a/docs/source/llm_grpc_audit.md
+++ b/docs/source/llm_grpc_audit.md
@@ -1,0 +1,16 @@
+# LLM gRPC Audit
+
+The architecture requires backend models to expose gRPC streaming endpoints. The `LLMService` in `src/grpc_services/llm_service.py` wraps `UnifiedLLMResource` and is served by `LLMGRPCAdapter`.
+
+The providers found in `src/plugins/builtin/resources/llm/providers/` rely on HTTP or SDK calls:
+
+- `OpenAIProvider`, `GeminiProvider`, `ClaudeProvider`, and `OllamaProvider` use `HttpLLMResource` for REST requests.
+- `BedrockProvider` uses `aioboto3` to invoke AWS Bedrock.
+- `EchoProvider` simply echoes the prompt.
+
+None of these providers expose gRPC directly. They are wrapped by `LLMService` when gRPC access is required.
+
+## Recommendations
+
+- Implement gRPC wrappers for each provider to allow direct gRPC consumption.
+- Alternatively, extend the provider interface with optional gRPC client methods so `LLMService` can delegate to them when available.


### PR DESCRIPTION
## Summary
- document which LLM providers only offer HTTP implementations
- propose gRPC wrappers for providers

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 365 errors)*
- `bandit -r src` *(command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686b0191d7a48322bb049277e0c42eba