### PR TITLE
Improve observability for tools

### DIFF
--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -45,3 +45,15 @@ Run it with:
 python examples/structured_logging_example.py
 ```
 
+## Plugin and Tool Observability
+
+Each plugin executed by the pipeline automatically logs start and finish events.
+Messages include the plugin name, stage and request ID so entries can be
+correlated across stages. Tool executions follow the same pattern. When a tool
+starts, finishes or fails, a structured log entry is emitted describing the
+result.
+
+Metrics are recorded alongside these logs. Duration and error counts are stored
+in ``context.metrics`` and can be exported to Prometheus using
+``pipeline.observability.start_metrics_server()``.
+


### PR DESCRIPTION
## Summary
- add structured logs for tool execution lifecycle
- document plugin and tool observability

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: many errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ImportError: cannot import name 'AdapterPlugin')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ImportError: cannot import name 'AdapterPlugin')*

------
https://chatgpt.com/codex/tasks/task_e_686b0199b7c08322b0c41e5c20b939e0