### PR TITLE
Add plugin stage validation test

### DIFF
--- a/tests/test_plugin_stage_attributes.py
+++ b/tests/test_plugin_stage_attributes.py
@@ -1,0 +1,50 @@
+import importlib
+import inspect
+import pkgutil
+
+from pipeline.base_plugins import BasePlugin, ToolPlugin
+from pipeline.stages import PipelineStage
+
+PACKAGE_NAMES = [
+    "user_plugins",
+    "pipeline.resources",
+]
+
+
+def iter_modules(package_name: str):
+    package = importlib.import_module(package_name)
+    if getattr(package, "__path__", None) is None:
+        return []
+    return [
+        m.name for m in pkgutil.walk_packages(package.__path__, package.__name__ + ".")
+    ]
+
+
+def gather_plugin_classes():
+    classes = []
+    for package_name in PACKAGE_NAMES:
+        for module_name in iter_modules(package_name):
+            try:
+                module = importlib.import_module(module_name)
+            except Exception:
+                continue
+            for obj in module.__dict__.values():
+                if (
+                    inspect.isclass(obj)
+                    and issubclass(obj, BasePlugin)
+                    and obj not in {BasePlugin, ToolPlugin}
+                    and obj.__module__ == module.__name__
+                ):
+                    classes.append(obj)
+    return classes
+
+
+def test_plugins_define_valid_stages():
+    for plugin_cls in gather_plugin_classes():
+        if issubclass(plugin_cls, ToolPlugin):
+            continue
+        stages = getattr(plugin_cls, "stages", None)
+        assert stages, f"{plugin_cls.__name__} missing stages"
+        assert all(
+            isinstance(stage, PipelineStage) for stage in stages
+        ), f"{plugin_cls.__name__} has invalid stage"


### PR DESCRIPTION
## Summary
- add a unit test to ensure plugin classes define `stages`

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 364 errors)*
- `bandit -r src`
- `PYTHONPATH=src python -m src.config.validator --config config/dev.yaml` *(fails: import errors)*
- `PYTHONPATH=src python -m src.config.validator --config config/prod.yaml` *(fails: import errors)*
- `PYTHONPATH=src python -m src.registry.validator` *(fails: import errors)*
- `PYTHONPATH=src pytest` *(fails: import errors)*


------
https://chatgpt.com/codex/tasks/task_e_686b013245708322b9dbbc640a6a979b