### PR TITLE
Add pipeline state snapshot property

### DIFF
--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from datetime import datetime
-from typing import (TYPE_CHECKING, Any, AsyncIterator, Callable, Dict, List,
-                    Optional, TypeVar, cast)
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypeVar,
+    cast,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from common_interfaces.resources import LLM
@@ -20,8 +29,7 @@ __all__ = ["PluginContext", "ConversationEntry", "ToolCall"]
 from .errors import ResourceError
 from .metrics import MetricsCollector
 from .stages import PipelineStage
-from .state import (ConversationEntry, FailureInfo, LLMResponse, PipelineState,
-                    ToolCall)
+from .state import ConversationEntry, FailureInfo, LLMResponse, PipelineState, ToolCall
 from .tools.base import RetryOptions
 from .tools.execution import execute_tool
 
@@ -44,6 +52,11 @@ class PluginContext:
     @property
     def _state(self) -> PipelineState:  # pragma: no cover - defensive measure
         raise AttributeError("Direct PipelineState access is not allowed")
+
+    @property
+    def state(self) -> PipelineState:
+        """Return a snapshot of the current pipeline state."""
+        return self.__state.snapshot()
 
     # --- Metrics helpers -------------------------------------------------
     def record_plugin_duration(self, plugin: str, duration: float) -> None:

--- a/tests/experiments/test_state_manager.py
+++ b/tests/experiments/test_state_manager.py
@@ -1,8 +1,14 @@
 import asyncio
 
 from experiments.state_manager import StateManager
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 
 


### PR DESCRIPTION
## Summary
- expose a snapshot of pipeline state via `PluginContext.state`
- keep formatting tidy

## Testing
- `poetry run isort src tests`
- `poetry run black src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 375 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: configuration invalid)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError: 'dotenv')*
- `poetry run pytest tests/experiments/test_state_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_686b2d2ef0cc8322ba10ad5ff5eccb86