### PR TITLE
Document testing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ For a high-level look at how the pieces connect, see [components_overview.md](co
 3. Start the agent with your desired configuration file.
 4. Copy `.env.example` to `.env` and fill in the values if you want to run the example scripts. See [examples/README.md](examples/README.md) for what each example expects.
 
+### Testing Setup
+
+Running the full test suite requires a local PostgreSQL server. The tests rely
+on `pytest-postgresql` which starts a temporary instance using `pg_ctl`. Install
+PostgreSQL and ensure `pg_ctl` is available in your `PATH`; otherwise the
+integration tests will be skipped or fail.
+
 For an infrastructure walkthrough on Amazon Web Services, see the [AWS deployment guide](docs/source/deploy_aws.md).
 
 <!-- start config -->


### PR DESCRIPTION
## Summary
- document PostgreSQL requirement for running tests

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 375 errors)*
- `bandit -r src`
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: configuration invalid)*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: configuration invalid)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest -q` *(fails: 70 failed, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d243d148322b8837324af4abfa5