### PR TITLE
Fix config adapter indentation

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -66,9 +66,9 @@ plugins:
     calculator:
       type: plugins.builtin.tools.calculator_tool:CalculatorTool
   adapters:
-  http:
-    type: plugins.builtin.adapters.http:HTTPAdapter
-    stages: [parse, deliver]
+    http:
+      type: plugins.builtin.adapters.http:HTTPAdapter
+      stages: [parse, deliver]
       auth_tokens:
         - dev-secret
       rate_limit:
@@ -76,9 +76,9 @@ plugins:
         interval: 60
       audit_log_path: logs/audit.log
       dashboard: true
-  cli:
-    type: plugins.builtin.adapters.cli:CLIAdapter
-    stages: [deliver]
+    cli:
+      type: plugins.builtin.adapters.cli:CLIAdapter
+      stages: [deliver]
   logging:
     type: plugins.builtin.adapters.logging:LoggingAdapter
     stages: [deliver]

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -73,19 +73,19 @@ plugins:
       type: plugins.builtin.tools.calculator_tool:CalculatorTool
       precision: 10
   adapters:
-  http:
-    type: plugins.builtin.adapters.http:HTTPAdapter
-    stages: [parse, deliver]
-    auth_tokens:
-      - ${HTTP_TOKEN}
+    http:
+      type: plugins.builtin.adapters.http:HTTPAdapter
+      stages: [parse, deliver]
+      auth_tokens:
+        - ${HTTP_TOKEN}
       rate_limit:
         requests: 100
         interval: 60
       audit_log_path: logs/audit.log
       dashboard: false
-  cli:
-    type: plugins.builtin.adapters.cli:CLIAdapter
-    stages: [deliver]
+    cli:
+      type: plugins.builtin.adapters.cli:CLIAdapter
+      stages: [deliver]
   logging:
     type: plugins.builtin.adapters.logging:LoggingAdapter
     stages: [deliver]


### PR DESCRIPTION
## Summary
- correct indentation for HTTP and CLI adapter settings in dev and prod configs

## Testing
- `poetry run pytest tests/integration/test_reliability.py -q`
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Missing stubs and type errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Additional properties not allowed)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Additional properties not allowed)*
- `PYTHONPATH=src poetry run python -m src.registry.validator` *(fails: Import error)*
- `poetry run pytest -q` *(fails: 70 failed, 101 passed, 8 skipped, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d414c208322b8fb92cf5b98cffe