### PR TITLE
Fix StorageResource instantiation and typing

### DIFF
--- a/experiments/storage/resource.py
+++ b/experiments/storage/resource.py
@@ -37,6 +37,10 @@ class StorageResource(ResourcePlugin):
     def from_config(cls, config: Dict) -> "StorageResource":
         return cls(config=config)
 
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
+        """Resource plugins are not executed directly."""
+        return None
+
     async def initialize(self) -> None:  # pragma: no cover - simple passthrough
         for backend in (self.database, self.vector_store, self.filesystem):
             if hasattr(backend, "initialize") and callable(backend.initialize):

--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, cast
 
 from registry import SystemRegistries
@@ -13,9 +13,10 @@ class AgentRuntime:
     """Execute messages through the pipeline."""
 
     registries: SystemRegistries
+    manager: PipelineManager[Dict[str, Any]] = field(init=False)
 
     def __post_init__(self) -> None:
-        self.manager = PipelineManager(self.registries)
+        self.manager = PipelineManager[Dict[str, Any]](self.registries)
 
     async def run_pipeline(self, message: str) -> Dict[str, Any]:
         async with self.registries.resources:
@@ -24,11 +25,16 @@ class AgentRuntime:
     async def handle(self, message: str) -> Dict[str, Any]:
         """Alias for :meth:`run_pipeline`."""
 
-        return cast(Dict[str, Any], await self.run_pipeline(message))
+        return await self.run_pipeline(message)
 
     async def __aenter__(self) -> "AgentRuntime":
         return self
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
         if hasattr(self.registries.resources, "shutdown_all"):
             await self.registries.resources.shutdown_all()

--- a/src/pipeline/tools/execution.py
+++ b/src/pipeline/tools/execution.py
@@ -26,11 +26,14 @@ async def execute_tool(
     for attempt in range(options.max_retries + 1):
         try:
             if hasattr(tool, "execute_function_with_retry"):
-                return await tool.execute_function_with_retry(
-                    call.params, options.max_retries, options.delay
+                return cast(
+                    ResultT,
+                    await tool.execute_function_with_retry(
+                        call.params, options.max_retries, options.delay
+                    ),
                 )
             if hasattr(tool, "execute_function"):
-                return await tool.execute_function(call.params)
+                return cast(ResultT, await tool.execute_function(call.params))
             func = getattr(tool, "run", None)
             if func is None:
                 raise ToolExecutionError(
@@ -123,7 +126,7 @@ async def execute_pending_tools(
                 },
             )
             try:
-                result = await execute_tool(tool, call, state, options)
+                result: ResultT = await execute_tool(tool, call, state, options)
             except Exception as exc:
                 err = f"Error: {exc}"
                 state.stage_results[call.result_key] = err


### PR DESCRIPTION
## Summary
- allow experimental StorageResource to be instantiated
- clarify AgentRuntime and tool execution typing
- update tests

## Testing
- `poetry run mypy src/pipeline/context.py src/pipeline/manager.py src/pipeline/runtime.py src/pipeline/tools/execution.py src/pipeline/interfaces.py`
- `bandit -r src`
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: Configuration invalid)*
- `PYTHONPATH=src python src/registry/validator.py --config config/dev.yaml` *(fails: ParserError)*
- `poetry run pytest tests/experiments/test_experiment_storage_resource.py`


------
https://chatgpt.com/codex/tasks/task_e_686b2d29f1808322bada7e362ccccdd1