### PR TITLE
Fix Postgres history test

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1933,6 +1933,21 @@ files = [
 ]
 
 [[package]]
+name = "mirakuru"
+version = "2.6.1"
+description = "Process executor (not only) for tests."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "mirakuru-2.6.1-py3-none-any.whl", hash = "sha256:4be0bfd270744454fa0c0466b8127b66bd55f4decaf05bbee9b071f2acbd9473"},
+    {file = "mirakuru-2.6.1.tar.gz", hash = "sha256:95d4f5a5ad406a625e9ca418f20f8e09386a35dad1ea30fd9073e0ae93f712c7"},
+]
+
+[package.dependencies]
+psutil = {version = ">=4.0.0", markers = "sys_platform != \"cygwin\""}
+
+[[package]]
 name = "msgpack"
 version = "1.1.1"
 description = "MessagePack serializer"
@@ -2416,6 +2431,18 @@ pyyaml = ">=6.0.2,<7.0"
 poetry-plugin = ["poetry (>=1.2.0,<3.0.0) ; python_version < \"4.0\""]
 
 [[package]]
+name = "port-for"
+version = "0.7.4"
+description = "Utility that helps with local TCP ports management. It can find an unused TCP localhost port and remember the association."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "port_for-0.7.4-py3-none-any.whl", hash = "sha256:08404aa072651a53dcefe8d7a598ee8a1dca320d9ac44ac464da16ccf2a02c4a"},
+    {file = "port_for-0.7.4.tar.gz", hash = "sha256:fc7713e7b22f89442f335ce12536653656e8f35146739eccaeff43d28436028d"},
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.20.0"
 description = "Python client for the Prometheus monitoring system."
@@ -2563,7 +2590,7 @@ version = "5.9.8"
 description = "Cross-platform lib for process and system monitoring in Python."
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "psutil-5.9.8-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:26bd09967ae00920df88e0352a91cff1a78f8d69b3ecabbfe733610c0af486c8"},
     {file = "psutil-5.9.8-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:05806de88103b25903dff19bb6692bd2e714ccf9e668d050d144012055cbca73"},
@@ -2585,6 +2612,30 @@ files = [
 
 [package.extras]
 test = ["enum34 ; python_version <= \"3.4\"", "ipaddress ; python_version < \"3.0\"", "mock ; python_version < \"3.0\"", "pywin32 ; sys_platform == \"win32\"", "wmi ; sys_platform == \"win32\""]
+
+[[package]]
+name = "psycopg"
+version = "3.2.9"
+description = "PostgreSQL database adapter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "psycopg-3.2.9-py3-none-any.whl", hash = "sha256:01a8dadccdaac2123c916208c96e06631641c0566b22005493f09663c7a8d3b6"},
+    {file = "psycopg-3.2.9.tar.gz", hash = "sha256:2fbb46fcd17bc81f993f28c47f1ebea38d66ae97cc2dbc3cad73b37cefbff700"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.6", markers = "python_version < \"3.13\""}
+tzdata = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+binary = ["psycopg-binary (==3.2.9) ; implementation_name != \"pypy\""]
+c = ["psycopg-c (==3.2.9) ; implementation_name != \"pypy\""]
+dev = ["ast-comments (>=1.1.2)", "black (>=24.1.0)", "codespell (>=2.2)", "dnspython (>=2.1)", "flake8 (>=4.0)", "isort-psycopg", "isort[colors] (>=6.0)", "mypy (>=1.14)", "pre-commit (>=4.0.1)", "types-setuptools (>=57.4)", "types-shapely (>=2.0)", "wheel (>=0.37)"]
+docs = ["Sphinx (>=5.0)", "furo (==2022.6.21)", "sphinx-autobuild (>=2021.3.14)", "sphinx-autodoc-typehints (>=1.12)"]
+pool = ["psycopg-pool"]
+test = ["anyio (>=4.0)", "mypy (>=1.14)", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
 
 [[package]]
 name = "publication"
@@ -2910,6 +2961,25 @@ pytest = ">=6.2.5"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "pytest-postgresql"
+version = "7.0.2"
+description = "Postgresql fixtures and fixture factories for Pytest."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_postgresql-7.0.2-py3-none-any.whl", hash = "sha256:0b0d31c51620a9c1d6be93286af354256bc58a47c379f56f4147b22da6e81fb5"},
+    {file = "pytest_postgresql-7.0.2.tar.gz", hash = "sha256:57c8d3f7d4e91d0ea8b2eac786d04f60080fa6ed6e66f1f94d747c71c9e5a4f4"},
+]
+
+[package.dependencies]
+mirakuru = ">=2.6.0"
+packaging = "*"
+port-for = ">=0.7.3"
+psycopg = ">=3.0.0"
+pytest = ">=7.2"
 
 [[package]]
 name = "python-dateutil"
@@ -3724,6 +3794,19 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "tzdata"
+version = "2025.2"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["dev"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
+    {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -4252,4 +4335,4 @@ examples = ["grpcio", "grpcio-tools", "websockets"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "f9c72d9303cac5e709a908b5318058a98fae3a95f2812d05daf2b9efe171ecd5"
+content-hash = "3f79159f35335bf6750498cd9590a1193c987ceb27d70c6352a7d5c6d5f92539"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ bandit = "^1.8.5"
 pydeps = "^3.0.1"
 types-protobuf = "^5.26.0.20240422"
 types-psutil = "^5.9.5.20240516"
+pytest-postgresql = "^7.0.2"
 
 
 [build-system]

--- a/src/plugins/builtin/resources/postgres.py
+++ b/src/plugins/builtin/resources/postgres.py
@@ -3,16 +3,13 @@ from __future__ import annotations
 """PostgreSQL database resource."""
 import json
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, AsyncIterator, Dict, List, Optional
+from typing import AsyncIterator, Dict, List, Optional
 
 import asyncpg
 
 from pipeline.observability.tracing import start_span
 from pipeline.reliability import CircuitBreaker, RetryPolicy
-
-if TYPE_CHECKING:  # pragma: no cover - type hints only
-    from pipeline.state import ConversationEntry
-
+from pipeline.state import ConversationEntry
 from plugins.builtin.resources.database import DatabaseResource
 
 

--- a/tests/integration/test_chat_history_backends.py
+++ b/tests/integration/test_chat_history_backends.py
@@ -37,7 +37,7 @@ async def run_history_test(resource):
         resource._history_table = "test_history"
         await resource.initialize()
 
-    memory = MemoryResource(storage=resource)
+    memory = MemoryResource(database=resource)
     resources = ResourceContainer()
     await resources.add("memory", memory)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())

--- a/tests/integration/test_postgres_history.py
+++ b/tests/integration/test_postgres_history.py
@@ -28,7 +28,7 @@ CONN = {
 def test_save_and_load_history(pg_env):
     async def run():
         db = PostgresResource(CONN)
-        memory = MemoryResource(storage=db)
+        memory = MemoryResource(database=db)
         try:
             await db.initialize()
         except OSError as exc:

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -43,7 +43,7 @@ def test_vector_memory_integration(pg_env):
         }
         db = PostgresResource(db_cfg)
         vm = PgVectorStore(vm_cfg)
-        memory = MemoryResource(storage=db, vector=vm)
+        memory = MemoryResource(database=db, vector_store=vm)
         llm = UnifiedLLMResource(
             {"provider": "echo", "base_url": "http://localhost", "model": "none"}
         )

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -43,7 +43,7 @@ def test_memory_persists_between_runs():
 def test_save_and_load_history():
     async def run():
         storage = MemoryStorage({})
-        memory = MemoryResource(storage=storage)
+        memory = MemoryResource(database=storage)
         history = [
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ]


### PR DESCRIPTION
## Summary
- install pytest-postgresql
- adjust MemoryResource usages in tests
- import ConversationEntry at runtime in Postgres resource

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: many missing stubs)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `sudo -u postgres PATH=/usr/lib/postgresql/16/bin:/usr/local/bin:$PATH /root/.cache/pypoetry/virtualenvs/entity-pBA_rQHY-py3.11/bin/pytest tests/integration/test_postgres_history.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_686b2d40799c8322bc38f76bb9ba8a98