### PR TITLE
Fix benchmark registration

### DIFF
--- a/tests/performance/test_full_pipeline_benchmark.py
+++ b/tests/performance/test_full_pipeline_benchmark.py
@@ -17,7 +17,7 @@ class RespondPlugin:
 @pytest.mark.benchmark
 def test_full_pipeline_benchmark(benchmark):
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DO)
+    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DO))
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
 


### PR DESCRIPTION
## Summary
- fix full pipeline benchmark plugin registration

## Testing
- `poetry run pytest tests/performance/test_full_pipeline_benchmark.py`
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Missing type parameters, untyped defs, etc.)*
- `bandit -r src` *(fails: command not found or security issues)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Configuration invalid)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(partial run, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d46002483228ddffa2ba9296291