### PR TITLE
Fix tool registration by using config names

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -66,9 +66,9 @@ plugins:
     calculator:
       type: plugins.builtin.tools.calculator_tool:CalculatorTool
   adapters:
-  http:
-    type: plugins.builtin.adapters.http:HTTPAdapter
-    stages: [parse, deliver]
+    http:
+      type: plugins.builtin.adapters.http:HTTPAdapter
+      stages: [parse, deliver]
       auth_tokens:
         - dev-secret
       rate_limit:
@@ -76,12 +76,12 @@ plugins:
         interval: 60
       audit_log_path: logs/audit.log
       dashboard: true
-  cli:
-    type: plugins.builtin.adapters.cli:CLIAdapter
-    stages: [deliver]
-  logging:
-    type: plugins.builtin.adapters.logging:LoggingAdapter
-    stages: [deliver]
+    cli:
+      type: plugins.builtin.adapters.cli:CLIAdapter
+      stages: [deliver]
+    logging:
+      type: plugins.builtin.adapters.logging:LoggingAdapter
+      stages: [deliver]
   prompts:
     chain_of_thought:
       type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -73,22 +73,22 @@ plugins:
       type: plugins.builtin.tools.calculator_tool:CalculatorTool
       precision: 10
   adapters:
-  http:
-    type: plugins.builtin.adapters.http:HTTPAdapter
-    stages: [parse, deliver]
-    auth_tokens:
-      - ${HTTP_TOKEN}
+    http:
+      type: plugins.builtin.adapters.http:HTTPAdapter
+      stages: [parse, deliver]
+      auth_tokens:
+        - ${HTTP_TOKEN}
       rate_limit:
         requests: 100
         interval: 60
       audit_log_path: logs/audit.log
       dashboard: false
-  cli:
-    type: plugins.builtin.adapters.cli:CLIAdapter
-    stages: [deliver]
-  logging:
-    type: plugins.builtin.adapters.logging:LoggingAdapter
-    stages: [deliver]
+    cli:
+      type: plugins.builtin.adapters.cli:CLIAdapter
+      stages: [deliver]
+    logging:
+      type: plugins.builtin.adapters.logging:LoggingAdapter
+      stages: [deliver]
   prompts:
     chain_of_thought:
       type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt


### PR DESCRIPTION
## Summary
- ensure tool names from configuration are preserved during initialization
- fix indentation in example dev and prod configurations

## Testing
- `poetry run pytest tests/registry/test_plugin_discovery.py`
- `poetry run mypy src` *(fails: Found 376 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Configuration invalid)*
- `PYTHONPATH=src poetry run python -m src.registry.validator` *(fails: ImportError)*


------
https://chatgpt.com/codex/tasks/task_e_686b2e64d4808322a95686b972fa9e1c