### PR TITLE
Fix config validation schema generation

### DIFF
--- a/src/entity_config/models.py
+++ b/src/entity_config/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import MISSING, asdict, dataclass, field, is_dataclass
-from typing import Any, Dict, get_args, get_origin
+from typing import Any, Dict, get_args, get_origin, get_type_hints
 
 from jsonschema import validate
 
@@ -98,14 +98,22 @@ def _type_to_schema(tp: Any) -> Dict[str, Any]:
 
 
 def _class_to_schema(cls: type) -> Dict[str, Any]:
+    """Generate a JSON schema for ``cls`` dataclass."""
+
     schema = {"type": "object", "properties": {}, "additionalProperties": False}
     required = []
+
+    hints = get_type_hints(cls)
+
     for field_obj in cls.__dataclass_fields__.values():
-        schema["properties"][field_obj.name] = _type_to_schema(field_obj.type)
+        field_type = hints.get(field_obj.name, field_obj.type)
+        schema["properties"][field_obj.name] = _type_to_schema(field_type)
         if field_obj.default is MISSING and field_obj.default_factory is MISSING:
             required.append(field_obj.name)
+
     if required:
         schema["required"] = required
+
     return schema
 
 


### PR DESCRIPTION
## Summary
- ensure dataclasses with postponed annotations resolve correctly
- generate schema using resolved type hints

## Testing
- `poetry run pytest tests/config/test_validation.py`
- `poetry run pytest` *(fails: 69 failed, 102 passed, 8 skipped, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d26e46c8322bce3aff753e3343d