### PR TITLE
Fix plugin registration async handling

### DIFF
--- a/src/pipeline/builder.py
+++ b/src/pipeline/builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
@@ -35,7 +36,9 @@ class AgentBuilder:
             raise TypeError(f"Plugin '{name}' must implement async '_execute_impl'")
         for stage in getattr(plugin, "stages", []):
             name = getattr(plugin, "name", plugin.__class__.__name__)
-            self.plugin_registry.register_plugin_for_stage(plugin, stage, name)
+            result = self.plugin_registry.register_plugin_for_stage(plugin, stage, name)
+            if asyncio.iscoroutine(result):
+                asyncio.run(result)
 
     def plugin(
         self,

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -4,26 +4,27 @@ import pytest
 
 from entity import Agent
 from pipeline import PipelineStage
+from pipeline.base_plugins import BasePlugin
 
 
-class ParsePlugin:
+class ParsePlugin(BasePlugin):
     stages = [PipelineStage.PARSE]
 
-    async def execute(self, context):
+    async def _execute_impl(self, context):
         context.set_stage_result("parsed", True)
 
 
-class ThinkPlugin:
+class ThinkPlugin(BasePlugin):
     stages = [PipelineStage.THINK]
 
-    async def execute(self, context):
+    async def _execute_impl(self, context):
         context.set_stage_result("thought", True)
 
 
-class RespondPlugin:
+class RespondPlugin(BasePlugin):
     stages = [PipelineStage.DO]
 
-    async def execute(self, context):
+    async def _execute_impl(self, context):
         context.set_response("ok")
 
 


### PR DESCRIPTION
## Summary
- ensure AgentBuilder handles async register_plugin_for_stage
- update full pipeline test plugin classes to inherit from BasePlugin

## Testing
- `poetry run black src/pipeline/builder.py tests/integration/test_full_pipeline.py`
- `poetry run isort src/pipeline/builder.py tests/integration/test_full_pipeline.py`
- `poetry run flake8 src/pipeline/builder.py tests/integration/test_full_pipeline.py`
- `poetry run mypy src/pipeline/builder.py`
- `bandit -r src/pipeline/builder.py` *(fails: command not found)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `PYTHONPATH=src poetry run python -m registry.validator` *(fails: ImportError)*
- `poetry run pytest tests/integration/test_full_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_686b2d40102c8322b8bff49e3ddac478