### PR TITLE
Fix example imports for pytest

### DIFF
--- a/examples/advanced_llm.py
+++ b/examples/advanced_llm.py
@@ -1,7 +1,5 @@
 """Demonstrate streaming and function-calling with UnifiedLLMResource."""
 
-"""Demonstrate streaming and function-calling with UnifiedLLMResource."""
-
 from __future__ import annotations
 
 import asyncio
@@ -12,7 +10,7 @@ from typing import Any, Dict
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-from utilities import enable_plugins_namespace
+from .utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/bedrock_deploy.py
+++ b/examples/bedrock_deploy.py
@@ -8,11 +8,11 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-from utilities import enable_plugins_namespace
+from .utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 
-from infrastructure.aws_bedrock import deploy
+from plugins.builtin.infrastructure.aws_bedrock import deploy
 
 
 def can_deploy() -> bool:

--- a/examples/cache_example.py
+++ b/examples/cache_example.py
@@ -8,7 +8,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-from utilities import enable_plugins_namespace
+from .utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/config_reload_example.py
+++ b/examples/config_reload_example.py
@@ -12,7 +12,7 @@ import yaml
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 # Expose local plugins namespace
-from utilities import enable_plugins_namespace
+from .utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/failure_example.py
+++ b/examples/failure_example.py
@@ -9,7 +9,7 @@ import sys
 # Make the repository's ``src`` directory importable
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-from utilities import enable_plugins_namespace
+from .utilities import enable_plugins_namespace
 
 # Expose the local ``plugins`` namespace
 enable_plugins_namespace()

--- a/examples/observability_metrics.py
+++ b/examples/observability_metrics.py
@@ -8,7 +8,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-from utilities import enable_plugins_namespace
+from .utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/observability_tracing.py
+++ b/examples/observability_tracing.py
@@ -8,7 +8,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-from utilities import enable_plugins_namespace
+from .utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/pipelines/duckdb_pipeline.py
+++ b/examples/pipelines/duckdb_pipeline.py
@@ -10,12 +10,11 @@ from typing import Any
 # Ensure project source is available for imports
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
-from utilities import enable_plugins_namespace
+from ..utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 
-from user_plugins.duckdb_database import DuckDBDatabaseResource
-from user_plugins.duckdb_vector_store import DuckDBVectorStore
+from user_plugins.resources import DuckDBDatabaseResource, DuckDBVectorStore
 from user_plugins.memory_resource import MemoryResource
 
 from entity import Agent

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -10,17 +10,17 @@ import sys
 # Ensure project source is available for imports
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))  # noqa: E402
 
-from utilities import enable_plugins_namespace
+from ..utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 
-from user_plugins.duckdb_vector_store import DuckDBVectorStore  # noqa: E402
-from user_plugins.memory_resource import MemoryResource  # noqa: E402
-from user_plugins.pg_vector_store import PgVectorStore  # noqa: E402
-from user_plugins.postgres import PostgresResource  # noqa: E402
-from user_plugins.sqlite_storage import (
+from plugins.builtin.resources.postgres import PostgresResource
+from plugins.builtin.resources.pg_vector_store import PgVectorStore
+from plugins.builtin.resources.sqlite_storage import (
     SQLiteStorageResource as SQLiteDatabaseResource,
 )
+from user_plugins.resources import DuckDBVectorStore
+from user_plugins.memory_resource import MemoryResource
 
 from entity import Agent  # noqa: E402
 from pipeline import PipelineStage, PromptPlugin  # noqa: E402

--- a/examples/pipelines/pipeline_example.py
+++ b/examples/pipelines/pipeline_example.py
@@ -10,7 +10,7 @@ from typing import Any, Dict
 # Ensure the repository's ``src`` directory is available for imports
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
-from utilities import enable_plugins_namespace
+from ..utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 from user_plugins.llm.unified import UnifiedLLMResource
@@ -81,7 +81,7 @@ def create_llm() -> UnifiedLLMResource:
         cfg = {"provider": "ollama", "base_url": base_url, "model": model}
     else:
         cfg = {"provider": "echo"}
-    return UnifiedLLMResource(ConfigLoader.from_dict(cfg))
+    return UnifiedLLMResource(cfg)
 
 
 def setup_registries() -> SystemRegistries:

--- a/examples/pipelines/vector_memory_pipeline.py
+++ b/examples/pipelines/vector_memory_pipeline.py
@@ -15,12 +15,12 @@ from typing import Dict, List
 # Ensure project source is available for imports
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))  # noqa: E402
 
-from utilities import enable_plugins_namespace
+from ..utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 from user_plugins.llm.unified import UnifiedLLMResource  # noqa: E402
-from user_plugins.pg_vector_store import PgVectorStore  # noqa: E402
-from user_plugins.postgres import PostgresResource  # noqa: E402
+from plugins.builtin.resources.pg_vector_store import PgVectorStore  # noqa: E402
+from plugins.builtin.resources.postgres import PostgresResource  # noqa: E402
 
 from entity_config.environment import load_env
 from entity import Agent  # noqa: E402

--- a/examples/servers/cli_adapter.py
+++ b/examples/servers/cli_adapter.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
-from utilities import enable_plugins_namespace
+from ..utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/servers/grpc_server.py
+++ b/examples/servers/grpc_server.py
@@ -14,7 +14,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
-from utilities import enable_plugins_namespace
+from ..utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/servers/http_server.py
+++ b/examples/servers/http_server.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
-from utilities import enable_plugins_namespace
+from ..utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/servers/websocket_server.py
+++ b/examples/servers/websocket_server.py
@@ -9,7 +9,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
-from utilities import enable_plugins_namespace
+from ..utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/storage_resource_example.py
+++ b/examples/storage_resource_example.py
@@ -10,7 +10,7 @@ from datetime import datetime
 # Make the repository's ``src`` directory importable
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-from utilities import enable_plugins_namespace
+from .utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/structured_logging_example.py
+++ b/examples/structured_logging_example.py
@@ -8,7 +8,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-from utilities import enable_plugins_namespace
+from .utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/tools/search_weather_example.py
+++ b/examples/tools/search_weather_example.py
@@ -9,7 +9,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-from utilities import enable_plugins_namespace
+from ..utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 

--- a/examples/utilities/plugin_loader.py
+++ b/examples/utilities/plugin_loader.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
-from utilities import enable_plugins_namespace
+from . import enable_plugins_namespace
 
 enable_plugins_namespace()
 


### PR DESCRIPTION
## Summary
- fix relative imports in examples so tests run
- simplify `create_llm` helper
- update provider imports for DB examples

## Testing
- `poetry run pytest tests/examples/test_examples.py`
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 375 errors)*
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: 68 failed, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d281b4483228177c46b66348944