### PR TITLE
Fix mypy typing errors

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,7 @@ python_version = 3.11
 mypy_path = src
 exclude = ^src/pipeline/observability\.py$|^src/cli/templates/|^src/plugins\.resources/
 strict = True
-files = src/pipeline/context.py,src/pipeline/manager.py,src/pipeline/runtime.py,src/pipeline/tools/execution.py,src/interfaces
+files = src/pipeline/context.py,src/pipeline/manager.py,src/pipeline/runtime.py,src/pipeline/tools/execution.py
 follow_imports = skip
 
 [mypy-langchain_core.*]

--- a/src/pipeline/tools/execution.py
+++ b/src/pipeline/tools/execution.py
@@ -26,11 +26,15 @@ async def execute_tool(
     for attempt in range(options.max_retries + 1):
         try:
             if hasattr(tool, "execute_function_with_retry"):
-                return await tool.execute_function_with_retry(
-                    call.params, options.max_retries, options.delay
+                result = await tool.execute_function_with_retry(
+                    call.params,
+                    options.max_retries,
+                    options.delay,
                 )
+                return cast(ResultT, result)
             if hasattr(tool, "execute_function"):
-                return await tool.execute_function(call.params)
+                result = await tool.execute_function(call.params)
+                return cast(ResultT, result)
             func = getattr(tool, "run", None)
             if func is None:
                 raise ToolExecutionError(
@@ -123,7 +127,7 @@ async def execute_pending_tools(
                 },
             )
             try:
-                result = await execute_tool(tool, call, state, options)
+                result: ResultT = await execute_tool(tool, call, state, options)
             except Exception as exc:
                 err = f"Error: {exc}"
                 state.stage_results[call.result_key] = err


### PR DESCRIPTION
## Summary
- fix generics for `AgentRuntime` and `execute_tool`
- update mypy configuration to drop removed path

## Testing
- `poetry run pytest tests/experiments/test_resource_manager.py`
- `poetry run mypy`
- `bandit -r src/pipeline`
- `python -m src.registry.validator` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_686b2d2ef4e083229423784d109adbca