### PR TITLE
Fix failing pytest and cleanup postgres fixture

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 from registry import SystemRegistries
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,13 +28,8 @@ def postgres_service(postgresql_proc):
     """Start a temporary PostgreSQL instance if available."""
     if shutil.which("pg_ctl") is None:
         pytest.skip("PostgreSQL server not installed")
-<<<<<< codex/run-pytest-and-address-issues
-    if os.geteuid() == 0:
-        pytest.skip("PostgreSQL cannot run as root")
-======
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         pytest.skip("PostgreSQL server cannot run as root")
->>>>>> main
     return postgresql_proc
 
 


### PR DESCRIPTION
## Summary
- remove merge conflict text from `tests/conftest.py`
- drop unused `cast` import from `runtime.py`

## Testing
- `poetry run pytest tests/test_agent_default_config.py`
- `poetry run isort src/pipeline/runtime.py tests/conftest.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing stubs and other errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686b319e5da08322952a6af8ffba28cb