### PR TITLE
Fix cache test setup

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 from registry import SystemRegistries
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,13 +28,8 @@ def postgres_service(postgresql_proc):
     """Start a temporary PostgreSQL instance if available."""
     if shutil.which("pg_ctl") is None:
         pytest.skip("PostgreSQL server not installed")
-<<<<<< codex/run-pytest-and-address-issues
-    if os.geteuid() == 0:
-        pytest.skip("PostgreSQL cannot run as root")
-======
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         pytest.skip("PostgreSQL server cannot run as root")
->>>>>> main
     return postgresql_proc
 
 


### PR DESCRIPTION
## Summary
- resolve merge artifacts in tests/conftest.py
- remove unused import in runtime

## Testing
- `poetry run pytest tests/test_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_686b31a45800832285219e5600885d47