### PR TITLE
Fix postgres fixture and unused import

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 from registry import SystemRegistries
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,13 +28,8 @@ def postgres_service(postgresql_proc):
     """Start a temporary PostgreSQL instance if available."""
     if shutil.which("pg_ctl") is None:
         pytest.skip("PostgreSQL server not installed")
-<<<<<< codex/run-pytest-and-address-issues
-    if os.geteuid() == 0:
-        pytest.skip("PostgreSQL cannot run as root")
-======
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         pytest.skip("PostgreSQL server cannot run as root")
->>>>>> main
     return postgresql_proc
 
 


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in `tests/conftest.py`
- remove unused typing import from `runtime.py`
- add runtime safety check for postgres service fixture
- run formatting and linting

## Testing
- `poetry run pytest tests/test_calculator_tool.py`
- `poetry run mypy src` *(fails: missing stubs and other type errors)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: loader error)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: loader error)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: unknown config option and import errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b31a64e60832296bcd6a17b07eb17