### PR TITLE
Fix Bedrock test

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 from registry import SystemRegistries
 

--- a/src/plugins/builtin/resources/llm/providers/bedrock.py
+++ b/src/plugins/builtin/resources/llm/providers/bedrock.py
@@ -22,6 +22,7 @@ class BedrockProvider(BaseProvider):
         super().__init__(config)
         self.model_id: str = str(config.get("model_id", ""))
         self.region: str = str(config.get("region", "us-east-1"))
+        self.endpoint_url: str | None = config.get("endpoint_url")
         self.params = {
             k: v
             for k, v in config.items()
@@ -33,6 +34,7 @@ class BedrockProvider(BaseProvider):
                 "base_url",
                 "model",
                 "api_key",
+                "endpoint_url",
             }
         }
 
@@ -45,11 +47,17 @@ class BedrockProvider(BaseProvider):
     async def _invoke(self, prompt: str) -> str:
         payload = {"prompt": prompt, **self.params}
 
+        endpoint_url = self.endpoint_url
+        if endpoint_url:
+            url = f"{endpoint_url}/model/{self.model_id}/invoke"
+            try:
+                body = await self._post_with_retry(url, payload)
+                return str(body.get("outputText") or body.get("completion", ""))
+            except Exception as exc:  # pragma: no cover - bubble up
+                raise ResourceError("bedrock provider request failed") from exc
+
         async def call() -> str:
             client_kwargs = {"region_name": self.region}
-            endpoint_url = self.params.get("endpoint_url")
-            if endpoint_url:
-                client_kwargs["endpoint_url"] = endpoint_url
             async with aioboto3.client("bedrock-runtime", **client_kwargs) as client:
                 response = await client.invoke_model(
                     modelId=self.model_id,
@@ -67,11 +75,10 @@ class BedrockProvider(BaseProvider):
 
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
-    ) -> LLMResponse:
-        text = await self._invoke(prompt)
-        return LLMResponse(content=text)
+    ) -> str:
+        return await self._invoke(prompt)
 
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
-        yield await (await self.generate(prompt)).content
+        yield await self.generate(prompt)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,13 +28,9 @@ def postgres_service(postgresql_proc):
     """Start a temporary PostgreSQL instance if available."""
     if shutil.which("pg_ctl") is None:
         pytest.skip("PostgreSQL server not installed")
-<<<<<< codex/run-pytest-and-address-issues
-    if os.geteuid() == 0:
-        pytest.skip("PostgreSQL cannot run as root")
-======
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         pytest.skip("PostgreSQL server cannot run as root")
->>>>>> main
+
     return postgresql_proc
 
 


### PR DESCRIPTION
## Summary
- remove merge markers from test fixture
- make BedrockProvider handle endpoint_url via HTTP
- return plain strings from BedrockProvider
- remove unused import in runtime

## Testing
- `poetry run isort src/plugins/builtin/resources/llm/providers/bedrock.py tests/conftest.py src/pipeline/runtime.py`
- `poetry run flake8 src/plugins/builtin/resources/llm/providers/bedrock.py tests/conftest.py src/pipeline/runtime.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator`
- `poetry run pytest tests/test_bedrock_resource.py`
- `poetry run pytest` *(fails: 51 failed, 120 passed, 10 skipped, 5 warnings, 1 error in 34.70s)*

------
https://chatgpt.com/codex/tasks/task_e_686b31a25ec48322aeedd4f756449efa