### PR TITLE
Fix plugin initialization in pipeline

### DIFF
--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,3 +1,7 @@
+# isort: skip_file
+from common_interfaces import plugins as _plugin_api
+from common_interfaces.base_plugin import BasePlugin
+
 from .agent import Agent
 from .base_plugins import (
     AdapterPlugin,

--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 from registry import SystemRegistries
 


### PR DESCRIPTION
## Summary
- ensure plugin globals configured during pipeline import
- fix missing cast import in `runtime.py`

## Testing
- `poetry run pytest tests/test_dependency_tree.py`
- `poetry run flake8 src/pipeline/__init__.py src/pipeline/runtime.py`
- `poetry run black src/pipeline/__init__.py src/pipeline/runtime.py`
- `poetry run isort src/pipeline/__init__.py src/pipeline/runtime.py`


------
https://chatgpt.com/codex/tasks/task_e_686b361e727c8322855cf0ec4c932784