### PR TITLE
Emphasize dev install before running checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ The `/architecture` folder contains the following documents:
   backward compatibility.
 - Prefer adding `TODO:` comments when scope is unclear.
 - Always use the Poetry environment for development.
-- Run `poetry install` before executing any quality checks.
+- Run `poetry install --with dev` before executing any quality checks or tests.
 
 ## Programmatic Checks
 Run the following commands before opening a pull request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for helping improve Entity Pipeline Framework! Always start with `poetry install` to create the virtual environment and install dependencies. After that, follow the project guidelines and run all checks before opening a pull request.
+Thank you for helping improve Entity Pipeline Framework! Always start with `poetry install --with dev` to create the virtual environment and install dependencies. After that, follow the project guidelines and run all checks before opening a pull request.
 
 ## Code Review Expectations
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For a high-level look at how the pieces connect, see [components_overview.md](co
 4. Copy `.env.example` to `.env` and fill in the values if you want to run the example scripts. See [examples/README.md](examples/README.md) for what each example expects.
 
 ### Testing Setup
+Run `poetry install --with dev` before executing tests or quality checks.
 
 Running the full test suite requires a local PostgreSQL server. The tests rely
 on `pytest-postgresql` which starts a temporary instance using `pg_ctl`. Install

--- a/docs/spikes/SPIKE-DX-001.md
+++ b/docs/spikes/SPIKE-DX-001.md
@@ -14,7 +14,7 @@ This spike captures recommended approaches for plugin discovery and runtime hot 
 - For iterative development, enable `watchfiles` to trigger reloads when code or configuration changes.
 
 ## Developer Workflow Tips
-1. Install dependencies with `poetry install`.
+1. Install dependencies with `poetry install --with dev`.
 2. Run formatters and linters before committing:
    ```bash
    poetry run black src tests


### PR DESCRIPTION
## Summary
- remind developers to install dev dependencies before running checks
- update contributing doc and spike

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F821 undefined name 'Any')*
- `poetry run mypy src` *(fails: Found 378 errors)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686b3c4a4e00832291d43351ddd33aba