### PR TITLE
Fix AgentRuntime manager initialization

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, cast
 
 from registry import SystemRegistries
@@ -13,7 +13,9 @@ class AgentRuntime:
     """Execute messages through the pipeline."""
 
     registries: SystemRegistries
-    manager: PipelineManager[Dict[str, Any]]
+    manager: PipelineManager[Dict[str, Any]] = field(
+        init=False, default_factory=PipelineManager
+    )
 
     def __post_init__(self) -> None:
         self.manager = PipelineManager[Dict[str, Any]](self.registries)


### PR DESCRIPTION
## Summary
- ensure AgentRuntime doesn't require a manager argument

## Testing
- `poetry run black src/pipeline/runtime.py`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F401, F821)*
- `poetry run mypy src` *(fails: many errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: NameError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: NameError)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_686b3c4979e88322ae9061e5e14580b5