### PR TITLE
Remove unused RegistryValidator import

### DIFF
--- a/src/registry/__init__.py
+++ b/src/registry/__init__.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from .registries import PluginRegistry, SystemRegistries, ToolRegistry
-from .validator import RegistryValidator
 
 __all__ = [
     "PluginRegistry",
     "ToolRegistry",
     "SystemRegistries",
-    "RegistryValidator",
 ]
 
 


### PR DESCRIPTION
## Summary
- stop importing `RegistryValidator` in `registry` package
- keep `RegistryValidator` import in `validator.py` but not exposed via `registry.__all__`

## Testing
- `poetry run black src/registry/__init__.py`
- `poetry run isort src tests` *(reverted unrelated changes)*
- `poetry run flake8 src tests` *(fails: F811 redefinition errors)*
- `poetry run mypy src` *(fails: found 378 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: NameError: name 'Any' is not defined)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: NameError: name 'Any' is not defined)*
- `PYTHONPATH=. poetry run python -m src.registry.validator --config config/dev.yaml` *(fails: circular import)
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686b3c479a68832287c28979920f0217