### PR TITLE
Update MemoryResource signature

### DIFF
--- a/src/pipeline/resources/memory_resource.py
+++ b/src/pipeline/resources/memory_resource.py
@@ -47,10 +47,25 @@ class MemoryResource(ResourcePlugin, Memory):
         self,
         database: DatabaseResource | None = None,
         vector_store: VectorStoreResource | None = None,
+        config: Dict | None = None,
         *,
         storage: DatabaseResource | None = None,
-        config: Dict | None = None,
     ) -> None:
+        """Initialize the resource.
+
+        Parameters
+        ----------
+        database:
+            Backend used to persist conversation history.
+        vector_store:
+            Backend used for similarity search.
+        config:
+            Optional configuration mapping.
+        storage:
+            Keyword-only alias for ``database`` kept for backward
+            compatibility.
+        """
+
         super().__init__(config or {})
         if storage is not None and database is None:
             database = storage
@@ -62,7 +77,7 @@ class MemoryResource(ResourcePlugin, Memory):
 
     @classmethod
     def from_config(cls, config: Dict) -> "MemoryResource":
-        return cls(config=config)
+        return cls(None, None, config=config)
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
         return None


### PR DESCRIPTION
## Summary
- adjust `MemoryResource.__init__` so config is the third positional parameter and `storage` remains keyword-only
- clarify initialization in docstring
- update `MemoryResource.from_config`

## Testing
- `poetry run black src/pipeline/resources/memory_resource.py`
- `poetry run isort src/pipeline/resources/memory_resource.py`
- `poetry run flake8 src/pipeline/resources/memory_resource.py`
- `poetry run mypy src` *(fails: 379 errors)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ImportError)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ImportError)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686b3df97b488322957d069990529aa3