### PR TITLE
Update memory resource

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict
 
 from registry import SystemRegistries


### PR DESCRIPTION
## Summary
- improve `SimpleMemoryResource` to store conversations in-memory
- relax `MemoryResource` initializer signature
- fix `AgentRuntime` dataclass import

## Testing
- `poetry run black src/pipeline/resources/memory_resource.py src/pipeline/runtime.py`
- `poetry run isort src/pipeline/resources/memory_resource.py src/pipeline/runtime.py`
- `poetry run flake8 src/pipeline/resources/memory_resource.py src/pipeline/runtime.py`
- `poetry run mypy src | tail -n 20`
- `bandit -r src | tail -n 2` *(fails: command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml | tail -n 20` *(fails: ImportError)*
- `poetry run python -m src.config.validator --config config/prod.yaml | tail -n 20` *(fails: ImportError)*
- `poetry run python -m src.registry.validator | tail -n 20` *(fails: ModuleNotFoundError)*
- `pytest | tail -n 20` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686b3de896a88322b73b5e57d2200082