### PR TITLE
Fix runtime PipelineManager initialization

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict
 
 from registry import SystemRegistries


### PR DESCRIPTION
## Summary
- ensure `AgentRuntime.manager` uses `field(init=False)`
- initialize `PipelineManager` in `__post_init__`

## Testing
- `poetry run black src/pipeline/runtime.py`
- `poetry run isort src/pipeline/runtime.py`
- `poetry run flake8 src/pipeline/runtime.py`
- `poetry run mypy src/pipeline/runtime.py` *(fails: Returning Any from function declared to return `dict[str, Any]`)*
- `bandit -r src/pipeline/runtime.py` *(fails: command not found)*
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: No module named 'yaml')*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: No module named 'common_interfaces')*
- `pytest tests/test_call_llm_logging.py` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686b3dd3f8108322bd00f66fd133f592