### PR TITLE
Fix UnifiedLLMResource return type

### DIFF
--- a/src/pipeline/resources/llm/unified.py
+++ b/src/pipeline/resources/llm/unified.py
@@ -7,14 +7,17 @@ from typing import Any, AsyncIterator, Dict, List, Type
 
 from pipeline.base_plugins import ValidationResult
 from pipeline.state import LLMResponse
+
 # Import provider implementations from the public plugin package. Using the
 # fully qualified path avoids ambiguity if this module is restructured.
-from plugins.builtin.resources.llm.providers import (BedrockProvider,
-                                                     ClaudeProvider,
-                                                     EchoProvider,
-                                                     GeminiProvider,
-                                                     OllamaProvider,
-                                                     OpenAIProvider)
+from plugins.builtin.resources.llm.providers import (
+    BedrockProvider,
+    ClaudeProvider,
+    EchoProvider,
+    GeminiProvider,
+    OllamaProvider,
+    OpenAIProvider,
+)
 from plugins.builtin.resources.llm_resource import LLMResource
 
 from ...exceptions import ResourceError
@@ -90,12 +93,13 @@ class UnifiedLLMResource(LLMResource):
 
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
-    ) -> LLMResponse:
+    ) -> str:
         self._select_model(prompt)
         last_exc: Exception | None = None
         for provider in self._providers:
             try:
-                return await provider.generate(prompt, functions)
+                response: LLMResponse = await provider.generate(prompt, functions)
+                return response.content
             except Exception as exc:  # noqa: BLE001
                 last_exc = exc
                 continue


### PR DESCRIPTION
## Summary
- return plain text from `UnifiedLLMResource.generate`
- update type hints accordingly

## Testing
- `poetry run black src/pipeline/resources/llm/unified.py`
- `poetry run isort src/pipeline/resources/llm/unified.py`
- `poetry run flake8 src/pipeline/resources/llm/unified.py`
- `poetry run mypy src/pipeline/resources/llm/unified.py` *(fails: Class cannot subclass `LLMResource`, etc.)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: circular import error)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: circular import error)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: `common_interfaces`)*
- `poetry run pytest` *(fails: NameError: `field` is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686b3de5ece88322ab9ddf32c108c353