### PR TITLE
Add console output for config validation

### DIFF
--- a/src/entity_config/validator.py
+++ b/src/entity_config/validator.py
@@ -17,8 +17,7 @@ from entity_config.environment import load_env  # noqa: E402
 from pipeline import SystemInitializer  # noqa: E402
 from pipeline.config import ConfigLoader  # noqa: E402
 from pipeline.logging import get_logger  # noqa: E402
-from plugins.builtin.adapters.logging_adapter import \
-    configure_logging  # noqa: E402
+from plugins.builtin.adapters.logging_adapter import configure_logging  # noqa: E402
 
 from .validators import _validate_memory  # noqa: E402
 from .validators import _validate_cache, _validate_vector_memory  # noqa: E402
@@ -82,8 +81,10 @@ class ConfigValidator:
                 asyncio.run(initializer.initialize())
             except (ValidationError, Exception) as exc:  # pragma: no cover - error path
                 logger.error("Configuration invalid: %s", exc)
+                print(f"Configuration invalid: {exc}")
                 return False
             logger.info("Configuration valid.")
+            print("Configuration valid")
             return True
 
         def backup(prev_text: str | None, new_text: str) -> None:

--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict
 
 from registry import SystemRegistries


### PR DESCRIPTION
## Summary
- print config validation outcome in CLI
- fix missing `field` import in AgentRuntime dataclass

## Testing
- `poetry run black src/entity_config/validator.py src/pipeline/runtime.py`
- `poetry run isort src/entity_config/validator.py src/pipeline/runtime.py`
- `poetry run flake8 src/entity_config/validator.py src/pipeline/runtime.py`
- `poetry run mypy src` *(fails: numerous errors)*
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ImportError)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ImportError)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/test_config_validator.py` *(fails: 3 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686b3dd7348483229872fb0fca4fa06c