### PR TITLE
Fix plugin discovery for decorated functions

### DIFF
--- a/src/pipeline/builder.py
+++ b/src/pipeline/builder.py
@@ -148,9 +148,12 @@ class AgentBuilder:
                     and obj not in {BasePlugin, BasePluginInterface}
                 ):
                     try:
-                        self.add_plugin(obj())
+                        instance = obj()
                     except TypeError:
-                        self.add_plugin(obj({}))
+                        instance = obj({})
+                    self.add_plugin(instance)
+                elif callable(obj) and hasattr(obj, "__entity_plugin__"):
+                    self.add_plugin(getattr(obj, "__entity_plugin__"))
                 elif callable(obj) and name.endswith("_plugin"):
                     self.plugin(obj)
             except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- ensure `_register_module_plugins` registers decorated plugin functions correctly

## Testing
- `poetry run black src/pipeline/builder.py`
- `poetry run isort src/pipeline/builder.py`
- `poetry run flake8 src/pipeline/builder.py`
- `poetry run mypy src/pipeline/builder.py`
- `poetry run bandit -r src/pipeline/builder.py`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: ImportError: cannot import name 'ConfigLoader')*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: ImportError: cannot import name 'ConfigLoader')*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `PYTHONPATH=src poetry run pytest` *(fails: NameError: name 'field' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686b3dd9b1188322850f6c61fe30b695