### PR TITLE
Add builtin memory resource wrapper

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict
 
 from registry import SystemRegistries

--- a/src/plugins/builtin/resources/memory_resource.py
+++ b/src/plugins/builtin/resources/memory_resource.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+"""Expose memory resource implementations for plugin imports."""
+
+from pipeline.resources.memory_resource import (MemoryResource,
+                                                SimpleMemoryResource)
+
+__all__ = ["MemoryResource", "SimpleMemoryResource"]


### PR DESCRIPTION
## Summary
- expose `MemoryResource` through builtin plugins
- fix missing `field` import in runtime module

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Missing type parameters)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: circular import)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: circular import)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: several tests)*

------
https://chatgpt.com/codex/tasks/task_e_686b3dea8f20832299067a2abbc92d42