### PR TITLE
Fix LoggingAdapter level

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict
 
 from registry import SystemRegistries

--- a/src/plugins/builtin/adapters/logging.py
+++ b/src/plugins/builtin/adapters/logging.py
@@ -17,6 +17,8 @@ class LoggingAdapter(AdapterPlugin):
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         super().__init__(config)
         self.logger = logging.getLogger("pipeline.output")
+        if self.logger.getEffectiveLevel() > logging.INFO:
+            self.logger.setLevel(logging.INFO)
 
     async def serve(self, registries) -> None:  # pragma: no cover - no server
         pass


### PR DESCRIPTION
## Summary
- ensure pipeline log adapter always logs at INFO
- fix missing `field` import for runtime

## Testing
- `poetry run black src/pipeline/runtime.py src/plugins/builtin/adapters/logging.py`
- `poetry run isort src/pipeline/runtime.py src/plugins/builtin/adapters/logging.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 378 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: circular import)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: circular import)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: 33 failed, 1 error)*


------
https://chatgpt.com/codex/tasks/task_e_686b3df822e8832284293bddb1132c65