### PR TITLE
Add sqlite storage health check

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict
 
 from registry import SystemRegistries

--- a/src/plugins/builtin/resources/sqlite_storage.py
+++ b/src/plugins/builtin/resources/sqlite_storage.py
@@ -92,5 +92,14 @@ class SQLiteStorageResource(DatabaseResource):
             await self._conn.close()
             self._conn = None
 
+    async def health_check(self) -> bool:
+        if self._conn is None:
+            return False
+        try:
+            await self._conn.execute("SELECT 1")
+            return True
+        except Exception:
+            return False
+
     async def _do_health_check(self, connection: aiosqlite.Connection) -> None:
         await connection.execute("SELECT 1")


### PR DESCRIPTION
## Summary
- implement a `health_check` method for SQLiteStorageResource
- fix missing import in runtime

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: many errors)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `poetry run pytest` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686b3e02ce888322abca82ff72ca722b