### PR TITLE
Fix registry validator dependencies

### DIFF
--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict
 
 from registry import SystemRegistries

--- a/src/plugins/builtin/resources/pg_vector_store.py
+++ b/src/plugins/builtin/resources/pg_vector_store.py
@@ -8,6 +8,7 @@ from typing import Dict, List
 from pgvector import Vector
 from pgvector.asyncpg import register_vector
 
+from pipeline.stages import PipelineStage
 from plugins.builtin.resources.postgres import PostgresResource
 from plugins.builtin.resources.vector_store import VectorStoreResource
 
@@ -15,6 +16,7 @@ from plugins.builtin.resources.vector_store import VectorStoreResource
 class PgVectorStore(VectorStoreResource):
     """Postgres-backed vector store using pgvector."""
 
+    stages = [PipelineStage.PARSE]
     name = "vector_memory"
 
     def __init__(

--- a/src/plugins/builtin/resources/postgres.py
+++ b/src/plugins/builtin/resources/postgres.py
@@ -9,6 +9,7 @@ import asyncpg
 
 from pipeline.observability.tracing import start_span
 from pipeline.reliability import CircuitBreaker, RetryPolicy
+from pipeline.stages import PipelineStage
 from pipeline.state import ConversationEntry
 from plugins.builtin.resources.database import DatabaseResource
 
@@ -16,6 +17,7 @@ from plugins.builtin.resources.database import DatabaseResource
 class PostgresResource(DatabaseResource):
     """PostgreSQL database resource with built-in connection pooling."""
 
+    stages = [PipelineStage.PARSE]
     name = "database"
 
     def __init__(self, config: Dict | None = None) -> None:

--- a/src/registry/__init__.py
+++ b/src/registry/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from .registries import PluginRegistry, SystemRegistries, ToolRegistry
-from .validator import RegistryValidator
 
 __all__ = [
     "PluginRegistry",
@@ -20,4 +19,8 @@ def __getattr__(name: str):
         from pipeline.resources import ResourceContainer
 
         return ResourceContainer
+    if name == "RegistryValidator":
+        from .validator import RegistryValidator
+
+        return RegistryValidator
     raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Summary
- add PipelineStage metadata to PostgresResource and PgVectorStore
- lazily load `RegistryValidator` to avoid circular imports
- enforce Postgres requirement for PgVectorStore in registry validator
- ensure AgentRuntime imports `field`
- tolerate missing ValidationResult when validating dependencies

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy`
- `poetry run mypy src`
- `bandit -r src` *(fails: command not found)*
- `PYTHONPATH=src poetry run python -m src.config.validator --config config/dev.yaml` *(failed: ImportError)*
- `PYTHONPATH=src poetry run python -m src.config.validator --config config/prod.yaml` *(failed: ImportError)*
- `PYTHONPATH=src poetry run python -m src.registry.validator --config config/dev.yaml`
- `poetry run pytest tests/test_registry_validator.py::test_vector_memory_requires_postgres tests/test_registry_validator.py::test_vector_memory_with_postgres -q`


------
https://chatgpt.com/codex/tasks/task_e_686b3dfae07c83228c9b774ee4085a4e