### PR TITLE
Improve pg_env skip logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,17 @@ def postgres_service(postgresql_proc):
 
 
 @pytest.fixture()
-def pg_env(postgres_service, postgresql):
+def pg_env(request):
     """Provide environment variables for the temporary PostgreSQL server."""
+    if shutil.which("pg_ctl") is None:
+        pytest.skip("PostgreSQL server not installed")
+
+    try:
+        request.getfixturevalue("postgres_service")
+        postgresql = request.getfixturevalue("postgresql")
+    except Exception as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"PostgreSQL service cannot start: {exc}")
+
     os.environ.update(
         {
             "DB_HOST": postgresql.info.host,


### PR DESCRIPTION
## Summary
- make `pg_env` check for `pg_ctl` and handle startup failures

## Testing
- `poetry run black tests/conftest.py -q`
- `poetry run isort tests/conftest.py`
- `poetry run flake8 tests/conftest.py`
- `poetry run mypy src` *(fails: 380 errors)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: loader error)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: loader error)*
- `PYTHONPATH=src python -m src.registry.validator --config config/dev.yaml`
- `pytest` *(fails: missing pytest-asyncio and hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_686ba900ce288322852c345d7f641b8b