### PR TITLE
Update gemini resource test path

### DIFF
--- a/tests/test_gemini_resource.py
+++ b/tests/test_gemini_resource.py
@@ -1,8 +1,13 @@
 import asyncio
 import json
 
-from pipeline import (MetricsCollector, PipelineState, PluginContext,
-                      SystemInitializer, SystemRegistries)
+from pipeline import (
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    SystemInitializer,
+    SystemRegistries,
+)
 from plugins.builtin.resources.llm.unified import UnifiedLLMResource
 
 
@@ -20,7 +25,7 @@ async def run_generate(server, handler):
     result = await resource.generate("hello")
     req = json.loads(handler.request_body.decode())
     assert req == {"contents": [{"parts": [{"text": "hello"}]}]}
-    assert handler.request_path == "/v1beta/models/gemini-pro:generateContent"
+    assert handler.request_path == "/v1beta/models/gemini-pro:generateContent?key=key"
     return result
 
 


### PR DESCRIPTION
## Summary
- fix expected path for unified LLM Gemini resource

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811 redefinition of unused variables in pipeline package)*
- `poetry run mypy src` *(fails: found 380 errors)*
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: module import issues)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: module import issues)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(failed to run due to missing 'yaml' module)*


------
https://chatgpt.com/codex/tasks/task_e_686ba8fa5bbc83228cceb5c771f2c615