### PR TITLE
Update LLM helper test to raise ResourceError

### DIFF
--- a/tests/test_llm_helpers.py
+++ b/tests/test_llm_helpers.py
@@ -6,6 +6,7 @@ import pytest
 from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
                       PipelineState, PluginContext, PluginRegistry,
                       PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline.errors import ResourceError
 from pipeline.resources import ResourceContainer
 
 
@@ -37,7 +38,7 @@ def test_ask_llm_returns_text():
 
 def test_ask_llm_without_llm_resource_raises():
     ctx = make_context()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ResourceError):
         asyncio.run(ctx.ask_llm("hi"))
 
 


### PR DESCRIPTION
## Summary
- update `test_ask_llm_without_llm_resource_raises` to expect `ResourceError`

## Testing
- `poetry run black tests/test_llm_helpers.py`
- `poetry run isort tests/test_llm_helpers.py`
- `poetry run flake8 tests/test_llm_helpers.py`
- `poetry run mypy src` *(fails: missing library stubs)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: missing dependency yaml)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: missing dependency yaml)*
- `python -m src.registry.validator` *(fails: missing module common_interfaces)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686ba8fc19248322b6b91da9495fc455