### PR TITLE
Fix test initializer resource lookup

### DIFF
--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -118,7 +118,7 @@ def test_initializer_from_json_and_dict(tmp_path):
         == len(pj.get_plugins_for_stage(PipelineStage.THINK))
         == len(pd.get_plugins_for_stage(PipelineStage.THINK))
     )
-    assert ry.get("A") and rj.get("A") and rd.get("A")
+    assert ry.get("a") and rj.get("a") and rd.get("a")
 
 
 def test_llm_resource_registration(tmp_path):


### PR DESCRIPTION
## Summary
- fix resource key case in initializer tests

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811 redefinition of unused)*
- `poetry run mypy src` *(errors: module and typing issues)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(errors: module loader cannot handle src.config.validator)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(errors: module loader cannot handle src.config.validator)*
- `poetry run python -m src.registry.validator` *(failed: ModuleNotFoundError: 'common_interfaces')*
- `poetry run pytest` *(fails: various test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686ba8f7eb548322bd839c95f4807e9f