### PR TITLE
Fix ErrorFormatter message

### DIFF
--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -74,4 +74,4 @@ def test_error_formatter_produces_message():
     """Ensure ErrorFormatter creates a user-facing error message."""
     registries = make_registries(ErrorFormatter)
     result = asyncio.run(execute_pipeline("hi", registries))
-    assert result == {"error": "FailPlugin failed: boom"}
+    assert result == {"error": "FailPlugin failed (RuntimeError): boom"}

--- a/user_plugins/failure/error_formatter.py
+++ b/user_plugins/failure/error_formatter.py
@@ -15,5 +15,5 @@ class ErrorFormatter(FailurePlugin):
         if info is None:
             context.set_response({"error": "Unknown error"})
             return
-        message = f"{info.plugin_name} failed: {info.error_message}"
+        message = f"{info.plugin_name} failed ({info.error_type}): {info.error_message}"
         context.set_response({"error": message})


### PR DESCRIPTION
## Summary
- standardize ErrorFormatter message format
- test ErrorFormatter with new format

## Testing
- `poetry run black user_plugins/failure/error_formatter.py tests/test_error_stage.py`
- `poetry run isort src tests` *(modified files reverted)*
- `poetry run flake8 src tests` *(fails: F811 redefinition errors)*
- `poetry run mypy src` *(fails: many errors)
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'aioboto3')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'aioboto3')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aioboto3')*

------
https://chatgpt.com/codex/tasks/task_e_686ba8f4c96883229c2915147c9d36f5