### PR TITLE
Fix logging adapter response access

### DIFF
--- a/examples/structured_logging_example.py
+++ b/examples/structured_logging_example.py
@@ -13,7 +13,6 @@ from .utilities import enable_plugins_namespace
 enable_plugins_namespace()
 
 from plugins.builtin.adapters.logging import LoggingAdapter
-
 from plugins.builtin.adapters.logging_adapter import configure_logging, get_logger
 
 
@@ -24,9 +23,17 @@ async def main() -> None:
     logger = get_logger("structured_logging_example")
     logger.info("Logging configured successfully")
 
+    class FakeState:
+        def __init__(self) -> None:
+            self.response = {"message": "hello"}
+
     class FakeContext:
-        def get_response(self):
-            return {"message": "hello"}
+        def __init__(self) -> None:
+            self.state = FakeState()
+
+        @property
+        def response(self):
+            return self.state.response
 
     await adapter.execute(FakeContext())
 

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from datetime import datetime
-from typing import (TYPE_CHECKING, Any, AsyncIterator, Callable, Dict, List,
-                    Optional, TypeVar, cast)
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypeVar,
+    cast,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from common_interfaces.resources import LLM
@@ -20,8 +29,7 @@ __all__ = ["PluginContext", "ConversationEntry", "ToolCall"]
 from .errors import ResourceError
 from .metrics import MetricsCollector
 from .stages import PipelineStage
-from .state import (ConversationEntry, FailureInfo, LLMResponse, PipelineState,
-                    ToolCall)
+from .state import ConversationEntry, FailureInfo, LLMResponse, PipelineState, ToolCall
 from .tools.base import RetryOptions
 from .tools.execution import execute_tool
 
@@ -192,6 +200,11 @@ class PluginContext:
     def has_response(self) -> bool:
         """Return ``True`` if a response has been provided."""
         return self.__state.response is not None
+
+    @property
+    def response(self) -> Any:
+        """Return the pipeline response if set."""
+        return self.__state.response
 
     def set_stage_result(self, key: str, value: Any) -> None:
         """Store intermediate ``value`` for the current stage under ``key``."""

--- a/src/plugins/builtin/adapters/logging.py
+++ b/src/plugins/builtin/adapters/logging.py
@@ -24,6 +24,7 @@ class LoggingAdapter(AdapterPlugin):
         pass
 
     async def _execute_impl(self, context) -> None:
-        response = context.get_response()
+        """Log the pipeline response if one has been produced."""
+        response = context.response
         if response is not None:
             self.logger.info("response delivered", extra={"response": response})


### PR DESCRIPTION
## Summary
- adjust LoggingAdapter to read `context.response`
- expose `PluginContext.response` property
- update structured logging example

## Testing
- `poetry run black src/plugins/builtin/adapters/logging.py src/pipeline/context.py examples/structured_logging_example.py`
- `poetry run isort src/plugins/builtin/adapters/logging.py src/pipeline/context.py examples/structured_logging_example.py`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'aioboto3')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'aioboto3')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aioboto3')*

------
https://chatgpt.com/codex/tasks/task_e_686ba8f3a8ec8322a0c49bb7f423bd3c