### PR TITLE
Update built-in adapter defaults

### DIFF
--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
-    "type": "user_plugins.adapters.logging:LoggingAdapter",
+    "type": "plugins.builtin.adapters.logging:LoggingAdapter",
     "stages": ["deliver"],
 }
 
@@ -47,14 +47,14 @@ DEFAULT_TOOLS: Dict[str, Dict[str, Any]] = {
 
 DEFAULT_ADAPTERS: Dict[str, Dict[str, Any]] = {
     "http": {
-        "type": "user_plugins.adapters.http:HTTPAdapter",
+        "type": "plugins.builtin.adapters.http:HTTPAdapter",
         "stages": ["parse", "deliver"],
     },
     "websocket": {
-        "type": "user_plugins.adapters.websocket:WebSocketAdapter",
+        "type": "plugins.builtin.adapters.websocket:WebSocketAdapter",
         "stages": ["deliver"],
     },
-    "cli": {"type": "user_plugins.adapters.cli:CLIAdapter", "stages": ["deliver"]},
+    "cli": {"type": "plugins.builtin.adapters.cli:CLIAdapter", "stages": ["deliver"]},
     "logging": DEFAULT_LOGGING_CONFIG,
 }
 


### PR DESCRIPTION
## Summary
- update default adapter paths to reference `plugins.builtin`

## Testing
- `poetry run black src/pipeline/defaults.py`
- `poetry run isort src/pipeline/defaults.py`
- `poetry run flake8 src tests` *(fails: F811 redefinition errors)*
- `poetry run mypy src` *(fails: 380 errors)*
- `bandit -r src` *(command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails to load module)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails to load module)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: 'common_interfaces')*
- `poetry run pytest -q` *(fails: 18 failed, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_686ba8eef44483229bf810c8c92a693b