### PR TITLE
Add ValidationResult imports to LLM providers

### DIFF
--- a/src/plugins/builtin/resources/llm/providers/claude.py
+++ b/src/plugins/builtin/resources/llm/providers/claude.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncIterator, Dict, List
 
 from pipeline.exceptions import ResourceError
 from pipeline.state import LLMResponse
+from pipeline.validation import ValidationResult
 
 from .base import BaseProvider
 
@@ -14,6 +15,11 @@ class ClaudeProvider(BaseProvider):
 
     name = "claude"
     requires_api_key = True
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        """Validate Claude provider configuration."""
+        return super().validate_config(config)
 
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None

--- a/src/plugins/builtin/resources/llm/providers/gemini.py
+++ b/src/plugins/builtin/resources/llm/providers/gemini.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncIterator, Dict, List
 
 from pipeline.exceptions import ResourceError
 from pipeline.state import LLMResponse
+from pipeline.validation import ValidationResult
 
 from .base import BaseProvider
 
@@ -14,6 +15,11 @@ class GeminiProvider(BaseProvider):
 
     name = "gemini"
     requires_api_key = True
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        """Validate Gemini provider configuration."""
+        return super().validate_config(config)
 
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None


### PR DESCRIPTION
## Summary
- import `ValidationResult` in Claude and Gemini providers
- add `validate_config` methods delegating to base class

## Testing
- `poetry run isort src/plugins/builtin/resources/llm/providers/claude.py src/plugins/builtin/resources/llm/providers/gemini.py`
- `poetry run black src/plugins/builtin/resources/llm/providers/claude.py src/plugins/builtin/resources/llm/providers/gemini.py`
- `poetry run flake8 src tests` *(fails: F811 redefinition errors)*
- `poetry run mypy src` *(fails: found 382 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_686ba8ee3b08832290ad07b1b972ee7b