### PR TITLE
Handle missing cdktf in example

### DIFF
--- a/examples/bedrock_deploy.py
+++ b/examples/bedrock_deploy.py
@@ -12,7 +12,14 @@ from .utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 
-from plugins.builtin.infrastructure.aws_bedrock import deploy
+try:  # optional dependency
+    from plugins.builtin.infrastructure.aws_bedrock import deploy
+except (ImportError, FileNotFoundError):  # noqa: WPS440
+
+    def deploy() -> None:
+        """Fallback when CDKTF is unavailable."""
+
+        return None
 
 
 def can_deploy() -> bool:

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -6,6 +6,11 @@ from pathlib import Path
 
 import pytest
 
+from plugins.builtin.infrastructure import infrastructure
+
+if not infrastructure.CDKTF_AVAILABLE:  # pragma: no cover - optional dependency
+    pytest.skip("cdktf not available", allow_module_level=True)
+
 from pipeline import SystemRegistries
 
 


### PR DESCRIPTION
## Summary
- update bedrock example to gracefully handle missing cdktf
- skip example tests when cdktf isn't available

## Testing
- `poetry run isort --check src tests` *(fails: imports are incorrectly sorted)*
- `poetry run flake8 src tests` *(fails: F811 redefinition errors)*
- `poetry run mypy src` *(fails: found 380 errors)*
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: ValidationResult not defined)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: HTTP_TOKEN not found)*
- `poetry run python -m src.registry.validator` *(fails: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686ba8e9e53083229161625073049e49