### PR TITLE
Flush audit log after throttle, ensure test log files

### DIFF
--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -2,8 +2,14 @@ import asyncio
 
 import httpx
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from plugins.builtin.adapters import HTTPAdapter
 
@@ -58,7 +64,9 @@ def test_http_adapter_token_auth(tmp_path):
             assert resp.status_code == 401
 
     asyncio.run(_request())
-    assert "invalid token" in (tmp_path / "audit.log").read_text().lower()
+    log_file = tmp_path / "audit.log"
+    assert log_file.exists()
+    assert "invalid token" in log_file.read_text().lower()
 
 
 def test_http_adapter_rate_limit(tmp_path):
@@ -80,7 +88,9 @@ def test_http_adapter_rate_limit(tmp_path):
             assert resp.status_code == 429
 
     asyncio.run(_requests())
-    assert "rate limit" in (tmp_path / "audit.log").read_text().lower()
+    log_file = tmp_path / "audit.log"
+    assert log_file.exists()
+    assert "rate limit" in log_file.read_text().lower()
 
 
 def test_http_adapter_dashboard():


### PR DESCRIPTION
## Summary
- flush audit log handler after writing rate limit messages
- recreate audit logger for each HTTPAdapter instance
- assert log file creation in auth and rate limit tests

## Testing
- `poetry run bandit -f json -q -r src/plugins/builtin/adapters/http.py`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Required environment variable HTTP_TOKEN not found)*
- `PYTHONPATH=src poetry run python -m src.registry.validator --config config/dev.yaml`
- `poetry run pytest tests/test_http_adapter.py::test_http_adapter_token_auth tests/test_http_adapter.py::test_http_adapter_rate_limit`

------
https://chatgpt.com/codex/tasks/task_e_686ba8fe818483228b07b40e8b5979b8