### PR TITLE
Return LLMResponse from BedrockProvider

### DIFF
--- a/src/plugins/builtin/resources/llm/providers/bedrock.py
+++ b/src/plugins/builtin/resources/llm/providers/bedrock.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncIterator, Dict, List
 import aioboto3
 
 from pipeline.exceptions import ResourceError
+from pipeline.state import LLMResponse
 from pipeline.validation import ValidationResult
 
 from .base import BaseProvider
@@ -74,10 +75,11 @@ class BedrockProvider(BaseProvider):
 
     async def generate(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
-    ) -> str:
-        return await self._invoke(prompt)
+    ) -> LLMResponse:
+        text = await self._invoke(prompt)
+        return LLMResponse(content=text)
 
     async def stream(
         self, prompt: str, functions: List[Dict[str, Any]] | None = None
     ) -> AsyncIterator[str]:
-        yield await self.generate(prompt)
+        yield (await self.generate(prompt)).content

--- a/tests/test_bedrock_resource.py
+++ b/tests/test_bedrock_resource.py
@@ -12,13 +12,14 @@ async def run_generate(server, handler):
         {"provider": "bedrock", "model_id": "mi", "endpoint_url": base_url}
     )
     handler.response = {"outputText": "hi"}
-    result = await resource.generate("hello")
+    result = await resource._providers[0].generate("hello")
     body = json.loads(handler.request_body.decode())
     assert body == {"prompt": "hello"}
     assert handler.request_path == "/model/mi/invoke"
     return result
 
 
-def test_generate_sends_prompt_and_returns_text(mock_llm_server):
+def test_generate_sends_prompt_and_returns_content(mock_llm_server):
     server, handler = mock_llm_server
-    assert asyncio.run(run_generate(server, handler)) == "hi"
+    result = asyncio.run(run_generate(server, handler))
+    assert result.content == "hi"


### PR DESCRIPTION
## Summary
- BedrockProvider.generate now returns an `LLMResponse`
- adjust streaming to yield response content
- update Bedrock provider tests to check `.content` field

## Testing
- `poetry run black src/plugins/builtin/resources/llm/providers/bedrock.py tests/test_bedrock_resource.py`
- `poetry run isort src/plugins/builtin/resources/llm/providers/bedrock.py tests/test_bedrock_resource.py`
- `poetry run flake8 src/plugins/builtin/resources/llm/providers/bedrock.py tests/test_bedrock_resource.py`
- `poetry run mypy src`
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `poetry run pytest` *(tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_686ba8ec6b808322944766e90834505a