### PR TITLE
Add load_env fallback test

### DIFF
--- a/tests/config/test_environment.py
+++ b/tests/config/test_environment.py
@@ -1,0 +1,17 @@
+import os
+
+from entity_config.environment import load_env
+
+
+def test_load_env_falls_back_to_example(tmp_path, monkeypatch):
+    example = tmp_path / ".env.example"
+    example.write_text("FOO=bar\nBAZ=qux")
+    env_path = tmp_path / ".env"
+
+    monkeypatch.delenv("FOO", raising=False)
+    monkeypatch.delenv("BAZ", raising=False)
+
+    load_env(env_path)
+
+    assert os.environ.get("FOO") == "bar"
+    assert os.environ.get("BAZ") == "qux"


### PR DESCRIPTION
## Summary
- test load_env fallback to `.env.example` when `.env` is missing

## Testing
- `poetry run poe check` *(fails: Invalid task 'lint')*
- `poetry run mypy`
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `PYTHONPATH=src poetry run python -m src.registry.validator --config config/dev.yaml`
- `poetry run pytest -q` *(fails: 10 failed, 162 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686bc53757f483229ed44a04b7ffd675