### PR TITLE
Add RegistryValidator stage tests

### DIFF
--- a/tests/registry/test_validator_stage.py
+++ b/tests/registry/test_validator_stage.py
@@ -1,0 +1,50 @@
+import yaml
+import pytest
+
+from pipeline import PromptPlugin, PipelineStage
+from registry.validator import RegistryValidator
+
+
+class GoodPlugin(PromptPlugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        return None
+
+
+class BadPlugin(PromptPlugin):
+    stages = ["BROKEN_STAGE"]
+
+    async def _execute_impl(self, context):
+        return None
+
+
+def test_validator_rejects_invalid_stage(tmp_path):
+    config = {
+        "plugins": {
+            "prompts": {
+                "bad": {"type": "tests.registry.test_validator_stage:BadPlugin"}
+            }
+        }
+    }
+    path = tmp_path / "invalid.yml"
+    path.write_text(yaml.dump(config))
+
+    validator = RegistryValidator(str(path))
+    with pytest.raises(SystemError, match="invalid stage values"):
+        validator.run()
+
+
+def test_validator_accepts_valid_stage(tmp_path):
+    config = {
+        "plugins": {
+            "prompts": {
+                "good": {"type": "tests.registry.test_validator_stage:GoodPlugin"}
+            }
+        }
+    }
+    path = tmp_path / "valid.yml"
+    path.write_text(yaml.dump(config))
+
+    validator = RegistryValidator(str(path))
+    validator.run()


### PR DESCRIPTION
## Summary
- test RegistryValidator rejects invalid stage values
- confirm valid stages work

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: common packages)*
- `poetry run bandit -r src`
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: asyncpg)*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: asyncpg)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `pytest` *(fails: ModuleNotFoundError: asyncpg)*

------
https://chatgpt.com/codex/tasks/task_e_686bc539098c8322ab98cc2d17623e8b