### PR TITLE
Remove obsolete config environment loader

### DIFF
--- a/config/environment.py
+++ b/config/environment.py
@@ -1,9 +1,0 @@
-from pathlib import Path
-
-from dotenv import load_dotenv
-
-
-def load_env(env_file: str | Path = ".env") -> None:
-    env_path = Path(env_file)
-    if env_path.exists():
-        load_dotenv(env_path)


### PR DESCRIPTION
## Summary
- remove deprecated `config.environment` loader

## Testing
- `poetry run poe check` *(fails: Invalid task 'lint')*
- `poetry run mypy src` *(fails: 381 errors)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: `ValidationResult` not defined)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: missing `HTTP_TOKEN`)*
- `poetry run python -m src.registry.validator` *(fails: `ModuleNotFoundError`)*
- `poetry run bandit -r src`
- `poetry run pytest` *(fails: 10 failed, 161 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686bc525b20483228127310671ae95d9