### PR TITLE
Fix asyncio loop usage

### DIFF
--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -338,7 +338,7 @@ class PluginContext:
             raise ResourceError("LLM resource not available")
 
         self.record_llm_call("PluginContext", "ask_llm")
-        start = asyncio.get_event_loop().time()
+        start = asyncio.get_running_loop().time()
 
         if hasattr(llm, "generate"):
             response = await llm.generate(prompt)
@@ -352,7 +352,7 @@ class PluginContext:
                 response = func(prompt)
 
         self.record_llm_duration(
-            "PluginContext", asyncio.get_event_loop().time() - start
+            "PluginContext", asyncio.get_running_loop().time() - start
         )
 
         if isinstance(response, LLMResponse):
@@ -363,11 +363,11 @@ class PluginContext:
         """Stream LLM output using server-sent events."""
         llm = self.get_llm()
         self.record_llm_call("PluginContext", "stream_llm")
-        start = asyncio.get_event_loop().time()
+        start = asyncio.get_running_loop().time()
         async for chunk in llm.stream(prompt):
             yield chunk
         self.record_llm_duration(
-            "PluginContext", asyncio.get_event_loop().time() - start
+            "PluginContext", asyncio.get_running_loop().time() - start
         )
 
     async def calculate(self, expression: str) -> Any:

--- a/src/pipeline/manager.py
+++ b/src/pipeline/manager.py
@@ -25,7 +25,7 @@ class PipelineManager(Generic[ResultT]):
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.new_event_loop()
         task = loop.create_task(self._run_pipeline(message))
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)


### PR DESCRIPTION
## Summary
- use `asyncio.get_running_loop().time()` in PluginContext
- fall back to `asyncio.new_event_loop()` in PipelineManager
- test correct loop behavior for PluginContext and PipelineManager

## Testing
- `poetry run mypy src/pipeline/context.py src/pipeline/manager.py`
- `poetry run bandit -r src/pipeline/context.py src/pipeline/manager.py`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Configuration invalid)*
- `PYTHONPATH=src poetry run python -m src.registry.validator --config config/dev.yaml`
- `poetry run pytest tests/test_llm_helpers.py::test_ask_llm_uses_running_loop tests/test_pipeline_manager.py::test_start_pipeline_uses_new_event_loop -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc535142883228f2bf1f6d2675582