### PR TITLE
Document MemoryResource default

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -128,6 +128,10 @@ storage = StorageResource(
 )
 ```
 
+MemoryResource is a composite store that defaults to a DuckDB-backed database in
+memory and supports optional SQL/NoSQL and vector backends. Because this default
+uses an in-memory DuckDB database, there is no separate `InMemoryResource`.
+
 ## Plugin System Details
 
 ### Plugin Base Classes

--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -41,7 +41,11 @@ An LLM resource wraps a language model provider. Plugins can call `context.ask_l
 
 ### Memory vs Storage
 
-`MemoryResource` stores conversation history and vectors persistently. `StorageResource` handles file CRUD across databases, vector stores, and file systems.
+`MemoryResource` stores conversation history and vectors persistently. It defaults to a
+DuckDB-backed database in memory and supports optional SQL/NoSQL and vector backends.
+Because this default uses an in-memory DuckDB database, there is no separate
+`InMemoryResource`. `StorageResource` handles file CRUD across databases, vector
+stores, and file systems.
 
 ## Adapters
 


### PR DESCRIPTION
## Summary
- clarify that MemoryResource defaults to an in-memory DuckDB database in docs

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Module "pipeline.state" does not explicitly export attribute "MetricsCollector" and others)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_686be7735040832293f79e58cea01539