### PR TITLE
Fix validator docs

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -7,7 +7,7 @@
 
 ## Dependency validation errors
 - **Plugin requires a resource not registered** – confirm that all names in `dependencies` exist under `plugins:` in the config file.
-- **Config validation failed** – run `python -m src.entity_config.validator --config your.yaml` to see detailed messages.
+- **Config validation failed** – run `python -m src.config.validator --config your.yaml` to see detailed messages.
 
 If initialization still fails, enable debug logging with `LOG_LEVEL=DEBUG` when running the validator for verbose output.
 

--- a/docs/spikes/SPIKE-CFG-001.md
+++ b/docs/spikes/SPIKE-CFG-001.md
@@ -5,7 +5,7 @@ This document summarizes how the Entity Pipeline handles configuration validatio
 
 ## Validation Strategy
 - **Fail-fast validation** ensures initialization stops if any plugin dependencies are missing. Each plugin class implements `validate_config` and `validate_dependencies`, returning `ValidationResult` objects.
-- Configuration files can be checked with `python -m src.entity_config.validator --config your.yaml` to see detailed messages before starting the agent.
+- Configuration files can be checked with `python -m src.config.validator --config your.yaml` to see detailed messages before starting the agent.
 - Plugins declare required stages and dependencies, and the initializer verifies them up front so execution order is safe.
 
 ## Security Considerations

--- a/docs/spikes/SPIKE-DX-001.md
+++ b/docs/spikes/SPIKE-DX-001.md
@@ -25,8 +25,8 @@ This spike captures recommended approaches for plugin discovery and runtime hot 
    ```bash
    poetry run mypy src
    bandit -r src
-   python -m src.entity_config.validator --config config/dev.yaml
-   python -m src.entity_config.validator --config config/prod.yaml
+   python -m src.config.validator --config config/dev.yaml
+   python -m src.config.validator --config config/prod.yaml
    python -m src.registry.validator
    pytest
    ```

--- a/docs/spikes/SPIKE-DX-002.md
+++ b/docs/spikes/SPIKE-DX-002.md
@@ -18,8 +18,8 @@ This spike consolidates recommended tooling and test practices for the Entity Pi
   poetry run flake8 src tests
   poetry run mypy src
   bandit -r src
-  python -m src.entity_config.validator --config config/dev.yaml
-  python -m src.entity_config.validator --config config/prod.yaml
+  python -m src.config.validator --config config/dev.yaml
+  python -m src.config.validator --config config/prod.yaml
   python -m src.registry.validator
   pytest
   ```


### PR DESCRIPTION
## Summary
- point docs to `python -m src.config.validator`

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing library stubs)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: duckdb)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: duckdb)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `pytest` *(fails: ModuleNotFoundError: duckdb)*

------
https://chatgpt.com/codex/tasks/task_e_686be7719a448322b50295446f6b7529