### PR TITLE
Fix config extension in docs and tests

### DIFF
--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -8,7 +8,7 @@
 Run an agent from a YAML configuration file:
 
 ```bash
-python src/cli.py --config config.yml
+python src/cli.py --config config.yaml
 ```
 
 ### Using the SearchTool

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -6,7 +6,7 @@ import yaml
 
 def test_cli_entrypoint(tmp_path):
     config = {"server": {"host": "127.0.0.1", "port": 8123}}
-    path = tmp_path / "config.yml"
+    path = tmp_path / "config.yaml"
     path.write_text(yaml.dump(config))
 
     result = subprocess.run(

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -63,7 +63,7 @@ def test_initializer_env_and_dependencies(tmp_path):
             },
         }
     }
-    path = tmp_path / "config.yml"
+    path = tmp_path / "config.yaml"
     path.write_text(yaml.dump(config))
 
     initializer = SystemInitializer.from_yaml(str(path))
@@ -78,7 +78,7 @@ def test_initializer_env_and_dependencies(tmp_path):
 
 def test_validate_dependencies_missing(tmp_path):
     config = {"plugins": {"prompts": {"d": {"type": "tests.test_initializer:D"}}}}
-    path = tmp_path / "config.yml"
+    path = tmp_path / "config.yaml"
     path.write_text(yaml.dump(config))
 
     initializer = SystemInitializer.from_yaml(str(path))

--- a/tests/test_plugin_registry_order.py
+++ b/tests/test_plugin_registry_order.py
@@ -64,7 +64,7 @@ def test_initializer_orders_by_priority(tmp_path):
             }
         }
     }
-    path = tmp_path / "config.yml"
+    path = tmp_path / "config.yaml"
     path.write_text(yaml.dump(config))
 
     initializer = SystemInitializer.from_yaml(str(path))

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -61,7 +61,7 @@ class ComplexPrompt(PromptPlugin):
 
 
 def _write_config(tmp_path, plugins):
-    path = tmp_path / "config.yml"
+    path = tmp_path / "config.yaml"
     path.write_text(yaml.dump({"plugins": plugins}))
     return path
 


### PR DESCRIPTION
## Summary
- update quick start instructions to use `config.yaml`
- align test fixtures with the `.yaml` config extension

## Testing
- `poetry run black tests/test_cli_entrypoint.py tests/test_initializer.py tests/test_plugin_registry_order.py tests/test_registry_validator.py`
- `poetry run isort tests/test_cli_entrypoint.py tests/test_initializer.py tests/test_plugin_registry_order.py tests/test_registry_validator.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Module "pipeline.state" does not explicitly export attribute "MetricsCollector" and others)*
- `poetry run bandit -r src`
- `PYTHONPATH=src poetry run python -m src.config.validator --config config/dev.yaml` *(failed: loader issue)*
- `PYTHONPATH=src poetry run python -m src.config.validator --config config/prod.yaml` *(failed: loader issue)*
- `PYTHONPATH=src poetry run python -m src.registry.validator --config config/dev.yaml`
- `poetry run pytest` *(fails: ValueError: All items in BadPlugin.stages must be PipelineStage instances)*

------
https://chatgpt.com/codex/tasks/task_e_686be775a0748322957c6391eee5440e