### PR TITLE
Update agent start command in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ def hello(context):
 Update plugin settings without restarting the agent.
 
 ```bash
-python src/cli.py reload-config updated.yaml
+poetry run python src/cli.py reload-config updated.yaml
 ```
 
 See [the architecture overview](architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure) for details on dynamic reconfiguration.
@@ -325,7 +325,7 @@ requires the `websockets` package, which is now listed in `pyproject.toml`.
 
 ```bash
 python examples/servers/http_server.py
-python src/cli.py serve-websocket --config config/dev.yaml
+poetry run python src/cli.py serve-websocket --config config/dev.yaml
 python examples/servers/grpc_server.py
 python examples/servers/cli_adapter.py
 ```

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -69,7 +69,7 @@ advanced storage without sacrificing the simple default setup.
 Update plugin settings without restarting the agent:
 
 ```bash
-python -m src.cli reload-config updated.yaml
+poetry run python src/cli.py reload-config updated.yaml
 ```
 
 The command waits for active pipelines to finish, then applies the new YAML
@@ -103,7 +103,7 @@ python examples/servers/http_server.py
 For a WebSocket server use the CLI:
 
 ```bash
-python src/cli.py serve-websocket --config config/dev.yaml
+poetry run python src/cli.py serve-websocket --config config/dev.yaml
 ```
 
 Run the gRPC server:

--- a/docs/source/config_cheatsheet.md
+++ b/docs/source/config_cheatsheet.md
@@ -30,6 +30,6 @@ plugins:
       type: plugins.builtin.adapters.logging:LoggingAdapter
 ```
 
-Use `entity src/cli.py --config config.yaml` to start the agent.
+Use `poetry run python src/cli.py --config config.yaml` to start the agent.
 This example references a plugin under the `user_plugins` package to
 demonstrate how custom modules can be loaded.

--- a/docs/source/deploy_local.md
+++ b/docs/source/deploy_local.md
@@ -8,6 +8,6 @@ Run the agent directly on your machine during development.
    ```
 2. Start the HTTP adapter:
    ```bash
-   python -m entity.cli --config config/dev.yaml
+   poetry run python src/cli.py --config config/dev.yaml
    ```
 3. Send messages to `http://localhost:8000` to interact with the agent.

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -164,8 +164,8 @@ for how to expose an `Agent` through a command line interface. Use `src/cli.py`
 to run the agent interactively or over a WebSocket connection:
 
 ```bash
-python src/cli.py --config config/dev.yaml
-python src/cli.py serve-websocket --config config/dev.yaml
+poetry run python src/cli.py --config config/dev.yaml
+poetry run python src/cli.py serve-websocket --config config/dev.yaml
 ```
 
 When implementing custom error handling, refer to

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -8,7 +8,7 @@
 Run an agent from a YAML configuration file:
 
 ```bash
-python src/cli.py --config config.yml
+poetry run python src/cli.py --config config.yml
 ```
 
 ### Using the SearchTool
@@ -51,7 +51,7 @@ contributors a working agent almost immediately.
 Reload plugin definitions while the agent is running:
 
 ```bash
-python src/cli.py reload-config updated.yaml
+poetry run python src/cli.py reload-config updated.yaml
 ```
 
 For more on dynamic configuration, see [the architecture overview](../../architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure).


### PR DESCRIPTION
## Summary
- align docs to use `poetry run python src/cli.py --config <config>`
- keep README examples consistent with docs

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: yaml)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `pytest` *(fails: ModuleNotFoundError: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_686be770f3b88322825ab4bd30ddcafb