### PR TITLE
Update docs/tests references to config.yaml

### DIFF
--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -8,7 +8,7 @@
 Run an agent from a YAML configuration file:
 
 ```bash
-python src/cli.py --config config.yml
+python src/cli.py --config config.yaml
 ```
 
 ### Using the SearchTool

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -6,7 +6,7 @@ import yaml
 
 def test_cli_entrypoint(tmp_path):
     config = {"server": {"host": "127.0.0.1", "port": 8123}}
-    path = tmp_path / "config.yml"
+    path = tmp_path / "config.yaml"
     path.write_text(yaml.dump(config))
 
     result = subprocess.run(

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -63,7 +63,7 @@ def test_initializer_env_and_dependencies(tmp_path):
             },
         }
     }
-    path = tmp_path / "config.yml"
+    path = tmp_path / "config.yaml"
     path.write_text(yaml.dump(config))
 
     initializer = SystemInitializer.from_yaml(str(path))
@@ -78,7 +78,7 @@ def test_initializer_env_and_dependencies(tmp_path):
 
 def test_validate_dependencies_missing(tmp_path):
     config = {"plugins": {"prompts": {"d": {"type": "tests.test_initializer:D"}}}}
-    path = tmp_path / "config.yml"
+    path = tmp_path / "config.yaml"
     path.write_text(yaml.dump(config))
 
     initializer = SystemInitializer.from_yaml(str(path))

--- a/tests/test_plugin_registry_order.py
+++ b/tests/test_plugin_registry_order.py
@@ -64,7 +64,7 @@ def test_initializer_orders_by_priority(tmp_path):
             }
         }
     }
-    path = tmp_path / "config.yml"
+    path = tmp_path / "config.yaml"
     path.write_text(yaml.dump(config))
 
     initializer = SystemInitializer.from_yaml(str(path))

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -61,7 +61,7 @@ class ComplexPrompt(PromptPlugin):
 
 
 def _write_config(tmp_path, plugins):
-    path = tmp_path / "config.yml"
+    path = tmp_path / "config.yaml"
     path.write_text(yaml.dump({"plugins": plugins}))
     return path
 


### PR DESCRIPTION
## Summary
- standardize docs and tests to use `config.yaml`

## Testing
- `poetry run black tests/test_plugin_registry_order.py tests/test_initializer.py tests/test_cli_entrypoint.py tests/test_registry_validator.py`
- `poetry run isort tests/test_plugin_registry_order.py tests/test_initializer.py tests/test_cli_entrypoint.py tests/test_registry_validator.py`
- `poetry run flake8 tests/test_plugin_registry_order.py tests/test_initializer.py tests/test_cli_entrypoint.py tests/test_registry_validator.py`
- `poetry run mypy src` *(fails: `Missing type parameters`)*
- `bandit -r src` *(fails: `command not found`)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: `ValidationResult not defined`)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: `HTTP_TOKEN not found`)*
- `poetry run python -m src.registry.validator` *(fails: `ModuleNotFoundError: No module named 'common_interfaces'`)*
- `poetry run pytest tests/test_plugin_registry_order.py tests/test_initializer.py tests/test_cli_entrypoint.py tests/test_registry_validator.py` *(fails: `ValidationResult not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_686be81b0cf48322a299e565053a0fb9