### PR TITLE
Unify agent start command in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ requires the `websockets` package, which is now listed in `pyproject.toml`.
 
 ```bash
 python examples/servers/http_server.py
-python src/cli.py serve-websocket --config config/dev.yaml
+poetry run python src/cli.py serve-websocket --config config/dev.yaml
 python examples/servers/grpc_server.py
 python examples/servers/cli_adapter.py
 ```

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -103,7 +103,7 @@ python examples/servers/http_server.py
 For a WebSocket server use the CLI:
 
 ```bash
-python src/cli.py serve-websocket --config config/dev.yaml
+poetry run python src/cli.py serve-websocket --config config/dev.yaml
 ```
 
 Run the gRPC server:

--- a/docs/source/config_cheatsheet.md
+++ b/docs/source/config_cheatsheet.md
@@ -30,6 +30,6 @@ plugins:
       type: plugins.builtin.adapters.logging:LoggingAdapter
 ```
 
-Use `entity src/cli.py --config config.yaml` to start the agent.
+Use `poetry run python src/cli.py --config config.yaml` to start the agent.
 This example references a plugin under the `user_plugins` package to
 demonstrate how custom modules can be loaded.

--- a/docs/source/deploy_local.md
+++ b/docs/source/deploy_local.md
@@ -8,6 +8,6 @@ Run the agent directly on your machine during development.
    ```
 2. Start the HTTP adapter:
    ```bash
-   python -m entity.cli --config config/dev.yaml
+   poetry run python src/cli.py --config config/dev.yaml
    ```
 3. Send messages to `http://localhost:8000` to interact with the agent.

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -164,8 +164,8 @@ for how to expose an `Agent` through a command line interface. Use `src/cli.py`
 to run the agent interactively or over a WebSocket connection:
 
 ```bash
-python src/cli.py --config config/dev.yaml
-python src/cli.py serve-websocket --config config/dev.yaml
+poetry run python src/cli.py --config config/dev.yaml
+poetry run python src/cli.py serve-websocket --config config/dev.yaml
 ```
 
 When implementing custom error handling, refer to

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -8,7 +8,7 @@
 Run an agent from a YAML configuration file:
 
 ```bash
-python src/cli.py --config config.yml
+poetry run python src/cli.py --config config.yml
 ```
 
 ### Using the SearchTool


### PR DESCRIPTION
## Summary
- update docs to consistently start the agent with `poetry run python src/cli.py --config <config.yaml>`
- refresh README server example

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing stubs and type errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: `ValidationResult` not defined)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: missing env var)*
- `poetry run python -m src.registry.validator` *(fails: `common_interfaces` module not found)*
- `pytest` *(fails: `yaml` module not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be81a54488322997a1103f179cf7c