### PR TITLE
Update docs about MemoryResource default

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -128,9 +128,10 @@ storage = StorageResource(
 )
 ```
 
-MemoryResource is a composite store that defaults to a DuckDB-backed database in
-memory and supports optional SQL/NoSQL and vector backends. Because this default
-uses an in-memory DuckDB database, there is no separate `InMemoryResource`.
+MemoryResource \u2013 composite store that defaults to a DuckDB-backed database
+in memory and supports optional SQL/NoSQL and vector backends. MemoryResource
+uses an in-memory DuckDB database by default, so there is no separate
+`InMemoryResource`.
 
 ## Plugin System Details
 

--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -41,11 +41,10 @@ An LLM resource wraps a language model provider. Plugins can call `context.ask_l
 
 ### Memory vs Storage
 
-`MemoryResource` stores conversation history and vectors persistently. It defaults to a
-DuckDB-backed database in memory and supports optional SQL/NoSQL and vector backends.
-Because this default uses an in-memory DuckDB database, there is no separate
-`InMemoryResource`. `StorageResource` handles file CRUD across databases, vector
-stores, and file systems.
+`MemoryResource` \u2013 composite store that defaults to a DuckDB-backed database in
+memory and supports optional SQL/NoSQL and vector backends. MemoryResource uses an
+in-memory DuckDB database by default, so there is no separate `InMemoryResource`.
+`StorageResource` handles file CRUD across databases, vector stores, and file systems.
 
 ## Adapters
 


### PR DESCRIPTION
## Summary
- mirror README description about MemoryResource defaults in docs

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Module "pipeline.state" does not explicitly export attribute)*
- `bandit -r src` *(fails: various issues found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'asyncpg')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: loader for src.entity_config.validator cannot handle src.config.validator)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_686be81ca08083228e74780c05cd2917