### PR TITLE
Improve developer and deployment docs

### DIFF
--- a/docs/source/deploy_production.md
+++ b/docs/source/deploy_production.md
@@ -1,0 +1,43 @@
+# Production Deployment Guide
+
+This document describes a minimal production setup for running the Entity Pipeline Framework.
+It assumes you already tested your configuration locally and want to move it to a
+reliable environment.
+
+## Container Image
+
+Build a Docker image containing your plugins and configuration:
+
+```bash
+docker build -t entity-agent:latest .
+```
+
+Tag and push the image to your registry of choice. Kubernetes and many PaaS
+providers can pull directly from Docker Hub or a private registry.
+
+## Environment Variables
+
+Secrets such as API keys should be provided through environment variables. The
+example `config/prod.yaml` expects variables like `OPENAI_API_KEY`. Avoid baking
+secrets into the image.
+
+## Process Manager
+
+Run the agent under a process supervisor to handle restarts:
+
+```bash
+poetry run python src/cli.py --config config/prod.yaml
+```
+
+Use `systemd` or a container orchestrator such as Kubernetes to keep the process
+healthy and to manage logs. Configure liveness probes on the HTTP or gRPC
+adapter endpoint so the orchestrator can restart the container on failures.
+
+## Scaling
+
+For horizontal scaling you can run multiple agent replicas behind a load
+balancer. Use a shared database and file store so each instance has access to
+conversation history and uploaded files. Enable monitoring and metrics (see
+`monitoring.md`) to gain visibility into resource usage.
+
+

--- a/docs/source/developer_examples.md
+++ b/docs/source/developer_examples.md
@@ -1,0 +1,21 @@
+# Developer Examples
+
+A number of small scripts under the `examples/` directory demonstrate how to
+extend and deploy the framework. Each example reads credentials from environment
+variables as described in [`examples/README.md`](../../examples/README.md).
+
+- `pipelines/pipeline_example.py` – basic end-to-end pipeline.
+- `pipelines/vector_memory_pipeline.py` – shows vector storage integration.
+- `tools/search_weather_example.py` – combines built-in search and weather tools.
+- `servers/cli_adapter.py` – exposes an agent via the command line interface.
+
+Run an example with Poetry:
+
+```bash
+poetry run python examples/pipelines/pipeline_example.py
+```
+
+These scripts are useful references when creating your own plugins or adapting
+the project to new environments.
+
+

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -18,8 +18,9 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [Plugin cheat sheet](plugin_cheatsheet.md)
 - [Detailed guide](plugin_guide.md)
 - [Naming conventions](plugins.md)
+- [Developer examples](developer_examples.md)
 
--### Architecture
+### Architecture
 - [Architecture overview](../../architecture/overview.md)
 - [Components overview](components_overview.md)
 - [Deliver-stage adapters](components_overview.md#deliver-stage-adapters)
@@ -38,6 +39,8 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [Local](deploy_local.md)
 - [Docker](deploy_docker.md)
 - [Cloud](deploy_cloud.md)
+- [Production guide](deploy_production.md)
+- [Migration guide](migration_guide.md)
 
 ```{toctree}
 :hidden:
@@ -48,6 +51,7 @@ config
 config_cheatsheet
 plugin_cheatsheet
 plugin_guide
+developer_examples
 context
 logging
 advanced_usage
@@ -59,6 +63,8 @@ deploy_aws
 deploy_local
 deploy_docker
 deploy_cloud
+deploy_production
+migration_guide
 principle_checklist
 apidocs/index
 api_reference

--- a/docs/source/migration_guide.md
+++ b/docs/source/migration_guide.md
@@ -1,0 +1,45 @@
+# Migrating from Experimental Features
+
+Early versions of this project exposed several modules under the `experiments`
+package. Those modules are no longer maintained and have been replaced by stable
+APIs in `src/plugins` and `src/pipeline`. Follow these steps to upgrade your
+project.
+
+## 1. Update Imports
+
+Remove any imports that reference `experiments.*` modules. Stable equivalents
+exist in the `plugins.builtin` package. For example:
+
+```python
+# Old
+from experiments.storage.resource import StorageResource
+
+# New
+from plugins.builtin.resources.storage import StorageResource
+```
+
+## 2. Check Configuration Files
+
+Experimental plugins used different keys and stage names. Use the sample
+`config/prod.yaml` file as a reference and adjust your own YAML accordingly.
+Run the config validator to confirm:
+
+```bash
+python -m src.config.validator --config your.yaml
+```
+
+## 3. Validate Plugins
+
+If you wrote custom plugins during the experimental phase, make sure they inherit
+from the current base classes in `pipeline.base_plugins`. Then update the
+`stages` list to use values from `pipeline.stages.PipelineStage`.
+
+## 4. Verify Stored Data
+
+Schema or format changes might have occurred. Back up your existing database or
+vector store before running the new version of the agent. Then migrate your data
+as needed.
+
+By following these steps you can remove all deprecated experimental features and
+rely on the stable interfaces going forward.
+

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -73,6 +73,12 @@ class = "my_pkg.calc:CalculatorTool"
 During initialization the discovered entries are merged into the config and
 their dependencies validated automatically.
 
+## Development Steps
+1. Create your plugin class and implement `_execute_impl`.
+2. Register the plugin with the `Agent` or include it in your YAML under `plugins:`.
+3. Run `python -m src.config.validator --config your.yaml` to verify configuration.
+4. Write unit tests and run `pytest` before committing changes.
+
 ## Implementing Storage Backends
 
 Storage resources persist conversation history and other agent data. To add a
@@ -171,3 +177,10 @@ poetry run python src/cli.py serve-websocket --config config/dev.yaml
 When implementing custom error handling, refer to
 [`examples/failure_example.py`](../../examples/failure_example.py) and the
 failure plugin template at `src/cli/templates/failure.py`.
+
+## Troubleshooting Plugins
+- **Plugin not executing** – confirm the `stages` list contains the desired pipeline stage.
+- **Missing dependency** – ensure the plugin name appears in `plugins.resources` or `plugins.tools`.
+- **Runtime errors** – run with `LOG_LEVEL=DEBUG` to see the full traceback.
+
+

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -14,7 +14,9 @@ If initialization still fails, enable debug logging with `LOG_LEVEL=DEBUG` when 
 ## Runtime errors
 - **No response generated** – verify each stage sets the pipeline response or passes control to the next stage.
 - **Tool not found** – make sure the tool is registered in `tool_registry` and that the calling plugin uses the correct name.
+- **Plugin failed to import** – confirm the module path and that the file is in your `PYTHONPATH`.
 
 ## Docker issues
 - **Container exits immediately** – check the command in your `Dockerfile` and ensure the configuration file path is correct.
 - **Ports not exposed** – run the container with `-p 8000:8000` so the HTTP adapter is reachable from the host.
+


### PR DESCRIPTION
## Summary
- document production deployment and migration from experimental features
- expand plugin development docs with steps and troubleshooting tips
- add a list of example scripts for developers
- fix index page formatting and links

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Module "pipeline.state" does not explicitly export attribute)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Required environment variable HTTP_TOKEN not found)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c12c87b7c8322973f54a5b0920e5e