### PR TITLE
Improve serialization and HTTP resource efficiency

### DIFF
--- a/src/pipeline/serialization.py
+++ b/src/pipeline/serialization.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Helpers for efficient pipeline state serialization."""
+
+import msgpack
+
+from .state import PipelineState
+
+
+def dumps_state(state: PipelineState) -> bytes:
+    """Serialize ``state`` to msgpack-encoded bytes."""
+    return msgpack.dumps(state.to_dict(), use_bin_type=True)
+
+
+def loads_state(data: bytes) -> PipelineState:
+    """Deserialize ``data`` into a :class:`PipelineState`."""
+    return PipelineState.from_dict(msgpack.loads(data, raw=False))
+
+
+__all__ = ["dumps_state", "loads_state"]

--- a/src/pipeline/state.py
+++ b/src/pipeline/state.py
@@ -10,7 +10,7 @@ from .metrics import MetricsCollector
 from .stages import PipelineStage
 
 
-@dataclass
+@dataclass(slots=True)
 class LLMResponse:
     """Result returned by an LLM call."""
 
@@ -21,7 +21,7 @@ class LLMResponse:
     cost: float | None = None
 
 
-@dataclass
+@dataclass(slots=True)
 class ConversationEntry:
     """Single message stored in the conversation history.
 
@@ -38,7 +38,7 @@ class ConversationEntry:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
-@dataclass(eq=False)
+@dataclass(eq=False, slots=True)
 class ToolCall:
     """Description of a tool execution request.
 
@@ -55,7 +55,7 @@ class ToolCall:
     source: str = "direct_execution"
 
 
-@dataclass
+@dataclass(slots=True)
 class FailureInfo:
     """Captured information about a pipeline failure.
 
@@ -78,7 +78,7 @@ class FailureInfo:
     timestamp: datetime = field(default_factory=datetime.now)
 
 
-@dataclass
+@dataclass(slots=True)
 class PipelineState:
     """Mutable state shared across pipeline stages.
 


### PR DESCRIPTION
## Summary
- speed up state persistence with msgpack helpers
- reduce memory use with dataclass slots
- persist pipeline state to msgpack when file ends with `.mpk` or `.msgpack`
- reuse HTTP client and add optional caching for LLM resources
- stream requests through pooled client

## Testing
- `poetry run black src/pipeline/serialization.py src/pipeline/pipeline.py src/pipeline/state.py src/plugins/builtin/resources/http_llm_resource.py src/plugins/builtin/resources/llm/providers/base.py`
- `poetry run isort src/pipeline/pipeline.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing stubs and other errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: ValidationResult undefined)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: missing HTTP_TOKEN)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: 10 failed, 166 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686c12c525d48322a1a4f6a7ddfcacab