### PR TITLE
Enable runtime plugin reconfiguration

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -82,6 +82,20 @@ For a hands-on demonstration, run `examples/config_reload_example.py`:
 python examples/config_reload_example.py
 ```
 
+### Runtime Reconfiguration and Rollback
+
+`update_plugin_configuration()` restarts plugins when necessary and validates
+their dependencies before applying new settings. If a dependent plugin rejects a
+change the framework rolls back to the previous configuration. Plugins expose a
+`config_version` and `rollback_config()` helper:
+
+```python
+result = await update_plugin_configuration(reg.plugins, "my_plugin", {"value": 2})
+if not result.success:
+    print(result.error_message)
+await reg.get_plugin("my_plugin").rollback_config()
+```
+
 ### Streaming and Function Calling
 
 UnifiedLLMResource now exposes streaming via Server-Sent Events and optional

--- a/src/registry/registries.py
+++ b/src/registry/registries.py
@@ -117,6 +117,11 @@ class PluginRegistry:
             plugins.extend(plist)
         return plugins
 
+    def get_plugin(self, name: str) -> BasePlugin | None:
+        """Return plugin instance registered under ``name``."""
+
+        return self._plugins_by_name.get(name)
+
     def get_plugin_name(self, plugin: BasePlugin) -> str:
         return self._names.get(plugin, plugin.__class__.__name__)
 

--- a/tests/test_config_update.py
+++ b/tests/test_config_update.py
@@ -1,9 +1,16 @@
 import asyncio
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry,
-                      ValidationResult, execute_pipeline,
-                      update_plugin_configuration)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    ValidationResult,
+    execute_pipeline,
+    update_plugin_configuration,
+)
 from pipeline.resources import ResourceContainer
 
 
@@ -61,7 +68,8 @@ def test_update_plugin_configuration_restart_required():
     result = asyncio.run(
         update_plugin_configuration(reg, "test_plugin", {"value": "y"})
     )
-    assert not result.success and result.requires_restart
+    assert result.success
+    assert p.config["value"] == "y"
 
 
 def test_update_waits_for_running_pipeline():
@@ -88,3 +96,42 @@ def test_update_waits_for_running_pipeline():
     assert result.success
     assert duration >= 0.2
     assert plugin.updated_to == "two"
+
+
+def test_dependency_conflict_triggers_rollback():
+    class DependentPlugin(PromptPlugin):
+        stages = [PipelineStage.THINK]
+        dependencies = ["test_plugin"]
+
+        async def _execute_impl(self, context):
+            pass
+
+        async def on_dependency_reconfigured(self, name, old, new):
+            return new["value"] != "bad"
+
+    async def run_test():
+        reg = PluginRegistry()
+        plugin = TestReconfigPlugin({"value": "one"})
+        dep = DependentPlugin()
+        await reg.register_plugin_for_stage(plugin, PipelineStage.THINK)
+        await reg.register_plugin_for_stage(dep, PipelineStage.THINK)
+        result = await update_plugin_configuration(reg, "test_plugin", {"value": "bad"})
+        return result, plugin
+
+    result, plugin = asyncio.run(run_test())
+    assert not result.success
+    assert plugin.config["value"] == "one"
+    assert plugin.config_version == 1
+
+
+def test_rollback_to_previous_version():
+    async def run_test():
+        reg, plugin = await make_registry()
+        await update_plugin_configuration(reg, "test_plugin", {"value": "two"})
+        await update_plugin_configuration(reg, "test_plugin", {"value": "three"})
+        await plugin.rollback_config(2)
+        return plugin
+
+    plugin = asyncio.run(run_test())
+    assert plugin.config_version == 2
+    assert plugin.config["value"] == "two"


### PR DESCRIPTION
## Summary
- add versioned config handling to plugins
- restart plugins on reconfigure if needed
- validate dependencies during config updates and roll back on failure
- add rollback helper and tests
- document reconfiguration and rollback

## Testing
- `poetry run black src tests --check` *(fails: would reformat many files)*
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: found 388 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Required environment variable HTTP_TOKEN not found)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `poetry run pytest -q tests/test_config_update.py`

------
https://chatgpt.com/codex/tasks/task_e_686c12bf57548322b344664f3f445922