### PR TITLE
Enable hot reloading of plugins

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -82,6 +82,18 @@ For a hands-on demonstration, run `examples/config_reload_example.py`:
 python examples/config_reload_example.py
 ```
 
+### Hot Reloading Plugins
+
+During development you can watch plugin directories for changes and replace
+plugins on the fly. Use the CLI `--watch-dir` option:
+
+```bash
+poetry run python src/cli.py run --config config/dev.yaml --watch-dir user_plugins
+```
+
+The reloader waits for running pipelines to finish before swapping in the
+updated plugin implementations.
+
 ### Streaming and Function Calling
 
 UnifiedLLMResource now exposes streaming via Server-Sent Events and optional

--- a/src/pipeline/hot_reload.py
+++ b/src/pipeline/hot_reload.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from contextlib import suppress
+from pathlib import Path
+from types import ModuleType
+from typing import Iterable, List
+
+from watchfiles import awatch
+
+from registry import PluginRegistry
+
+from .base_plugins import BasePlugin
+from .config_update import wait_for_pipeline_completion
+from .manager import PipelineManager
+
+
+class PluginReloader:
+    """Watch plugin directories and hot reload changed modules."""
+
+    def __init__(
+        self,
+        registry: PluginRegistry,
+        directories: Iterable[str],
+        *,
+        pipeline_manager: PipelineManager | None = None,
+    ) -> None:
+        self.registry = registry
+        self.pipeline_manager = pipeline_manager
+        self.directories = [Path(d).resolve() for d in directories]
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._watch_loop())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._task
+
+    async def __aenter__(self) -> "PluginReloader":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()
+
+    async def _watch_loop(self) -> None:
+        async for changes in awatch(*self.directories):
+            await wait_for_pipeline_completion(self.pipeline_manager)
+            for _change, path in changes:
+                if path.endswith(".py"):
+                    await self._reload_path(Path(path))
+
+    async def _reload_path(self, path: Path) -> None:
+        module = self._import_module(path)
+        if module is None:
+            return
+        await self._reload_plugins_from_module(module)
+
+    @staticmethod
+    def _import_module(path: Path) -> ModuleType | None:
+        spec = importlib.util.spec_from_file_location(path.stem, path)
+        if spec and spec.loader:
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+        return None
+
+    async def _reload_plugins_from_module(self, module: ModuleType) -> None:
+        for obj in vars(module).values():
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, BasePlugin)
+                and obj is not BasePlugin
+            ):
+                name = getattr(obj, "name", obj.__name__)
+                instance = self.registry.get_by_name(name)
+                if instance is None:
+                    continue
+                config = getattr(instance, "config", {})
+                try:
+                    new_instance = obj(config)
+                except Exception:
+                    new_instance = obj()
+                await self.registry.replace_plugin(name, new_instance)


### PR DESCRIPTION
## Summary
- add PluginReloader utility for watching plugin directories
- allow replacing plugins at runtime via PluginRegistry
- expose `--watch-dir` option in the CLI
- document how to enable hot reload

## Testing
- `poetry run black src/cli.py src/registry/registries.py src/pipeline/hot_reload.py`
- `poetry run isort src/cli.py src/registry/registries.py src/pipeline/hot_reload.py`
- `poetry run flake8 src/cli.py src/registry/registries.py src/pipeline/hot_reload.py`
- `poetry run mypy src/cli.py src/registry/registries.py src/pipeline/hot_reload.py`
- `poetry run bandit -r src/pipeline/hot_reload.py src/cli.py src/registry/registries.py`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Required environment variable HTTP_TOKEN not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(failed to load module)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(failed to load module)*
- `poetry run python -m src.registry.validator` *(failed: ModuleNotFoundError)*
- `poetry run pytest` *(fails: several tests failing)*


------
https://chatgpt.com/codex/tasks/task_e_686c12c7874c8322b1ca3016ec0a338c