### PR TITLE
Update pipeline docs to explain iteration

### DIFF
--- a/architecture/pipeline_overview.md
+++ b/architecture/pipeline_overview.md
@@ -9,3 +9,8 @@ The Entity Pipeline Framework executes a single pass through a series of stages.
 - **review** – format and validate responses
 - **deliver** – send output to the user
 - **error** – handle failures gracefully
+
+After completing these stages, the pipeline checks `state.response`. If no
+response has been produced, the same stages run again until a response exists or
+`max_iterations` is reached. The default limit is five iterations. When the
+limit is exceeded the pipeline triggers the `error` stage.

--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -11,6 +11,11 @@ stages. Plugins implement each stage and provide reusable behavior.
 - **deliver** – send output to the user
 - **error** – handle failures gracefully
 
+After each pass through these stages, the pipeline examines `state.response`.
+If the response is still empty, the stages repeat until a response exists or
+`max_iterations` is hit. By default the framework allows five iterations. Once
+this limit is exceeded, the pipeline jumps to the `error` stage.
+
 ## Plugin Layers
 1. **Resource plugins** – databases, LLMs and storage backends
 2. **Tool plugins** – execute tasks such as search or math

--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -15,6 +15,11 @@ A pipeline is a fixed sequence of stages that an agent runs on each request:
 
 Each stage is independent, making the agent's behavior easier to reason about.
 
+After a full pass, the pipeline checks `state.response`. If it is still empty,
+the stages run again until a response is produced or `max_iterations` is
+reached. Five iterations are allowed by default; exceeding this limit invokes
+the `error` stage.
+
 ## Plugins
 
 Plugins implement the work at each stage. They interact with the system through `PluginContext` and may use resources or tools. See the [Plugin Guide](plugin_guide.md) for implementation details.

--- a/src/pipeline/hot_reload.py
+++ b/src/pipeline/hot_reload.py
@@ -5,7 +5,7 @@ import importlib.util
 from contextlib import suppress
 from pathlib import Path
 from types import ModuleType
-from typing import Iterable, List
+from typing import Iterable
 
 from watchfiles import awatch
 


### PR DESCRIPTION
## Summary
- clarify that the pipeline loops until `state.response` is set or `max_iterations` is reached
- mention default limit of five iterations
- fix unused import warning in hot reload module

## Testing
- `poetry run black src/pipeline/hot_reload.py`
- `poetry run isort src/pipeline/hot_reload.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: BasePlugin has no attribute errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'common_interfaces')*
- `pytest -q` *(fails: ModuleNotFoundError: 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c22c5906c83229cea84e21a11e8e9