### PR TITLE
Integrate dashboard metrics

### DIFF
--- a/docs/source/monitoring.md
+++ b/docs/source/monitoring.md
@@ -17,6 +17,17 @@ The exporter provides stage latency, LLM latency and failure counters along with
 CPU and memory usage. Point Prometheus at the server to scrape these metrics.
 See `examples/observability_metrics.py` for a minimal example.
 
+### Built-in Dashboard
+
+Enable the HTTP adapter dashboard to visualize metrics without extra tooling.
+When `dashboard: true` is configured, the adapter starts the metrics server and
+exposes:
+
+* `/dashboard` – basic HTML dashboard with charts for LLM latency and failures
+* `/metrics` – Prometheus endpoint consumed by the dashboard
+
+Navigate to `/dashboard` during development to quickly inspect pipeline health.
+
 ## OpenTelemetry Tracing
 
 Wrap tasks with `start_span()` to emit traces. When the

--- a/src/pipeline/hot_reload.py
+++ b/src/pipeline/hot_reload.py
@@ -5,7 +5,7 @@ import importlib.util
 from contextlib import suppress
 from pathlib import Path
 from types import ModuleType
-from typing import Iterable, List
+from typing import Iterable
 
 from watchfiles import awatch
 

--- a/src/pipeline/metrics.py
+++ b/src/pipeline/metrics.py
@@ -18,6 +18,7 @@ class MetricsCollector:
     llm_durations: dict[str, list[float]] = field(default_factory=dict)
     llm_token_count: dict[str, int] = field(default_factory=dict)
     llm_cost: dict[str, float] = field(default_factory=dict)
+    dashboard_requests: int = 0
 
     def record_pipeline_duration(self, duration: float) -> None:
         self.pipeline_durations.append(duration)
@@ -61,6 +62,10 @@ class MetricsCollector:
         key = f"{stage}:{plugin}"
         self.llm_cost[key] = self.llm_cost.get(key, 0.0) + cost
 
+    def record_dashboard_request(self) -> None:
+        """Increment the dashboard request counter."""
+        self.dashboard_requests += 1
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "pipeline_durations": self.pipeline_durations,
@@ -73,4 +78,5 @@ class MetricsCollector:
             "llm_durations": self.llm_durations,
             "llm_token_count": self.llm_token_count,
             "llm_cost": self.llm_cost,
+            "dashboard_requests": self.dashboard_requests,
         }

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -2,8 +2,14 @@ import asyncio
 
 import httpx
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from plugins.builtin.adapters import HTTPAdapter
 
@@ -98,7 +104,9 @@ def test_http_adapter_dashboard():
             await client.post("/", json={"message": "hi"})
             resp = await client.get("/dashboard")
             assert resp.status_code == 200
-            assert resp.json() == {"active_pipelines": 0}
+            assert "Entity Dashboard" in resp.text
+            metrics = await client.get("/metrics")
+            assert metrics.status_code == 200
 
     asyncio.run(_requests())
 


### PR DESCRIPTION
## Summary
- start Prometheus metrics server when the dashboard is enabled
- expose `/metrics` endpoint and simple dashboard page
- track dashboard request counts in `MetricsCollector`
- document metrics integration with the dashboard
- update hot reload typing

## Testing
- `poetry run black src/pipeline/observability/metrics.py tests/test_http_adapter.py src/pipeline/hot_reload.py src/pipeline/metrics.py src/plugins/builtin/adapters/http.py >/tmp/black.log && tail -n 5 /tmp/black.log`
- `poetry run isort --profile black src/pipeline/hot_reload.py src/pipeline/metrics.py src/pipeline/observability/metrics.py src/plugins/builtin/adapters/http.py tests/test_http_adapter.py >/tmp/isort.log && cat /tmp/isort.log`
- `poetry run flake8 src/pipeline/hot_reload.py src/pipeline/metrics.py src/pipeline/observability/metrics.py src/plugins/builtin/adapters/http.py tests/test_http_adapter.py >/tmp/flake8.log && cat /tmp/flake8.log`
- `poetry run mypy src/pipeline/hot_reload.py src/pipeline/metrics.py src/pipeline/observability/metrics.py src/plugins/builtin/adapters/http.py >/tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `poetry run bandit -r src/pipeline/hot_reload.py src/pipeline/metrics.py src/pipeline/observability/metrics.py src/plugins/builtin/adapters/http.py >/tmp/bandit.log && tail -n 20 /tmp/bandit.log`
- `python -m src.config.validator --config config/dev.yaml >/tmp/val_dev.log && tail -n 5 /tmp/val_dev.log`
- `python -m src.config.validator --config config/prod.yaml >/tmp/val_prod.log && tail -n 5 /tmp/val_prod.log`
- `python -m src.registry.validator >/tmp/registry.log && tail -n 5 /tmp/registry.log`
- `pytest tests/test_http_adapter.py >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_686c22b6968083229df24db666ce60d8