### PR TITLE
Add DashboardAdapter with dashboard routes

### DIFF
--- a/docs/source/dashboard.md
+++ b/docs/source/dashboard.md
@@ -1,0 +1,27 @@
+# Dashboard Adapter
+
+`DashboardAdapter` extends `HTTPAdapter` to provide a small web UI for monitoring pipeline activity.
+
+## Configuration
+
+Enable the adapter in your YAML configuration:
+
+```yaml
+plugins:
+  adapters:
+    dashboard:
+      type: plugins.builtin.adapters.dashboard:DashboardAdapter
+      stages: [parse, deliver]
+      dashboard: true
+      state_log_path: ./state.log
+      pipeline_config: ./config/dev.yaml
+```
+
+- `state_log_path` – JSONL file containing state transitions logged with `StateLogger`.
+- `pipeline_config` – path to a pipeline config used for generating the stage diagram.
+
+## Usage
+
+Start your agent normally and visit `/dashboard` on the running server. The page displays the number of active pipelines, a diagram of the configured pipeline and the most recent state transitions.
+
+The endpoint `/dashboard/transitions` returns raw transition data which can be used to build custom visualizations.

--- a/src/plugins/builtin/adapters/__init__.py
+++ b/src/plugins/builtin/adapters/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Adapter implementations used to expose the pipeline externally."""
 
 from .cli import CLIAdapter
+from .dashboard import DashboardAdapter
 from .grpc import LLMGRPCAdapter
 from .http import HTTPAdapter
 from .logging import LoggingAdapter
@@ -11,6 +12,7 @@ from .websocket import WebSocketAdapter
 
 __all__ = [
     "HTTPAdapter",
+    "DashboardAdapter",
     "CLIAdapter",
     "WebSocketAdapter",
     "LLMGRPCAdapter",

--- a/src/plugins/builtin/adapters/dashboard.py
+++ b/src/plugins/builtin/adapters/dashboard.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""HTTP dashboard adapter."""
+
+import json
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+from fastapi import Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from pipeline.stages import PipelineStage
+from plugins.builtin.adapters.http import HTTPAdapter
+from tools.pipeline_viz import PipelineGraphBuilder
+
+
+class DashboardAdapter(HTTPAdapter):
+    """HTTP adapter with a simple status dashboard."""
+
+    def __init__(self, manager=None, config=None) -> None:
+        super().__init__(manager, config)
+        templates_dir = Path(__file__).parent / "templates"
+        self.templates = Jinja2Templates(directory=str(templates_dir))
+        self.state_log_path = Path(self.config.get("state_log_path", "state.log"))
+        self.pipeline_config = self.config.get("pipeline_config")
+
+    def _setup_routes(self) -> None:
+        super()._setup_routes()
+        if not self.dashboard_enabled:
+            return
+
+        @self.app.get("/dashboard", response_class=HTMLResponse)
+        async def dashboard(request: Request) -> HTMLResponse:
+            count = 0
+            if self.manager is not None:
+                count = self.manager.active_pipeline_count()
+            graph = self._render_graph()
+            return self.templates.TemplateResponse(
+                "dashboard.html",
+                {
+                    "request": request,
+                    "active_pipelines": count,
+                    "graph": graph,
+                },
+            )
+
+        @self.app.get("/dashboard/transitions")
+        async def transitions(limit: int = 50) -> list[dict[str, Any]]:
+            return self._load_transitions(limit)
+
+    def _load_transitions(self, limit: int) -> list[dict[str, Any]]:
+        if not self.state_log_path.exists():
+            return []
+        with self.state_log_path.open("r", encoding="utf-8") as handle:
+            items = deque(handle, maxlen=limit)
+        return [json.loads(line) for line in items]
+
+    def _render_graph(self) -> str:
+        if not self.pipeline_config:
+            return ""
+        builder = PipelineGraphBuilder(self.pipeline_config)
+        graph = builder.build()
+        lines = ["graph LR"]
+        prev = None
+        for stage in PipelineStage:
+            if stage == PipelineStage.ERROR:
+                continue
+            lines.append(f"{stage.name}[{stage.name}]")
+            if prev is not None:
+                lines.append(f"{prev.name} --> {stage.name}")
+            prev = stage
+            for plugin in graph._mapping.get(stage, []):
+                lines.append(f"{stage.name} -.-> {plugin}")
+        return "\n".join(lines)

--- a/src/plugins/builtin/adapters/templates/dashboard.html
+++ b/src/plugins/builtin/adapters/templates/dashboard.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Entity Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+  </head>
+  <body>
+    <h1>Entity Pipeline Dashboard</h1>
+    <p>Active pipelines: {{ active_pipelines }}</p>
+    <div class="mermaid">
+{{ graph }}
+    </div>
+    <h2>Recent Transitions</h2>
+    <pre id="transitions"></pre>
+    <script>
+      mermaid.initialize({ startOnLoad: true });
+      async function loadTransitions() {
+        const resp = await fetch('/dashboard/transitions');
+        const data = await resp.json();
+        document.getElementById('transitions').textContent = JSON.stringify(data, null, 2);
+      }
+      loadTransitions();
+    </script>
+  </body>
+</html>

--- a/tests/test_dashboard_adapter.py
+++ b/tests/test_dashboard_adapter.py
@@ -1,0 +1,68 @@
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.resources import ResourceContainer
+from plugins.builtin.adapters import DashboardAdapter
+
+
+class RespPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        first = context.get_conversation_history()[0]
+        context.set_response({"msg": first.content})
+
+
+def make_adapter(tmp_path: Path) -> DashboardAdapter:
+    plugins = PluginRegistry()
+    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
+    manager = PipelineManager(registries)
+    log_path = tmp_path / "state.log"
+    cfg = {
+        "dashboard": True,
+        "state_log_path": str(log_path),
+        "pipeline_config": str(Path("config/dev.yaml")),
+    }
+    return DashboardAdapter(manager, cfg), log_path
+
+
+def write_log(path: Path) -> None:
+    entry = {
+        "timestamp": "t",
+        "pipeline_id": "p",
+        "stage": "parse",
+        "state": {},
+    }
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+def test_dashboard_routes(tmp_path):
+    adapter, log_path = make_adapter(tmp_path)
+    write_log(log_path)
+
+    async def _requests():
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=adapter.app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.get("/dashboard")
+            assert resp.status_code == 200
+            resp = await client.get("/dashboard/transitions")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert isinstance(data, list) and len(data) == 1
+
+    asyncio.run(_requests())


### PR DESCRIPTION
## Summary
- add new DashboardAdapter to serve basic dashboard
- include HTML template and docs on dashboard usage
- add tests for dashboard routes

## Testing
- `poetry run black src/plugins/builtin/adapters/__init__.py src/plugins/builtin/adapters/dashboard.py tests/test_dashboard_adapter.py`
- `poetry run isort src/plugins/builtin/adapters/__init__.py src/plugins/builtin/adapters/dashboard.py tests/test_dashboard_adapter.py`
- `poetry run flake8 src/plugins/builtin/adapters/dashboard.py tests/test_dashboard_adapter.py src/plugins/builtin/adapters/__init__.py`
- `poetry run mypy src/plugins/builtin/adapters/dashboard.py`
- `bandit -r src/plugins/builtin/adapters/dashboard.py` *(failed: command not found)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(failed: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(failed: Configuration invalid)*
- `poetry run python -m src.registry.validator` *(failed: ModuleNotFoundError)*
- `poetry run pytest tests/test_dashboard_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_686c22b61c188322a0337de0cf328cfb