### PR TITLE
Add iteration field to PipelineState

### DIFF
--- a/src/pipeline/hot_reload.py
+++ b/src/pipeline/hot_reload.py
@@ -5,7 +5,7 @@ import importlib.util
 from contextlib import suppress
 from pathlib import Path
 from types import ModuleType
-from typing import Iterable, List
+from typing import Iterable
 
 from watchfiles import awatch
 

--- a/src/pipeline/state.py
+++ b/src/pipeline/state.py
@@ -106,6 +106,7 @@ class PipelineState:
     pending_tool_calls: List[ToolCall] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
     pipeline_id: str = ""
+    iteration: int = 0
     current_stage: Optional[PipelineStage] = None
     last_completed_stage: Optional[PipelineStage] = None
     metrics: MetricsCollector = field(default_factory=MetricsCollector)
@@ -136,6 +137,7 @@ class PipelineState:
             ],
             "metadata": self.metadata,
             "pipeline_id": self.pipeline_id,
+            "iteration": self.iteration,
             "current_stage": str(self.current_stage) if self.current_stage else None,
             "last_completed_stage": (
                 str(self.last_completed_stage) if self.last_completed_stage else None
@@ -169,6 +171,7 @@ class PipelineState:
             ],
             metadata=data.get("metadata", {}),
             pipeline_id=data.get("pipeline_id", ""),
+            iteration=data.get("iteration", 0),
             current_stage=(
                 PipelineStage.from_str(data["current_stage"])
                 if data.get("current_stage")


### PR DESCRIPTION
## Summary
- track pipeline iteration count
- pass iteration through serialization helpers
- clean up unused typing import

## Testing
- `poetry run black src/pipeline/state.py src/pipeline/hot_reload.py`
- `poetry run isort src/pipeline/state.py src/pipeline/hot_reload.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: yaml)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `pytest` *(fails: ModuleNotFoundError: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_686c22c093a083228cbf37a64920f4a8