### PR TITLE
Add pipeline looping tests

### DIFF
--- a/src/pipeline/hot_reload.py
+++ b/src/pipeline/hot_reload.py
@@ -5,7 +5,7 @@ import importlib.util
 from contextlib import suppress
 from pathlib import Path
 from types import ModuleType
-from typing import Iterable, List
+from typing import Iterable
 
 from watchfiles import awatch
 

--- a/tests/test_pipeline_looping.py
+++ b/tests/test_pipeline_looping.py
@@ -1,0 +1,88 @@
+import asyncio
+from typing import Optional
+
+from pipeline import (FailurePlugin, PipelineStage, PluginRegistry,
+                      PromptPlugin, SystemRegistries, ToolRegistry,
+                      execute_pipeline)
+from pipeline.resources import ResourceContainer
+from pipeline.state import FailureInfo, PipelineState
+
+
+class CountingDeliverPlugin(PromptPlugin):
+    stages = [PipelineStage.DELIVER]
+
+    def __init__(self, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.calls = 0
+
+    async def _execute_impl(self, context):
+        self.calls += 1
+        if self.calls == 2:
+            context.set_response("ok")
+
+
+class NoResponseDeliverPlugin(PromptPlugin):
+    stages = [PipelineStage.DELIVER]
+
+    def __init__(self, config: Optional[dict] = None) -> None:
+        super().__init__(config)
+        self.calls = 0
+
+    async def _execute_impl(self, context):
+        self.calls += 1
+        # never sets a response
+
+
+class RecordFailurePlugin(FailurePlugin):
+    stages = [PipelineStage.ERROR]
+
+    def __init__(self, store: list[FailureInfo]):
+        super().__init__()
+        self.store = store
+
+    async def _execute_impl(self, context):
+        info = context.get_failure_info()
+        if info:
+            self.store.append(info)
+
+
+async def make_registries(plugin):
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(plugin, PipelineStage.DELIVER)
+    return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
+
+
+def test_pipeline_loops_until_response():
+    plugin = CountingDeliverPlugin({})
+
+    async def run():
+        registries = await make_registries(plugin)
+        result = await execute_pipeline("hi", registries)
+        return result
+
+    result = asyncio.run(run())
+    assert result == "ok"
+    assert plugin.calls == 2
+
+
+def test_max_iterations_triggers_error():
+    plugin = NoResponseDeliverPlugin({})
+    failures: list[FailureInfo] = []
+
+    async def run() -> PipelineState:
+        plugins = PluginRegistry()
+        await plugins.register_plugin_for_stage(plugin, PipelineStage.DELIVER)
+        await plugins.register_plugin_for_stage(
+            RecordFailurePlugin(failures), PipelineStage.ERROR
+        )
+        registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
+        state = PipelineState(conversation=[], pipeline_id="id", metrics=None)
+        result = await execute_pipeline(
+            "hi", registries, state=state, max_iterations=2  # type: ignore[arg-type]
+        )
+        assert isinstance(result, dict)
+        return state
+
+    state = asyncio.run(run())
+    assert state.iteration == 2  # type: ignore[attr-defined]
+    assert failures


### PR DESCRIPTION
## Summary
- add tests for pipeline looping behavior and iteration limits
- drop unused import from hot_reload

## Testing
- `poetry run black src/pipeline/hot_reload.py tests/test_pipeline_looping.py`
- `poetry run isort src/pipeline/hot_reload.py tests/test_pipeline_looping.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 395 errors)*
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest -q` *(fails: 13 failed, 169 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686c22c43be48322886a1ab86b662f96