### PR TITLE
Add error handling guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ poetry run python src/cli.py --config config.yaml
 This project relies on `httpx==0.27.*`, which Poetry will install automatically.
 <!-- end quick_start -->
 For a high-level look at how the pieces connect, see [components_overview.md](components_overview.md).
+For details on failures and recovery see [docs/source/error_handling.md](docs/source/error_handling.md).
 
 ## Environment Setup
 

--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -1,0 +1,90 @@
+# Error Handling and Recovery
+
+This guide explains how the Entity pipeline surfaces errors and restores state.
+
+## `PipelineError` Hierarchy
+
+All pipeline exceptions inherit from `PipelineError`. The key subclasses are:
+
+```python
+from pipeline.errors import (
+    PipelineError,
+    PluginExecutionError,
+    ResourceError,
+    ToolExecutionError,
+    PipelineContextError,
+    StageExecutionError,
+    PluginContextError,
+)
+```
+
+`PluginExecutionError`, `ResourceError`, and `ToolExecutionError` indicate failures in plugins, resources, and tools. The context-aware classes carry additional fields like the stage and plugin name.
+
+## StateManager Snapshots and Rollbacks
+
+`PipelineState` supports snapshotting and restoration:
+
+```python
+state = PipelineState(...)
+copy = state.snapshot()       # deep copy of current state
+state.prompt = "new"
+state.restore(copy)           # revert fields from snapshot
+```
+
+`experiments.state_manager.StateManager` persists snapshots for later retrieval:
+
+```python
+manager = StateManager(max_states=2)
+await manager.save_state(state)       # stores a snapshot
+saved = await manager.load_state(state.pipeline_id)
+if saved:
+    state.restore(saved)
+```
+
+## Reliability Helpers
+
+`RetryPolicy` retries asynchronous calls with exponential backoff. `CircuitBreaker` wraps a call and prevents execution when failures exceed a threshold.
+
+```python
+policy = RetryPolicy(attempts=5, backoff=2.0)
+result = await policy.execute(do_work)
+
+breaker = CircuitBreaker(failure_threshold=3, recovery_timeout=30)
+await breaker.call(do_work)
+```
+
+Tool plugins can define `max_retries` and `retry_delay` attributes:
+
+```python
+class MyTool(ToolPlugin):
+    max_retries = 2
+    retry_delay = 0.5
+```
+
+Base plugins include a simple circuit breaker using `failure_threshold` and `failure_reset_timeout` settings.
+
+## Error Responses and Failure Plugins
+
+When a stage fails the pipeline records a `FailureInfo` object and runs plugins assigned to the `ERROR` stage. A failure plugin can inspect the info and set a response:
+
+```python
+class ErrorFormatter(FailurePlugin):
+    stages = [PipelineStage.ERROR]
+    async def _execute_impl(self, ctx: PluginContext) -> None:
+        info = ctx.get_failure_info()
+        ctx.set_response({"error": info.error_message})
+```
+
+If failure handling itself fails the framework returns a static response created by `create_static_error_response`:
+
+```python
+{
+    "error": "System error occurred",
+    "message": "An unexpected error prevented processing your request.",
+    "error_id": "<pipeline id>",
+    "timestamp": "<iso timestamp>",
+    "type": "static_fallback",
+}
+```
+
+Use `BasicLogger` and `ErrorFormatter` from `user_plugins.failure` as templates for custom failure handling.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -30,6 +30,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [API reference](api_reference.md)
 - [Advanced usage](advanced_usage.md)
 - [Module map](module_map.md)
+- [Error handling](error_handling.md)
 - [gRPC services](grpc_services.md)
 - [LLM gRPC audit](llm_grpc_audit.md)
 - [Troubleshooting](troubleshooting.md)
@@ -58,6 +59,7 @@ logging
 state_logging
 advanced_usage
 module_map
+error_handling
 grpc_services
 llm_grpc_audit
 troubleshooting

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -175,8 +175,9 @@ poetry run python src/cli.py serve-websocket --config config/dev.yaml
 ```
 
 When implementing custom error handling, refer to
-[`examples/failure_example.py`](../../examples/failure_example.py) and the
-failure plugin template at `src/cli/templates/failure.py`.
+[`examples/failure_example.py`](../../examples/failure_example.py),
+the failure plugin template at `src/cli/templates/failure.py`,
+and the [error handling guide](error_handling.md).
 
 ## Troubleshooting Plugins
 - **Plugin not executing** – confirm the `stages` list contains the desired pipeline stage.


### PR DESCRIPTION
## Summary
- document PipelineError hierarchy and recovery features
- explain state snapshots and retries
- link the guide from the docs index, README, and plugin guide

## Testing
- `poetry run make -C docs html` *(fails: WARNING/CRITICAL messages but build succeeds)*
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: E501 in http adapter)*
- `poetry run mypy src` *(fails: 402 errors)*
- `bandit -r src` *(command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(failed: runtime warning)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(failed: runtime warning)*
- `poetry run python -m src.registry.validator` *(failed: ModuleNotFoundError)*
- `poetry run pytest` *(fails: 22 failed, 163 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686c271389ec8322b73de23603b75a0d