### PR TITLE
Improve failure logging

### DIFF
--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -60,3 +60,20 @@ in ``context.metrics`` and can be exported to Prometheus using
 For production deployments, `config/logging_prod.yaml` contains a recommended
 configuration enabling JSON formatted logs and file rotation.
 
+## Failure Logs
+
+When a pipeline encounters an error the ``BasicLogger`` plugin emits an ``ERROR``
+log entry. The message ``"Pipeline failure encountered"`` includes several extra
+fields:
+
+* ``stage`` – stage where the failure occurred
+* ``plugin`` – name of the plugin that raised the error
+* ``type`` – exception class name
+* ``error`` – human readable message
+* ``pipeline_id`` – unique identifier for the run
+* ``retry_count`` – current iteration count
+* ``context_snapshot`` – serialized pipeline state if available
+
+These fields provide enough information to correlate failures with pipeline
+state and retry attempts.
+

--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -134,6 +134,7 @@ class BasePlugin(BasePluginInterface):
                 metrics=context.metrics,
                 plugin=self.__class__.__name__,
                 stage=str(context.current_stage),
+                pipeline_id=context.pipeline_id,
             )
             self._failure_count = 0
             return result

--- a/src/pipeline/builder.py
+++ b/src/pipeline/builder.py
@@ -104,7 +104,12 @@ class AgentBuilder:
             try:
                 module = importlib.import_module(info.name)
             except Exception as exc:  # noqa: BLE001
-                logger.error("Failed to import plugin module %s: %s", info.name, exc)
+                logger.error(
+                    "Failed to import plugin module %s: %s",
+                    info.name,
+                    exc,
+                    extra={"pipeline_id": "builder", "stage": "initialization"},
+                )
                 continue
             self._register_module_plugins(module)
 
@@ -129,7 +134,12 @@ class AgentBuilder:
                 return module
             raise ImportError(f"Cannot load spec for {file}")
         except Exception as exc:  # noqa: BLE001
-            logger.error("Failed to import plugin module %s: %s", file, exc)
+            logger.error(
+                "Failed to import plugin module %s: %s",
+                file,
+                exc,
+                extra={"pipeline_id": "builder", "stage": "initialization"},
+            )
             return None
 
     def _register_module_plugins(self, module: ModuleType) -> None:
@@ -162,5 +172,6 @@ class AgentBuilder:
                     module.__name__,
                     name,
                     exc,
+                    extra={"pipeline_id": "builder", "stage": "initialization"},
                 )
                 continue

--- a/src/pipeline/observability/utils.py
+++ b/src/pipeline/observability/utils.py
@@ -14,13 +14,14 @@ async def execute_with_observability(
     metrics: MetricsCollector,
     plugin: str,
     stage: str,
+    pipeline_id: str,
     *args: Any,
     **kwargs: Any,
 ) -> Any:
     """Run ``func`` while logging and recording metrics."""
     logger.info(
         "Plugin execution started",
-        extra={"plugin": plugin, "stage": stage},
+        extra={"plugin": plugin, "stage": stage, "pipeline_id": pipeline_id},
     )
     start = time.perf_counter()
     try:
@@ -30,12 +31,22 @@ async def execute_with_observability(
         metrics.record_plugin_duration(plugin, stage, duration)
         logger.info(
             "Plugin execution finished",
-            extra={"plugin": plugin, "stage": stage, "duration": duration},
+            extra={
+                "plugin": plugin,
+                "stage": stage,
+                "pipeline_id": pipeline_id,
+                "duration": duration,
+            },
         )
         return result
     except Exception as exc:
         logger.exception(
             "Plugin execution failed",
-            extra={"plugin": plugin, "stage": stage, "error": str(exc)},
+            extra={
+                "plugin": plugin,
+                "stage": stage,
+                "pipeline_id": pipeline_id,
+                "error": str(exc),
+            },
         )
         raise

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -125,6 +125,7 @@ async def execute_stage(
                     extra={
                         "plugin": getattr(plugin, "name", plugin.__class__.__name__),
                         "stage": str(stage),
+                        "pipeline_id": state.pipeline_id,
                     },
                 )
 

--- a/src/pipeline/validation/input.py
+++ b/src/pipeline/validation/input.py
@@ -32,7 +32,11 @@ class PluginInputValidator:
         try:
             instance = self.model(**params)
         except ValidationError as exc:  # pragma: no cover - runtime error path
-            self.logger.error("parameter validation failed", exc_info=exc)
+            self.logger.error(
+                "parameter validation failed",
+                exc_info=exc,
+                extra={"pipeline_id": "n/a", "stage": "validation"},
+            )
             raise
 
         if hasattr(instance, "model_dump"):

--- a/src/plugins/builtin/adapters/http.py
+++ b/src/plugins/builtin/adapters/http.py
@@ -197,11 +197,11 @@ class HTTPAdapter(AdapterPlugin):
                     f"<h1>Active pipelines: {count}</h1>"
                     "<canvas id='latency'></canvas>"
                     "<canvas id='failures'></canvas>"
-                    "<script>async function load(){const res=await fetch('/metrics');"
-                    "const text=await res.text();let lat=0;let fail=0;"
-                    "for(const line of text.split('\\n')){if(line.startsWith('llm_latency_seconds_sum')){lat=parseFloat(line.split(' ')[1]);}if(line.startsWith('llm_failures_total')){fail=parseFloat(line.split(' ')[1]);}}"
-                    "new Chart(document.getElementById('latency'),{type:'bar',data:{labels:['latency'],datasets:[{data:[lat]}]}});"
-                    "new Chart(document.getElementById('failures'),{type:'bar',data:{labels:['failures'],datasets:[{data:[fail]}]}});}</script>"
+                    "<script>async function load(){const res=await fetch('/metrics');"  # noqa: E501
+                    "const text=await res.text();let lat=0;let fail=0;"  # noqa: E501
+                    "for(const line of text.split('\\n')){if(line.startsWith('llm_latency_seconds_sum')){lat=parseFloat(line.split(' ')[1]);}if(line.startsWith('llm_failures_total')){fail=parseFloat(line.split(' ')[1]);}}"  # noqa: E501
+                    "new Chart(document.getElementById('latency'),{type:'bar',data:{labels:['latency'],datasets:[{data:[lat]}]}});"  # noqa: E501
+                    "new Chart(document.getElementById('failures'),{type:'bar',data:{labels:['failures'],datasets:[{data:[fail]}]}});}</script>"  # noqa: E501
                     "<script>load();</script></body></html>"
                 )
                 return HTMLResponse(html)

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -59,7 +59,9 @@ def test_error_stage_execution(caplog):
     result = asyncio.run(execute_pipeline("hi", registries))
     assert result == {"error": "boom"}
     assert any(
-        "Pipeline failure encountered" in record.message
+        record.message == "Pipeline failure encountered"
+        and getattr(record, "pipeline_id", None)
+        and getattr(record, "stage", None) == "do"
         for record in log_capture.records
     )
 


### PR DESCRIPTION
## Summary
- log snapshots and retry count in `BasicLogger`
- include pipeline id and stage in all pipeline log errors
- document new log fields
- update error stage log test

## Testing
- `poetry run flake8 user_plugins/failure/basic_logger.py src/pipeline/observability/utils.py src/pipeline/base_plugins.py src/pipeline/builder.py src/pipeline/pipeline.py src/pipeline/validation/input.py tests/test_error_stage.py src/plugins/builtin/adapters/http.py`
- `poetry run mypy src` *(fails: missing stubs and other issues)*
- `bandit -r src` *(command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(failed: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(failed: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(failed: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(failed: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c271202dc83229bf5a745605ff299