### PR TITLE
Add plugin retry logic and fallback error handler

### DIFF
--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -26,6 +26,7 @@ from .errors import ToolExecutionError
 from .exceptions import CircuitBreakerTripped, PipelineError, PluginExecutionError
 from .logging import get_logger
 from .observability.utils import execute_with_observability
+from .reliability import RetryPolicy
 from .stages import PipelineStage
 from .validation import ValidationResult
 from plugins.builtin.config_models import (
@@ -56,6 +57,8 @@ class BasePlugin(BasePluginInterface):
     stages: List[PipelineStage]
     priority: int = 50
     dependencies: List[str] = []
+    max_retries: int = 1
+    retry_delay: float = 0.0
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -105,6 +108,8 @@ class BasePlugin(BasePluginInterface):
         self.failure_reset_timeout = float(
             self.config.get("failure_reset_timeout", 60.0)
         )
+        self.max_retries = int(self.config.get("max_retries", self.max_retries))
+        self.retry_delay = float(self.config.get("retry_delay", self.retry_delay))
         self._failure_count = 0
         self._last_failure = 0.0
         self.config_version = 1
@@ -125,7 +130,10 @@ class BasePlugin(BasePluginInterface):
             raise CircuitBreakerTripped(self.__class__.__name__)
 
         async def run() -> Any:
-            return await self._execute_impl(context)
+            policy = RetryPolicy(
+                attempts=self.max_retries + 1, backoff=self.retry_delay
+            )
+            return await policy.execute(self._execute_impl, context)
 
         try:
             result = await execute_with_observability(

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -12,6 +12,7 @@ import time
 from datetime import datetime
 from typing import Any, Dict
 
+from plugins.builtin.failure.fallback_error_plugin import FallbackErrorPlugin
 from registry import SystemRegistries
 
 from .context import ConversationEntry, PluginContext
@@ -142,6 +143,11 @@ async def execute_stage(
                 reset_request_id(token)
     duration = time.perf_counter() - start
     state.metrics.record_stage_duration(str(stage), duration)
+
+    if stage == PipelineStage.ERROR and state.response is None:
+        fallback = FallbackErrorPlugin({})
+        context = PluginContext(state, registries)
+        await fallback.execute(context)
 
 
 async def execute_pipeline(

--- a/src/plugins/builtin/failure/__init__.py
+++ b/src/plugins/builtin/failure/__init__.py
@@ -1,8 +1,11 @@
 """Failure handling plugins for logging and user-friendly errors."""
 
-from plugins.builtin.failure import BasicLogger, ErrorFormatter
+from .basic_logger import BasicLogger
+from .error_formatter import ErrorFormatter
+from .fallback_error_plugin import FallbackErrorPlugin
 
 __all__ = [
     "BasicLogger",
     "ErrorFormatter",
+    "FallbackErrorPlugin",
 ]

--- a/src/plugins/builtin/failure/fallback_error_plugin.py
+++ b/src/plugins/builtin/failure/fallback_error_plugin.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Fallback error plugin used when no response is produced."""
+
+from pipeline.base_plugins import FailurePlugin
+from pipeline.context import PluginContext
+from pipeline.errors import create_static_error_response
+from pipeline.stages import PipelineStage
+
+
+class FallbackErrorPlugin(FailurePlugin):
+    """Provide a generic error response."""
+
+    stages = [PipelineStage.ERROR]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        context.set_response(create_static_error_response(context.pipeline_id))

--- a/tests/test_fallback_error_plugin.py
+++ b/tests/test_fallback_error_plugin.py
@@ -1,0 +1,32 @@
+import asyncio
+
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.resources import ResourceContainer
+from user_plugins.failure.basic_logger import BasicLogger
+
+
+class FailPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        raise RuntimeError("boom")
+
+
+def make_registries():
+    plugins = PluginRegistry()
+    asyncio.run(plugins.register_plugin_for_stage(FailPlugin({}), PipelineStage.DO))
+    asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
+    return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
+
+
+def test_fallback_error_plugin_sets_response():
+    registries = make_registries()
+    result = asyncio.run(execute_pipeline("hi", registries))
+    assert result["type"] == "static_fallback"

--- a/tests/test_plugin_retry.py
+++ b/tests/test_plugin_retry.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.resources import ResourceContainer
+from user_plugins.failure.basic_logger import BasicLogger
+
+
+class FlakyPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.calls = 0
+
+    async def _execute_impl(self, context):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("boom")
+        context.set_response("ok")
+
+
+def make_registries():
+    plugins = PluginRegistry()
+    asyncio.run(
+        plugins.register_plugin_for_stage(
+            FlakyPlugin({"max_retries": 1, "retry_delay": 0}), PipelineStage.DO
+        )
+    )
+    asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
+    return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
+
+
+def test_plugin_retry_succeeds():
+    registries = make_registries()
+    plugin = registries.plugins.get_plugins_for_stage(PipelineStage.DO)[0]
+    result = asyncio.run(execute_pipeline("hi", registries))
+    assert result == "ok"
+    assert plugin.calls == 2


### PR DESCRIPTION
## Summary
- add optional retry and delay settings to BasePlugin
- retry plugin execution using RetryPolicy
- implement FallbackErrorPlugin for generic failures
- invoke fallback plugin from execute_stage
- add tests covering retries and fallback behavior

## Testing
- `poetry run black src/pipeline/base_plugins.py src/pipeline/pipeline.py src/plugins/builtin/failure/__init__.py src/plugins/builtin/failure/fallback_error_plugin.py tests/test_plugin_retry.py tests/test_fallback_error_plugin.py`
- `poetry run isort src/pipeline/base_plugins.py src/pipeline/pipeline.py src/plugins/builtin/failure/__init__.py src/plugins/builtin/failure/fallback_error_plugin.py tests/test_plugin_retry.py tests/test_fallback_error_plugin.py`
- `poetry run flake8 src/pipeline/base_plugins.py src/pipeline/pipeline.py src/plugins/builtin/failure/__init__.py src/plugins/builtin/failure/fallback_error_plugin.py tests/test_plugin_retry.py tests/test_fallback_error_plugin.py`
- `poetry run mypy`
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: missing HTTP_TOKEN)*
- `PYTHONPATH=src poetry run python -m src.registry.validator --config config/dev.yaml`
- `poetry run pytest` *(fails: 22 failed, 165 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686c271117fc8322ad127b52d3409ee8