### PR TITLE
Enhance pipeline error handling

### DIFF
--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict
 
-from .context import (PipelineContextError, PluginContextError,
-                      StageExecutionError)
-from .exceptions import (PipelineError, PluginExecutionError, ResourceError,
-                         ToolExecutionError)
+from ..state import FailureInfo
+from .context import PipelineContextError, PluginContextError, StageExecutionError
+from .exceptions import (
+    PipelineError,
+    PluginExecutionError,
+    ResourceError,
+    ToolExecutionError,
+)
 
 __all__ = [
     "create_static_error_response",
+    "create_error_response",
     "PipelineError",
     "PluginExecutionError",
     "ResourceError",
@@ -35,3 +40,17 @@ def create_static_error_response(pipeline_id: str) -> Dict[str, Any]:
     response["error_id"] = pipeline_id
     response["timestamp"] = datetime.now().isoformat()
     return response
+
+
+def create_error_response(pipeline_id: str, failure: FailureInfo) -> Dict[str, Any]:
+    """Return a standardized error payload for ``failure``."""
+
+    return {
+        "error": failure.error_message,
+        "error_type": failure.error_type,
+        "stage": failure.stage,
+        "plugin": failure.plugin_name,
+        "pipeline_id": pipeline_id,
+        "timestamp": datetime.now().isoformat(),
+        "type": "plugin_error",
+    }

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -74,6 +74,14 @@ async def execute_stage(
                         )
                     state.pending_tool_calls.clear()
             except CircuitBreakerTripped as exc:
+                logger.exception(
+                    "Circuit breaker tripped",
+                    extra={
+                        "plugin": getattr(plugin, "name", plugin.__class__.__name__),
+                        "stage": str(stage),
+                        "pipeline_id": state.pipeline_id,
+                    },
+                )
                 state.failure_info = FailureInfo(
                     stage=str(stage),
                     plugin_name=getattr(plugin, "name", plugin.__class__.__name__),
@@ -83,6 +91,14 @@ async def execute_stage(
                 )
                 return
             except PluginExecutionError as exc:
+                logger.exception(
+                    "Plugin execution failed",
+                    extra={
+                        "plugin": getattr(plugin, "name", plugin.__class__.__name__),
+                        "stage": str(stage),
+                        "pipeline_id": state.pipeline_id,
+                    },
+                )
                 state.failure_info = FailureInfo(
                     stage=str(stage),
                     plugin_name=getattr(plugin, "name", plugin.__class__.__name__),
@@ -92,6 +108,14 @@ async def execute_stage(
                 )
                 return
             except ToolExecutionError as exc:
+                logger.exception(
+                    "Tool execution failed",
+                    extra={
+                        "plugin": exc.tool_name,
+                        "stage": str(stage),
+                        "pipeline_id": state.pipeline_id,
+                    },
+                )
                 state.failure_info = FailureInfo(
                     stage=str(stage),
                     plugin_name=exc.tool_name,
@@ -101,6 +125,14 @@ async def execute_stage(
                 )
                 return
             except ResourceError as exc:
+                logger.exception(
+                    "Resource error",
+                    extra={
+                        "plugin": getattr(plugin, "name", plugin.__class__.__name__),
+                        "stage": str(stage),
+                        "pipeline_id": state.pipeline_id,
+                    },
+                )
                 state.failure_info = FailureInfo(
                     stage=str(stage),
                     plugin_name=getattr(plugin, "name", plugin.__class__.__name__),
@@ -110,6 +142,14 @@ async def execute_stage(
                 )
                 return
             except PipelineError as exc:
+                logger.exception(
+                    "Pipeline error",
+                    extra={
+                        "plugin": getattr(plugin, "name", plugin.__class__.__name__),
+                        "stage": str(stage),
+                        "pipeline_id": state.pipeline_id,
+                    },
+                )
                 state.failure_info = FailureInfo(
                     stage=str(stage),
                     plugin_name=getattr(plugin, "name", plugin.__class__.__name__),

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,13 +1,26 @@
 import asyncio
 
-from pipeline import (FailurePlugin, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry,
-                      execute_pipeline)
-from pipeline.errors import (PipelineError, PluginContextError,
-                             PluginExecutionError, ResourceError,
-                             StageExecutionError, ToolExecutionError,
-                             create_static_error_response)
+from pipeline import (
+    FailurePlugin,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.errors import (
+    PipelineError,
+    PluginContextError,
+    PluginExecutionError,
+    ResourceError,
+    StageExecutionError,
+    ToolExecutionError,
+    create_error_response,
+    create_static_error_response,
+)
 from pipeline.resources import ResourceContainer
+from pipeline.state import FailureInfo
 from user_plugins.failure.basic_logger import BasicLogger
 
 
@@ -54,6 +67,20 @@ def test_static_error_response():
     resp = create_static_error_response(pipeline_id)
     assert resp["error_id"] == pipeline_id
     assert resp["type"] == "static_fallback"
+
+
+def test_create_error_response():
+    info = FailureInfo(
+        stage="do",
+        plugin_name="Boom",
+        error_type="RuntimeError",
+        error_message="bad",
+        original_exception=RuntimeError("bad"),
+    )
+    resp = create_error_response("id", info)
+    assert resp["plugin"] == "Boom"
+    assert resp["stage"] == "do"
+    assert resp["type"] == "plugin_error"
 
 
 def test_error_hierarchy():

--- a/tests/test_plugin_retry.py
+++ b/tests/test_plugin_retry.py
@@ -1,0 +1,38 @@
+import asyncio
+
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.resources import ResourceContainer
+
+
+class FlakyPlugin(PromptPlugin):
+    stages = [PipelineStage.DO]
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.calls = 0
+
+    async def _execute_impl(self, context):
+        self.calls += 1
+        if self.calls < 2:
+            raise RuntimeError("boom")
+        context.set_response("ok")
+
+
+def test_plugin_retry_succeeds():
+    plugins = PluginRegistry()
+    asyncio.run(
+        plugins.register_plugin_for_stage(
+            FlakyPlugin({"retry_attempts": 2, "retry_backoff": 0}),
+            PipelineStage.DO,
+        )
+    )
+    regs = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
+    result = asyncio.run(execute_pipeline("hi", regs))
+    assert result == "ok"

--- a/user_plugins/failure/__init__.py
+++ b/user_plugins/failure/__init__.py
@@ -1,4 +1,5 @@
 from .basic_logger import BasicLogger
+from .default_responder import DefaultResponder
 from .error_formatter import ErrorFormatter
 
-__all__ = ["BasicLogger", "ErrorFormatter"]
+__all__ = ["BasicLogger", "ErrorFormatter", "DefaultResponder"]

--- a/user_plugins/failure/default_responder.py
+++ b/user_plugins/failure/default_responder.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pipeline.base_plugins import FailurePlugin
+from pipeline.context import PluginContext
+from pipeline.errors import create_error_response, create_static_error_response
+from pipeline.stages import PipelineStage
+
+
+class DefaultResponder(FailurePlugin):
+    """Return a standardized error message when failures occur."""
+
+    stages = [PipelineStage.ERROR]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        info = context.get_failure_info()
+        if info is None:
+            context.set_response(create_static_error_response(context.pipeline_id))
+        else:
+            context.set_response(create_error_response(context.pipeline_id, info))


### PR DESCRIPTION
## Summary
- add `create_error_response` helper and `DefaultResponder` plugin
- support retry attempts in `BasePlugin`
- log plugin failures with more context
- document new error recovery features
- test plugin retries and error response helpers

## Testing
- `poetry run flake8 src/pipeline/base_plugins.py src/pipeline/errors/__init__.py src/pipeline/pipeline.py user_plugins/failure/default_responder.py user_plugins/failure/__init__.py tests/test_error_handling.py tests/test_plugin_retry.py`
- `poetry run mypy src/pipeline/base_plugins.py src/pipeline/errors/__init__.py src/pipeline/pipeline.py user_plugins/failure/default_responder.py user_plugins/failure/__init__.py` *(fails: missing type hints)*
- `poetry run bandit -r src/pipeline/base_plugins.py src/pipeline/errors/__init__.py src/pipeline/pipeline.py user_plugins/failure/default_responder.py user_plugins/failure/__init__.py`
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `poetry run pytest tests/test_error_handling.py tests/test_plugin_retry.py`

------
https://chatgpt.com/codex/tasks/task_e_686c2a948c24832295d383c8972a4cad