### PR TITLE
Fix ValidationResult import for resources

### DIFF
--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -8,9 +8,10 @@ if TYPE_CHECKING:  # pragma: no cover
 
 import logging
 
+from pipeline.validation import ValidationResult
+
 if TYPE_CHECKING:  # pragma: no cover
     from pipeline.state import LLMResponse
-    from pipeline.validation import ValidationResult
 
 
 @runtime_checkable


### PR DESCRIPTION
## Summary
- import `ValidationResult` outside type-checking blocks
- remove duplicate type-checking import

## Testing
- `poetry run black src/common_interfaces/resources.py`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Required environment variable HTTP_TOKEN not found)*
- `poetry run mypy src` *(fails: found 402 errors)*
- `poetry run bandit -r src`
- `poetry run pytest` *(fails: 19 failed, 166 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c2d951bc08322a05cc462e56fd687