### PR TITLE
Add HTTP_TOKEN placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ DB_PASSWORD=
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=llama3:8b-instruct-q6_K
 WEATHER_API_KEY=changeme
+HTTP_TOKEN=


### PR DESCRIPTION
## Summary
- add missing HTTP_TOKEN placeholder to .env.example

## Testing
- `poetry run black .env.example` *(fails: Cannot parse for target version)*
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError and other errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: loader error)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: loader error)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686c2d95835883228672c3ce283ffd27