### PR TITLE
Fix contributor docs for validators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ poetry run isort src tests
 poetry run flake8 src tests
 poetry run mypy src
 bandit -r src
-python -m src.entity_config.validator --config config/dev.yaml
-python -m src.entity_config.validator --config config/prod.yaml
+poetry run python -m src.entity_config.validator --config config/dev.yaml
+poetry run python -m src.entity_config.validator --config config/prod.yaml
 python -m src.registry.validator
 pytest tests/integration/ -v
 pytest tests/infrastructure/ -v


### PR DESCRIPTION
## Summary
- clarify how to run validator scripts in CONTRIBUTING guide

## Testing
- `poetry run black CONTRIBUTING.md` *(fails: cannot parse for target version Python 3.11)*
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: found 402 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c2d9714dc83229aadea4618c116fc