### PR TITLE
Update pipeline looping test

### DIFF
--- a/tests/test_pipeline_looping.py
+++ b/tests/test_pipeline_looping.py
@@ -84,5 +84,6 @@ def test_max_iterations_triggers_error():
         return state
 
     state = asyncio.run(run())
-    assert state.iteration == 2  # type: ignore[attr-defined]
+    assert state.iteration == 3  # type: ignore[attr-defined]
     assert failures
+    assert failures[0].error_type == "MaxIterationsExceeded"


### PR DESCRIPTION
## Summary
- update pipeline looping test to check MaxIterationsExceeded failure info

## Testing
- `poetry run black tests/test_pipeline_looping.py`
- `poetry run isort tests/test_pipeline_looping.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 402 errors)*
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: module loader error)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: module loader error)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: 22 failed, 163 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c2daf1e28832296b60f34e9cdb899