### PR TITLE
Update docs for pipeline iteration argument

### DIFF
--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -14,7 +14,11 @@ stages. Plugins implement each stage and provide reusable behavior.
 After each pass through these stages, the pipeline examines `state.response`.
 If the response is still empty, the stages repeat until a response exists or
 `max_iterations` is hit. By default the framework allows five iterations. Once
-this limit is exceeded, the pipeline jumps to the `error` stage.
+this limit is exceeded, the pipeline jumps to the `error` stage. The
+`execute_pipeline` function exposes this limit via a ``max_iterations``
+argument so callers can adjust it per request. When the limit is reached a
+``MaxIterationsExceeded`` failure is recorded and handled by error-stage
+plugins.
 
 ## Plugin Layers
 1. **Resource plugins** – databases, LLMs and storage backends

--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -18,7 +18,10 @@ Each stage is independent, making the agent's behavior easier to reason about.
 After a full pass, the pipeline checks `state.response`. If it is still empty,
 the stages run again until a response is produced or `max_iterations` is
 reached. Five iterations are allowed by default; exceeding this limit invokes
-the `error` stage.
+the `error` stage. You can override this behavior by passing a
+``max_iterations`` argument to ``execute_pipeline``. When the limit is hit a
+``MaxIterationsExceeded`` failure is raised, triggering the error-stage
+plugins.
 
 ## Plugins
 


### PR DESCRIPTION
## Summary
- note `max_iterations` parameter of `execute_pipeline`
- explain `MaxIterationsExceeded` failure

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run python src/entity_config/validator.py --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'tools')*
- `poetry run python src/entity_config/validator.py --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'tools')*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `poetry run pytest`
- `poetry run make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_686c2db112f08322a6a75b2d1a00fbf0