### PR TITLE
Add MaxIterationsExceeded exception

### DIFF
--- a/src/pipeline/exceptions.py
+++ b/src/pipeline/exceptions.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 """Compatibility exceptions for pipeline modules."""
 
-from .errors import (PipelineError, PluginExecutionError, ResourceError,
-                     ToolExecutionError)
+from .errors import (
+    PipelineError,
+    PluginExecutionError,
+    ResourceError,
+    ToolExecutionError,
+)
 
 
 class CircuitBreakerTripped(PipelineError):
@@ -14,10 +18,19 @@ class CircuitBreakerTripped(PipelineError):
         super().__init__(f"Circuit breaker tripped for {plugin_name}")
 
 
+class MaxIterationsExceeded(PipelineError):
+    """Raised when the pipeline exceeds the configured iteration limit."""
+
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        super().__init__(f"Maximum iterations of {limit} exceeded")
+
+
 __all__ = [
     "PipelineError",
     "PluginExecutionError",
     "ToolExecutionError",
     "ResourceError",
     "CircuitBreakerTripped",
+    "MaxIterationsExceeded",
 ]

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -16,6 +16,7 @@ from registry import SystemRegistries
 
 from .context import ConversationEntry, PluginContext
 from .errors import create_static_error_response
+from .exceptions import MaxIterationsExceeded  # noqa: F401 - reserved for future use
 from .exceptions import (
     CircuitBreakerTripped,
     PipelineError,


### PR DESCRIPTION
## Summary
- define a MaxIterationsExceeded exception for pipelines
- expose new exception through __all__
- import the new exception in pipeline module

## Testing
- `poetry run black src/pipeline/exceptions.py src/pipeline/pipeline.py`
- `poetry run isort src/pipeline/exceptions.py src/pipeline/pipeline.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: yaml, etc.)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `poetry run pytest -q` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686c2da91a3883229306f85e5cd724d9