### PR TITLE
Add iterative pipeline loop

### DIFF
--- a/architecture/pipeline_overview.md
+++ b/architecture/pipeline_overview.md
@@ -13,4 +13,5 @@ The Entity Pipeline Framework executes a single pass through a series of stages.
 After completing these stages, the pipeline checks `state.response`. If no
 response has been produced, the same stages run again until a response exists or
 `max_iterations` is reached. The default limit is five iterations. When the
-limit is exceeded the pipeline triggers the `error` stage.
+limit is exceeded the pipeline triggers the `error` stage. Pass a different
+`max_iterations` value to `execute_pipeline` to adjust this limit.

--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -14,7 +14,9 @@ stages. Plugins implement each stage and provide reusable behavior.
 After each pass through these stages, the pipeline examines `state.response`.
 If the response is still empty, the stages repeat until a response exists or
 `max_iterations` is hit. By default the framework allows five iterations. Once
-this limit is exceeded, the pipeline jumps to the `error` stage.
+this limit is exceeded, the pipeline jumps to the `error` stage. The limit can
+be overridden by passing a different value for `max_iterations` to
+`execute_pipeline`.
 
 ## Plugin Layers
 1. **Resource plugins** – databases, LLMs and storage backends

--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -18,7 +18,8 @@ Each stage is independent, making the agent's behavior easier to reason about.
 After a full pass, the pipeline checks `state.response`. If it is still empty,
 the stages run again until a response is produced or `max_iterations` is
 reached. Five iterations are allowed by default; exceeding this limit invokes
-the `error` stage.
+the `error` stage. You may supply a custom limit with the `max_iterations`
+argument of `execute_pipeline`.
 
 ## Plugins
 

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -155,6 +155,7 @@ async def execute_pipeline(
     state_logger: "StateLogger" | None = None,
     return_metrics: bool = False,
     state: PipelineState | None = None,
+    max_iterations: int = 5,
 ) -> Dict[str, Any] | tuple[Dict[str, Any], MetricsCollector]:
     if state is None:
         if state_file and os.path.exists(state_file):
@@ -182,41 +183,66 @@ async def execute_pipeline(
     try:
         async with registries.resources:
             async with start_span("pipeline.execute"):
-                for stage in [
-                    PipelineStage.PARSE,
-                    PipelineStage.THINK,
-                    PipelineStage.DO,
-                    PipelineStage.REVIEW,
-                    PipelineStage.DELIVER,
-                ]:
-                    if (
-                        state.last_completed_stage is not None
-                        and stage.value <= state.last_completed_stage.value
-                    ):
-                        continue
-                    try:
-                        await execute_stage(stage, state, registries)
-                    finally:
-                        if state_file:
-                            if state_file.endswith((".mpk", ".msgpack")):
-                                with open(state_file, "wb") as fh:
-                                    fh.write(dumps_state(state))
-                            else:
-                                with open(state_file, "w", encoding="utf-8") as fh:
+                while True:
+                    for stage in [
+                        PipelineStage.PARSE,
+                        PipelineStage.THINK,
+                        PipelineStage.DO,
+                        PipelineStage.REVIEW,
+                        PipelineStage.DELIVER,
+                    ]:
+                        if (
+                            state.last_completed_stage is not None
+                            and stage.value <= state.last_completed_stage.value
+                        ):
+                            continue
+                        try:
+                            await execute_stage(stage, state, registries)
+                        finally:
+                            if state_file:
+                                if state_file.endswith((".mpk", ".msgpack")):
+                                    with open(state_file, "wb") as fh:
+                                        fh.write(dumps_state(state))
+                                else:
+                                    with open(state_file, "w", encoding="utf-8") as fh:
+                                        json.dump(state.to_dict(), fh)
+                            if snapshots_dir:
+                                os.makedirs(snapshots_dir, exist_ok=True)
+                                snap_path = os.path.join(
+                                    snapshots_dir,
+                                    f"{state.pipeline_id}_{stage.name.lower()}.json",
+                                )
+                                with open(snap_path, "w", encoding="utf-8") as fh:
                                     json.dump(state.to_dict(), fh)
-                        if snapshots_dir:
-                            os.makedirs(snapshots_dir, exist_ok=True)
-                            snap_path = os.path.join(
-                                snapshots_dir,
-                                f"{state.pipeline_id}_{stage.name.lower()}.json",
+                            if state_logger is not None:
+                                state_logger.log(state, stage)
+                        if state.failure_info:
+                            break
+                        state.last_completed_stage = stage
+
+                    state.iteration += 1
+                    if (
+                        state.response is not None
+                        or state.failure_info is not None
+                        or state.iteration >= max_iterations
+                    ):
+                        if (
+                            state.response is None
+                            and state.failure_info is None
+                            and state.iteration >= max_iterations
+                        ):
+                            state.failure_info = FailureInfo(
+                                stage="iteration_guard",
+                                plugin_name="pipeline",
+                                error_type="max_iterations",
+                                error_message=f"Reached {max_iterations} iterations",
+                                original_exception=RuntimeError(
+                                    "max iteration limit reached"
+                                ),
                             )
-                            with open(snap_path, "w", encoding="utf-8") as fh:
-                                json.dump(state.to_dict(), fh)
-                        if state_logger is not None:
-                            state_logger.log(state, stage)
-                    if state.failure_info:
                         break
-                    state.last_completed_stage = stage
+
+                    state.last_completed_stage = None
 
         if state.failure_info:
             try:


### PR DESCRIPTION
## Summary
- implement a looping mechanism in `execute_pipeline`
- clarify iteration limit usage in the docs

## Testing
- `poetry run black src/pipeline/pipeline.py`
- `poetry run isort src/pipeline/pipeline.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: library stubs not installed)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `python -m src.registry.validator` *(fails: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686c3711ffb08322bcaa565f898bf92b