### PR TITLE
Add model shortcut to validate_params

### DIFF
--- a/src/pipeline/validation/input.py
+++ b/src/pipeline/validation/input.py
@@ -60,9 +60,13 @@ def validate_params(
     validator = PluginInputValidator(model)
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        """Validate ``params`` before calling ``func``."""
+
         async def wrapper(
-            self: Any, params: Dict[str, Any], *args: Any, **kwargs: Any
+            self: Any, params: BaseModel | Dict[str, Any], *args: Any, **kwargs: Any
         ) -> Any:
+            if isinstance(params, model):
+                return await func(self, params, *args, **kwargs)
             try:
                 validated = validator(params)
             except ValidationError as exc:

--- a/tests/test_validate_params.py
+++ b/tests/test_validate_params.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from pipeline.validation.input import validate_params
+
+
+class Echo:
+    class Params(BaseModel):
+        text: str
+
+    @validate_params(Params)
+    async def run(self, params: Params) -> str:
+        return params.text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validate_params_accepts_model_instance() -> None:
+    obj = Echo()
+    model = Echo.Params(text="hi")
+    assert await obj.run(model) == "hi"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validate_params_validates_dict() -> None:
+    obj = Echo()
+    assert await obj.run({"text": "hello"}) == "hello"


### PR DESCRIPTION
## Summary
- allow validate_params decorator to accept model instances directly
- add tests covering new behavior

## Testing
- `poetry run isort src/pipeline/validation/input.py tests/test_validate_params.py`
- `poetry run flake8 src/pipeline/validation/input.py tests/test_validate_params.py`
- `poetry run mypy src/pipeline/validation/input.py`
- `poetry run mypy src` *(fails: multiple errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `poetry run pytest` *(fails: 21 failed, 166 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c370e20448322b82aa7dffe5d8d55