### PR TITLE
Fix runtime import for ValidationResult

### DIFF
--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Protocol, runtime_checkable
 
+from pipeline.validation import ValidationResult
+
 if TYPE_CHECKING:  # pragma: no cover
     from registry import ClassRegistry
 
@@ -10,7 +12,6 @@ import logging
 
 if TYPE_CHECKING:  # pragma: no cover
     from pipeline.state import LLMResponse
-    from pipeline.validation import ValidationResult
 
 
 @runtime_checkable


### PR DESCRIPTION
## Summary
- import ValidationResult directly in resources interface

## Testing
- `poetry run black src/common_interfaces/resources.py`
- `poetry run isort src/common_interfaces/resources.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: library stubs not installed)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'duckdb')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'duckdb')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_686c370790148322af5e3d4d0bb8f097