### PR TITLE
Handle missing auth tokens for adapters

### DIFF
--- a/src/plugins/builtin/adapters/http.py
+++ b/src/plugins/builtin/adapters/http.py
@@ -115,7 +115,7 @@ class HTTPAdapter(AdapterPlugin):
             mapping = {t: ["http"] for t in tokens_cfg}
         else:
             mapping = {str(k): v for k, v in dict(tokens_cfg).items()}
-        self.authenticator = AdapterAuthenticator(mapping)
+        self.authenticator = AdapterAuthenticator(mapping) if mapping else None
         self.app = FastAPI()
         self._setup_audit_logger()
         self._setup_middleware()
@@ -143,7 +143,7 @@ class HTTPAdapter(AdapterPlugin):
         self.audit_logger.setLevel(logging.INFO)
 
     def _setup_middleware(self) -> None:
-        if self.authenticator:
+        if self.authenticator is not None:
             self.app.add_middleware(
                 TokenAuthMiddleware,
                 authenticator=self.authenticator,


### PR DESCRIPTION
## Summary
- allow HTTP and WebSocket adapters to run without authentication
- skip adding auth middleware when auth tokens are absent

## Testing
- `poetry run black src/plugins/builtin/adapters/http.py src/plugins/builtin/adapters/websocket.py`
- `poetry run isort src/plugins/builtin/adapters/http.py src/plugins/builtin/adapters/websocket.py`
- `poetry run flake8 src/plugins/builtin/adapters/http.py src/plugins/builtin/adapters/websocket.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `PYTHONPATH=. poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `PYTHONPATH=. poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run pytest` *(failed: 17 failed, 166 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c370b9704832292fcc901239e586f