### PR TITLE
Fix tool param validation

### DIFF
--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -381,14 +381,21 @@ class ToolPlugin(BasePlugin):
             )
         return True
 
-    def validate_tool_params(self, params: Dict[str, Any]) -> Any:
-        """Validate ``params`` using a :class:`pydantic.BaseModel` if provided."""
+    def validate_tool_params(
+        self, params: BaseModel | Dict[str, Any]
+    ) -> BaseModel | Dict[str, Any]:
+        """Validate ``params`` using ``Params`` model when provided."""
+
+        if isinstance(params, BaseModel):
+            return params
+
         model_cls: Type[BaseModel] | None = getattr(self, "Params", None)
         if model_cls is not None and issubclass(model_cls, BaseModel):
             try:
                 return model_cls(**params)
-            except ValidationError as exc:
+            except ValidationError as exc:  # pragma: no cover - re-raise
                 raise ToolExecutionError(self.__class__.__name__, exc) from exc
+
         self._validate_required_params(params)
         return params
 


### PR DESCRIPTION
## Summary
- return pydantic `BaseModel` args without re-validating

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: No module named 'watchfiles')*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_686c370fce108322a52f90aa46b50ba4