### PR TITLE
Fix SecureToolWrapper execution

### DIFF
--- a/src/pipeline/security/wrapper.py
+++ b/src/pipeline/security/wrapper.py
@@ -22,4 +22,4 @@ class SecureToolWrapper(ToolPlugin):
     async def execute_function(self, params: Dict[str, Any]) -> Any:
         validated = self._validator(params)
         sanitized = validated.model_dump()
-        return await self._plugin.execute(sanitized)
+        return await self._plugin.execute_function_with_retry(sanitized)


### PR DESCRIPTION
## Summary
- ensure SecureToolWrapper uses plugin retry logic

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 403 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `PYTHONPATH=. poetry run python -m src.registry.validator` *(fails: ImportError)*
- `poetry run pytest` *(fails: 61 failed, 129 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c371cbc58832296b50c63b0034844