### PR TITLE
Add ErrorResponse dataclass

### DIFF
--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 import logging
 
-from pipeline.validation import ValidationResult
-
 if TYPE_CHECKING:  # pragma: no cover
     from pipeline.state import LLMResponse
 

--- a/src/pipeline/errors/response.py
+++ b/src/pipeline/errors/response.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class ErrorResponse:
+    """Serialized representation of an error."""
+
+    error: str
+    message: str
+    error_id: str | None = None
+    timestamp: str | None = None
+    type: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a dictionary representation of this error."""
+        return {
+            "error": self.error,
+            "message": self.message,
+            "error_id": self.error_id,
+            "timestamp": self.timestamp,
+            "type": self.type,
+        }
+
+
+__all__ = ["ErrorResponse"]


### PR DESCRIPTION
## Summary
- add `ErrorResponse` dataclass for standard error payloads
- fix duplicate imports in `resources.py`

## Testing
- `poetry run black src/common_interfaces/resources.py src/pipeline/errors/response.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: yaml)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `pytest` *(fails: ModuleNotFoundError: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_686c3aa53e8c832292ef4812238e5374