### PR TITLE
Add JSON helpers for serialization

### DIFF
--- a/src/pipeline/serialization.py
+++ b/src/pipeline/serialization.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 """Helpers for efficient pipeline state serialization."""
 
+import json
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
 import msgpack
 
 from .state import PipelineState
@@ -17,4 +21,21 @@ def loads_state(data: bytes) -> PipelineState:
     return PipelineState.from_dict(msgpack.loads(data, raw=False))
 
 
-__all__ = ["dumps_state", "loads_state"]
+def dumps_json(obj: Any) -> str:
+    """Serialize ``obj`` to JSON, handling dataclasses."""
+    if is_dataclass(obj):
+        obj = asdict(obj)
+    return json.dumps(obj)
+
+
+def loads_json(data: str, cls: type | None = None) -> Any:
+    """Deserialize ``data`` to ``cls`` or a plain object."""
+    obj = json.loads(data)
+    if cls is not None:
+        if is_dataclass(cls):
+            return cls(**obj)
+        return cls(obj)
+    return obj
+
+
+__all__ = ["dumps_state", "loads_state", "dumps_json", "loads_json"]

--- a/tests/test_serialization_helpers.py
+++ b/tests/test_serialization_helpers.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+
+from pipeline.serialization import dumps_json, loads_json
+
+
+@dataclass
+class Sample:
+    x: int
+    y: str
+
+
+def test_dumps_json_handles_dataclass():
+    obj = Sample(1, "a")
+    data = dumps_json(obj)
+    assert data == '{"x": 1, "y": "a"}'
+
+
+def test_loads_json_round_trip_dataclass():
+    obj = Sample(2, "b")
+    data = dumps_json(obj)
+    loaded = loads_json(data, Sample)
+    assert loaded == obj
+
+
+def test_loads_json_default_to_dict():
+    obj = {"k": "v"}
+    data = dumps_json(obj)
+    assert loads_json(data) == obj


### PR DESCRIPTION
## Summary
- add `dumps_json` and `loads_json` for dataclass aware JSON conversion
- export new helpers
- add tests verifying the JSON helpers

## Testing
- `poetry run black src/pipeline/serialization.py tests/test_serialization_helpers.py`
- `poetry run isort src/pipeline/serialization.py tests/test_serialization_helpers.py`
- `poetry run flake8 src/pipeline/serialization.py tests/test_serialization_helpers.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'duckdb')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'duckdb')*
- `python -m src.registry.validator` *(fails: ImportError due to circular import)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_686c3aaa108c8322b0141f687908dbd6