### PR TITLE
Refactor plugin registration sync API

### DIFF
--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 import logging
 
-from pipeline.validation import ValidationResult
-
 if TYPE_CHECKING:  # pragma: no cover
     from pipeline.state import LLMResponse
 

--- a/src/pipeline/builder.py
+++ b/src/pipeline/builder.py
@@ -50,9 +50,9 @@ class AgentBuilder:
             raise TypeError(f"Plugin '{name}' must implement async '_execute_impl'")
         for stage in getattr(plugin, "stages", []):
             name = getattr(plugin, "name", plugin.__class__.__name__)
-            result = self.plugin_registry.register_plugin_for_stage(plugin, stage, name)
-            if asyncio.iscoroutine(result):
-                asyncio.run(result)
+            task = self.plugin_registry.register_plugin_for_stage(plugin, stage, name)
+            if task is not None:
+                asyncio.run(task)
 
     def plugin(
         self,

--- a/src/registry/registries.py
+++ b/src/registry/registries.py
@@ -83,29 +83,41 @@ class PluginRegistry:
         self._dependents: Dict[str, List[BasePlugin]] = defaultdict(list)
         self._lock = asyncio.Lock()
 
-    async def register_plugin_for_stage(
+    def register_plugin_for_stage(
         self, plugin: BasePlugin, stage: PipelineStage | str, name: str | None = None
-    ) -> None:
+    ) -> asyncio.Task | None:
         """Register ``plugin`` to execute during ``stage``."""
+
+        async def _register() -> None:
+            try:
+                stage_obj = PipelineStage(stage)
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise ValueError(f"Invalid stage: {stage}") from exc
+            async with self._lock:
+                plugins = self._stage_plugins[stage_obj]
+                insert_at = len(plugins)
+                for idx, existing in enumerate(plugins):
+                    if plugin.priority < existing.priority:
+                        insert_at = idx
+                        break
+                plugins.insert(insert_at, plugin)
+
+                plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
+                self._names[plugin] = plugin_name
+                self._plugins_by_name[plugin_name] = plugin
+
+                for dep in getattr(plugin, "dependencies", []):
+                    self._dependents.setdefault(dep, []).append(plugin)
+
         try:
-            stage = PipelineStage(stage)
-        except ValueError as exc:
-            raise ValueError(f"Invalid stage: {stage}") from exc
-        async with self._lock:
-            plugins = self._stage_plugins[stage]
-            insert_at = len(plugins)
-            for idx, existing in enumerate(plugins):
-                if plugin.priority < existing.priority:
-                    insert_at = idx
-                    break
-            plugins.insert(insert_at, plugin)
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
 
-            plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
-            self._names[plugin] = plugin_name
-            self._plugins_by_name[plugin_name] = plugin
-
-            for dep in getattr(plugin, "dependencies", []):
-                self._dependents.setdefault(dep, []).append(plugin)
+        if loop is None:
+            asyncio.run(_register())
+            return None
+        return loop.create_task(_register())
 
     def get_plugins_for_stage(self, stage: PipelineStage) -> List[BasePlugin]:
         """Return list of plugins registered for ``stage``."""

--- a/tests/performance/test_full_pipeline_benchmark.py
+++ b/tests/performance/test_full_pipeline_benchmark.py
@@ -2,8 +2,13 @@ import asyncio
 
 import pytest
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 
 
@@ -17,7 +22,7 @@ class RespondPlugin:
 @pytest.mark.benchmark
 def test_full_pipeline_benchmark(benchmark):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DO))
+    plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
 

--- a/tests/performance/test_pipeline_benchmark.py
+++ b/tests/performance/test_pipeline_benchmark.py
@@ -2,8 +2,14 @@ import asyncio
 
 import pytest
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 
 
@@ -16,7 +22,7 @@ class NoOpPlugin(PromptPlugin):
 
 def _make_manager():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 

--- a/tests/pipeline/debug/test_state_logger.py
+++ b/tests/pipeline/debug/test_state_logger.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime
 
-from pipeline import (PluginRegistry, PromptPlugin, SystemRegistries,
-                      ToolRegistry)
+from pipeline import PluginRegistry, PromptPlugin, SystemRegistries, ToolRegistry
 from pipeline.debug import LogReplayer, StateLogger
 from pipeline.pipeline import execute_pipeline
 from pipeline.resources import ResourceContainer
@@ -53,7 +52,7 @@ class RespondPlugin(PromptPlugin):
 
 def test_execute_pipeline_logs_states(tmp_path):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
     log_file = tmp_path / "run.jsonl"

--- a/tests/pipeline/debug/test_state_manager.py
+++ b/tests/pipeline/debug/test_state_manager.py
@@ -1,7 +1,13 @@
 import asyncio
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.debug import StateManager
 from pipeline.resources import ResourceContainer
 

--- a/tests/security/test_stage_input_validator.py
+++ b/tests/security/test_stage_input_validator.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.pipeline import execute_stage
 from pipeline.resources import ResourceContainer
 
@@ -26,7 +32,7 @@ def test_validator_runs_before_plugin():
         metrics=MetricsCollector(),
     )
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(DummyPlugin(), PipelineStage.DO))
+    plugins.register_plugin_for_stage(DummyPlugin(), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     called = False
 

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -1,8 +1,14 @@
 import asyncio
 import time
 
-from pipeline import (PipelineStage, PluginRegistry, SystemRegistries,
-                      ToolPlugin, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.base_plugins import PluginAutoClassifier
 from pipeline.context import PluginContext
 from pipeline.resources import ResourceContainer
@@ -28,7 +34,7 @@ def make_registries() -> SystemRegistries:
         use_tool_plugin,
         {"stage": PipelineStage.DO, "name": "UseToolPlugin"},
     )
-    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DO))
+    plugins.register_plugin_for_stage(plugin, PipelineStage.DO)
     return SystemRegistries(resources, tools, plugins)
 
 

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,7 +1,13 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter
@@ -22,7 +28,7 @@ def make_registries():
             PipelineStage.DO,
         )
     )
-    asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
+    plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR)
     asyncio.run(
         plugins.register_plugin_for_stage(ErrorFormatter({}), PipelineStage.ERROR)
     )

--- a/tests/test_cli_adapter.py
+++ b/tests/test_cli_adapter.py
@@ -2,8 +2,14 @@ import asyncio
 import logging
 from typing import Any
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from plugins.builtin.adapters.cli import CLIAdapter
 
@@ -18,7 +24,7 @@ class EchoPlugin(PromptPlugin):
 
 def make_adapter() -> tuple[CLIAdapter, SystemRegistries]:
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return CLIAdapter(manager), registries

--- a/tests/test_config_update.py
+++ b/tests/test_config_update.py
@@ -64,7 +64,7 @@ def test_update_plugin_configuration_restart_required():
 
     reg = PluginRegistry()
     p = NRPlugin({"value": "x"})
-    asyncio.run(reg.register_plugin_for_stage(p, PipelineStage.THINK))
+    reg.register_plugin_for_stage(p, PipelineStage.THINK)
     result = asyncio.run(
         update_plugin_configuration(reg, "test_plugin", {"value": "y"})
     )

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1,8 +1,14 @@
 import asyncio
 
-from pipeline import (ConversationManager, PipelineManager, PipelineStage,
-                      PluginRegistry, PromptPlugin, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationManager,
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 
 
@@ -24,8 +30,8 @@ class RespondPlugin(PromptPlugin):
 
 def make_manager():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DO))
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DO)
+    plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     conv = ConversationManager(registries, manager)

--- a/tests/test_dashboard_adapter.py
+++ b/tests/test_dashboard_adapter.py
@@ -26,7 +26,7 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter(tmp_path: Path) -> DashboardAdapter:
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     log_path = tmp_path / "state.log"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -48,8 +48,8 @@ class FallbackPlugin(FailurePlugin):
 
 def make_registries(error_plugin, main_plugin=BoomPlugin):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(main_plugin({}), PipelineStage.DO))
-    asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
+    plugins.register_plugin_for_stage(main_plugin({}), PipelineStage.DO)
+    plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR)
     asyncio.run(
         plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
     )

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -43,8 +43,8 @@ class BadErrorPlugin(FailurePlugin):
 
 def make_registries(error_plugin):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(FailPlugin({}), PipelineStage.DO))
-    asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
+    plugins.register_plugin_for_stage(FailPlugin({}), PipelineStage.DO)
+    plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR)
     asyncio.run(
         plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
     )

--- a/tests/test_execute_stage.py
+++ b/tests/test_execute_stage.py
@@ -42,7 +42,7 @@ def make_state():
 
 def make_registries(plugin):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DO))
+    plugins.register_plugin_for_stage(plugin, PipelineStage.DO)
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 

--- a/tests/test_fallback_error_plugin.py
+++ b/tests/test_fallback_error_plugin.py
@@ -21,8 +21,8 @@ class FailPlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(FailPlugin({}), PipelineStage.DO))
-    asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
+    plugins.register_plugin_for_stage(FailPlugin({}), PipelineStage.DO)
+    plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR)
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -24,7 +24,7 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter(config=None):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return HTTPAdapter(manager, config)

--- a/tests/test_logging_adapter.py
+++ b/tests/test_logging_adapter.py
@@ -1,8 +1,14 @@
 import asyncio
 import logging
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from plugins.builtin.adapters.logging import LoggingAdapter
 
@@ -17,7 +23,7 @@ class EchoPlugin(PromptPlugin):
 
 def make_manager() -> PipelineManager:
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO)
     asyncio.run(
         plugins.register_plugin_for_stage(LoggingAdapter({}), PipelineStage.DELIVER)
     )

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -1,13 +1,18 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.context import ConversationEntry
 from pipeline.resources import ResourceContainer
 from pipeline.resources.memory import Memory
-from pipeline.resources.memory_resource import (MemoryResource,
-                                                SimpleMemoryResource)
+from pipeline.resources.memory_resource import MemoryResource, SimpleMemoryResource
 from plugins.builtin.resources.memory_storage import MemoryStorage
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,8 +1,15 @@
 import asyncio
 
-from pipeline import (LLMResponse, PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolPlugin, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    LLMResponse,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.resources import ResourceContainer
 
 
@@ -29,7 +36,7 @@ class MetricsPlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DO)
     resources = ResourceContainer()
     asyncio.run(resources.add("llm", EchoLLM()))
     tools = ToolRegistry()

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,8 +1,14 @@
 import asyncio
 import time
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.resources import ResourceContainer
 
 
@@ -16,7 +22,7 @@ class TimedPlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(TimedPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(TimedPlugin({}), PipelineStage.DO)
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 

--- a/tests/test_pipeline_looping.py
+++ b/tests/test_pipeline_looping.py
@@ -1,9 +1,15 @@
 import asyncio
 from typing import Optional
 
-from pipeline import (FailurePlugin, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    FailurePlugin,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.resources import ResourceContainer
 from pipeline.state import FailureInfo, PipelineState
 

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -21,7 +21,7 @@ class WaitPlugin(PromptPlugin):
 
 def make_manager():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(WaitPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(WaitPlugin({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -2,9 +2,16 @@ import asyncio
 from datetime import datetime
 from pathlib import Path
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.pipeline import execute_pipeline
 from pipeline.resources import ResourceContainer
 
@@ -44,7 +51,7 @@ def test_restore_replaces_state():
 
 def test_execute_pipeline_persists_snapshots(tmp_path: Path):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     snap_dir = tmp_path / "snaps"
     result = asyncio.run(

--- a/tests/test_plugin_layers.py
+++ b/tests/test_plugin_layers.py
@@ -1,8 +1,14 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, ResourcePlugin,
-                      SystemRegistries, ToolPlugin, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    ResourcePlugin,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.base_plugins import PluginAutoClassifier
 from pipeline.context import PluginContext
 from pipeline.resources import ResourceContainer
@@ -37,7 +43,7 @@ def make_registries() -> SystemRegistries:
         my_prompt,
         {"stage": PipelineStage.DO, "name": "MyPrompt"},
     )
-    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DO))
+    plugins.register_plugin_for_stage(plugin, PipelineStage.DO)
     return SystemRegistries(resources, tools, plugins)
 
 

--- a/tests/test_plugin_registry_order.py
+++ b/tests/test_plugin_registry_order.py
@@ -2,9 +2,15 @@ import asyncio
 
 import yaml
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemInitializer, SystemRegistries, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemInitializer,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.resources import ResourceContainer
 
 
@@ -46,9 +52,9 @@ def _set_final_response(context):
 
 def test_plugin_priority_order_matches_execution():
     registry = PluginRegistry()
-    asyncio.run(registry.register_plugin_for_stage(First({}), PipelineStage.DO))
-    asyncio.run(registry.register_plugin_for_stage(Third({}), PipelineStage.DO))
-    asyncio.run(registry.register_plugin_for_stage(Second({}), PipelineStage.DO))
+    registry.register_plugin_for_stage(First({}), PipelineStage.DO)
+    registry.register_plugin_for_stage(Third({}), PipelineStage.DO)
+    registry.register_plugin_for_stage(Second({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), registry)
     result = asyncio.run(execute_pipeline("hi", registries))
     assert result == ["third", "second", "first"]

--- a/tests/test_plugin_retry.py
+++ b/tests/test_plugin_retry.py
@@ -33,7 +33,7 @@ def make_registries():
             FlakyPlugin({"max_retries": 1, "retry_delay": 0}), PipelineStage.DO
         )
     )
-    asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
+    plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR)
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 

--- a/tests/test_stage_checks.py
+++ b/tests/test_stage_checks.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from pipeline import PipelineStage, PluginRegistry, PromptPlugin
@@ -34,4 +32,4 @@ def test_registry_rejects_invalid_stage():
     reg = PluginRegistry()
     plugin = GoodPlugin({})
     with pytest.raises(ValueError):
-        asyncio.run(reg.register_plugin_for_stage(plugin, "bogus"))
+        reg.register_plugin_for_stage(plugin, "bogus")

--- a/tests/test_state_logging.py
+++ b/tests/test_state_logging.py
@@ -52,7 +52,7 @@ class RespondPlugin(PromptPlugin):
 
 def test_execute_pipeline_logs_states(tmp_path):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
     log_file = tmp_path / "run.jsonl"

--- a/tests/test_tool_error_propagation.py
+++ b/tests/test_tool_error_propagation.py
@@ -1,8 +1,14 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolPlugin, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -1,9 +1,13 @@
-import asyncio
-
 from fastapi.testclient import TestClient
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from plugins.builtin.adapters import WebSocketAdapter
 
@@ -18,7 +22,7 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
+    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return WebSocketAdapter(manager)


### PR DESCRIPTION
## Summary
- adjust `PluginRegistry.register_plugin_for_stage` to return an optional `Task`
- ensure `AgentBuilder` handles returned tasks
- drop unused imports from a few tests
- update tests to call the new sync registration API

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing type stubs)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'asyncpg')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'pgvector')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_686c370a468c83228babcbc6e1a34630