### PR TITLE
Update error tests to use ErrorResponse

### DIFF
--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any, Dict
 
@@ -15,6 +16,7 @@ from .exceptions import (
 __all__ = [
     "create_static_error_response",
     "create_error_response",
+    "ErrorResponse",
     "PipelineError",
     "PluginExecutionError",
     "ResourceError",
@@ -34,23 +36,45 @@ STATIC_ERROR_RESPONSE: Dict[str, Any] = {
 }
 
 
-def create_static_error_response(pipeline_id: str) -> Dict[str, Any]:
+@dataclass(slots=True)
+class ErrorResponse:
+    """Standard error response structure."""
+
+    error: str
+    message: str | None = None
+    error_type: str | None = None
+    stage: str | None = None
+    plugin: str | None = None
+    pipeline_id: str | None = None
+    error_id: str | None = None
+    timestamp: str | None = field(default_factory=lambda: datetime.now().isoformat())
+    type: str = "plugin_error"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def create_static_error_response(pipeline_id: str) -> ErrorResponse:
     """Return a copy of :data:`STATIC_ERROR_RESPONSE` populated with runtime info."""
-    response = STATIC_ERROR_RESPONSE.copy()
-    response["error_id"] = pipeline_id
-    response["timestamp"] = datetime.now().isoformat()
-    return response
+
+    return ErrorResponse(
+        error=STATIC_ERROR_RESPONSE["error"],
+        message=STATIC_ERROR_RESPONSE["message"],
+        error_id=pipeline_id,
+        timestamp=datetime.now().isoformat(),
+        type="static_fallback",
+    )
 
 
-def create_error_response(pipeline_id: str, failure: FailureInfo) -> Dict[str, Any]:
+def create_error_response(pipeline_id: str, failure: FailureInfo) -> ErrorResponse:
     """Return a standardized error payload for ``failure``."""
 
-    return {
-        "error": failure.error_message,
-        "error_type": failure.error_type,
-        "stage": failure.stage,
-        "plugin": failure.plugin_name,
-        "pipeline_id": pipeline_id,
-        "timestamp": datetime.now().isoformat(),
-        "type": "plugin_error",
-    }
+    return ErrorResponse(
+        error=failure.error_message,
+        error_type=failure.error_type,
+        stage=failure.stage,
+        plugin=failure.plugin_name,
+        pipeline_id=pipeline_id,
+        timestamp=datetime.now().isoformat(),
+        type="plugin_error",
+    )

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,7 +1,14 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.errors import ErrorResponse
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter
@@ -34,4 +41,5 @@ def test_circuit_breaker_trips():
     asyncio.run(execute_pipeline("hi", registries))
     asyncio.run(execute_pipeline("hi", registries))
     result = asyncio.run(execute_pipeline("hi", registries))
-    assert "circuit breaker" in result["error"].lower()
+    assert isinstance(result, ErrorResponse)
+    assert "circuit breaker" in result.error.lower()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -10,6 +10,7 @@ from pipeline import (
     execute_pipeline,
 )
 from pipeline.errors import (
+    ErrorResponse,
     PipelineError,
     PluginContextError,
     PluginExecutionError,
@@ -65,8 +66,10 @@ def test_error_plugin_runs():
 def test_static_error_response():
     pipeline_id = "123"
     resp = create_static_error_response(pipeline_id)
-    assert resp["error_id"] == pipeline_id
-    assert resp["type"] == "static_fallback"
+    assert isinstance(resp, ErrorResponse)
+    data = resp.to_dict()
+    assert data["error_id"] == pipeline_id
+    assert data["type"] == "static_fallback"
 
 
 def test_create_error_response():
@@ -78,9 +81,11 @@ def test_create_error_response():
         original_exception=RuntimeError("bad"),
     )
     resp = create_error_response("id", info)
-    assert resp["plugin"] == "Boom"
-    assert resp["stage"] == "do"
-    assert resp["type"] == "plugin_error"
+    assert isinstance(resp, ErrorResponse)
+    data = resp.to_dict()
+    assert data["plugin"] == "Boom"
+    assert data["stage"] == "do"
+    assert data["type"] == "plugin_error"
 
 
 def test_error_hierarchy():

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -11,6 +11,7 @@ from pipeline import (
     ToolRegistry,
     execute_pipeline,
 )
+from pipeline.errors import ErrorResponse
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter
@@ -76,4 +77,9 @@ def test_error_formatter_produces_message():
     """Ensure ErrorFormatter creates a user-facing error message."""
     registries = make_registries(ErrorFormatter)
     result = asyncio.run(execute_pipeline("hi", registries))
-    assert result == {"error": "FailPlugin failed (RuntimeError): boom"}
+    assert isinstance(result, ErrorResponse)
+    data = result.to_dict()
+    assert data["error"] == "boom"
+    assert data["plugin"] == "FailPlugin"
+    assert data["stage"] == "do"
+    assert data["type"] == "plugin_error"

--- a/tests/test_tool_error_propagation.py
+++ b/tests/test_tool_error_propagation.py
@@ -1,8 +1,15 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolPlugin, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
+from pipeline.errors import ErrorResponse
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter
@@ -35,4 +42,9 @@ def make_registries():
 def test_tool_failure_propagates_to_error_stage():
     registries = make_registries()
     result = asyncio.run(execute_pipeline("hi", registries))
-    assert result == {"error": "fail failed (RuntimeError): tool boom"}
+    assert isinstance(result, ErrorResponse)
+    data = result.to_dict()
+    assert data["error"] == "tool boom"
+    assert data["plugin"] == "fail"
+    assert data["stage"] == "do"
+    assert data["type"] == "plugin_error"

--- a/user_plugins/failure/error_formatter.py
+++ b/user_plugins/failure/error_formatter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pipeline.base_plugins import FailurePlugin
 from pipeline.context import PluginContext
+from pipeline.errors import create_error_response, create_static_error_response
 from pipeline.stages import PipelineStage
 
 
@@ -13,7 +14,6 @@ class ErrorFormatter(FailurePlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         info = context.get_failure_info()
         if info is None:
-            context.set_response({"error": "Unknown error"})
+            context.set_response(create_static_error_response(context.pipeline_id))
             return
-        message = f"{info.plugin_name} failed ({info.error_type}): {info.error_message}"
-        context.set_response({"error": message})
+        context.set_response(create_error_response(context.pipeline_id, info))


### PR DESCRIPTION
## Summary
- introduce `ErrorResponse` dataclass for standard error payloads
- update `ErrorFormatter` to return `ErrorResponse`
- adjust error-handling tests to consume the new response object
- update tests using `ErrorFormatter`

## Testing
- `poetry run black src/pipeline/errors/__init__.py user_plugins/failure/error_formatter.py tests/test_error_handling.py tests/test_error_stage.py tests/test_tool_error_propagation.py tests/test_circuit_breaker.py`
- `poetry run isort src/pipeline/errors/__init__.py user_plugins/failure/error_formatter.py tests/test_error_handling.py tests/test_error_stage.py tests/test_tool_error_propagation.py tests/test_circuit_breaker.py`
- `poetry run flake8 src/pipeline/errors/__init__.py user_plugins/failure/error_formatter.py tests/test_error_handling.py tests/test_error_stage.py tests/test_tool_error_propagation.py tests/test_circuit_breaker.py`
- `poetry run mypy src/pipeline/errors/__init__.py user_plugins/failure/error_formatter.py` *(fails: Class cannot subclass "FailurePlugin")*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'aioboto3')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'aioboto3')*
- `python -m src.registry.validator` *(fails: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aioboto3')*

------
https://chatgpt.com/codex/tasks/task_e_686c3a6807ac83228ce99aea7f0d5a66