### PR TITLE
Wrap error responses in dataclass

### DIFF
--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 import logging
 
-from pipeline.validation import ValidationResult
-
 if TYPE_CHECKING:  # pragma: no cover
     from pipeline.state import LLMResponse
 

--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict
 
@@ -12,7 +13,20 @@ from .exceptions import (
     ToolExecutionError,
 )
 
+
+@dataclass(slots=True)
+class ErrorResponse:
+    """Simple wrapper for error payloads."""
+
+    data: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a copy of the payload as a plain dictionary."""
+        return self.data.copy()
+
+
 __all__ = [
+    "ErrorResponse",
     "create_static_error_response",
     "create_error_response",
     "PipelineError",
@@ -34,12 +48,12 @@ STATIC_ERROR_RESPONSE: Dict[str, Any] = {
 }
 
 
-def create_static_error_response(pipeline_id: str) -> Dict[str, Any]:
+def create_static_error_response(pipeline_id: str) -> ErrorResponse:
     """Return a copy of :data:`STATIC_ERROR_RESPONSE` populated with runtime info."""
     response = STATIC_ERROR_RESPONSE.copy()
     response["error_id"] = pipeline_id
     response["timestamp"] = datetime.now().isoformat()
-    return response
+    return ErrorResponse(response)
 
 
 def create_error_response(pipeline_id: str, failure: FailureInfo) -> Dict[str, Any]:

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -297,10 +297,10 @@ async def execute_pipeline(
                 if state_logger is not None:
                     state_logger.log(state, PipelineStage.ERROR)
             except Exception:
-                result = create_static_error_response(state.pipeline_id)
+                result = create_static_error_response(state.pipeline_id).to_dict()
                 return (result, state.metrics) if return_metrics else result
             if state.response is None:
-                result = create_static_error_response(state.pipeline_id)
+                result = create_static_error_response(state.pipeline_id).to_dict()
                 return (result, state.metrics) if return_metrics else result
             result = state.response
         elif state.response is None:

--- a/src/plugins/builtin/failure/fallback_error_plugin.py
+++ b/src/plugins/builtin/failure/fallback_error_plugin.py
@@ -14,4 +14,6 @@ class FallbackErrorPlugin(FailurePlugin):
     stages = [PipelineStage.ERROR]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        context.set_response(create_static_error_response(context.pipeline_id))
+        context.set_response(
+            create_static_error_response(context.pipeline_id).to_dict()
+        )

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -64,7 +64,7 @@ def test_error_plugin_runs():
 
 def test_static_error_response():
     pipeline_id = "123"
-    resp = create_static_error_response(pipeline_id)
+    resp = create_static_error_response(pipeline_id).to_dict()
     assert resp["error_id"] == pipeline_id
     assert resp["type"] == "static_fallback"
 

--- a/user_plugins/failure/default_responder.py
+++ b/user_plugins/failure/default_responder.py
@@ -14,6 +14,8 @@ class DefaultResponder(FailurePlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         info = context.get_failure_info()
         if info is None:
-            context.set_response(create_static_error_response(context.pipeline_id))
+            context.set_response(
+                create_static_error_response(context.pipeline_id).to_dict()
+            )
         else:
             context.set_response(create_error_response(context.pipeline_id, info))

--- a/user_plugins/failure/error_formatter.py
+++ b/user_plugins/failure/error_formatter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pipeline.base_plugins import FailurePlugin
 from pipeline.context import PluginContext
+from pipeline.errors import ErrorResponse
 from pipeline.stages import PipelineStage
 
 
@@ -13,7 +14,7 @@ class ErrorFormatter(FailurePlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         info = context.get_failure_info()
         if info is None:
-            context.set_response({"error": "Unknown error"})
+            context.set_response(ErrorResponse({"error": "Unknown error"}).to_dict())
             return
         message = f"{info.plugin_name} failed ({info.error_type}): {info.error_message}"
-        context.set_response({"error": message})
+        context.set_response(ErrorResponse({"error": message}).to_dict())


### PR DESCRIPTION
## Summary
- add `ErrorResponse` dataclass
- convert static error creation to return `ErrorResponse`
- ensure error plugins pass dictionaries
- fix flake8 failure in `resources.py`

## Testing
- `poetry run black src/pipeline/errors/__init__.py user_plugins/failure/error_formatter.py user_plugins/failure/default_responder.py src/plugins/builtin/failure/fallback_error_plugin.py src/pipeline/pipeline.py tests/test_error_handling.py`
- `poetry run isort src/pipeline/errors/__init__.py user_plugins/failure/error_formatter.py user_plugins/failure/default_responder.py src/plugins/builtin/failure/fallback_error_plugin.py src/pipeline/pipeline.py tests/test_error_handling.py`
- `poetry run isort src/common_interfaces/resources.py`
- `poetry run black src/common_interfaces/resources.py`
- `poetry run flake8 src tests` *(fails: src/config/__init__.py ModuleNotFoundError: No module named 'yaml')*
- `poetry run mypy src` *(fails: Found 403 errors in 112 files)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c3b182dd48322b7163539af22654d