### PR TITLE
Implement ErrorResponse usage

### DIFF
--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 import logging
 
-from pipeline.validation import ValidationResult
-
 if TYPE_CHECKING:  # pragma: no cover
     from pipeline.state import LLMResponse
 

--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Any, Dict
 
@@ -13,6 +14,7 @@ from .exceptions import (
 )
 
 __all__ = [
+    "ErrorResponse",
     "create_static_error_response",
     "create_error_response",
     "PipelineError",
@@ -24,6 +26,26 @@ __all__ = [
     "PluginContextError",
 ]
 
+
+@dataclass(slots=True)
+class ErrorResponse:
+    """Structured error information returned to the caller."""
+
+    error: str
+    message: str | None = None
+    error_id: str | None = None
+    timestamp: str | None = None
+    error_type: str | None = None
+    stage: str | None = None
+    plugin: str | None = None
+    pipeline_id: str | None = None
+    type: str = "error"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a plain ``dict`` representation."""
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
 # Generic fallback returned when even error handling fails
 STATIC_ERROR_RESPONSE: Dict[str, Any] = {
     "error": "System error occurred",
@@ -34,12 +56,16 @@ STATIC_ERROR_RESPONSE: Dict[str, Any] = {
 }
 
 
-def create_static_error_response(pipeline_id: str) -> Dict[str, Any]:
-    """Return a copy of :data:`STATIC_ERROR_RESPONSE` populated with runtime info."""
-    response = STATIC_ERROR_RESPONSE.copy()
-    response["error_id"] = pipeline_id
-    response["timestamp"] = datetime.now().isoformat()
-    return response
+def create_static_error_response(pipeline_id: str) -> ErrorResponse:
+    """Return a fallback :class:`ErrorResponse` populated with runtime info."""
+
+    return ErrorResponse(
+        error=STATIC_ERROR_RESPONSE["error"],
+        message=STATIC_ERROR_RESPONSE["message"],
+        error_id=pipeline_id,
+        timestamp=datetime.now().isoformat(),
+        type="static_fallback",
+    )
 
 
 def create_error_response(pipeline_id: str, failure: FailureInfo) -> Dict[str, Any]:

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -297,10 +297,10 @@ async def execute_pipeline(
                 if state_logger is not None:
                     state_logger.log(state, PipelineStage.ERROR)
             except Exception:
-                result = create_static_error_response(state.pipeline_id)
+                result = create_static_error_response(state.pipeline_id).to_dict()
                 return (result, state.metrics) if return_metrics else result
             if state.response is None:
-                result = create_static_error_response(state.pipeline_id)
+                result = create_static_error_response(state.pipeline_id).to_dict()
                 return (result, state.metrics) if return_metrics else result
             result = state.response
         elif state.response is None:

--- a/src/plugins/builtin/failure/fallback_error_plugin.py
+++ b/src/plugins/builtin/failure/fallback_error_plugin.py
@@ -14,4 +14,6 @@ class FallbackErrorPlugin(FailurePlugin):
     stages = [PipelineStage.ERROR]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        context.set_response(create_static_error_response(context.pipeline_id))
+        context.set_response(
+            create_static_error_response(context.pipeline_id).to_dict()
+        )

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -64,7 +64,7 @@ def test_error_plugin_runs():
 
 def test_static_error_response():
     pipeline_id = "123"
-    resp = create_static_error_response(pipeline_id)
+    resp = create_static_error_response(pipeline_id).to_dict()
     assert resp["error_id"] == pipeline_id
     assert resp["type"] == "static_fallback"
 

--- a/user_plugins/failure/default_responder.py
+++ b/user_plugins/failure/default_responder.py
@@ -14,6 +14,8 @@ class DefaultResponder(FailurePlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         info = context.get_failure_info()
         if info is None:
-            context.set_response(create_static_error_response(context.pipeline_id))
+            context.set_response(
+                create_static_error_response(context.pipeline_id).to_dict()
+            )
         else:
             context.set_response(create_error_response(context.pipeline_id, info))

--- a/user_plugins/failure/error_formatter.py
+++ b/user_plugins/failure/error_formatter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pipeline.base_plugins import FailurePlugin
 from pipeline.context import PluginContext
+from pipeline.errors import ErrorResponse
 from pipeline.stages import PipelineStage
 
 
@@ -13,7 +14,9 @@ class ErrorFormatter(FailurePlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         info = context.get_failure_info()
         if info is None:
-            context.set_response({"error": "Unknown error"})
+            response = ErrorResponse(error="Unknown error")
+            context.set_response(response.to_dict())
             return
         message = f"{info.plugin_name} failed ({info.error_type}): {info.error_message}"
-        context.set_response({"error": message})
+        response = ErrorResponse(error=message)
+        context.set_response(response.to_dict())


### PR DESCRIPTION
## Summary
- switch static error helpers to return ErrorResponse objects
- update error formatter, fallback responder, and pipeline to pass dicts
- call `.to_dict()` in DefaultResponder for static errors
- adjust tests for new helper return type
- remove duplicated import in Resource interface

## Testing
- `poetry run black . --quiet`
- `poetry run isort . --quiet`
- `poetry run flake8 src tests user_plugins`
- `poetry run mypy src` *(fails: 403 errors)*
- `bandit -r src` *(passes with warnings)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: VersionError: mismatched Protobuf)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: VersionError: mismatched Protobuf)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: 'common_interfaces')*
- `pytest -q` *(fails: VersionError: mismatched Protobuf)*

------
https://chatgpt.com/codex/tasks/task_e_686c3b480a888322a5820b8147392687