### PR TITLE
Introduce ErrorResponse dataclass

### DIFF
--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 import logging
 
-from pipeline.validation import ValidationResult
-
 if TYPE_CHECKING:  # pragma: no cover
     from pipeline.state import LLMResponse
 

--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime
 from typing import Any, Dict
 
 from ..state import FailureInfo
-from .context import PipelineContextError, PluginContextError, StageExecutionError
-from .exceptions import (
-    PipelineError,
-    PluginExecutionError,
-    ResourceError,
-    ToolExecutionError,
-)
+from .context import (PipelineContextError, PluginContextError,
+                      StageExecutionError)
+from .exceptions import (PipelineError, PluginExecutionError, ResourceError,
+                         ToolExecutionError)
+from .models import ErrorResponse
 
 __all__ = [
     "create_static_error_response",
@@ -22,24 +21,24 @@ __all__ = [
     "PipelineContextError",
     "StageExecutionError",
     "PluginContextError",
+    "ErrorResponse",
 ]
 
 # Generic fallback returned when even error handling fails
-STATIC_ERROR_RESPONSE: Dict[str, Any] = {
-    "error": "System error occurred",
-    "message": "An unexpected error prevented processing your request.",
-    "error_id": None,
-    "timestamp": None,
-    "type": "static_fallback",
-}
+STATIC_ERROR_RESPONSE = ErrorResponse(
+    error="System error occurred",
+    message="An unexpected error prevented processing your request.",
+    type="static_fallback",
+)
 
 
-def create_static_error_response(pipeline_id: str) -> Dict[str, Any]:
+def create_static_error_response(pipeline_id: str) -> ErrorResponse:
     """Return a copy of :data:`STATIC_ERROR_RESPONSE` populated with runtime info."""
-    response = STATIC_ERROR_RESPONSE.copy()
-    response["error_id"] = pipeline_id
-    response["timestamp"] = datetime.now().isoformat()
-    return response
+    return replace(
+        STATIC_ERROR_RESPONSE,
+        error_id=pipeline_id,
+        timestamp=datetime.now().isoformat(),
+    )
 
 
 def create_error_response(pipeline_id: str, failure: FailureInfo) -> Dict[str, Any]:

--- a/src/pipeline/errors/models.py
+++ b/src/pipeline/errors/models.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ErrorResponse:
+    """Structure returned when a pipeline error occurs."""
+
+    error: str
+    message: Optional[str] = None
+    error_type: Optional[str] = None
+    stage: Optional[str] = None
+    plugin: Optional[str] = None
+    pipeline_id: Optional[str] = None
+    error_id: Optional[str] = None
+    timestamp: Optional[str] = None
+    type: Optional[str] = None

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,24 +1,13 @@
 import asyncio
 
-from pipeline import (
-    FailurePlugin,
-    PipelineStage,
-    PluginRegistry,
-    PromptPlugin,
-    SystemRegistries,
-    ToolRegistry,
-    execute_pipeline,
-)
-from pipeline.errors import (
-    PipelineError,
-    PluginContextError,
-    PluginExecutionError,
-    ResourceError,
-    StageExecutionError,
-    ToolExecutionError,
-    create_error_response,
-    create_static_error_response,
-)
+from pipeline import (FailurePlugin, PipelineStage, PluginRegistry,
+                      PromptPlugin, SystemRegistries, ToolRegistry,
+                      execute_pipeline)
+from pipeline.errors import (PipelineError, PluginContextError,
+                             PluginExecutionError, ResourceError,
+                             StageExecutionError, ToolExecutionError,
+                             create_error_response,
+                             create_static_error_response)
 from pipeline.resources import ResourceContainer
 from pipeline.state import FailureInfo
 from user_plugins.failure.basic_logger import BasicLogger
@@ -65,8 +54,8 @@ def test_error_plugin_runs():
 def test_static_error_response():
     pipeline_id = "123"
     resp = create_static_error_response(pipeline_id)
-    assert resp["error_id"] == pipeline_id
-    assert resp["type"] == "static_fallback"
+    assert resp.error_id == pipeline_id
+    assert resp.type == "static_fallback"
 
 
 def test_create_error_response():

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -69,7 +69,7 @@ def test_error_stage_execution(caplog):
 def test_static_fallback_on_error_stage_failure():
     registries = make_registries(BadErrorPlugin)
     result = asyncio.run(execute_pipeline("hi", registries))
-    assert result["type"] == "static_fallback"
+    assert result.type == "static_fallback"
 
 
 def test_error_formatter_produces_message():

--- a/tests/test_fallback_error_plugin.py
+++ b/tests/test_fallback_error_plugin.py
@@ -1,13 +1,7 @@
 import asyncio
 
-from pipeline import (
-    PipelineStage,
-    PluginRegistry,
-    PromptPlugin,
-    SystemRegistries,
-    ToolRegistry,
-    execute_pipeline,
-)
+from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
+                      SystemRegistries, ToolRegistry, execute_pipeline)
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 
@@ -29,4 +23,4 @@ def make_registries():
 def test_fallback_error_plugin_sets_response():
     registries = make_registries()
     result = asyncio.run(execute_pipeline("hi", registries))
-    assert result["type"] == "static_fallback"
+    assert result.type == "static_fallback"


### PR DESCRIPTION
## Summary
- add `ErrorResponse` dataclass
- return `ErrorResponse` from `create_static_error_response`
- fix duplicate import in resources module
- adjust tests for `ErrorResponse`

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: "BasePlugin" has no attribute "rollback_config" and more)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686c3b4e69c4832298fbe767b4e1c33f