### PR TITLE
Add standardized ErrorResponse dataclass

### DIFF
--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 import logging
 
-from pipeline.validation import ValidationResult
-
 if TYPE_CHECKING:  # pragma: no cover
     from pipeline.state import LLMResponse
 

--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -11,10 +11,12 @@ from .exceptions import (
     ResourceError,
     ToolExecutionError,
 )
+from .response import ErrorResponse
 
 __all__ = [
     "create_static_error_response",
     "create_error_response",
+    "ErrorResponse",
     "PipelineError",
     "PluginExecutionError",
     "ResourceError",
@@ -34,12 +36,15 @@ STATIC_ERROR_RESPONSE: Dict[str, Any] = {
 }
 
 
-def create_static_error_response(pipeline_id: str) -> Dict[str, Any]:
-    """Return a copy of :data:`STATIC_ERROR_RESPONSE` populated with runtime info."""
-    response = STATIC_ERROR_RESPONSE.copy()
-    response["error_id"] = pipeline_id
-    response["timestamp"] = datetime.now().isoformat()
-    return response
+def create_static_error_response(pipeline_id: str) -> ErrorResponse:
+    """Return a generic :class:`ErrorResponse` populated with runtime info."""
+    return ErrorResponse(
+        error=STATIC_ERROR_RESPONSE["error"],
+        message=STATIC_ERROR_RESPONSE["message"],
+        error_id=pipeline_id,
+        timestamp=datetime.now(),
+        type=STATIC_ERROR_RESPONSE["type"],
+    )
 
 
 def create_error_response(pipeline_id: str, failure: FailureInfo) -> Dict[str, Any]:

--- a/src/pipeline/errors/response.py
+++ b/src/pipeline/errors/response.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict
+
+
+@dataclass(slots=True)
+class ErrorResponse:
+    """Standard structure for pipeline errors."""
+
+    error: str
+    message: str
+    error_id: str | None
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    type: str = "error"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "error": self.error,
+            "message": self.message,
+            "error_id": self.error_id,
+            "timestamp": self.timestamp.isoformat(),
+            "type": self.type,
+        }

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -297,10 +297,10 @@ async def execute_pipeline(
                 if state_logger is not None:
                     state_logger.log(state, PipelineStage.ERROR)
             except Exception:
-                result = create_static_error_response(state.pipeline_id)
+                result = create_static_error_response(state.pipeline_id).to_dict()
                 return (result, state.metrics) if return_metrics else result
             if state.response is None:
-                result = create_static_error_response(state.pipeline_id)
+                result = create_static_error_response(state.pipeline_id).to_dict()
                 return (result, state.metrics) if return_metrics else result
             result = state.response
         elif state.response is None:

--- a/src/pipeline/serialization.py
+++ b/src/pipeline/serialization.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 """Helpers for efficient pipeline state serialization."""
 
+import json
+from dataclasses import asdict, is_dataclass
+from datetime import datetime
+
 import msgpack
 
 from .state import PipelineState
@@ -17,4 +21,29 @@ def loads_state(data: bytes) -> PipelineState:
     return PipelineState.from_dict(msgpack.loads(data, raw=False))
 
 
-__all__ = ["dumps_state", "loads_state"]
+def _json_default(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if is_dataclass(value):
+        return asdict(value)
+    raise TypeError(f"Object of type {type(value)!r} is not JSON serializable")
+
+
+def dumps_json(obj: object) -> str:
+    """Serialize ``obj`` to JSON using dataclass support."""
+    if is_dataclass(obj):
+        obj = asdict(obj)
+    return json.dumps(obj, default=_json_default)
+
+
+def loads_json(data: str) -> object:
+    """Deserialize ``data`` from JSON."""
+    return json.loads(data)
+
+
+__all__ = [
+    "dumps_state",
+    "loads_state",
+    "dumps_json",
+    "loads_json",
+]

--- a/src/plugins/builtin/failure/fallback_error_plugin.py
+++ b/src/plugins/builtin/failure/fallback_error_plugin.py
@@ -14,4 +14,6 @@ class FallbackErrorPlugin(FailurePlugin):
     stages = [PipelineStage.ERROR]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        context.set_response(create_static_error_response(context.pipeline_id))
+        context.set_response(
+            create_static_error_response(context.pipeline_id).to_dict()
+        )

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,7 +1,13 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter
@@ -34,4 +40,5 @@ def test_circuit_breaker_trips():
     asyncio.run(execute_pipeline("hi", registries))
     asyncio.run(execute_pipeline("hi", registries))
     result = asyncio.run(execute_pipeline("hi", registries))
-    assert "circuit breaker" in result["error"].lower()
+    assert "circuit breaker" in result["message"].lower()
+    assert result["type"] == "formatted_error"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -19,6 +19,7 @@ from pipeline.errors import (
     create_error_response,
     create_static_error_response,
 )
+from pipeline.errors.response import ErrorResponse
 from pipeline.resources import ResourceContainer
 from pipeline.state import FailureInfo
 from user_plugins.failure.basic_logger import BasicLogger
@@ -65,8 +66,9 @@ def test_error_plugin_runs():
 def test_static_error_response():
     pipeline_id = "123"
     resp = create_static_error_response(pipeline_id)
-    assert resp["error_id"] == pipeline_id
-    assert resp["type"] == "static_fallback"
+    assert isinstance(resp, ErrorResponse)
+    assert resp.error_id == pipeline_id
+    assert resp.type == "static_fallback"
 
 
 def test_create_error_response():

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -76,4 +76,6 @@ def test_error_formatter_produces_message():
     """Ensure ErrorFormatter creates a user-facing error message."""
     registries = make_registries(ErrorFormatter)
     result = asyncio.run(execute_pipeline("hi", registries))
-    assert result == {"error": "FailPlugin failed (RuntimeError): boom"}
+    assert result["message"] == "FailPlugin failed (RuntimeError): boom"
+    assert result["error"] == "boom"
+    assert result["type"] == "formatted_error"

--- a/tests/test_tool_error_propagation.py
+++ b/tests/test_tool_error_propagation.py
@@ -1,8 +1,14 @@
 import asyncio
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolPlugin, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter
@@ -35,4 +41,6 @@ def make_registries():
 def test_tool_failure_propagates_to_error_stage():
     registries = make_registries()
     result = asyncio.run(execute_pipeline("hi", registries))
-    assert result == {"error": "fail failed (RuntimeError): tool boom"}
+    assert result["message"] == "fail failed (RuntimeError): tool boom"
+    assert result["error"] == "tool boom"
+    assert result["type"] == "formatted_error"

--- a/user_plugins/failure/default_responder.py
+++ b/user_plugins/failure/default_responder.py
@@ -14,6 +14,8 @@ class DefaultResponder(FailurePlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         info = context.get_failure_info()
         if info is None:
-            context.set_response(create_static_error_response(context.pipeline_id))
+            context.set_response(
+                create_static_error_response(context.pipeline_id).to_dict()
+            )
         else:
             context.set_response(create_error_response(context.pipeline_id, info))

--- a/user_plugins/failure/error_formatter.py
+++ b/user_plugins/failure/error_formatter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pipeline.base_plugins import FailurePlugin
 from pipeline.context import PluginContext
+from pipeline.errors.response import ErrorResponse
 from pipeline.stages import PipelineStage
 
 
@@ -13,7 +14,20 @@ class ErrorFormatter(FailurePlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         info = context.get_failure_info()
         if info is None:
-            context.set_response({"error": "Unknown error"})
+            response = ErrorResponse(
+                error="Unknown error",
+                message="Unknown error",
+                error_id=context.pipeline_id,
+                type="formatted_error",
+            )
+            context.set_response(response.to_dict())
             return
+
         message = f"{info.plugin_name} failed ({info.error_type}): {info.error_message}"
-        context.set_response({"error": message})
+        response = ErrorResponse(
+            error=info.error_message,
+            message=message,
+            error_id=context.pipeline_id,
+            type="formatted_error",
+        )
+        context.set_response(response.to_dict())


### PR DESCRIPTION
## Summary
- introduce `ErrorResponse` dataclass for consistent error replies
- update static error helper and failure plugins to use the dataclass
- ensure pipeline falls back to serialized `ErrorResponse` objects
- extend serialization helpers with JSON support
- adjust tests for the new error response structure

## Testing
- `poetry run black src/pipeline/errors/response.py src/pipeline/errors/__init__.py src/plugins/builtin/failure/fallback_error_plugin.py user_plugins/failure/default_responder.py user_plugins/failure/error_formatter.py src/pipeline/pipeline.py src/pipeline/serialization.py tests/test_error_handling.py tests/test_error_stage.py tests/test_tool_error_propagation.py tests/test_circuit_breaker.py src/common_interfaces/resources.py`
- `poetry run isort --profile black src/pipeline/errors/response.py src/pipeline/errors/__init__.py src/plugins/builtin/failure/fallback_error_plugin.py user_plugins/failure/default_responder.py user_plugins/failure/error_formatter.py src/pipeline/pipeline.py src/pipeline/serialization.py tests/test_error_handling.py tests/test_error_stage.py tests/test_tool_error_propagation.py tests/test_circuit_breaker.py src/common_interfaces/resources.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(failed: 405 errors)*
- `bandit -r src` *(command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(failed: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(failed: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(failed: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(failed: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c3b70555083228eb7ca5463aba556