### PR TITLE
Update docs for ErrorResponse usage

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -287,11 +287,23 @@ class BasePlugin:
 ```python
 # When ERROR stage plugins fail
 STATIC_ERROR_RESPONSE = {
-    "error": "System error occurred", 
+    "error": "System error occurred",
     "message": "An unexpected error prevented processing your request.",
     "pipeline_id": pipeline_id,
     "type": "static_fallback"
 }
+```
+
+### ErrorResponse Utility
+```python
+from pipeline.errors.response import ErrorResponse
+
+info = ctx.get_failure_info()
+payload = ErrorResponse(
+    error=info.error_message,
+    message="Unable to complete request",
+).to_dict()
+ctx.set_response(payload)
 ```
 
 ## Developer Experience Features

--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -64,11 +64,18 @@ Base plugins include a simple circuit breaker using `failure_threshold` and `fai
 When a stage fails the pipeline records a `FailureInfo` object and runs plugins assigned to the `ERROR` stage. A failure plugin can inspect the info and set a response:
 
 ```python
+from pipeline.errors.response import ErrorResponse
+
 class ErrorFormatter(FailurePlugin):
     stages = [PipelineStage.ERROR]
     async def _execute_impl(self, ctx: PluginContext) -> None:
         info = ctx.get_failure_info()
-        ctx.set_response({"error": info.error_message})
+        ctx.set_response(
+            ErrorResponse(
+                error=info.error_message,
+                message="Unable to process request",
+            ).to_dict()
+        )
 ```
 
 If failure handling itself fails the framework returns a static response created by `create_static_error_response`:
@@ -99,4 +106,5 @@ class MyPlugin(PromptPlugin):
 plugin = MyPlugin({"retry_attempts": 3, "retry_backoff": 0.5})
 ```
 
-If all retries fail the `DefaultResponder` plugin converts the captured `FailureInfo` into a JSON response using `create_error_response`.
+If all retries fail the `DefaultResponder` plugin converts the captured `FailureInfo`
+into an `ErrorResponse` and returns its `to_dict()` form via `create_error_response`.


### PR DESCRIPTION
## Summary
- show `ErrorResponse` examples using `to_dict()` in the error-handling docs
- document `ErrorResponse` helper in architecture overview

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: `BasePlugin` has no attribute `rollback_config`)*
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: `ModuleNotFoundError: No module named 'aioboto3'`)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: `ModuleNotFoundError: No module named 'aioboto3'`)*
- `python -m src.registry.validator` *(fails: `ModuleNotFoundError: No module named 'common_interfaces'`)*
- `pytest` *(fails: `ModuleNotFoundError: No module named 'aioboto3'`)*

------
https://chatgpt.com/codex/tasks/task_e_686c3a5b53e48322ab4416b40fd5f699