### PR TITLE
Fix retry option names in docs

### DIFF
--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -87,7 +87,7 @@ Use `BasicLogger` and `ErrorFormatter` from `user_plugins.failure` as templates 
 
 ## Error Recovery Strategies
 
-Plugins can retry failures by specifying `retry_attempts` and `retry_backoff` in their configuration. `BasePlugin` applies a `RetryPolicy` so `_execute_impl` is re-run before a failure is reported.
+Plugins can retry failures by specifying `max_retries` and `retry_delay` in their configuration. `BasePlugin` applies a `RetryPolicy` so `_execute_impl` is re-run before a failure is reported.
 
 ```python
 class MyPlugin(PromptPlugin):
@@ -96,7 +96,7 @@ class MyPlugin(PromptPlugin):
     async def _execute_impl(self, ctx: PluginContext) -> None:
         ...
 
-plugin = MyPlugin({"retry_attempts": 3, "retry_backoff": 0.5})
+plugin = MyPlugin({"max_retries": 3, "retry_delay": 0.5})
 ```
 
 If all retries fail the `DefaultResponder` plugin converts the captured `FailureInfo` into a JSON response using `create_error_response`.


### PR DESCRIPTION
## Summary
- update retry option names in the error handling guide

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811 redefinition errors)*
- `poetry run mypy src` *(fails: many errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `pytest` *(fails: ModuleNotFoundError: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_686c425939bc8322bd6c71e134846534