### PR TITLE
Handle missing metrics in pipeline

### DIFF
--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -184,7 +184,8 @@ async def execute_stage(
             finally:
                 reset_request_id(token)
     duration = time.perf_counter() - start
-    state.metrics.record_stage_duration(str(stage), duration)
+    if state.metrics:
+        state.metrics.record_stage_duration(str(stage), duration)
 
     if stage == PipelineStage.ERROR and state.response is None:
         fallback = FallbackErrorPlugin({})
@@ -311,11 +312,12 @@ async def execute_pipeline(
     finally:
         if pipeline_manager is not None:
             await pipeline_manager.deregister(state.pipeline_id)
-        state.metrics.record_pipeline_duration(time.time() - start)
+        if state.metrics:
+            state.metrics.record_pipeline_duration(time.time() - start)
         if state_file and os.path.exists(state_file) and state.failure_info is None:
             os.remove(state_file)
         server = get_metrics_server()
-        if server is not None:
+        if server is not None and state.metrics:
             server.update(state.metrics)
 
 


### PR DESCRIPTION
## Summary
- guard metrics recording if metrics aren't attached to the state

## Testing
- `poetry run black --check src/pipeline/pipeline.py`
- `poetry run isort --check --profile black src/pipeline/pipeline.py`
- `poetry run flake8 src tests` *(fails: F811 redefinition of unused 'ErrorResponse')*
- `poetry run mypy src` *(fails: found 414 errors)*
- `bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: ImportError: cannot import name 'LLM')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c425789508322ad5fe32842a253de