### PR TITLE
Add dataclass support in loads_json

### DIFF
--- a/src/pipeline/serialization.py
+++ b/src/pipeline/serialization.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
+from typing import Type, TypeVar
 
 import msgpack
 
@@ -36,8 +37,28 @@ def dumps_json(obj: object) -> str:
     return json.dumps(obj, default=_json_default)
 
 
-def loads_json(data: str) -> object:
-    """Deserialize ``data`` from JSON."""
+T = TypeVar("T")
+
+
+def loads_json(data: str, cls: Type[T] | None = None) -> T | object:
+    """Deserialize ``data`` from JSON.
+
+    Parameters
+    ----------
+    data:
+        JSON string to deserialize.
+    cls:
+        Optional dataclass type to instantiate from the JSON payload.
+
+    Returns
+    -------
+    T | object
+        Instance of ``cls`` if provided and a dataclass, otherwise a plain
+        ``dict`` or other deserialized object.
+    """
+
+    if cls is not None and is_dataclass(cls):
+        return cls(**json.loads(data))
     return json.loads(data)
 
 


### PR DESCRIPTION
## Summary
- update `loads_json` helper to optionally instantiate dataclasses

## Testing
- `poetry run flake8 src tests` *(fails: F811 redefinition, F821 undefined name)*
- `poetry run mypy src` *(fails: found 415 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c42573f388322b89239b9e6494fb4