### PR TITLE
Fix tool params conversion

### DIFF
--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -431,6 +431,8 @@ class ToolPlugin(BasePlugin):
         delay: float | None = None,
     ):
         validated = self.validate_tool_params(params)
+        if isinstance(validated, BaseModel):
+            validated = validated.model_dump()
         max_retry_count = self.max_retries if max_retries is None else max_retries
         retry_delay_seconds = self.retry_delay if delay is None else delay
         for attempt in range(max_retry_count + 1):

--- a/tests/security/test_secure_tool_wrapper.py
+++ b/tests/security/test_secure_tool_wrapper.py
@@ -13,7 +13,12 @@ class EchoTool(ToolPlugin):
     class Params(BaseModel):
         text: str
 
+    def __init__(self, config=None) -> None:
+        super().__init__(config)
+        self.last_params: dict | None = None
+
     async def execute_function(self, params: dict) -> str:  # type: ignore[override]
+        self.last_params = params
         return params["text"]
 
 
@@ -25,6 +30,8 @@ async def test_secure_wrapper_validates_and_sanitizes():
 
     result = await secure.execute({"text": "hello"})
     assert result == "hello"
+    assert plugin.last_params == {"text": "hello"}
+    assert isinstance(plugin.last_params, dict)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure validated tool params become plain dicts
- verify SecureToolWrapper passes sanitized params correctly

## Testing
- `poetry run black src/pipeline/base_plugins.py tests/security/test_secure_tool_wrapper.py`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811, F821)*
- `poetry run mypy src` *(fails: found 414 errors)*
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: 60 failed, 135 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c42544fa483228b68fb621c2df821