### PR TITLE
Centralize ErrorResponse dataclass

### DIFF
--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -1,33 +1,22 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any, Dict
 
 from ..state import FailureInfo
-from .context import (PipelineContextError, PluginContextError,
-                      StageExecutionError)
-from .exceptions import (PipelineError, PluginExecutionError, ResourceError,
-                         ToolExecutionError)
+from .context import PipelineContextError, PluginContextError, StageExecutionError
+from .exceptions import (
+    PipelineError,
+    PluginExecutionError,
+    ResourceError,
+    ToolExecutionError,
+)
 from .models import ErrorResponse
-
-
-@dataclass(slots=True)
-class ErrorResponse:
-    """Simple wrapper for error payloads."""
-
-    data: Dict[str, Any]
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Return a copy of the payload as a plain dictionary."""
-        return self.data.copy()
-
 
 __all__ = [
     "ErrorResponse",
     "create_static_error_response",
     "create_error_response",
-    "ErrorResponse",
     "PipelineError",
     "PluginExecutionError",
     "ResourceError",
@@ -35,28 +24,7 @@ __all__ = [
     "PipelineContextError",
     "StageExecutionError",
     "PluginContextError",
-    "ErrorResponse",
 ]
-
-
-@dataclass(slots=True)
-class ErrorResponse:
-    """Structured error information returned to the caller."""
-
-    error: str
-    message: str | None = None
-    error_id: str | None = None
-    timestamp: str | None = None
-    error_type: str | None = None
-    stage: str | None = None
-    plugin: str | None = None
-    pipeline_id: str | None = None
-    type: str = "error"
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Return a plain ``dict`` representation."""
-        return {k: v for k, v in asdict(self).items() if v is not None}
-
 
 # Generic fallback returned when even error handling fails
 STATIC_ERROR_RESPONSE: Dict[str, Any] = {
@@ -66,24 +34,6 @@ STATIC_ERROR_RESPONSE: Dict[str, Any] = {
     "timestamp": None,
     "type": "static_fallback",
 }
-
-
-@dataclass(slots=True)
-class ErrorResponse:
-    """Standard error response structure."""
-
-    error: str
-    message: str | None = None
-    error_type: str | None = None
-    stage: str | None = None
-    plugin: str | None = None
-    pipeline_id: str | None = None
-    error_id: str | None = None
-    timestamp: str | None = field(default_factory=lambda: datetime.now().isoformat())
-    type: str = "plugin_error"
-
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
 
 
 def create_static_error_response(pipeline_id: str) -> ErrorResponse:

--- a/src/pipeline/errors/response.py
+++ b/src/pipeline/errors/response.py
@@ -1,25 +1,5 @@
-from __future__ import annotations
+"""Compatibility wrapper for :mod:`pipeline.errors.models`."""
 
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Any, Dict
+from .models import ErrorResponse
 
-
-@dataclass(slots=True)
-class ErrorResponse:
-    """Standard structure for pipeline errors."""
-
-    error: str
-    message: str
-    error_id: str | None
-    timestamp: datetime = field(default_factory=datetime.utcnow)
-    type: str = "error"
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "error": self.error,
-            "message": self.message,
-            "error_id": self.error_id,
-            "timestamp": self.timestamp.isoformat(),
-            "type": self.type,
-        }
+__all__ = ["ErrorResponse"]

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -8,6 +8,7 @@ from pipeline import (
     ToolRegistry,
     execute_pipeline,
 )
+from pipeline.errors import ErrorResponse
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter

--- a/tests/test_tool_error_propagation.py
+++ b/tests/test_tool_error_propagation.py
@@ -9,6 +9,7 @@ from pipeline import (
     ToolRegistry,
     execute_pipeline,
 )
+from pipeline.errors import ErrorResponse
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter


### PR DESCRIPTION
## Summary
- centralize `ErrorResponse` in `errors.models`
- simplify `errors.__init__` and export helpers
- keep `errors.response` as compatibility wrapper
- fix tests to import `ErrorResponse`

## Testing
- `poetry run black src/pipeline/errors/__init__.py src/pipeline/errors/response.py tests/test_circuit_breaker.py tests/test_tool_error_propagation.py`
- `poetry run isort src tests` *(reverted unrelated changes)*
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: BasePlugin missing attributes)*
- `bandit -r src` *(command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(failed: ModuleNotFoundError: 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(failed: ModuleNotFoundError: 'yaml')*
- `python -m src.registry.validator` *(failed: ModuleNotFoundError: 'common_interfaces')*
- `pytest` *(failed: ModuleNotFoundError: 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c41c6a41c8322a14793593f33f517