### PR TITLE
Update retry options

### DIFF
--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -49,7 +49,8 @@ breaker = CircuitBreaker(failure_threshold=3, recovery_timeout=30)
 await breaker.call(do_work)
 ```
 
-Tool plugins can define `max_retries` and `retry_delay` attributes:
+Tool plugins can define `max_retries` and `retry_delay` attributes (formerly
+called `retry_attempts` and `retry_backoff`):
 
 ```python
 class MyTool(ToolPlugin):

--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -135,7 +135,10 @@ class BasePlugin(BasePluginInterface):
             )
             return await policy.execute(self._execute_impl, context)
 
-        policy = RetryPolicy(attempts=self.retry_attempts, backoff=self.retry_backoff)
+        policy = RetryPolicy(
+            attempts=self.max_retries + 1,
+            backoff=self.retry_delay,
+        )
 
         async def run_with_retry() -> Any:
             return await policy.execute(run)

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,13 +1,8 @@
 import asyncio
 
-from pipeline import (
-    PipelineStage,
-    PluginRegistry,
-    PromptPlugin,
-    SystemRegistries,
-    ToolRegistry,
-    execute_pipeline,
-)
+from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
+                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline.errors import ErrorResponse
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter

--- a/tests/test_tool_error_propagation.py
+++ b/tests/test_tool_error_propagation.py
@@ -1,14 +1,9 @@
 import asyncio
 
-from pipeline import (
-    PipelineStage,
-    PluginRegistry,
-    PromptPlugin,
-    SystemRegistries,
-    ToolPlugin,
-    ToolRegistry,
-    execute_pipeline,
-)
+from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
+                      SystemRegistries, ToolPlugin, ToolRegistry,
+                      execute_pipeline)
+from pipeline.errors import ErrorResponse
 from pipeline.resources import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 from user_plugins.failure.error_formatter import ErrorFormatter


### PR DESCRIPTION
## Summary
- use max_retries and retry_delay consistently
- update docs with the new option names
- fix imports in tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Library stubs not installed)*
- `bandit -r src` *(command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: VersionError: mismatched Protobuf)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: VersionError: mismatched Protobuf)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `pytest` *(fails: VersionError: mismatched Protobuf)*

------
https://chatgpt.com/codex/tasks/task_e_686c4251670c8322b20b31a418185752