### PR TITLE
Integrate ConversationManager into memory resource

### DIFF
--- a/examples/servers/http_server.py
+++ b/examples/servers/http_server.py
@@ -14,17 +14,18 @@ enable_plugins_namespace()
 import asyncio
 from typing import Any
 
-from plugins.builtin.adapters.http import HTTPAdapter, MessageRequest
-
-from pipeline import ConversationManager, PipelineManager
+from pipeline import PipelineManager
 from pipeline.initializer import SystemInitializer
+from pipeline.resources.memory_resource import MemoryResource
+from plugins.builtin.adapters.http import HTTPAdapter, MessageRequest
 
 
 async def main() -> None:
     initializer = SystemInitializer.from_yaml("config/dev.yaml")
     registries = await initializer.initialize()
     pipeline_manager = PipelineManager(registries)
-    conversation_manager = ConversationManager(registries, pipeline_manager)
+    memory: MemoryResource = registries.resources.get("memory")  # type: ignore[arg-type]
+    conversation_manager = memory.get_conversation_manager(registries, pipeline_manager)
     adapter = HTTPAdapter(pipeline_manager, {"host": "127.0.0.1", "port": 8000})
 
     @adapter.app.post("/conversation")

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -20,7 +20,6 @@ from .base_plugins import (
 from .builder import AgentBuilder
 from .config_update import ConfigUpdateResult, update_plugin_configuration
 from .context import ConversationEntry, PluginContext, ToolCall
-from .conversation_manager import ConversationManager
 from .decorators import plugin
 from .errors import create_static_error_response
 from .initializer import (
@@ -83,7 +82,6 @@ __all__ = [
     "AgentBuilder",
     "AgentRuntime",
     "PipelineManager",
-    "ConversationManager",
     "execute_with_observability",
 ]
 
@@ -122,7 +120,6 @@ def __getattr__(name: str) -> Any:
         "AgentBuilder": "pipeline.builder",
         "AgentRuntime": "pipeline.runtime",
         "PipelineManager": "pipeline.manager",
-        "ConversationManager": "pipeline.conversation_manager",
         "execute_pipeline": "pipeline.pipeline",
         "create_default_response": "pipeline.pipeline",
         "create_static_error_response": "pipeline.errors",

--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict
+from typing import Any, Dict
 
 from ..state import FailureInfo
 from .context import PipelineContextError, PluginContextError, StageExecutionError

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1,9 +1,15 @@
 import asyncio
 
-from pipeline import (ConversationManager, PipelineManager, PipelineStage,
-                      PluginRegistry, PromptPlugin, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
+from pipeline.resources.memory_resource import SimpleMemoryResource
 
 
 class ContinuePlugin(PromptPlugin):
@@ -26,9 +32,12 @@ def make_manager():
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DO))
     asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
-    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
+    resources = ResourceContainer()
+    asyncio.run(resources.add("memory", SimpleMemoryResource()))
+    registries = SystemRegistries(resources, ToolRegistry(), plugins)
     manager = PipelineManager(registries)
-    conv = ConversationManager(registries, manager)
+    memory = resources.get("memory")
+    conv = memory.get_conversation_manager(registries, manager)  # type: ignore[arg-type]
     return conv, manager
 
 

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -1,7 +1,15 @@
+import asyncio
+
 from fastapi.testclient import TestClient
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from plugins.builtin.adapters import WebSocketAdapter
 


### PR DESCRIPTION
## Summary
- route ConversationManager requests through Memory resource
- drop ConversationManager export from pipeline init
- adjust tests and HTTP server example
- fix minor lint issues

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing stubs)*
- `bandit -r src`
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_686c4ab395588322927255bef14aeaae