### PR TITLE
Default pipeline stages for plugin subclasses

### DIFF
--- a/src/pipeline/base_plugins.py
+++ b/src/pipeline/base_plugins.py
@@ -66,8 +66,14 @@ class BasePlugin(BasePluginInterface):
         if cls.__module__ in {__name__, "pipeline.base_plugins.base"}:
             return
 
-        if "ToolPlugin" in [base.__name__ for base in cls.__mro__]:
-            return
+        mro_names = {base.__name__ for base in cls.__mro__}
+
+        if "ToolPlugin" in mro_names and "stages" not in cls.__dict__:
+            cls.stages = [PipelineStage.DO]
+        elif "PromptPlugin" in mro_names and "stages" not in cls.__dict__:
+            cls.stages = [PipelineStage.THINK]
+        elif "AdapterPlugin" in mro_names and "stages" not in cls.__dict__:
+            cls.stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
 
         stages = getattr(cls, "stages", None)
         if stages is None:

--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict
+from typing import Any, Dict
 
 from ..state import FailureInfo
-from .context import PipelineContextError, PluginContextError, StageExecutionError
-from .exceptions import (
-    PipelineError,
-    PluginExecutionError,
-    ResourceError,
-    ToolExecutionError,
-)
+from .context import (PipelineContextError, PluginContextError,
+                      StageExecutionError)
+from .exceptions import (PipelineError, PluginExecutionError, ResourceError,
+                         ToolExecutionError)
 from .models import ErrorResponse
 
 __all__ = [

--- a/src/plugins/builtin/adapters/http.py
+++ b/src/plugins/builtin/adapters/http.py
@@ -26,7 +26,6 @@ from pipeline.metrics import MetricsCollector
 from pipeline.observability import get_metrics_server, start_metrics_server
 from pipeline.pipeline import execute_pipeline
 from pipeline.security import AdapterAuthenticator
-from pipeline.stages import PipelineStage
 from registry import SystemRegistries
 
 
@@ -100,8 +99,6 @@ class MessageRequest(BaseModel):
 
 class HTTPAdapter(AdapterPlugin):
     """FastAPI based HTTP adapter for request/response handling."""
-
-    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
 
     def __init__(
         self,

--- a/src/plugins/builtin/prompts/complex_prompt.py
+++ b/src/plugins/builtin/prompts/complex_prompt.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
 from pipeline.base_plugins import PromptPlugin
-from pipeline.stages import PipelineStage
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from pipeline.context import ConversationEntry, PluginContext
@@ -21,7 +20,6 @@ class ComplexPrompt(PromptPlugin):
     """
 
     dependencies = ["llm", "memory"]
-    stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         """Compose a context-aware reply.

--- a/src/plugins/builtin/prompts/memory_retrieval.py
+++ b/src/plugins/builtin/prompts/memory_retrieval.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
 from pipeline.base_plugins import PromptPlugin
-from pipeline.stages import PipelineStage
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from pipeline.context import ConversationEntry, PluginContext
@@ -17,7 +16,6 @@ class MemoryRetrievalPrompt(PromptPlugin):
     """Fetch past conversation from memory and append it to the context."""
 
     dependencies = ["memory", "llm"]
-    stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         memory: MemoryResource = context.get_resource("memory")

--- a/tests/test_default_stages.py
+++ b/tests/test_default_stages.py
@@ -1,0 +1,29 @@
+from pipeline.base_plugins import AdapterPlugin, PromptPlugin, ToolPlugin
+from pipeline.stages import PipelineStage
+
+
+class MyTool(ToolPlugin):
+    async def execute_function(self, params):
+        return params
+
+
+class MyPrompt(PromptPlugin):
+    async def _execute_impl(self, context):
+        pass
+
+
+class MyAdapter(AdapterPlugin):
+    async def _execute_impl(self, context):
+        pass
+
+
+def test_tool_plugin_default_stage():
+    assert MyTool.stages == [PipelineStage.DO]
+
+
+def test_prompt_plugin_default_stage():
+    assert MyPrompt.stages == [PipelineStage.THINK]
+
+
+def test_adapter_plugin_default_stage():
+    assert MyAdapter.stages == [PipelineStage.PARSE, PipelineStage.DELIVER]

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi.testclient import TestClient
 
 from pipeline import (PipelineManager, PipelineStage, PluginRegistry,


### PR DESCRIPTION
## Summary
- set default `stages` in `BasePlugin.__init_subclass__`
- drop redundant stage assignments from built-in plugins
- adjust HTTP adapter imports
- update websocket adapter test imports
- add regression tests for default stage assignment

## Testing
- `poetry run black src/pipeline/base_plugins.py src/pipeline/errors/__init__.py src/plugins/builtin/adapters/http.py src/plugins/builtin/prompts/complex_prompt.py src/plugins/builtin/prompts/memory_retrieval.py tests/test_websocket_adapter.py tests/test_default_stages.py`
- `poetry run isort src/pipeline/base_plugins.py src/pipeline/errors/__init__.py src/plugins/builtin/adapters/http.py src/plugins/builtin/prompts/complex_prompt.py src/plugins/builtin/prompts/memory_retrieval.py tests/test_websocket_adapter.py tests/test_default_stages.py`
- `poetry run flake8 src/pipeline/base_plugins.py src/pipeline/errors/__init__.py src/plugins/builtin/adapters/http.py src/plugins/builtin/prompts/complex_prompt.py src/plugins/builtin/prompts/memory_retrieval.py tests/test_websocket_adapter.py tests/test_default_stages.py`
- `poetry run mypy src/pipeline/base_plugins.py src/pipeline/errors/__init__.py src/plugins/builtin/adapters/http.py src/plugins/builtin/prompts/complex_prompt.py src/plugins/builtin/prompts/memory_retrieval.py` *(fails: Function is missing a type annotation, etc.)*
- `bandit -r src/pipeline/base_plugins.py src/pipeline/errors/__init__.py src/plugins/builtin/adapters/http.py src/plugins/builtin/prompts/complex_prompt.py src/plugins/builtin/prompts/memory_retrieval.py` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest tests/test_default_stages.py -q` *(fails: ModuleNotFoundError: No module named 'aioboto3')*

------
https://chatgpt.com/codex/tasks/task_e_686c4ac86fe08322bd5fcb794c6948ec