### PR TITLE
Add analyze-plugin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ poetry run python src/cli.py reload-config updated.yaml
 
 See [the architecture overview](architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure) for details on dynamic reconfiguration.
 
+## Plugin Utilities
+Generate or analyze plugins using ``plugin_tool.py``:
+
+```bash
+poetry run python src/cli/plugin_tool.py generate my_plugin --type prompt
+poetry run python src/cli/plugin_tool.py analyze-plugin user_plugins/my_plugin.py
+```
+
+The analyze command loads async functions from the file and reports which pipeline
+stage the ``PluginAutoClassifier`` would assign.
+
 ### Using the "llm" Resource Key
 Define your LLM once and share it across plugins:
 

--- a/architecture/architecture_models.md
+++ b/architecture/architecture_models.md
@@ -89,8 +89,8 @@ class ComplexPlugin(ToolPlugin):
 ```
 
 **2. Interactive Stage Discovery**:
-- CLI command: `poetry run python src/cli.py analyze-plugin my_plugin.py`
-- Framework analyzes plugin behavior and asks: "This plugin calls external APIs. Should it run in THINK (planning) or DO (execution)?"
+- CLI command: `poetry run python src/cli/plugin_tool.py analyze-plugin my_plugin.py`
+- The tool inspects async functions and suggests stages based on `PluginAutoClassifier` heuristics.
 - Provides stage recommendations with clear reasoning
 
 **3. Clear Stage Mental Model**:

--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict
+from typing import Any, Dict
 
 from ..state import FailureInfo
 from .context import PipelineContextError, PluginContextError, StageExecutionError

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -1,7 +1,14 @@
+import asyncio
 from fastapi.testclient import TestClient
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from plugins.builtin.adapters import WebSocketAdapter
 

--- a/tests/tools/test_plugin_tool_analyze.py
+++ b/tests/tools/test_plugin_tool_analyze.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+
+
+def test_analyze_plugin(tmp_path):
+    path = tmp_path / "my_plugin.py"
+    path.write_text(
+        """async def my_plugin(ctx):\n    # analyze input\n    await ctx.ask_llm('hi')\n"""
+    )
+    result = subprocess.run(
+        [sys.executable, "src/cli/plugin_tool.py", "analyze-plugin", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "my_plugin -> think" in result.stdout.lower()
+
+
+def test_analyze_plugin_failure(tmp_path):
+    path = tmp_path / "bad.py"
+    path.write_text("def no_plugin():\n    pass\n")
+    result = subprocess.run(
+        [sys.executable, "src/cli/plugin_tool.py", "analyze-plugin", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- extend PluginToolCLI with `analyze-plugin` subcommand
- infer plugin stages using `PluginAutoClassifier`
- document the new command in README and architecture docs
- cover command via unit tests and fix missing imports

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Too many arguments for "BasePlugin" and other errors)*
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator`
- `poetry run pytest -q` *(failed: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_686c4ab8d8b88322ac1b2e845d2c9771