### PR TITLE
Replace deprecated execute_tool usages

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -186,7 +186,7 @@ async def _execute_impl(self, context):
 - Natural async/await patterns
 - No queuing complexity
 
-**Note**: `context.execute_tool()` is deprecated in favor of `context.use_tool()` for consistency.
+**Tip**: Use `context.use_tool()` to run tools directly.
 
 ## State Management
 

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -323,6 +323,15 @@ class PluginContext:
                 result = f"Error: {exc}"
                 self.set_stage_result(call.result_key, result)
                 self.record_tool_error(call.name, str(exc))
+                self.add_failure(
+                    FailureInfo(
+                        stage=str(state.current_stage),
+                        plugin_name=call.name,
+                        error_type=exc.__class__.__name__,
+                        error_message=str(exc),
+                        original_exception=exc,
+                    )
+                )
             state.pending_tool_calls.remove(call)
         result = self.get_stage_result(result_key)
         state.stage_results.pop(result_key, None)

--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict
+from typing import Any, Dict
 
 from ..state import FailureInfo
 from .context import PipelineContextError, PluginContextError, StageExecutionError

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -1,9 +1,15 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from user_plugins.prompts.chain_of_thought import ChainOfThoughtPrompt
 
@@ -66,7 +72,4 @@ def test_chain_of_thought_records_steps_and_tool_call():
         "We need to calculate result",
         "Final answer is 42",
     ]
-    assert len(state.pending_tool_calls) == 1
-    call = state.pending_tool_calls[0]
-    assert call.name == "analysis_tool"
-    assert call.params["data"] == "How does this work?"
+    assert len(state.pending_tool_calls) == 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,8 +1,15 @@
 import asyncio
 
-from pipeline import (LLMResponse, PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolPlugin, ToolRegistry,
-                      execute_pipeline)
+from pipeline import (
+    LLMResponse,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolPlugin,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.resources import ResourceContainer
 
 
@@ -22,7 +29,7 @@ class MetricsPlugin(PromptPlugin):
     stages = [PipelineStage.DO]
 
     async def _execute_impl(self, context):
-        context.execute_tool("echo", {"text": "hello"})
+        await context.use_tool("echo", text="hello")
         await self.call_llm(context, "hi", "test")
         context.set_response("ok")
 

--- a/tests/test_react_prompt.py
+++ b/tests/test_react_prompt.py
@@ -1,9 +1,15 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from user_plugins.prompts.react_prompt import ReActPrompt
 from user_plugins.tools.calculator_tool import CalculatorTool
@@ -56,9 +62,6 @@ def test_react_prompt_multiple_steps_and_tool_call():
     asyncio.run(plugin.execute(ctx))
 
     assert state.response == "4"
-    assert len(state.pending_tool_calls) == 1
-    call = state.pending_tool_calls[0]
-    assert call.name == "calculator_tool"
-    assert call.params["expression"] == "2+2"
+    assert len(state.pending_tool_calls) == 0
     assistant_entries = [e for e in state.conversation if e.role == "assistant"]
     assert len(assistant_entries) == 3

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -1,11 +1,16 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
-from pipeline.tools.execution import execute_pending_tools
 from user_plugins.tools.search_tool import SearchTool
 
 
@@ -21,9 +26,7 @@ async def run_search() -> str:
     await tools.add("search", SearchTool())
     registries = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
     ctx = PluginContext(state, registries)
-    key = ctx.execute_tool("search", {"query": "open source"})
-    result = (await execute_pending_tools(state, registries))[key]
-    return result
+    return await ctx.use_tool("search", query="open source")
 
 
 def test_search_tool_returns_result():

--- a/tests/test_tool_error_propagation.py
+++ b/tests/test_tool_error_propagation.py
@@ -24,7 +24,7 @@ class CallToolPlugin(PromptPlugin):
     stages = [PipelineStage.DO]
 
     async def _execute_impl(self, context):
-        context.execute_tool("fail", {})
+        await context.use_tool("fail")
 
 
 def make_registries():
@@ -36,7 +36,7 @@ def make_registries():
     )
 
     tools = ToolRegistry()
-    tools.add("fail", FailingTool({"max_retries": 0}))
+    asyncio.run(tools.add("fail", FailingTool({"max_retries": 0})))
 
     return SystemRegistries(ResourceContainer(), tools, plugins)
 

--- a/tests/test_weather_api_tool.py
+++ b/tests/test_weather_api_tool.py
@@ -3,11 +3,16 @@ from datetime import datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
-from pipeline.tools.execution import execute_pending_tools
 from user_plugins.tools.weather_api_tool import WeatherApiTool
 
 
@@ -41,8 +46,7 @@ async def run_weather() -> dict:
     registries = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
     ctx = PluginContext(state, registries)
     try:
-        key = ctx.execute_tool("weather", {"location": "Berlin"})
-        result = (await execute_pending_tools(state, registries))[key]
+        result = await ctx.use_tool("weather", location="Berlin")
     finally:
         server.shutdown()
         thread.join()

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -1,7 +1,15 @@
+import asyncio
+
 from fastapi.testclient import TestClient
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from plugins.builtin.adapters import WebSocketAdapter
 

--- a/user_plugins/prompts/chain_of_thought.py
+++ b/user_plugins/prompts/chain_of_thought.py
@@ -48,9 +48,10 @@ class ChainOfThoughtPrompt(PromptPlugin):
             )
 
             if self._needs_tools(reasoning.content):
-                context.execute_tool(
+                await context.use_tool(
                     "analysis_tool",
-                    {"data": conversation_text, "reasoning_step": reasoning.content},
+                    data=conversation_text,
+                    reasoning_step=reasoning.content,
                 )
 
             if "final answer" in reasoning.content.lower():

--- a/user_plugins/prompts/react_prompt.py
+++ b/user_plugins/prompts/react_prompt.py
@@ -71,7 +71,7 @@ class ReActPrompt(PromptPlugin):
                     metadata={"react_step": step, "type": "action"},
                 )
 
-                context.execute_tool(action_name, params)
+                await context.use_tool(action_name, **params)
 
         context.set_response(
             "I've reached my reasoning limit without finding a definitive answer."


### PR DESCRIPTION
## Summary
- update tests and examples to use `context.use_tool`
- propagate tool failures in plugin context
- document `use_tool` in architecture guide

## Testing
- `poetry run mypy src/pipeline/context.py src/pipeline/errors/__init__.py`
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `PYTHONPATH=src poetry run python -m src.registry.validator` *(fails: cannot import name 'LLM')*
- `poetry run pytest tests/test_metrics.py tests/test_search_tool.py tests/test_weather_api_tool.py tests/test_tool_error_propagation.py tests/test_chain_of_thought_prompt.py tests/test_react_prompt.py tests/test_websocket_adapter.py -q`
- `poetry run pytest` *(fails: 12 failed, 183 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c4ac140f883228724fe70de1b4fa3