### PR TITLE
Refactor RedisCache reuse

### DIFF
--- a/user_plugins/resources/cache_backends/redis.py
+++ b/user_plugins/resources/cache_backends/redis.py
@@ -1,31 +1,11 @@
-from __future__ import annotations
+"""Compatibility wrapper for the Redis cache backend.
 
-from typing import Any
+This module re-exports :class:`RedisCache` from the community plugins so
+user configuration can continue referencing
+``user_plugins.resources.cache_backends.redis:RedisCache`` without
+duplicating its implementation.
+"""
 
-import redis.asyncio as redis
+from plugins.contrib.resources.cache_backends.redis import RedisCache
 
-from pipeline.cache.base import CacheBackend
-
-
-class RedisCache(CacheBackend):
-    """Redis-based cache backend."""
-
-    def __init__(
-        self, url: str = "redis://localhost:6379/0", default_ttl: int | None = None
-    ) -> None:
-        self._client = redis.from_url(url)
-        self._default_ttl = default_ttl
-
-    async def get(self, key: str) -> Any:
-        value = await self._client.get(key)
-        return value.decode() if isinstance(value, bytes) else value
-
-    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
-        ttl = ttl if ttl is not None else self._default_ttl
-        await self._client.set(key, value, ex=ttl)
-
-    async def delete(self, key: str) -> None:
-        await self._client.delete(key)
-
-    async def clear(self) -> None:
-        await self._client.flushdb()
+__all__ = ["RedisCache"]


### PR DESCRIPTION
## Summary
- share RedisCache implementation under community plugins
- re-export RedisCache from user plugin module

## Testing
- `poetry run black user_plugins/resources/cache_backends/redis.py`
- `poetry run isort user_plugins/resources/cache_backends/redis.py`
- `poetry run flake8 user_plugins/resources/cache_backends/redis.py`
- `poetry run mypy user_plugins/resources/cache_backends/redis.py`
- `bandit -r user_plugins/resources/cache_backends/redis.py` *(fails: command not found)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `PYTHONPATH=src poetry run python -m src.registry.validator` *(fails: ImportError)*
- `poetry run pytest` *(fails: 15 failed, 180 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c4bb2de288322afdb53e1f8a8baf1