### PR TITLE
Refactor EchoProvider path

### DIFF
--- a/src/pipeline/errors/__init__.py
+++ b/src/pipeline/errors/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict
+from typing import Any, Dict
 
 from ..state import FailureInfo
 from .context import PipelineContextError, PluginContextError, StageExecutionError

--- a/src/plugins/llm/providers/__init__.py
+++ b/src/plugins/llm/providers/__init__.py
@@ -1,17 +1,6 @@
 """LLM provider implementations."""
 
-from .bedrock import BedrockProvider
-from .claude import ClaudeProvider
-from .echo import EchoProvider
-from .gemini import GeminiProvider
-from .ollama import OllamaProvider
-from .openai import OpenAIProvider
+from plugins.builtin.resources.llm.providers import *  # noqa: F401,F403
+from plugins.builtin.resources.llm.providers import __all__ as _ALL
 
-__all__ = [
-    "OpenAIProvider",
-    "OllamaProvider",
-    "GeminiProvider",
-    "ClaudeProvider",
-    "EchoProvider",
-    "BedrockProvider",
-]
+__all__ = list(_ALL)

--- a/src/plugins/llm/providers/echo.py
+++ b/src/plugins/llm/providers/echo.py
@@ -1,30 +1,5 @@
-from __future__ import annotations
+"""Echo provider module re-export."""
 
-"""Adapter that echoes the prompt back."""
-from typing import Any, AsyncIterator, Dict, List
+from plugins.builtin.resources.llm.providers.echo import EchoProvider
 
-from pipeline.state import LLMResponse
-from pipeline.validation import ValidationResult
-
-from .base import BaseProvider
-
-
-class EchoProvider(BaseProvider):
-    """Adapter that simply echoes the prompt."""
-
-    name = "echo"
-
-    @classmethod
-    def validate_config(cls, config: Dict) -> ValidationResult:
-        """Echo provider requires no specific configuration."""
-        return ValidationResult.success_result()
-
-    async def generate(
-        self, prompt: str, functions: List[Dict[str, Any]] | None = None
-    ) -> LLMResponse:  # noqa: D401 - simple echo
-        return LLMResponse(content=prompt)
-
-    async def stream(
-        self, prompt: str, functions: List[Dict[str, Any]] | None = None
-    ) -> AsyncIterator[str]:
-        yield prompt
+__all__ = ["EchoProvider"]

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -1,7 +1,15 @@
+import asyncio
+
 from fastapi.testclient import TestClient
 
-from pipeline import (PipelineManager, PipelineStage, PluginRegistry,
-                      PromptPlugin, SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineManager,
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from plugins.builtin.adapters import WebSocketAdapter
 


### PR DESCRIPTION
## Summary
- centralize EchoProvider under builtin resources
- re-export provider for backwards compatibility
- fix missing Any import in error utilities
- update websocket adapter tests

## Testing
- `poetry run isort src/plugins/llm/providers/echo.py src/plugins/llm/providers/__init__.py src/pipeline/errors/__init__.py tests/test_websocket_adapter.py`
- `poetry run black src/plugins/llm/providers/echo.py src/plugins/llm/providers/__init__.py src/pipeline/errors/__init__.py tests/test_websocket_adapter.py`
- `poetry run flake8 src/plugins/llm/providers/echo.py src/plugins/llm/providers/__init__.py src/pipeline/errors/__init__.py tests/test_websocket_adapter.py`
- `poetry run mypy`
- `bandit -r src/plugins/llm/providers/echo.py src/plugins/llm/providers/__init__.py src/pipeline/errors/__init__.py tests/test_websocket_adapter.py`
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration valid)*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: Configuration valid)*
- `PYTHONPATH=src python -m src.registry.validator` *(failed: ImportError)*
- `pytest` *(failed: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_686c4bb42c648322b76a7ac9027b31d5