### PR TITLE
Centralize BaseResource

### DIFF
--- a/experiments/unified_registry/resource_manager.py
+++ b/experiments/unified_registry/resource_manager.py
@@ -5,6 +5,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Dict
 
+from plugins.resources.base import BaseResource
+
 
 @dataclass
 class ManagerMetrics:
@@ -15,19 +17,6 @@ class ManagerMetrics:
     health_checks: int = 0
     health_failures: int = 0
     init_durations: Dict[str, float] = field(default_factory=dict)
-
-
-class BaseResource:
-    """Base class for managed resources."""
-
-    async def initialize(self) -> None:  # pragma: no cover - optional
-        pass
-
-    async def shutdown(self) -> None:  # pragma: no cover - optional
-        pass
-
-    async def health_check(self) -> bool:  # pragma: no cover - optional
-        return True
 
 
 class AsyncResourceManager:
@@ -70,3 +59,6 @@ class AsyncResourceManager:
             self.metrics.health_checks += 1
             report[name] = healthy
         return report
+
+
+__all__ = ["AsyncResourceManager", "BaseResource", "ManagerMetrics"]

--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Protocol, runtime_checkable
+from typing import (TYPE_CHECKING, Any, AsyncIterator, Dict, Protocol,
+                    runtime_checkable)
 
 from pipeline.validation import ValidationResult
-
-if TYPE_CHECKING:  # pragma: no cover
-    from registry import ClassRegistry
-
-import logging
+from plugins.resources.base import BaseResource
 
 if TYPE_CHECKING:  # pragma: no cover
     from pipeline.state import LLMResponse
@@ -23,32 +20,6 @@ class Resource(Protocol):
     async def health_check(self) -> bool: ...
 
     def get_metrics(self) -> dict[str, Any]: ...
-
-
-class BaseResource:
-    def __init__(self, config: Dict | None = None) -> None:
-        self.config = config or {}
-        self.logger = logging.getLogger(self.__class__.__name__)
-
-    async def initialize(self) -> None:
-        return None
-
-    async def shutdown(self) -> None:
-        return None
-
-    async def health_check(self) -> bool:
-        return True
-
-    def get_metrics(self) -> dict[str, Any]:
-        return {"status": "healthy"}
-
-    @classmethod
-    def validate_config(cls, config: Dict) -> ValidationResult:
-        return ValidationResult.success_result()
-
-    @classmethod
-    def validate_dependencies(cls, registry: "ClassRegistry") -> ValidationResult:
-        return ValidationResult.success_result()
 
 
 class LLM(ABC):

--- a/src/plugins/resources/base.py
+++ b/src/plugins/resources/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Base class for HTTP LLM providers."""
+"""Common base implementation for asynchronous resources."""
 from typing import TYPE_CHECKING, Any, Dict, Protocol, runtime_checkable
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -63,3 +63,6 @@ class BaseResource:
     @classmethod
     def validate_dependencies(cls, registry: "ClassRegistry") -> ValidationResult:
         return ValidationResult.success_result()
+
+
+__all__ = ["Resource", "BaseResource"]


### PR DESCRIPTION
## Summary
- consolidate base resource implementation under `plugins.resources`
- remove duplicate implementation from common interfaces
- reuse shared class in experiment registry

## Testing
- `poetry run black src/plugins/resources/base.py src/common_interfaces/resources.py experiments/unified_registry/resource_manager.py`
- `poetry run isort src/plugins/resources/base.py src/common_interfaces/resources.py experiments/unified_registry/resource_manager.py`
- `poetry run flake8 src/plugins/resources/base.py src/common_interfaces/resources.py experiments/unified_registry/resource_manager.py`
- `poetry run mypy src/plugins/resources/base.py src/common_interfaces/resources.py experiments/unified_registry/resource_manager.py` *(fails: Missing type parameters for generic type Dict, etc.)*
- `bandit -r src/plugins/resources/base.py src/common_interfaces/resources.py experiments/unified_registry/resource_manager.py` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest tests/experiments/test_resource_manager.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c535e691c832299095b0e84518d6a