### PR TITLE
Create HTTPProviderResource base class

### DIFF
--- a/src/plugins/builtin/resources/http_provider_resource.py
+++ b/src/plugins/builtin/resources/http_provider_resource.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+"""Shared HTTP logic for LLM providers."""
+import asyncio
+import json
+from typing import Any, AsyncIterator, Dict, Optional
+
+import httpx
+
+from pipeline.exceptions import ResourceError
+from pipeline.validation import ValidationResult
+
+from .http_llm_resource import HttpLLMResource
+from .llm_base import LLM
+
+
+class HTTPProviderResource(LLM):
+    """Reusable base class for HTTP based providers."""
+
+    name = "http_provider"
+    requires_api_key: bool = False
+
+    def __init__(self, config: Dict) -> None:
+        self.http = HttpLLMResource(config, require_api_key=self.requires_api_key)
+        self.retry_attempts = int(config.get("retries", 3))
+        self.timeout = float(config.get("timeout", 30))
+        self._client: httpx.AsyncClient | None = None
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        """Validate configuration using :class:`HttpLLMResource`."""
+        return HttpLLMResource(
+            config, require_api_key=cls.requires_api_key
+        ).validate_config()
+
+    async def __aenter__(self) -> "HTTPProviderResource":
+        self._client = httpx.AsyncClient(timeout=self.timeout)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+        self._client = None
+
+    async def validate_runtime(self) -> ValidationResult:
+        if not self.http.base_url:
+            return ValidationResult.error_result("'base_url' is required")
+        client = self._client or httpx.AsyncClient(timeout=self.timeout)
+        close_client = self._client is None
+        try:
+            resp = await client.get(self.http.base_url)
+            resp.raise_for_status()
+            return ValidationResult.success_result()
+        except Exception as exc:  # noqa: BLE001
+            return ValidationResult.error_result(str(exc))
+        finally:
+            if close_client:
+                await client.aclose()
+
+    async def _post_with_retry(
+        self,
+        url: str,
+        payload: Dict[str, Any],
+        headers: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return await self.http._post_request(url, payload, headers, params)
+
+    async def _stream_post_request(
+        self,
+        url: str,
+        payload: Dict[str, Any],
+        headers: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        last_exc: Exception | None = None
+        for attempt in range(self.retry_attempts):
+            try:
+                client = self._client or httpx.AsyncClient(timeout=self.timeout)
+                close_client = self._client is None
+                try:
+                    async with client.stream(
+                        "POST", url, json=payload, headers=headers, params=params
+                    ) as response:
+                        response.raise_for_status()
+                        async for line in response.aiter_lines():
+                            if not line:
+                                continue
+                            if line.startswith("data: "):
+                                line = line[6:]
+                            if line == "[DONE]":
+                                break
+                            yield json.loads(line)
+                    return
+                finally:
+                    if close_client:
+                        await client.aclose()
+            except Exception as exc:  # noqa: BLE001 - retry
+                last_exc = exc
+                await asyncio.sleep(2**attempt)
+        raise ResourceError(f"{self.name} provider request failed") from last_exc

--- a/src/plugins/builtin/resources/llm/providers/base.py
+++ b/src/plugins/builtin/resources/llm/providers/base.py
@@ -1,84 +1,13 @@
 from __future__ import annotations
 
 """Base class for HTTP LLM providers."""
-import asyncio
-import json
-from typing import Any, AsyncIterator, Dict, Optional
 
-import httpx
+from typing import Dict
 
-from pipeline.exceptions import ResourceError
-from pipeline.validation import ValidationResult
-from plugins.builtin.resources.http_llm_resource import HttpLLMResource
-from plugins.builtin.resources.llm_base import LLM
+from plugins.builtin.resources.http_provider_resource import HTTPProviderResource
 
 
-class BaseProvider(LLM):
+class BaseProvider(HTTPProviderResource):
     """Base class for HTTP LLM providers."""
 
     name = "base"
-    requires_api_key: bool = False
-
-    def __init__(self, config: Dict) -> None:
-        self.http = HttpLLMResource(config, require_api_key=self.requires_api_key)
-        self.retry_attempts = int(config.get("retries", 3))
-        self.timeout = float(config.get("timeout", 30))
-        self._client: httpx.AsyncClient | None = None
-
-    @classmethod
-    def validate_config(cls, config: Dict) -> ValidationResult:
-        return HttpLLMResource(
-            config, require_api_key=cls.requires_api_key
-        ).validate_config()
-
-    async def validate_runtime(self) -> ValidationResult:
-        if not self.http.base_url:
-            return ValidationResult.error_result("'base_url' is required")
-        client = self._client or httpx.AsyncClient(timeout=self.timeout)
-        close_client = self._client is None
-        try:
-            resp = await client.get(self.http.base_url)
-            resp.raise_for_status()
-            return ValidationResult.success_result()
-        except Exception as exc:  # noqa: BLE001 - network issues
-            return ValidationResult.error_result(str(exc))
-        finally:
-            if close_client:
-                await client.aclose()
-
-    async def _post_with_retry(
-        self,
-        url: str,
-        payload: Dict[str, Any],
-        headers: Optional[Dict[str, str]] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-        return await self.http._post_request(url, payload, headers, params)
-
-    async def _stream_post_request(
-        self,
-        url: str,
-        payload: Dict[str, Any],
-        headers: Optional[Dict[str, str]] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> AsyncIterator[Dict[str, Any]]:
-        last_exc: Exception | None = None
-        for attempt in range(self.retry_attempts):
-            try:
-                async with self.http._client.stream(
-                    "POST", url, json=payload, headers=headers, params=params
-                ) as response:
-                    response.raise_for_status()
-                    async for line in response.aiter_lines():
-                        if not line:
-                            continue
-                        if line.startswith("data: "):
-                            line = line[6:]
-                        if line == "[DONE]":
-                            break
-                        yield json.loads(line)
-                return
-            except Exception as exc:  # noqa: BLE001 - retry
-                last_exc = exc
-                await asyncio.sleep(2**attempt)
-        raise ResourceError(f"{self.name} provider request failed") from last_exc

--- a/src/plugins/llm/providers/base.py
+++ b/src/plugins/llm/providers/base.py
@@ -1,83 +1,13 @@
 from __future__ import annotations
 
 """Base class for HTTP LLM providers."""
-import asyncio
-import json
-from typing import Any, AsyncIterator, Dict, Optional
 
-import httpx
+from typing import Dict
 
-from pipeline.validation import ValidationResult
-from plugins.builtin.resources.http_llm_resource import HttpLLMResource
-from plugins.builtin.resources.llm_base import LLM
+from plugins.builtin.resources.http_provider_resource import HTTPProviderResource
 
 
-class BaseProvider(LLM):
+class BaseProvider(HTTPProviderResource):
     """Base class for HTTP LLM providers."""
 
     name = "base"
-    requires_api_key: bool = False
-
-    def __init__(self, config: Dict) -> None:
-        self.http = HttpLLMResource(config, require_api_key=self.requires_api_key)
-        self.retry_attempts = int(config.get("retries", 3))
-        self.timeout = float(config.get("timeout", 30))
-        self._client: httpx.AsyncClient | None = None
-
-    async def __aenter__(self) -> "BaseProvider":
-        self._client = httpx.AsyncClient(timeout=self.timeout)
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb) -> None:
-        if self._client is not None:
-            await self._client.aclose()
-        self._client = None
-
-    @classmethod
-    def validate_config(cls, config: Dict) -> ValidationResult:
-        return HttpLLMResource(
-            config, require_api_key=cls.requires_api_key
-        ).validate_config()
-
-    async def _post_with_retry(
-        self,
-        url: str,
-        payload: Dict[str, Any],
-        headers: Optional[Dict[str, str]] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-        return await self.http._post_request(url, payload, headers, params)
-
-    async def _stream_post_request(
-        self,
-        url: str,
-        payload: Dict[str, Any],
-        headers: Optional[Dict[str, str]] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> AsyncIterator[Dict[str, Any]]:
-        last_exc: Exception | None = None
-        for attempt in range(self.retry_attempts):
-            try:
-                client = self._client or httpx.AsyncClient(timeout=self.timeout)
-                close_client = self._client is None
-                try:
-                    async with client.stream(
-                        "POST", url, json=payload, headers=headers, params=params
-                    ) as response:
-                        response.raise_for_status()
-                        async for line in response.aiter_lines():
-                            if not line:
-                                continue
-                            if line.startswith("data: "):
-                                line = line[6:]
-                            if line == "[DONE]":
-                                break
-                            yield json.loads(line)
-                    return
-                finally:
-                    if close_client:
-                        await client.aclose()
-            except Exception as exc:  # noqa: BLE001 - retry
-                last_exc = exc
-                await asyncio.sleep(2**attempt)
-        raise RuntimeError(f"{self.name} provider request failed") from last_exc


### PR DESCRIPTION
## Summary
- centralize HTTP request logic in `HTTPProviderResource`
- refactor provider base classes to extend the new shared class

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing stubs and modules)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686c536bfea08322a940a3f939a25814