### PR TITLE
Resolve logging adapter name collision

### DIFF
--- a/src/plugins/builtin/adapters/__init__.py
+++ b/src/plugins/builtin/adapters/__init__.py
@@ -7,7 +7,7 @@ from .dashboard import DashboardAdapter
 from .grpc import LLMGRPCAdapter
 from .http import HTTPAdapter
 from .logging import LoggingAdapter
-from .logging_adapter import LoggingAdapter as LoggingAdapterWrapper
+from .logging_adapter import StructuredLoggingAdapter
 from .websocket import WebSocketAdapter
 
 __all__ = [
@@ -17,5 +17,5 @@ __all__ = [
     "WebSocketAdapter",
     "LLMGRPCAdapter",
     "LoggingAdapter",
-    "LoggingAdapterWrapper",
+    "StructuredLoggingAdapter",
 ]

--- a/src/plugins/builtin/adapters/logging_adapter.py
+++ b/src/plugins/builtin/adapters/logging_adapter.py
@@ -119,7 +119,7 @@ def get_logger(name: str) -> logging.Logger:
     return logger
 
 
-class LoggingAdapter(AdapterPlugin):
+class StructuredLoggingAdapter(AdapterPlugin):
     """Adapter placeholder for logging setup."""
 
     stages = [PipelineStage.DELIVER]
@@ -129,7 +129,7 @@ class LoggingAdapter(AdapterPlugin):
 
 
 __all__ = [
-    "LoggingAdapter",
+    "StructuredLoggingAdapter",
     "RequestIdFilter",
     "JsonFormatter",
     "configure_logging",


### PR DESCRIPTION
## Summary
- rename the helper class in `logging_adapter.py` to `StructuredLoggingAdapter`
- expose `StructuredLoggingAdapter` from the adapters package

## Testing
- `poetry run black src/plugins/builtin/adapters/logging_adapter.py src/plugins/builtin/adapters/__init__.py`
- `poetry run isort src/plugins/builtin/adapters/logging_adapter.py src/plugins/builtin/adapters/__init__.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: missing stubs and other type errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: aioboto3)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: aioboto3)*
- `python -m src.registry.validator` *(fails: ImportError: cannot import name 'LLM')*
- `pytest` *(fails: ModuleNotFoundError: aioboto3)*

------
https://chatgpt.com/codex/tasks/task_e_686c536de1dc832281a1bcc8577eb401