### PR TITLE
Refactor imports to use plugin resources

### DIFF
--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -22,14 +22,14 @@ DEFAULT_RESOURCES: Dict[str, Dict[str, Any]] = {
     "memory": {
         "type": "pipeline.resources.memory_resource:MemoryResource",
         "database": {
-            "type": "pipeline.resources.duckdb_database:DuckDBDatabaseResource"
+            "type": "plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource"
         },
         "vector_store": {
             "type": "user_plugins.resources.duckdb_vector_store:DuckDBVectorStore"
         },
     },
     "storage": {
-        "type": "pipeline.resources.storage_resource:StorageResource",
+        "type": "plugins.builtin.resources.storage_resource:StorageResource",
         "filesystem": {
             "type": "user_plugins.resources.local_filesystem:LocalFileSystemResource"
         },

--- a/tests/integration/test_chat_history_backends.py
+++ b/tests/integration/test_chat_history_backends.py
@@ -6,15 +6,22 @@ from pathlib import Path
 import pytest
 
 from entity_config.environment import load_env
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginContext, PluginRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
-from pipeline.resources.duckdb_database import DuckDBDatabaseResource
 from pipeline.resources.memory_resource import MemoryResource
-from pipeline.resources.memory_storage import MemoryStorage
-from pipeline.resources.postgres import PostgresResource
-from pipeline.resources.sqlite_storage import SQLiteStorageResource
+from plugins.builtin.resources.duckdb_database import DuckDBDatabaseResource
+from plugins.builtin.resources.memory_storage import MemoryStorage
+from plugins.builtin.resources.postgres import PostgresResource
+from plugins.builtin.resources.sqlite_storage import SQLiteStorageResource
 from user_plugins.prompts.chat_history import ChatHistory
 
 load_env(Path(__file__).resolve().parents[2] / ".env")

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -6,14 +6,20 @@ from pathlib import Path
 import pytest
 
 from entity_config.environment import load_env
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from pipeline.resources.llm import UnifiedLLMResource
 from pipeline.resources.memory_resource import MemoryResource
-from pipeline.resources.pg_vector_store import PgVectorStore
-from pipeline.resources.postgres import PostgresResource
+from plugins.builtin.resources.pg_vector_store import PgVectorStore
+from plugins.builtin.resources.postgres import PostgresResource
 from user_plugins.prompts.complex_prompt import ComplexPrompt
 
 if hasattr(os, "geteuid") and os.geteuid() == 0:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,15 +1,22 @@
 from datetime import datetime
 
 import pipeline.context as context_module
-from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
-                      PipelineState, PluginContext, PluginRegistry,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineStage,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.base_plugins import PromptPlugin
 from pipeline.cache import InMemoryCache
 from pipeline.resources import ResourceContainer
-from pipeline.resources.llm_base import LLM
 from pipeline.state import ToolCall
 from pipeline.tools.execution import execute_pending_tools
+from plugins.builtin.resources.llm_base import LLM
 from user_plugins.resources.cache import CacheResource
 
 context_module.LLM = LLM

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from pipeline.resources.llm_resource import LLMResource
+from plugins.builtin.resources.llm_resource import LLMResource
 from user_plugins.tools.calculator_tool import CalculatorTool
 
 

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -1,13 +1,18 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.context import ConversationEntry
 from pipeline.resources import ResourceContainer
-from pipeline.resources.memory import Memory
-from pipeline.resources.memory_resource import (MemoryResource,
-                                                SimpleMemoryResource)
+from pipeline.resources.memory_resource import MemoryResource, SimpleMemoryResource
+from plugins.builtin.resources.memory import Memory
 from plugins.builtin.resources.memory_storage import MemoryStorage
 
 

--- a/tests/test_storage_resource.py
+++ b/tests/test_storage_resource.py
@@ -1,8 +1,8 @@
 import asyncio
 from pathlib import Path
 
-from pipeline.resources.storage_resource import StorageResource
 from plugins.builtin.resources.local_filesystem import LocalFileSystemResource
+from plugins.builtin.resources.storage_resource import StorageResource
 
 
 async def make_resource(tmp_path: Path) -> StorageResource:


### PR DESCRIPTION
## Summary
- use plugin resources instead of thin wrappers
- adjust default configuration
- format test files

## Testing
- `poetry run black --check src tests` *(fails: would reformat 46 files)*
- `poetry run isort --check src tests` *(fails: imports are incorrectly sorted)*
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Found 398 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest` *(fails: 16 failed, 185 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686c536f40308322971e6fab07ddbff7