### PR TITLE
Resolve style issue

### DIFF
--- a/src/plugins/builtin/resources/llm/providers/base.py
+++ b/src/plugins/builtin/resources/llm/providers/base.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 """Base class for HTTP LLM providers."""
 
-from typing import Dict
 
-from plugins.builtin.resources.http_provider_resource import HTTPProviderResource
+from plugins.builtin.resources.http_provider_resource import \
+    HTTPProviderResource
 
 
 class BaseProvider(HTTPProviderResource):


### PR DESCRIPTION
## Summary
- remove unused import from BaseProvider class

## Testing
- `poetry run flake8 src/plugins/builtin/resources/llm/providers/base.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `python -m src.config.validator --config config/dev.yaml`
- `python -m src.config.validator --config config/prod.yaml`
- `python -m src.registry.validator`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686c57d2e7e0832282dde77e4b214e6a