### PR TITLE
Add streaming helper to HTTP LLM resource

### DIFF
--- a/src/plugins/builtin/resources/llm/providers/claude.py
+++ b/src/plugins/builtin/resources/llm/providers/claude.py
@@ -63,7 +63,7 @@ class ClaudeProvider(BaseProvider):
         if functions:
             payload["functions"] = functions
 
-        async for data in self._stream_post_request(url, payload, headers):
+        async for data in self.http.stream_request(url, payload, headers):
             text = data.get("content", [{}])[0].get("text")
             if text:
                 yield str(text)

--- a/src/plugins/builtin/resources/llm/providers/gemini.py
+++ b/src/plugins/builtin/resources/llm/providers/gemini.py
@@ -59,7 +59,7 @@ class GeminiProvider(BaseProvider):
         if functions:
             payload["functions"] = functions
 
-        async for data in self._stream_post_request(url, payload, headers, params):
+        async for data in self.http.stream_request(url, payload, headers, params):
             text = (
                 data.get("candidates", [{}])[0]
                 .get("content", {})

--- a/src/plugins/builtin/resources/llm/providers/ollama.py
+++ b/src/plugins/builtin/resources/llm/providers/ollama.py
@@ -44,7 +44,7 @@ class OllamaProvider(BaseProvider):
         if functions:
             payload["functions"] = functions
 
-        async for data in self._stream_post_request(url, payload):
+        async for data in self.http.stream_request(url, payload):
             text = data.get("response")
             if text:
                 yield str(text)

--- a/src/plugins/builtin/resources/llm/providers/openai.py
+++ b/src/plugins/builtin/resources/llm/providers/openai.py
@@ -57,7 +57,7 @@ class OpenAIProvider(BaseProvider):
         if functions:
             payload["functions"] = functions
 
-        async for data in self._stream_post_request(url, payload, headers):
+        async for data in self.http.stream_request(url, payload, headers):
             delta = data.get("choices", [{}])[0].get("delta", {})
             content = delta.get("content")
             if content:


### PR DESCRIPTION
## Summary
- implement `stream_request` in `HttpLLMResource`
- delegate `_stream_post_request` to the helper
- update provider implementations to use the shared streaming method

## Testing
- `poetry run flake8 src/plugins/builtin/resources/http_llm_resource.py src/plugins/builtin/resources/http_provider_resource.py src/plugins/builtin/resources/llm/providers/claude.py src/plugins/builtin/resources/llm/providers/gemini.py src/plugins/builtin/resources/llm/providers/ollama.py src/plugins/builtin/resources/llm/providers/openai.py`
- `poetry run mypy src/plugins/builtin/resources/http_llm_resource.py src/plugins/builtin/resources/http_provider_resource.py src/plugins/builtin/resources/llm/providers/claude.py src/plugins/builtin/resources/llm/providers/gemini.py src/plugins/builtin/resources/llm/providers/ollama.py src/plugins/builtin/resources/llm/providers/openai.py` *(fails: Class cannot subclass `BaseProvider` and other type errors)*
- `bandit -r src/plugins/builtin/resources/http_llm_resource.py src/plugins/builtin/resources/http_provider_resource.py src/plugins/builtin/resources/llm/providers/claude.py src/plugins/builtin/resources/llm/providers/gemini.py src/plugins/builtin/resources/llm/providers/ollama.py src/plugins/builtin/resources/llm/providers/openai.py`
- `python -m src.config.validator --config config/dev.yaml` *(fails: VersionError: mismatched protobuf runtime)*
- `python -m src.config.validator --config config/prod.yaml` *(fails: VersionError: mismatched protobuf runtime)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: VersionError: mismatched protobuf runtime)*

------
https://chatgpt.com/codex/tasks/task_e_686cf9708d688322a15dcb22504ed336