### PR TITLE
Refactor LLM resources to use ProviderResource

### DIFF
--- a/src/plugins/builtin/resources/llm/__init__.py
+++ b/src/plugins/builtin/resources/llm/__init__.py
@@ -5,9 +5,11 @@ from plugins.llm.providers import (ClaudeProvider, EchoProvider,
                                    OpenAIProvider)
 
 from ..llm_base import LLM
+from .provider_resource import ProviderResource
 
 __all__ = [
     "LLM",
+    "ProviderResource",
     "OpenAIProvider",
     "OllamaProvider",
     "ClaudeProvider",

--- a/src/plugins/builtin/resources/llm/provider_resource.py
+++ b/src/plugins/builtin/resources/llm/provider_resource.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Resource wrapper around an LLM provider."""
+
+from typing import Any, AsyncIterator, Dict, List
+
+from pipeline.state import LLMResponse
+from pipeline.validation import ValidationResult
+
+from ..llm_resource import LLMResource
+from .providers.base import BaseProvider
+
+
+class ProviderResource(LLMResource):  # type: ignore[misc]
+    """Adapter that delegates calls to a provider instance."""
+
+    name = "provider"
+
+    def __init__(self, provider: BaseProvider) -> None:
+        super().__init__()
+        self._provider = provider
+
+    @property
+    def provider(self) -> BaseProvider:
+        return self._provider
+
+    @classmethod
+    def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        if hasattr(cls, "provider_cls"):
+            return cls.provider_cls.validate_config(config)
+        return ValidationResult.success_result()
+
+    async def __aenter__(self) -> "ProviderResource":
+        if hasattr(self.provider, "__aenter__"):
+            await self.provider.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: Any | None,
+    ) -> None:
+        if hasattr(self.provider, "__aexit__"):
+            await self.provider.__aexit__(exc_type, exc, tb)
+
+    async def validate_runtime(self) -> ValidationResult:
+        if hasattr(self.provider, "validate_runtime"):
+            return await self.provider.validate_runtime()
+        return ValidationResult.success_result()
+
+    async def generate(
+        self, prompt: str, functions: List[Dict[str, Any]] | None = None
+    ) -> LLMResponse:
+        return await self.provider.generate(prompt, functions)
+
+    async def stream(
+        self, prompt: str, functions: List[Dict[str, Any]] | None = None
+    ) -> AsyncIterator[str]:
+        async for chunk in self.provider.stream(prompt, functions):
+            yield chunk


### PR DESCRIPTION
## Summary
- create `ProviderResource` for provider-backed LLM resources
- refactor built-in LLM resources (OpenAI, Gemini, Claude, Ollama) to use the provider base
- export `ProviderResource` from `plugins.builtin.resources.llm`

## Testing
- `poetry run black src/plugins/builtin/resources/claude.py src/plugins/builtin/resources/gemini.py src/plugins/builtin/resources/openai.py src/plugins/builtin/resources/ollama_llm.py src/plugins/builtin/resources/llm/provider_resource.py src/plugins/builtin/resources/llm/__init__.py`
- `poetry run isort src/plugins/builtin/resources/claude.py src/plugins/builtin/resources/gemini.py src/plugins/builtin/resources/openai.py src/plugins/builtin/resources/ollama_llm.py src/plugins/builtin/resources/llm/provider_resource.py src/plugins/builtin/resources/llm/__init__.py`
- `poetry run flake8 src/plugins/builtin/resources/claude.py src/plugins/builtin/resources/gemini.py src/plugins/builtin/resources/openai.py src/plugins/builtin/resources/ollama_llm.py src/plugins/builtin/resources/llm/provider_resource.py src/plugins/builtin/resources/llm/__init__.py`
- `poetry run mypy src/plugins/builtin/resources/claude.py src/plugins/builtin/resources/gemini.py src/plugins/builtin/resources/openai.py src/plugins/builtin/resources/ollama_llm.py src/plugins/builtin/resources/llm/provider_resource.py`
- `bandit -r src/plugins/builtin/resources/claude.py src/plugins/builtin/resources/gemini.py src/plugins/builtin/resources/openai.py src/plugins/builtin/resources/ollama_llm.py src/plugins/builtin/resources/llm/provider_resource.py src/plugins/builtin/resources/llm/__init__.py`
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid: type object 'SQLiteStorageResource' has no attribute 'validate_dependencies')*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: Configuration invalid: type object 'SQLiteStorageResource' has no attribute 'validate_dependencies')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_686cf9632ab08322b790752e17086ab7