### PR TITLE
Add empty directory pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,10 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
+  - repo: local
+    hooks:
+      - id: check-empty-dirs
+        name: Detect directories without files
+        entry: python tools/check_empty_dirs.py
+        language: system
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ pytest tests/infrastructure/ -v
 pytest tests/performance/ -m benchmark
 ```
 
+Pre-commit will also run `tools/check_empty_dirs.py` to ensure no directories
+exist without files. If such folders are found, the commit will fail.
+
 ## Optional Dependencies for Examples
 
 The examples under `examples/` rely on packages such as `websockets` and `grpcio-tools`.

--- a/tools/check_empty_dirs.py
+++ b/tools/check_empty_dirs.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""Detect directories that contain no files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+import sys
+
+
+class DirectoryScanner:
+    """Scan directories recursively and report those without files."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def _has_file(self, path: Path) -> bool:
+        for item in path.iterdir():
+            if item.is_file():
+                return True
+        return False
+
+    def find_dirs_without_files(self) -> List[Path]:
+        """Return directories that contain no files."""
+        directories: List[Path] = []
+        for p in self.root.rglob("*"):
+            if not p.is_dir():
+                continue
+            if "\.git" in p.parts:
+                continue
+            if not self._has_file(p):
+                directories.append(p)
+        return directories
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    root = Path.cwd() if argv is None else Path(argv[0]).resolve()
+    scanner = DirectoryScanner(root)
+    empty_dirs = scanner.find_dirs_without_files()
+    if empty_dirs:
+        print("Directories without files detected:")
+        for d in empty_dirs:
+            print(d)
+        return 1
+    print("No directories without files detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- detect empty directories via `check_empty_dirs.py`
- fail CI when empty directories are present using pre-commit
- document empty directory check

## Testing
- `poetry install --with dev`
- `poetry run black src tests tools`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `bandit -r src` *(fails: command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(fails: module error)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(fails: module error)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686cfcb692248322a1f571183d928105