### PR TITLE
Add empty directory pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,11 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
+  - repo: local
+    hooks:
+      - id: check-empty-dirs
+        name: Check for empty directories
+        entry: python tools/check_empty_dirs.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Thank you for helping improve Entity Pipeline Framework! Always start with `poet
 - Describe the purpose of the change and any new dependencies.
 - Ensure tests and documentation are updated when relevant.
 - Maintain readable, well-structured code. Favor object oriented design.
+- Pre-commit hooks run automatically. They will fail if the repository contains
+  empty directories; remove them before committing.
 
 ## Quality Checks
 
@@ -20,6 +22,7 @@ poetry run isort src tests
 poetry run flake8 src tests
 poetry run mypy src
 bandit -r src
+python tools/check_empty_dirs.py
 poetry run python -m src.entity_config.validator --config config/dev.yaml
 poetry run python -m src.entity_config.validator --config config/prod.yaml
 python -m src.registry.validator

--- a/tools/check_empty_dirs.py
+++ b/tools/check_empty_dirs.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+class EmptyDirectoryChecker:
+    """Detect directories within the repository that contain no files or subdirectories."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def find(self) -> list[Path]:
+        """Return a list of empty directories under the repository root."""
+        empty_dirs: list[Path] = []
+        for path in self.root.rglob("*"):
+            if ".git" in path.parts or not path.is_dir():
+                continue
+            if not any(path.iterdir()):
+                empty_dirs.append(path)
+        return empty_dirs
+
+    def run(self) -> int:
+        """Print any empty directories found and return an exit code."""
+        empty = self.find()
+        if empty:
+            print("Empty directories found:")
+            for directory in empty:
+                print(directory.relative_to(self.root))
+            return 1
+        return 0
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    checker = EmptyDirectoryChecker(repo_root)
+    return checker.run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `tools/check_empty_dirs.py` to detect empty directories
- run this script in pre-commit
- document empty directory check in contributing guide

## Testing
- `poetry run black src tests tools/check_empty_dirs.py`
- `poetry run isort tools/check_empty_dirs.py`
- `poetry run flake8 src tests tools/check_empty_dirs.py`
- `poetry run mypy src` *(fails: missing stubs and type errors)*
- `bandit -r src` *(command not found)*
- `poetry run python -m src.config.validator --config config/dev.yaml` *(error running module)*
- `poetry run python -m src.config.validator --config config/prod.yaml` *(error running module)*
- `poetry run python -m src.registry.validator` *(failed to import modules)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686d0918dcac83228c8b4e85c0e5d2ed