### PR TITLE
Add empty directory scan script to pre-commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,14 @@ pytest tests/infrastructure/ -v
 pytest tests/performance/ -m benchmark
 ```
 
-Pre-commit will also run `tools/check_empty_dirs.py` to ensure no directories
-exist without files. If such folders are found, the commit will fail.
+Pre-commit also runs `tools/check_empty_dirs.py`. This tool searches for
+directories that do not contain any files (even if subdirectories are present)
+and rejects the commit when such directories are found. You can run it
+manually with:
+
+```bash
+python tools/check_empty_dirs.py
+```
 
 ## Optional Dependencies for Examples
 

--- a/tools/check_empty_dirs.py
+++ b/tools/check_empty_dirs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Detect directories that contain no files."""
+"""Detect directories that contain no files at any depth."""
 
 from __future__ import annotations
 
@@ -14,11 +14,9 @@ class DirectoryScanner:
     def __init__(self, root: Path) -> None:
         self.root = root
 
-    def _has_file(self, path: Path) -> bool:
-        for item in path.iterdir():
-            if item.is_file():
-                return True
-        return False
+    def _contains_file(self, path: Path) -> bool:
+        """Return ``True`` if ``path`` or any descendant directory contains a file."""
+        return any(p.is_file() for p in path.rglob("*"))
 
     def find_dirs_without_files(self) -> List[Path]:
         """Return directories that contain no files."""
@@ -26,9 +24,9 @@ class DirectoryScanner:
         for p in self.root.rglob("*"):
             if not p.is_dir():
                 continue
-            if "\.git" in p.parts:
+            if ".git" in p.parts:
                 continue
-            if not self._has_file(p):
+            if not self._contains_file(p):
                 directories.append(p)
         return directories
 


### PR DESCRIPTION
## Summary
- improve `check_empty_dirs.py` to search recursively
- mention the check in `CONTRIBUTING.md`

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686d214fc2e48322b780a663ea0bff88