### PR TITLE
Fix duplicate import in CLI

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -16,7 +16,6 @@ import yaml  # noqa: E402
 
 from pipeline import Agent  # noqa: E402
 from pipeline import update_plugin_configuration  # noqa: E402
-from pipeline import Agent
 from pipeline.base_plugins import ResourcePlugin, ToolPlugin  # noqa: E402
 from pipeline.initializer import ClassRegistry  # noqa: E402
 from pipeline.interfaces import import_plugin_class  # noqa: E402


### PR DESCRIPTION
## Summary
- remove duplicate `from pipeline import Agent` import in CLI
- keep imports sorted and formatted

## Testing
- `poetry run black src/cli.py`
- `poetry run isort src/cli.py`
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 338 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(fails: Configuration invalid)*
- `poetry run python -m src.registry.validator` *(fails: ImportError)*
- `poetry run pytest` *(fails: 16 failed, 185 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686d38c87fe4832291c66f1e615cf178