### PR TITLE
Run isort

### DIFF
--- a/src/plugins/builtin/infrastructure/infrastructure.py
+++ b/src/plugins/builtin/infrastructure/infrastructure.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+
 # subprocess used for CLI invocation
 import subprocess  # nosec B404
 from pathlib import Path

--- a/src/plugins/builtin/resources/sqlite_storage.py
+++ b/src/plugins/builtin/resources/sqlite_storage.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 import json
 import re
 from datetime import datetime
-from importlib import util as import_util
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import aiosqlite
 
 from pipeline.observability.tracing import start_span
 from pipeline.stages import PipelineStage
-from pipeline.validation import ValidationResult
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from pipeline.state import ConversationEntry


### PR DESCRIPTION
## Summary
- apply isort to keep imports tidy
- remove unused imports in SQLite storage

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: `BaseHTTPMiddleware` missing stubs, etc.)*
- `poetry run bandit -r src`
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: `No module named 'yaml'`)*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: `No module named 'yaml'`)*
- `python -m src.registry.validator` *(fails: `No module named 'common_interfaces'`)*
- `pytest` *(fails: `ModuleNotFoundError: No module named 'yaml'`)*

------
https://chatgpt.com/codex/tasks/task_e_686d3da54bc08322b3de885ebdca21a5