### PR TITLE
fix: clean up CLI imports

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -173,7 +173,6 @@ class CLI:
 
         main_path = target / "src" / "main.py"
         main_path.write_text(
-            """from pipeline import Agent\n\n\n"""
             "def main() -> None:\n"
             "    agent = Agent('config/dev.yaml')\n"
             "    agent.run_http()\n\n\n"

--- a/src/plugins/builtin/infrastructure/infrastructure.py
+++ b/src/plugins/builtin/infrastructure/infrastructure.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import os
 import re
 import shutil
-# subprocess used for CLI invocation
 import subprocess  # nosec B404
 from pathlib import Path
 from typing import Any, Dict, Type


### PR DESCRIPTION
## Summary
- stop writing a duplicate `from pipeline import Agent` line when scaffolding projects
- make `infrastructure.py` import ordering consistent

## Testing
- `poetry run black src/cli.py src/plugins/builtin/infrastructure/infrastructure.py --check`
- `poetry run isort src/cli.py src/plugins/builtin/infrastructure/infrastructure.py --check`
- `poetry run black src tests --check` *(fails: would reformat src/plugins/builtin/infrastructure/infrastructure.py)*
- `poetry run isort src tests --check` *(fails: many files not correctly sorted)*
- `poetry run flake8 src tests` *(fails: import formatting issues)*
- `poetry run mypy src` *(fails: 342 errors in 94 files)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml` *(interrupted)*
- `poetry run python -m src.registry.validator` *(failed to import due to circular import)*
- `poetry run pytest -q` *(1 failed, 29 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686d3da6730883229cc14f4d4be43f9a