### PR TITLE
Improve typing in CLI modules

### DIFF
--- a/src/pipeline/security/auth.py
+++ b/src/pipeline/security/auth.py
@@ -17,4 +17,7 @@ class AdapterAuthenticator:
 
     def authorize(self, token: str | None, role: str) -> bool:
         """Return ``True`` if ``token`` grants ``role`` access."""
-        return self.authenticate(token) and role in self._tokens.get(token, [])
+        if not self.authenticate(token):
+            return False
+        assert token is not None
+        return role in self._tokens.get(token, [])

--- a/src/pipeline/user_plugins/resources/cache.py
+++ b/src/pipeline/user_plugins/resources/cache.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from user_plugins.resources.cache import CacheResource
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     if name == "CacheResource":
         from user_plugins.resources.cache import CacheResource
 


### PR DESCRIPTION
## Summary
- add `CLIArgs` dataclass and use it in `CLI`
- add `PluginToolArgs` dataclass and apply stricter checks
- refine typing in pipeline utilities

## Testing
- `poetry run isort src/cli.py src/cli/plugin_tool.py src/pipeline/user_plugins/resources/cache.py src/pipeline/security/auth.py --profile black --check`
- `poetry run flake8 src/cli.py src/cli/plugin_tool.py src/pipeline/security/auth.py src/pipeline/user_plugins/resources/cache.py`
- `poetry run mypy src/cli.py src/cli/plugin_tool.py src/pipeline/security/auth.py src/pipeline/user_plugins/resources/cache.py`
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: ImportError)*
- `poetry run pytest` *(fails: AttributeError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686d3da6f31883228e3836a0bce07d0d