### PR TITLE
fix: validate SQLite storage dependencies

### DIFF
--- a/src/plugins/builtin/resources/sqlite_storage.py
+++ b/src/plugins/builtin/resources/sqlite_storage.py
@@ -27,6 +27,13 @@ class SQLiteStorageResource(DatabaseResource):
     stages = [PipelineStage.PARSE]
     name = "database"
 
+    @classmethod
+    def validate_dependencies(cls, registry) -> ValidationResult:
+        """Ensure the ``aiosqlite`` package is available."""
+        if import_util.find_spec("aiosqlite") is None:
+            return ValidationResult.error_result("'aiosqlite' package not installed")
+        return ValidationResult.success_result()
+
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config)
         self._path = self.config.get("path", ":memory:")


### PR DESCRIPTION
## Summary
- ensure SQLite storage checks for aiosqlite

## Testing
- `poetry run black src/plugins/builtin/resources/sqlite_storage.py`
- `poetry run isort src/plugins/builtin/resources/sqlite_storage.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Class cannot subclass "BaseModel" ...)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: cannot import name 'LLM' from partially initialized module...)*
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_686d3da906a88322a22738067762fe91