### PR TITLE
Update docs for DuckDB defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ plugins:
       model: tinyllama
       base_url: "http://localhost:11434"
 ```
-Lightweight deployments can use SQLite:
+Lightweight deployments can use DuckDB:
 
 ```yaml
 plugins:
   resources:
     database:
-      type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
-      path: ./entity.db
+      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      path: ./entity.duckdb
       pool_min_size: 1
       pool_max_size: 5
 ```
@@ -250,8 +250,8 @@ plugins:
     storage:
       type: storage
       database:
-        type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
-        path: ./agent.db
+        type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+        path: ./agent.duckdb
 ```
 
 ### DuckDB Configuration
@@ -322,8 +322,8 @@ plugins:
     storage:
       type: storage
       database:
-        type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
-        path: ./agent.db
+        type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+        path: ./agent.duckdb
       filesystem:
         type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
         base_path: ./files
@@ -370,7 +370,7 @@ python examples/servers/cli_adapter.py
 
 3. **Provide Sensible Defaults**
    ```python
-   # If no config provided, use SQLite + local filesystem
+   # If no config provided, use DuckDB + local filesystem
    storage = StorageResource()  # Works out of the box
    ```
 

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -11,8 +11,8 @@ tool_registry:
 plugins:
   resources:
     database:
-      type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
-      path: ./dev.db
+      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      path: ./dev.duckdb
     llm:
       type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
       provider: ollama
@@ -23,8 +23,8 @@ plugins:
     memory:
       type: pipeline.resources.memory_resource:MemoryResource
       storage:
-        type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
-        path: ./dev.db
+        type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+        path: ./dev.duckdb
     vector_store:
       type: plugins.builtin.resources.memory_vector_store:MemoryVectorStore
       table: vector_mem

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -11,8 +11,8 @@ tool_registry:
 plugins:
   resources:
     database:
-      type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
-      path: ./prod.db
+      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      path: ./prod.duckdb
     llm:
       type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
       provider: ollama

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -34,7 +34,7 @@ plugins:
 
 `MemoryResource` persists conversation history and vectors. `StorageResource` extends it with file CRUD across the configured backends.
 
-For local experimentation you can swap the database section with SQLite:
+For local experimentation you can swap the database section with DuckDB:
 
 ```yaml
 plugins:
@@ -42,8 +42,8 @@ plugins:
     storage:
       type: storage
       database:
-        type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
-        path: ./agent.db
+        type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+        path: ./agent.duckdb
 ```
 
 You can also use `StorageResource` for a lighter setup:
@@ -54,8 +54,8 @@ plugins:
     storage:
       type: storage
       database:
-        type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
-        path: ./agent.db
+        type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+        path: ./agent.duckdb
       filesystem:
         type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
         base_path: ./files

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -128,7 +128,7 @@ Several example pipelines in the `examples/` directory showcase more advanced pa
 
 ```python
 storage = StorageResource(
-    database=SQLiteDatabaseResource({"path": "./agent.db"}),
+    database=DuckDBDatabaseResource({"path": "./agent.duckdb"}),
     vector_store=PgVectorStore({"table": "embeddings"}),
     filesystem=LocalFileSystemResource({"base_path": "./files"}),
 )
@@ -138,7 +138,7 @@ storage = StorageResource(
 
 ```python
 storage = StorageResource(
-    database=SQLiteDatabaseResource({"path": "./agent.db"}),
+    database=DuckDBDatabaseResource({"path": "./agent.duckdb"}),
     filesystem=LocalFileSystemResource({"base_path": "./files"}),
 )
 ```


### PR DESCRIPTION
## Summary
- adjust dev and prod config to use DuckDB for the example database
- switch README examples from SQLite to DuckDB
- update docs to reflect DuckDB defaults

## Testing
- `poetry run black src tests`
- `poetry run isort src tests` *(failed: command not found)*
- `poetry run flake8 src tests` *(failed: command not found)*
- `poetry run mypy src` *(failed to run)*
- `bandit -r src` *(failed: command not found)*
- `python -m src.entity_config.validator --config config/dev.yaml` *(failed to run)*
- `python -m src.entity_config.validator --config config/prod.yaml` *(failed to run)*
- `python -m src.registry.validator` *(failed to run)*
- `pytest` *(failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_686d4295fbec8322b6c6e05d041f6957