### PR TITLE
Fix check_empty_dirs script

### DIFF
--- a/tools/check_empty_dirs.py
+++ b/tools/check_empty_dirs.py
@@ -32,7 +32,7 @@ class EmptyDirectoryChecker:
 
 def main(argv: Iterable[str] | None = None) -> int:
     root = Path.cwd() if argv is None else Path(argv[0]).resolve()
-    scanner = DirectoryScanner(root)
+    scanner = EmptyDirectoryChecker(root)
     empty_dirs = scanner.find_dirs_without_files()
     if empty_dirs:
         print("Directories without files detected:")


### PR DESCRIPTION
## Summary
- instantiate EmptyDirectoryChecker instead of DirectoryScanner
- run black

## Testing
- `python tools/check_empty_dirs.py | head -n 20`
- `poetry run black src tests`
- `poetry run isort src tests` *(reverted changes)*
- `poetry run flake8 src tests` *(fails: F821 undefined names)*
- `poetry run mypy src` *(fails: found 354 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: ImportError cannot import name 'LLM')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686d58c309208322ac3368d853813230