### PR TITLE
Clarify experimental modules

### DIFF
--- a/experiments/config_loader/README.md
+++ b/experiments/config_loader/README.md
@@ -1,0 +1,5 @@
+# Config Loader Experiment
+
+This folder contains a small prototype for reloading YAML configuration files
+at runtime. It exists purely for experimentation and is **not** part of the
+supported pipeline. Use the code here as reference only.

--- a/experiments/config_loader/__init__.py
+++ b/experiments/config_loader/__init__.py
@@ -1,1 +1,2 @@
-"""Example configuration hot reload."""
+"""Example configuration hot reload.
+Experimental; not for production use."""

--- a/experiments/config_loader/loader.py
+++ b/experiments/config_loader/loader.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Prototype config watcher for demos only, not production ready."""
+
 import asyncio
 from pathlib import Path
 from typing import Any, Callable

--- a/experiments/error_handling/README.md
+++ b/experiments/error_handling/README.md
@@ -5,3 +5,5 @@ This folder contains small programs exploring error handling techniques.
 Run `state_machine_example.py` to see a tiny state machine that rolls back
 its state when a plugin error occurs.
 
+
+These experiments are not meant for production.

--- a/experiments/error_handling/state_machine_example.py
+++ b/experiments/error_handling/state_machine_example.py
@@ -1,4 +1,5 @@
-"""Demonstrate simple rollback logic using the new error classes."""
+"""Demonstrate simple rollback logic using the new error classes.
+Experimental example, not for production."""
 
 from __future__ import annotations
 

--- a/experiments/performance/README.md
+++ b/experiments/performance/README.md
@@ -1,0 +1,5 @@
+# Performance Benchmarks
+
+`serialization_bench.py` contains quick benchmarks for different
+serialization formats. These scripts are kept for reference and are not
+part of the production pipeline.

--- a/experiments/performance/__init__.py
+++ b/experiments/performance/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental benchmarks, not for production."""

--- a/experiments/performance/serialization_bench.py
+++ b/experiments/performance/serialization_bench.py
@@ -1,4 +1,4 @@
-"""Benchmark common serialization formats."""
+"""Benchmark common serialization formats. Experimental utility, not for production."""
 
 from __future__ import annotations
 

--- a/experiments/plugin_discovery/README.md
+++ b/experiments/plugin_discovery/README.md
@@ -10,3 +10,5 @@ attribute are used to compute an execution order with
 
 The `hot_reload.py` script watches the directory for changes and
 reloads plugins when files are added, removed or modified.
+
+This is experimental code and should not be used in production.

--- a/experiments/plugin_discovery/__init__.py
+++ b/experiments/plugin_discovery/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin discovery experiment utilities."""

--- a/experiments/plugin_discovery/hot_reload.py
+++ b/experiments/plugin_discovery/hot_reload.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Prototype hot reloader for plugin discovery experiments."""
+
 import time
 from typing import Callable, List
 

--- a/experiments/plugin_discovery/plugin_loader.py
+++ b/experiments/plugin_discovery/plugin_loader.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Simple plugin loader used for experimentation only."""
+
 import importlib.util
 from dataclasses import dataclass
 from pathlib import Path

--- a/experiments/secure_config/README.md
+++ b/experiments/secure_config/README.md
@@ -1,0 +1,5 @@
+# Secure Config Prototype
+
+These modules demonstrate one approach to loading encrypted YAML
+configuration files. The implementation is experimental and should not
+be used in production systems.

--- a/experiments/secure_config/__init__.py
+++ b/experiments/secure_config/__init__.py
@@ -1,0 +1,1 @@
+"""Prototype secure configuration loader. Not for production use."""

--- a/experiments/secure_config/loader.py
+++ b/experiments/secure_config/loader.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Experimental encrypted config loader."""
+
 import os
 from pathlib import Path
 from typing import Any, Protocol

--- a/experiments/simple_plugins/README.md
+++ b/experiments/simple_plugins/README.md
@@ -1,0 +1,5 @@
+# Simple Plugin Examples
+
+This package contains bare-bones implementations of prompt, resource and
+tool plugins. They illustrate composition techniques but are not part of
+the supported plugin set.

--- a/experiments/simple_plugins/__init__.py
+++ b/experiments/simple_plugins/__init__.py
@@ -1,4 +1,4 @@
-"""Simplified plugin examples using composition."""
+"""Simplified plugin examples using composition. Not for production."""
 
 from .prompt import ComposedPrompt
 from .resource import ComposedResource

--- a/experiments/simple_plugins/prompt.py
+++ b/experiments/simple_plugins/prompt.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Demonstration prompt plugin, not production ready."""
+
 from typing import Awaitable, Callable
 
 from pipeline.base_plugins import PromptPlugin

--- a/experiments/simple_plugins/resource.py
+++ b/experiments/simple_plugins/resource.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Demonstration resource plugin, not production ready."""
+
 from typing import Any, Dict, Protocol
 
 from pipeline.base_plugins import ResourcePlugin

--- a/experiments/simple_plugins/tool.py
+++ b/experiments/simple_plugins/tool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Demonstration tool plugin, not production ready."""
+
 from typing import Any, Dict, Protocol
 
 from pipeline.base_plugins import ToolPlugin

--- a/experiments/storage/README.md
+++ b/experiments/storage/README.md
@@ -1,0 +1,5 @@
+# Storage Resource Prototype
+
+This directory contains an early prototype of a composite storage
+resource. It is retained for reference only and is not maintained for
+production use.

--- a/experiments/storage/__init__.py
+++ b/experiments/storage/__init__.py
@@ -1,4 +1,4 @@
-"""Storage resource prototype."""
+"""Storage resource prototype. Not for production."""
 
 from .resource import StorageResource
 

--- a/experiments/storage/resource.py
+++ b/experiments/storage/resource.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-"""Experimental StorageResource supporting composable backends."""
+"""Experimental StorageResource supporting composable backends.
+Not for production use."""
 
 from contextlib import asynccontextmanager
 from typing import Dict, List

--- a/experiments/tool_pool/README.md
+++ b/experiments/tool_pool/README.md
@@ -4,3 +4,5 @@ This directory contains a minimal asynchronous execution pool for running
 tool callables concurrently. The pool tracks basic metrics such as task
 latency and throughput. It is intended for experimentation only and is not
 used by the main pipeline.
+
+This prototype is not part of the production pipeline.

--- a/experiments/tool_pool/__init__.py
+++ b/experiments/tool_pool/__init__.py
@@ -1,0 +1,1 @@
+"""Async tool pool prototype."""

--- a/experiments/tool_pool/pool.py
+++ b/experiments/tool_pool/pool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Experimental async pool for running tools. Not production ready."""
+
 import asyncio
 import time
 from dataclasses import dataclass, field

--- a/experiments/unified_registry/README.md
+++ b/experiments/unified_registry/README.md
@@ -12,3 +12,5 @@ Key features:
 
 The same manager can be integrated with Django by creating the instance inside
 `apps.py` and exposing resources through dependency injection utilities.
+
+This code is experimental and not intended for production use.

--- a/experiments/unified_registry/__init__.py
+++ b/experiments/unified_registry/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental resource manager prototype."""

--- a/experiments/unified_registry/di_demo.py
+++ b/experiments/unified_registry/di_demo.py
@@ -1,4 +1,5 @@
-"""Demonstrates using AsyncResourceManager with different DI frameworks."""
+"""Demonstrates using AsyncResourceManager with different DI frameworks.
+Prototype only, not for production."""
 
 from __future__ import annotations
 

--- a/experiments/unified_registry/resource_manager.py
+++ b/experiments/unified_registry/resource_manager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Prototype async resource registry. Not production ready."""
+
 import asyncio
 import time
 from dataclasses import dataclass, field


### PR DESCRIPTION
## Summary
- note that modules under `experiments/` are prototypes
- add README files for missing experiments
- mark python files as experimental via inline comments

## Testing
- `poetry run black experiments src tests`
- `poetry run isort experiments src tests`
- `poetry run flake8 experiments src tests` *(fails: undefined names)*
- `poetry run mypy src` *(fails: missing stubs and type errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686d58c65d588322b8f3c9b333387028