### PR TITLE
Document lazy imports for resource wrappers

### DIFF
--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,5 +1,7 @@
 """Public resource wrappers for pipeline consumers."""
 
+# Lazy imports so optional resources don't load heavy dependencies.
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only

--- a/src/pipeline/resources/database.py
+++ b/src/pipeline/resources/database.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 """Database resource wrapper used by tests."""
 
+# __getattr__ keeps heavy DB drivers out of memory until requested.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.database import DatabaseResource
 

--- a/src/pipeline/resources/duckdb_database.py
+++ b/src/pipeline/resources/duckdb_database.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 """Wrapper for DuckDBDatabaseResource."""
 
+# Defer duckdb import until the resource is accessed.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.duckdb_database import DuckDBDatabaseResource
 

--- a/src/pipeline/resources/filesystem.py
+++ b/src/pipeline/resources/filesystem.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 """Filesystem resource wrapper used by pipeline components."""
 
+# Lazy import keeps optional filesystem drivers lightweight.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.filesystem import FileSystemResource
 

--- a/src/pipeline/resources/in_memory_storage.py
+++ b/src/pipeline/resources/in_memory_storage.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 """Wrapper for InMemoryStorageResource."""
 
+# Import lazily so heavy plugin deps load only when accessed.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.in_memory_storage import InMemoryStorageResource
 

--- a/src/pipeline/resources/llm_base.py
+++ b/src/pipeline/resources/llm_base.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 """Public re-export of :class:`LLM`."""
 
+# Import the concrete LLM class lazily to reduce startup time.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.llm_base import LLM
 

--- a/src/pipeline/resources/llm_resource.py
+++ b/src/pipeline/resources/llm_resource.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 """Public re-export of :class:`LLMResource`."""
 
+# Load the real LLM resource only when requested.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.llm_resource import LLMResource
 

--- a/src/pipeline/resources/memory.py
+++ b/src/pipeline/resources/memory.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 """Memory resource interface wrapper."""
 
+# Avoid importing the full memory plugin until it is needed.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.memory import Memory
 

--- a/src/pipeline/resources/pg_vector_store.py
+++ b/src/pipeline/resources/pg_vector_store.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 """Wrapper for PgVectorStore."""
 
+# Defer import until used to avoid loading database drivers too early.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.pg_vector_store import PgVectorStore
 

--- a/src/pipeline/resources/postgres.py
+++ b/src/pipeline/resources/postgres.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 """Wrapper for PostgresResource."""
 
+# Delays import so psycopg and friends load only when needed.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.postgres import PostgresResource
 

--- a/src/pipeline/resources/sqlite_storage.py
+++ b/src/pipeline/resources/sqlite_storage.py
@@ -4,14 +4,15 @@ from typing import TYPE_CHECKING
 
 """Wrapper for SQLiteStorageResource."""
 
+# Lazy import avoids pulling in SQLite driver during startup.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.sqlite_storage import SQLiteStorageResource
 
 
 def __getattr__(name: str):
     if name == "SQLiteStorageResource":
-        from plugins.builtin.resources.sqlite_storage import \
-            SQLiteStorageResource
+        from plugins.builtin.resources.sqlite_storage import SQLiteStorageResource
 
         return SQLiteStorageResource
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/pipeline/resources/storage_resource.py
+++ b/src/pipeline/resources/storage_resource.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 """Thin wrapper exposing the built-in filesystem StorageResource."""
 
+# Uses lazy import to keep heavy filesystem deps optional.
+
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from plugins.builtin.resources.storage_resource import StorageResource
 


### PR DESCRIPTION
## Summary
- explain lazy imports for each resource wrapper
- run formatting and checks

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: undefined names)*
- `poetry run mypy src` *(fails: found errors)*
- `poetry run bandit -r src`
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686d6181d5748322aee1cf84d1972798