### PR TITLE
Refactor examples to use package imports

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,10 @@
 # Example Scripts
 
 This folder contains small programs that showcase different features of the Entity pipeline framework.
-Many of them read credentials from environment variables. Copy `.env.example` to `.env` and fill in the values before running the scripts.
+Run them with ``python -m examples.<script>`` from the repository root or install
+the package in editable mode with ``pip install -e .``.
+Many scripts read credentials from environment variables. Copy `.env.example` to
+`.env` and fill in the values before running them.
 
 ## Variables by Example
 

--- a/examples/advanced_llm.py
+++ b/examples/advanced_llm.py
@@ -1,14 +1,14 @@
-"""Demonstrate streaming and function-calling with UnifiedLLMResource."""
+"""Demonstrate streaming and function-calling with UnifiedLLMResource.
+
+Run with ``python -m examples.advanced_llm`` or install the package in
+editable mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import os
-import pathlib
-import sys
 from typing import Any, Dict
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from .utilities import enable_plugins_namespace
 

--- a/examples/bedrock_deploy.py
+++ b/examples/bedrock_deploy.py
@@ -1,12 +1,13 @@
-"""Auto deploy AWS Bedrock infrastructure."""
+"""Auto deploy AWS Bedrock infrastructure.
+
+Run with ``python -m examples.bedrock_deploy`` or install the package in
+editable mode.
+"""
 
 from __future__ import annotations
 
 import os
-import pathlib
-import sys
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from .utilities import enable_plugins_namespace
 

--- a/examples/cache_example.py
+++ b/examples/cache_example.py
@@ -1,12 +1,12 @@
-"""Demonstrate CacheResource with an in-memory backend."""
+"""Demonstrate CacheResource with an in-memory backend.
+
+Run with ``python -m examples.cache_example`` or install the package in editable
+mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import pathlib
-import sys
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from .utilities import enable_plugins_namespace
 

--- a/examples/config_reload_example.py
+++ b/examples/config_reload_example.py
@@ -1,4 +1,8 @@
-"""Demonstrate runtime configuration reload using the CLI."""
+"""Demonstrate runtime configuration reload using the CLI.
+
+Run with ``python -m examples.config_reload_example`` or install the package in
+editable mode.
+"""
 
 from __future__ import annotations
 
@@ -9,7 +13,6 @@ import tempfile
 import yaml
 
 # Allow importing from the repository's src directory
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 # Expose local plugins namespace
 from .utilities import enable_plugins_namespace

--- a/examples/failure_example.py
+++ b/examples/failure_example.py
@@ -1,13 +1,13 @@
-"""Example demonstrating error handling with BasicLogger and ErrorFormatter."""
+"""Example demonstrating error handling with BasicLogger and ErrorFormatter.
+
+Run with ``python -m examples.failure_example`` or install the package in
+editable mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import pathlib
-import sys
 
-# Make the repository's ``src`` directory importable
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from .utilities import enable_plugins_namespace
 

--- a/examples/observability_metrics.py
+++ b/examples/observability_metrics.py
@@ -1,12 +1,13 @@
-"""Start Prometheus metrics and trace a simple asynchronous task."""
+"""Start Prometheus metrics and trace a simple asynchronous task.
+
+Run with ``python -m examples.observability_metrics`` or install the package in
+editable mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import pathlib
-import sys
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from .utilities import enable_plugins_namespace
 

--- a/examples/observability_tracing.py
+++ b/examples/observability_tracing.py
@@ -1,12 +1,12 @@
-"""Demonstrate basic tracing with OpenTelemetry."""
+"""Demonstrate basic tracing with OpenTelemetry.
+
+Run with ``python -m examples.observability_tracing`` or install the package in
+editable mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import pathlib
-import sys
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from .utilities import enable_plugins_namespace
 

--- a/examples/pipelines/duckdb_pipeline.py
+++ b/examples/pipelines/duckdb_pipeline.py
@@ -1,14 +1,13 @@
-"""DuckDB memory pipeline example."""
+"""DuckDB memory pipeline example.
+
+Run with ``python -m examples.pipelines.duckdb_pipeline`` or install the package
+in editable mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import pathlib
-import sys
 from typing import Any
-
-# Ensure project source is available for imports
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
 from ..utilities import enable_plugins_namespace
 

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -1,14 +1,14 @@
-"""Demonstrate composed memory resource using SQLite, PGVector and local files."""
+"""Demonstrate composed memory resource using SQLite, PGVector and local files.
+
+Run with ``python -m examples.pipelines.memory_composition_pipeline`` or install
+the package in editable mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import os
-import pathlib
-import sys
 
-# Ensure project source is available for imports
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))  # noqa: E402
 
 from ..utilities import enable_plugins_namespace
 

--- a/examples/pipelines/pipeline_example.py
+++ b/examples/pipelines/pipeline_example.py
@@ -1,14 +1,13 @@
-"""Simple pipeline execution example without installing the package."""
+"""Simple pipeline execution example without installing the package.
+
+Run with ``python -m examples.pipelines.pipeline_example`` or install the package
+in editable mode.
+"""
 
 from __future__ import annotations
 
 import os
-import pathlib
-import sys
 from typing import Any, Dict
-
-# Ensure the repository's ``src`` directory is available for imports
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
 from ..utilities import enable_plugins_namespace
 

--- a/examples/pipelines/vector_memory_pipeline.py
+++ b/examples/pipelines/vector_memory_pipeline.py
@@ -1,19 +1,16 @@
 """Run a pipeline with vector memory support.
 
 Usage:
-    python examples/vector_memory_pipeline.py
+    python -m examples.pipelines.vector_memory_pipeline
+
+Run with the ``-m`` flag or install the package in editable mode.
 """
 
 from __future__ import annotations
 
 import asyncio
 import os
-import pathlib
-import sys
 from typing import Dict, List
-
-# Ensure project source is available for imports
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))  # noqa: E402
 
 from ..utilities import enable_plugins_namespace
 

--- a/examples/servers/cli_adapter.py
+++ b/examples/servers/cli_adapter.py
@@ -1,11 +1,11 @@
-"""Run a simple CLI adapter using the Entity framework."""
+"""Run a simple CLI adapter using the Entity framework.
+
+Run with ``python -m examples.servers.cli_adapter`` or install the package in
+editable mode.
+"""
 
 from __future__ import annotations
 
-import pathlib
-import sys
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
 from ..utilities import enable_plugins_namespace
 

--- a/examples/servers/grpc_server.py
+++ b/examples/servers/grpc_server.py
@@ -3,16 +3,16 @@
 Refer to the "Regenerating gRPC Code" section in
 ``docs/source/grpc_services.md`` for instructions on rebuilding the gRPC
 bindings.
+
+Run with ``python -m examples.servers.grpc_server`` or install the package in
+editable mode.
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
-import pathlib
-import sys
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
 from ..utilities import enable_plugins_namespace
 

--- a/examples/servers/http_server.py
+++ b/examples/servers/http_server.py
@@ -1,11 +1,11 @@
-"""Run a simple HTTP server using the Entity framework."""
+"""Run a simple HTTP server using the Entity framework.
+
+Run with ``python -m examples.servers.http_server`` or install the package in
+editable mode.
+"""
 
 from __future__ import annotations
 
-import pathlib
-import sys
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
 from ..utilities import enable_plugins_namespace
 

--- a/examples/servers/websocket_server.py
+++ b/examples/servers/websocket_server.py
@@ -1,13 +1,14 @@
-"""Run a simple WebSocket server using the Entity framework."""
+"""Run a simple WebSocket server using the Entity framework.
+
+Run with ``python -m examples.servers.websocket_server`` or install the package
+in editable mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
-import pathlib
-import sys
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
 from ..utilities import enable_plugins_namespace
 

--- a/examples/storage_resource_example.py
+++ b/examples/storage_resource_example.py
@@ -1,14 +1,13 @@
-"""Demonstrate StorageResource with SQLite and local files."""
+"""Demonstrate StorageResource with SQLite and local files.
+
+Run with ``python -m examples.storage_resource_example`` or install the package
+in editable mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import pathlib
-import sys
 from datetime import datetime
-
-# Make the repository's ``src`` directory importable
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from .utilities import enable_plugins_namespace
 

--- a/examples/structured_logging_example.py
+++ b/examples/structured_logging_example.py
@@ -1,12 +1,13 @@
-"""Demonstrate LoggingAdapter and structured logging."""
+"""Demonstrate LoggingAdapter and structured logging.
+
+Run with ``python -m examples.structured_logging_example`` or install the
+package in editable mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
-import pathlib
-import sys
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from .utilities import enable_plugins_namespace
 

--- a/examples/tools/search_weather_example.py
+++ b/examples/tools/search_weather_example.py
@@ -1,13 +1,14 @@
-"""Minimal pipeline using SearchTool and WeatherApiTool."""
+"""Minimal pipeline using SearchTool and WeatherApiTool.
+
+Run with ``python -m examples.tools.search_weather_example`` or install the
+package in editable mode.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import os
-import pathlib
-import sys
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from ..utilities import enable_plugins_namespace
 

--- a/examples/utilities/plugin_loader.py
+++ b/examples/utilities/plugin_loader.py
@@ -1,11 +1,12 @@
-"""Example showing Agent.from_directory error handling."""
+"""Example showing Agent.from_directory error handling.
+
+Run with ``python -m examples.utilities.plugin_loader`` or install the package in
+editable mode.
+"""
 
 from __future__ import annotations
 
 import pathlib
-import sys
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
 
 from . import enable_plugins_namespace
 


### PR DESCRIPTION
## Summary
- refactor examples to rely on package imports
- drop all sys.path hacks
- document running examples via `python -m`

## Testing
- `poetry run black examples`
- `poetry run isort src tests` *(modified tests reverted)*
- `poetry run flake8 src tests` *(fails: F821 undefined name 'dataclass')*
- `poetry run mypy src` *(fails: found 354 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_686d61b6a04483229d34ce3e545b280f