### PR TITLE
Fix mypy exclude paths

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 python_version = 3.11
 mypy_path = src
-exclude = ^src/pipeline/observability\.py$|^src/cli/templates/|^src/plugins\.resources/
+exclude = ^src/pipeline/observability/|^src/cli/templates/|^src/plugins.resources/
 strict = True
 files = src/pipeline/context.py,src/pipeline/manager.py,src/pipeline/runtime.py,src/pipeline/tools/execution.py
 follow_imports = skip


### PR DESCRIPTION
## Summary
- update the mypy exclude regex

## Testing
- `poetry run black --check mypy.ini` *(fails: cannot parse file)*
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811 redefinition of unused 'main')*
- `poetry run mypy src` *(fails: missing type stubs and other errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686d9c94113483228bfa65277cc73d34