### PR TITLE
Fix missing typing imports in check_empty_dirs

### DIFF
--- a/tools/check_empty_dirs.py
+++ b/tools/check_empty_dirs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Iterable, List
 
 
 class EmptyDirectoryChecker:


### PR DESCRIPTION
## Summary
- fix imports in `tools/check_empty_dirs.py`

## Testing
- `poetry run black src tests tools/check_empty_dirs.py`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F821, E402, etc.)*
- `poetry run mypy src` *(fails: Found 356 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686d9c8836888322974ee22f8d510a95