### PR TITLE
Remove path manipulation from CLI

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -2,18 +2,11 @@ from __future__ import annotations
 
 """CLI entry point for interacting with the Entity pipeline."""
 
-import sys
-from pathlib import Path
-
-# Resolve repository root and ensure it's on ``sys.path`` before other imports
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
 import argparse  # noqa: E402
 import asyncio  # noqa: E402
 import shutil  # noqa: E402
 from dataclasses import dataclass  # noqa: E402
+from pathlib import Path
 from typing import Any, Optional  # noqa: E402
 
 import yaml  # noqa: E402
@@ -51,10 +44,6 @@ class CLI:
 
     def __init__(self) -> None:
         """Initialize and parse command-line arguments."""
-        ROOT = Path(__file__).resolve().parent.parent
-        if str(ROOT) not in sys.path:
-            sys.path.insert(0, str(ROOT))
-
         self.args: CLIArgs = self._parse_args()
 
     def _parse_args(self) -> CLIArgs:


### PR DESCRIPTION
## Summary
- drop path insertion logic from `src/cli.py`
- keep imports absolute so CLI still works when installed

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F811 redefinition, F821 undefined names, etc.)*
- `poetry run mypy src` *(fails: found 356 errors)*
- `bandit -r src` *(command not found)*
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: ImportError - circular import)*
- `poetry run pytest` *(fails: AttributeError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686d9c922b888322b197ecbc8436608f