### PR TITLE
Introduce MetricsServerManager

### DIFF
--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -55,7 +55,7 @@ result.
 
 Metrics are recorded alongside these logs. Duration and error counts are stored
 in ``context.metrics`` and can be exported to Prometheus using
-``pipeline.observability.start_metrics_server()``.
+``pipeline.observability.MetricsServerManager.start()``.
 
 For production deployments, `config/logging_prod.yaml` contains a recommended
 configuration enabling JSON formatted logs and file rotation.

--- a/docs/source/monitoring.md
+++ b/docs/source/monitoring.md
@@ -4,13 +4,13 @@ This guide shows how to collect metrics and traces from an Entity deployment.
 
 ## Prometheus Metrics
 
-Call `start_metrics_server()` at application startup to expose metrics on
+Call `MetricsServerManager.start()` at application startup to expose metrics on
 `/metrics`:
 
 ```python
-from pipeline.observability import start_metrics_server
+from pipeline.observability import MetricsServerManager
 
-start_metrics_server(port=9001)
+MetricsServerManager.start(port=9001)
 ```
 
 The exporter provides stage latency, LLM latency and failure counters along with

--- a/docs/spikes/SPIKE-OBS-001/observability.md
+++ b/docs/spikes/SPIKE-OBS-001/observability.md
@@ -12,7 +12,7 @@
 
 ## Prometheus Metrics
 - `pipeline.observability.metrics` exposes a `MetricsServer` that collects latency and failure counts.
-- Calling `start_metrics_server(port=9001)` starts an HTTP endpoint at `/metrics` for Prometheus to scrape.
+- Calling `MetricsServerManager.start(port=9001)` starts an HTTP endpoint at `/metrics` for Prometheus to scrape.
 - CPU and memory gauges help identify resource bottlenecks.
 
 ## State Machine Visualization

--- a/examples/observability_metrics.py
+++ b/examples/observability_metrics.py
@@ -8,12 +8,11 @@ from __future__ import annotations
 
 import asyncio
 
-
 from .utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
 
-from pipeline.observability import start_metrics_server, start_span
+from pipeline.observability import MetricsServerManager, start_span
 
 
 async def sample_task() -> None:
@@ -22,7 +21,7 @@ async def sample_task() -> None:
 
 
 async def main() -> None:
-    start_metrics_server(port=9001)
+    MetricsServerManager.start(port=9001)
     await sample_task()
 
 

--- a/src/pipeline/observability/__init__.py
+++ b/src/pipeline/observability/__init__.py
@@ -1,14 +1,13 @@
 """Observability helpers for logging and metrics."""
 
 from .memory import profile_memory
-from .metrics import get_metrics_server, start_metrics_server
+from .metrics import MetricsServerManager
 from .tracing import start_span, traced
 from .utils import execute_with_observability
 
 __all__ = [
     "execute_with_observability",
-    "start_metrics_server",
-    "get_metrics_server",
+    "MetricsServerManager",
     "start_span",
     "traced",
     "profile_memory",

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -17,18 +17,15 @@ from registry import SystemRegistries
 
 from .context import ConversationEntry, PluginContext
 from .errors import create_static_error_response
-from .exceptions import MaxIterationsExceeded  # noqa: F401 - reserved for future use
-from .exceptions import (
-    CircuitBreakerTripped,
-    PipelineError,
-    PluginExecutionError,
-    ResourceError,
-    ToolExecutionError,
-)
+from .exceptions import \
+    MaxIterationsExceeded  # noqa: F401 - reserved for future use
+from .exceptions import (CircuitBreakerTripped, PipelineError,
+                         PluginExecutionError, ResourceError,
+                         ToolExecutionError)
 from .logging import get_logger, reset_request_id, set_request_id
 from .manager import PipelineManager
 from .metrics import MetricsCollector
-from .observability.metrics import get_metrics_server
+from .observability.metrics import MetricsServerManager
 from .observability.tracing import start_span
 from .serialization import dumps_state, loads_state
 from .stages import PipelineStage
@@ -316,7 +313,7 @@ async def execute_pipeline(
             state.metrics.record_pipeline_duration(time.time() - start)
         if state_file and os.path.exists(state_file) and state.failure_info is None:
             os.remove(state_file)
-        server = get_metrics_server()
+        server = MetricsServerManager.get()
         if server is not None and state.metrics:
             server.update(state.metrics)
 

--- a/src/plugins/resources/metrics.py
+++ b/src/plugins/resources/metrics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from pipeline.observability import start_metrics_server
+from pipeline.observability import MetricsServerManager
 from pipeline.validation import ValidationResult
 from plugins.resources.base import BaseResource
 
@@ -27,7 +27,7 @@ class MetricsResource(BaseResource):
         return ValidationResult.success_result()
 
     async def initialize(self) -> None:
-        start_metrics_server(self._port)
+        MetricsServerManager.start(self._port)
 
     def get_metrics(self) -> Dict[str, int]:
         return {"port": self._port}


### PR DESCRIPTION
## Summary
- add `MetricsServerManager` to manage Prometheus metrics server
- update modules to call `MetricsServerManager` instead of `start_metrics_server`
- revise documentation and examples accordingly

## Testing
- `poetry run black src examples/observability_metrics.py`
- `poetry run isort src/pipeline/observability/metrics.py src/pipeline/observability/__init__.py src/pipeline/pipeline.py src/plugins/builtin/adapters/http.py src/plugins/resources/metrics.py examples/observability_metrics.py`
- `poetry run flake8 src/pipeline/observability/metrics.py src/pipeline/observability/__init__.py src/pipeline/pipeline.py src/plugins/builtin/adapters/http.py src/plugins/resources/metrics.py examples/observability_metrics.py`
- `poetry run mypy src/pipeline/observability/metrics.py src/pipeline/observability/__init__.py src/pipeline/pipeline.py src/plugins/builtin/adapters/http.py src/plugins/resources/metrics.py examples/observability_metrics.py` *(failed: missing type stubs and annotation issues)*
- `poetry run bandit -r src/pipeline/observability/metrics.py src/pipeline/observability/__init__.py src/pipeline/pipeline.py src/plugins/resources/metrics.py src/plugins/builtin/adapters/http.py examples/observability_metrics.py`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(failed: ImportError - circular dependency)*
- `pytest` *(failed: unknown config option and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d9c8a826083228a2f0fa68dc37cd9