### PR TITLE
Update CLI module load

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,5 +1,6 @@
 """Expose the CLI helpers for tests and entry points."""
 
+import sys
 from importlib import util
 from pathlib import Path
 
@@ -8,6 +9,7 @@ _spec = util.spec_from_file_location("_entity_cli", _cli_path)
 _module = util.module_from_spec(_spec)
 if _spec.loader is None:  # pragma: no cover - sanity check
     raise RuntimeError("Failed to load CLI module")
+sys.modules[_spec.name] = _module
 _spec.loader.exec_module(_module)
 
 CLI = _module.CLI


### PR DESCRIPTION
## Summary
- ensure CLI module available before execution

## Testing
- `poetry run black src/cli/__init__.py`
- `poetry run isort src/cli/__init__.py`
- `poetry run flake8 src/cli/__init__.py`
- `poetry run mypy src`
- `bandit -r src` *(fails: command not found)*
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686da39d571483229c175ee6a7ff19a1