### PR TITLE
Fix runtime creation to build resources first

### DIFF
--- a/src/pipeline/builder.py
+++ b/src/pipeline/builder.py
@@ -117,6 +117,7 @@ class AgentBuilder:
 
     # ------------------------------ runtime build -----------------------------
     def build_runtime(self) -> "AgentRuntime":
+        asyncio.run(self.resource_registry.build_all())
         registries = SystemRegistries(
             resources=self.resource_registry,
             tools=self.tool_registry,


### PR DESCRIPTION
## Summary
- build registered resources before creating the runtime

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: ImportError: cannot import name 'LLM')*
- `poetry run pytest` *(fails: AttributeError: 'NoneType' object has no attribute '__dict__')*

------
https://chatgpt.com/codex/tasks/task_e_686da39cf4b4832296f4045a317cfd51