### PR TITLE
Update default server config

### DIFF
--- a/src/entity_config/models.py
+++ b/src/entity_config/models.py
@@ -60,13 +60,19 @@ class ToolRegistryConfig:
 
 @dataclass
 class EntityConfig:
-    server: ServerConfig
+    server: ServerConfig = field(
+        default_factory=lambda: ServerConfig(host="localhost", port=8000)
+    )
     plugins: PluginsSection = field(default_factory=PluginsSection)
     tool_registry: ToolRegistryConfig = field(default_factory=ToolRegistryConfig)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "EntityConfig":
-        server = ServerConfig(**data.get("server", {}))
+        server_data = data.get("server")
+        if server_data is None:
+            server = ServerConfig(host="localhost", port=8000)
+        else:
+            server = ServerConfig(**server_data)
         plugins = PluginsSection.from_dict(data.get("plugins", {}))
         tool_reg_cfg = ToolRegistryConfig(**data.get("tool_registry", {}))
         return cls(server, plugins, tool_reg_cfg)


### PR DESCRIPTION
## Summary
- add a default server config in `EntityConfig`
- allow missing server section when loading config

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: ImportError)*
- `poetry run pytest` *(fails: AttributeError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686da39e97e483229b657a4100519274