### PR TITLE
Fix plugin tool load path

### DIFF
--- a/tools/plugin_cli/__init__.py
+++ b/tools/plugin_cli/__init__.py
@@ -22,6 +22,8 @@ def _load_plugin_tool() -> ModuleType:
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Cannot import {path}")
     module = importlib.util.module_from_spec(spec)
+    # Register module before execution to ensure imports resolve correctly
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 


### PR DESCRIPTION
## Summary
- ensure plugin_tool is registered when loading in plugin_cli

## Testing
- `poetry run black src tests tools/plugin_cli/__init__.py`
- `poetry run isort tools/plugin_cli/__init__.py`
- `poetry run flake8 tools/plugin_cli/__init__.py`
- `poetry run mypy src` *(fails: Found 341 errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: yaml)*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: common_interfaces)*
- `poetry run pytest` *(fails during collection)*
- `poetry run pytest tests/tools/test_plugin_cli.py::test_scaffold_plugin tests/tools/test_plugin_tool_analyze.py::test_analyze_plugin -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_686da3a0c4a48322bd049050df976468