### PR TITLE
Update plugin guide for external debug plugin

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -73,6 +73,19 @@ class = "my_pkg.calc:CalculatorTool"
 During initialization the discovered entries are merged into the config and
 their dependencies validated automatically.
 
+### External Plugin Repositories
+
+Plugins can live in their own repositories. The
+[`entity-debug-plugin`](https://github.com/Ladvien/entity-debug-plugin) example
+demonstrates a standalone debug plugin that relies on the local `entity`
+package through a path dependency. Point `plugin_dirs` at the repository so the
+initializer discovers its `pyproject.toml`:
+
+```yaml
+plugin_dirs:
+  - ../entity-debug-plugin
+```
+
 ## Development Steps
 1. Create your plugin class and implement `_execute_impl`.
 2. Register the plugin with the `Agent` or include it in your YAML under `plugins:`.


### PR DESCRIPTION
## Summary
- reference the `entity-debug-plugin` repository
- show how to include external plugin directories

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: redefinition and undefined name errors)*
- `poetry run mypy src` *(fails: many errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: ImportError: cannot import name 'LLM')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686da559b4608322b4b2774157a27580