### PR TITLE
Add example debug plugin package

### DIFF
--- a/entity-debug-plugin/README.md
+++ b/entity-debug-plugin/README.md
@@ -1,0 +1,22 @@
+# Entity Debug Plugin
+
+This package provides a simple debug prompt for the Entity agent.
+
+## Installation
+
+Install in editable mode with development dependencies:
+
+```bash
+poetry install --with dev
+```
+
+## Usage
+
+Point `plugin_dirs` at this package when running the agent:
+
+```yaml
+plugin_dirs:
+  - path/to/entity-debug-plugin
+```
+
+This ensures the `DebugPrompt` is discovered and loaded.

--- a/entity-debug-plugin/debug_plugin.py
+++ b/entity-debug-plugin/debug_plugin.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pipeline.base_plugins import PromptPlugin
+from pipeline.context import PluginContext
+from pipeline.stages import PipelineStage
+
+
+class DebugPrompt(PromptPlugin):
+    """Simple prompt plugin for debugging."""
+
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        self.logger.info("DebugPrompt executed")
+        context.add_conversation_entry(
+            content="DebugPrompt executed",
+            role="assistant",
+        )

--- a/entity-debug-plugin/pyproject.toml
+++ b/entity-debug-plugin/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "entity-debug-plugin"
+version = "0.1.0"
+description = "Debug plugin for Entity"
+authors = ["Example <example@example.com>"]
+package-mode = true
+
+[tool.poetry.dependencies]
+python = "^3.11"
+entity = { path = "../", develop = true }
+
+[tool.entity.plugins.prompts.debug_prompt]
+class = "debug_plugin:DebugPrompt"


### PR DESCRIPTION
## Summary
- add new `entity-debug-plugin` folder with its own `pyproject.toml`
- implement a minimal `DebugPrompt` plugin derived from `PromptPlugin`
- document installation and usage in README

## Testing
- `poetry run black entity-debug-plugin`
- `poetry run flake8 src tests entity-debug-plugin` *(fails: F821 undefined names)*
- `poetry run mypy src` *(fails with many errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: circular import)*
- `poetry run pytest` *(fails: AttributeError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686da5595bfc8322906b0c6e411699cb