### PR TITLE
Improve debug plugin install docs

### DIFF
--- a/entity-debug-plugin/README.md
+++ b/entity-debug-plugin/README.md
@@ -4,7 +4,9 @@ This package provides a simple debug prompt for the Entity agent.
 
 ## Installation
 
-Install in editable mode with development dependencies:
+Install in editable mode with development dependencies.
+Running the command below installs `entity` and all of its dependencies,
+including `grpcio`:
 
 ```bash
 poetry install --with dev

--- a/entity-debug-plugin/pyproject.toml
+++ b/entity-debug-plugin/pyproject.toml
@@ -8,6 +8,7 @@ package-mode = true
 [tool.poetry.dependencies]
 python = "^3.11"
 entity = { path = "../", develop = true }
+grpcio = "^1.62.2"
 
 [tool.entity.plugins.prompts.debug_prompt]
 class = "debug_plugin:DebugPrompt"


### PR DESCRIPTION
## Summary
- clarify plugin install docs to mention grpcio
- add explicit grpcio dependency for entity-debug-plugin

## Testing
- `poetry run black src tests`
- `poetry run isort src tests`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: Missing type parameters for generic type "dict" and other errors)*
- `bandit -r src` *(fails: command not found)*
- `python -m src.entity_config.validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.entity_config.validator --config config/prod.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686dad1364dc8322b73bed7c390f5bcc