### PR TITLE
Handle missing grpcio gracefully

### DIFF
--- a/src/plugins/builtin/adapters/__init__.py
+++ b/src/plugins/builtin/adapters/__init__.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from .cli import CLIAdapter
 from .dashboard import DashboardAdapter
-from .grpc import LLMGRPCAdapter
+
+try:  # pragma: no cover - covered in tests
+    from .grpc import LLMGRPCAdapter
+except ImportError:  # pragma: no cover - absence of grpc is tested
+    LLMGRPCAdapter = None  # type: ignore[assignment]
+
 from .http import HTTPAdapter
 from .logging import LoggingAdapter
 from .logging_adapter import StructuredLoggingAdapter
@@ -15,7 +20,9 @@ __all__ = [
     "DashboardAdapter",
     "CLIAdapter",
     "WebSocketAdapter",
-    "LLMGRPCAdapter",
     "LoggingAdapter",
     "StructuredLoggingAdapter",
 ]
+
+if LLMGRPCAdapter is not None:
+    __all__.append("LLMGRPCAdapter")

--- a/tests/test_adapters_grpc_optional.py
+++ b/tests/test_adapters_grpc_optional.py
@@ -1,0 +1,22 @@
+import builtins
+import importlib
+import sys
+
+import plugins.builtin.adapters as adapters
+
+
+def test_import_without_grpc(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"grpc", "plugins.builtin.adapters.grpc"}:
+            raise ImportError("grpc unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "plugins.builtin.adapters.grpc", raising=False)
+
+    module = importlib.reload(adapters)
+
+    assert module.LLMGRPCAdapter is None
+    assert "LLMGRPCAdapter" not in module.__all__


### PR DESCRIPTION
## Summary
- make grpc adapter optional to fix imports when grpcio is missing
- add regression test ensuring adapters package imports without grpc

## Testing
- `poetry run black src/plugins/builtin/adapters/__init__.py tests/test_adapters_grpc_optional.py`
- `poetry run isort src/plugins/builtin/adapters/__init__.py tests/test_adapters_grpc_optional.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: 330 errors)*
- `poetry run bandit -r src`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run python -m src.registry.validator` *(fails: circular import)*
- `poetry run pytest` *(fails: 7 failed, 193 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686dad130a388322b6a1294528baad45