### PR TITLE
Rename stage result methods

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -441,7 +441,7 @@ class MemoryResource:
 **Implementation**: 
 - `context.set_response()` method restricted to DELIVER stage plugins only
 - Pipeline continues looping (PARSE → THINK → DO → REVIEW → DELIVER) until a DELIVER plugin calls `set_response()`
-- Earlier stages use `context.set_stage_result()` to store intermediate outputs for DELIVER plugins to access
+- Earlier stages use `context.store()` to store intermediate outputs for DELIVER plugins to access
 - Maximum iteration limit (default 5) prevents infinite loops when no DELIVER plugin sets a response
 
 **Benefits**: Ensures consistent output processing, logging, and formatting while maintaining the hybrid pipeline-state machine mental model.

--- a/architecture/architecture_tasks.md
+++ b/architecture/architecture_tasks.md
@@ -5,11 +5,11 @@
 - **Update pipeline loop logic** - Ensure only DELIVER stage responses terminate iteration
 - **Add validation error** - Clear error message when non-DELIVER plugins try to set response
 
-### 2. Stage Results Accumulation  
-- **Rename methods in `PluginContext`**:
-  - `set_stage_result()` → `store()`
-  - `get_stage_result()` → `load()` 
-  - `has_stage_result()` → `has()`
+### 2. Stage Results Accumulation
+- **PluginContext API update**:
+  - Use `store()` to save results
+  - Use `load()` to retrieve results
+  - Use `has()` to check for a stored value
 - **Update all plugin examples** in docs and templates
 - **Update method documentation** and type hints
 

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -210,7 +210,7 @@ class PluginContext:
         """Return the pipeline response if set."""
         return self.__state.response
 
-    def set_stage_result(self, key: str, value: Any) -> None:
+    def store(self, key: str, value: Any) -> None:
         """Store intermediate ``value`` for the current stage under ``key``."""
         state = self.__state
         if key in state.stage_results:
@@ -222,13 +222,13 @@ class PluginContext:
             if oldest != key:
                 state.stage_results.pop(oldest, None)
 
-    def get_stage_result(self, key: str) -> Any:
-        """Retrieve a stage result stored with :meth:`set_stage_result`."""
+    def load(self, key: str) -> Any:
+        """Retrieve a stage result previously stored via :meth:`store`."""
         if key not in self.__state.stage_results:
             raise KeyError(key)
         return self.__state.stage_results[key]
 
-    def has_stage_result(self, key: str) -> bool:
+    def has(self, key: str) -> bool:
         """Return ``True`` if ``key`` exists in stage results."""
         return key in self.__state.stage_results
 

--- a/src/pipeline/context_helpers.py
+++ b/src/pipeline/context_helpers.py
@@ -37,7 +37,7 @@ class AdvancedContext:
             tool = self._ctx._registries.tools.get(call.name)
             if not tool:
                 result = f"Error: tool {call.name} not found"
-                self._ctx.set_stage_result(call.result_key, result)
+                self._ctx.store(call.result_key, result)
                 state.pending_tool_calls.remove(call)
                 return result
             tool = cast(Any, tool)
@@ -47,11 +47,11 @@ class AdvancedContext:
             )
             try:
                 result = await execute_tool(tool, call, state, options)
-                self._ctx.set_stage_result(call.result_key, result)
+                self._ctx.store(call.result_key, result)
                 self._ctx.record_tool_execution(call.name, call.result_key, call.source)
             except Exception as exc:  # noqa: BLE001
                 result = f"Error: {exc}"
-                self._ctx.set_stage_result(call.result_key, result)
+                self._ctx.store(call.result_key, result)
                 self._ctx.record_tool_error(call.name, str(exc))
                 state.failure_info = FailureInfo(
                     stage=str(state.current_stage),
@@ -63,6 +63,6 @@ class AdvancedContext:
                 state.pending_tool_calls.remove(call)
                 raise ToolExecutionError(call.name, exc, call.result_key)
             state.pending_tool_calls.remove(call)
-        result = self._ctx.get_stage_result(result_key)
+        result = self._ctx.load(result_key)
         state.stage_results.pop(result_key, None)
         return result

--- a/tests/integration/test_chaos.py
+++ b/tests/integration/test_chaos.py
@@ -16,7 +16,7 @@ class CrashPlugin:
         if not context.metadata.get("crashed"):
             context.metadata["crashed"] = True
             raise RuntimeError("boom")
-        context.set_stage_result("parse", True)
+        context.store("parse", True)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -10,14 +10,14 @@ class ParsePlugin(BasePlugin):
     stages = [PipelineStage.PARSE]
 
     async def _execute_impl(self, context):
-        context.set_stage_result("parsed", True)
+        context.store("parsed", True)
 
 
 class ThinkPlugin(BasePlugin):
     stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context):
-        context.set_stage_result("thought", True)
+        context.store("thought", True)
 
 
 class RespondPlugin(BasePlugin):

--- a/tests/integration/test_stage_failures.py
+++ b/tests/integration/test_stage_failures.py
@@ -24,7 +24,7 @@ def make_failing_plugin(stage: PipelineStage):
             if not context.get_metadata("failed"):
                 context.set_metadata("failed", True)
                 raise RuntimeError("boom")
-            context.set_stage_result(str(stage), True)
+            context.store(str(stage), True)
 
     return FailingPlugin()
 

--- a/user_plugins/prompts/chain_of_thought.py
+++ b/user_plugins/prompts/chain_of_thought.py
@@ -57,8 +57,8 @@ class ChainOfThoughtPrompt(PromptPlugin):
             if "final answer" in reasoning.content.lower():
                 break
 
-        context.set_stage_result("reasoning_complete", True)
-        context.set_stage_result("reasoning_steps", reasoning_steps)
+        context.store("reasoning_complete", True)
+        context.store("reasoning_steps", reasoning_steps)
 
     def _needs_tools(self, reasoning_text: str) -> bool:
         """Return True if ``reasoning_text`` suggests tool usage."""

--- a/user_plugins/prompts/intent_classifier.py
+++ b/user_plugins/prompts/intent_classifier.py
@@ -35,4 +35,4 @@ class IntentClassifierPrompt(PromptPlugin):
         last_message = context.get_conversation_history()[-1].content
         prompt = "Classify the user's intent in one word.\n" f"Message: {last_message}"
         response = await self.call_llm(context, prompt, purpose="intent_classification")
-        context.set_stage_result("intent", response.content)
+        context.store("intent", response.content)


### PR DESCRIPTION
## Summary
- update PluginContext method names: `store`, `load`, `has`
- fix advanced context and plugin examples
- adjust docs for new API
- update integration tests

## Testing
- `poetry run pytest tests/integration/test_full_pipeline.py tests/integration/test_stage_failures.py tests/integration/test_chaos.py -q` *(fails: asyncio.run() cannot be called from a running event loop)*

------
https://chatgpt.com/codex/tasks/task_e_686dc10823648322a1b6a99fb7f6f367