### PR TITLE
Restrict plugin hot reload scope

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -242,8 +242,10 @@ class PluginContext:
 - **LLM Provider Swapping**: OpenAI ↔ Ollama without restart (framework is LLM agnostic)
 - **Plugin Configuration**: Update parameters, retry settings at runtime
 - **Resource Backends**: SQLite → PostgreSQL migration while running
-- **Tool Addition**: Add new capabilities dynamically
 - **Memory Backends**: Switch from in-memory to persistent storage
+
+Only configuration values of existing plugins can be reloaded. Adding or removing
+plugins or altering their stages or dependencies requires restarting the system.
 
 ### Configuration Update Process
 ```python
@@ -399,10 +401,9 @@ CMD ["python", "-m", "entity", "--config", "config/prod.yaml", "serve-http"]
 
 ## Architecture Benefits
 
-### For Developers
 - **Mental Model Clarity**: Pipeline stages are intuitive
 - **Progressive Disclosure**: Simple → Complex as needed
-- **Hot Reconfiguration**: Change behavior without restarts
+- **Hot Reconfiguration**: Parameter tweaks without restarts
 - **Rich Tooling**: Built-in observability and debugging
 
 ### For Operations  

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -73,8 +73,10 @@ poetry run python src/cli.py reload-config updated.yaml
 ```
 
 The command waits for active pipelines to finish, then applies the new YAML
-configuration. This demonstrates **Dynamic Configuration Updates**, letting you
-tweak resources or tools at runtime while keeping the system responsive.
+configuration. Only parameter updates to **existing plugins** are hot reloadable;
+adding plugins or changing their stages or dependencies requires a full
+restart. This demonstrates **Dynamic Configuration Updates** for tunable values
+while keeping the system responsive.
 
 For a hands-on demonstration, run `examples/config_reload_example.py`:
 

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -48,13 +48,15 @@ This fast path aligns with the **15-Minute Rule (2)**, giving new
 contributors a working agent almost immediately.
 
 ### Runtime Configuration Reload
-Reload plugin definitions while the agent is running:
+Reload parameter values for existing plugins while the agent is running:
 
 ```bash
 poetry run python src/cli.py reload-config updated.yaml
 ```
 
-For more on dynamic configuration, see [the architecture overview](../../architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure).
+Only configuration parameters can be reloaded. Adding or removing plugins or
+changing their stages requires restarting the agent. For more on dynamic
+configuration, see [the architecture overview](../../architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure).
 
 ### Using the "llm" Resource Key
 Configure a shared LLM resource in YAML:


### PR DESCRIPTION
## Summary
- reject plugin topology changes in `update_plugin_configuration`
- disallow runtime plugin registration via CLI
- clarify hot reload limits in docs

## Testing
- `poetry run pytest -q` *(fails: RuntimeError asyncio.run() cannot be called from a running event loop)*

------
https://chatgpt.com/codex/tasks/task_e_686dc11b3eb48322af96d71240f5c54c