### PR TITLE
Refactor resource dependency injection

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -113,19 +113,16 @@ Resources are composed from simpler backends:
 
 ```python
 # Simple setup
-memory = MemoryResource(
-    database=SQLiteDatabaseResource("./agent.db")
-)
+memory = MemoryResource({})
+memory.database = SQLiteDatabaseResource("./agent.db")
 
-# Production setup  
-memory = MemoryResource(
-    database=PostgresResource(connection_str),
-    vector_store=PgVectorStore(postgres, dimensions=768)
-)
+# Production setup
+memory = MemoryResource({})
+memory.database = PostgresResource(connection_str)
+memory.vector_store = PgVectorStore({"dimensions": 768})
 
-storage = StorageResource(
-    filesystem=S3FileSystem(bucket="agent-files")
-)
+storage = StorageResource({})
+storage.filesystem = S3FileSystem(bucket="agent-files")
 ```
 
 MemoryResource \u2013 composite store that defaults to a DuckDB-backed database

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -22,9 +22,7 @@ plugins:
       backoff: 1.0
     memory:
       type: pipeline.resources.memory_resource:MemoryResource
-      storage:
-        type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
-        path: ./dev.duckdb
+      dependencies: [database, vector_store]
     vector_store:
       type: plugins.builtin.resources.memory_vector_store:MemoryVectorStore
       table: vector_mem

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -23,13 +23,7 @@ plugins:
       backoff: 2.0
     memory:
       type: pipeline.resources.memory_resource:MemoryResource
-      storage:
-        type: plugins.builtin.resources.postgres:PostgresResource
-        host: "${DB_HOST}"
-        port: 5432
-        name: "${DB_NAME}"
-        username: "${DB_USERNAME}"
-        password: "${DB_PASSWORD}"
+      dependencies: [database, vector_store]
     vector_store:
       type: plugins.builtin.resources.memory_vector_store:MemoryVectorStore
       table: vector_mem

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -19,15 +19,10 @@ plugins:
       model: "${OLLAMA_MODEL}"
     memory:
       type: pipeline.resources.memory_resource:MemoryResource
-      database:
-        type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
-        path: ./agent.db
+      dependencies: [database]
     storage:
       type: pipeline.resources.storage_resource:StorageResource
-      filesystem:
-        type: plugins.builtin.resources.s3_filesystem:S3FileSystem
-        bucket: agent-files
-        region: us-east-1
+      dependencies: [filesystem]
     cache:
       type: user_plugins.resources.cache:CacheResource
       backend:

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -12,24 +12,25 @@ Use `StorageResource` with a Postgres database and optional S3 file storage:
 ```yaml
 plugins:
   resources:
+    postgres:
+      type: plugins.builtin.resources.postgres:PostgresResource
+      host: localhost
+      port: 5432
+      name: dev_db
+      username: agent
+      setup_commands:
+        - "CREATE EXTENSION IF NOT EXISTS vector"
+    vector_store:
+      type: plugins.builtin.resources.pg_vector_store:PgVectorStore
+      dimensions: 768
+      table: embeddings
+    filesystem:
+      type: plugins.builtin.resources.s3_filesystem:S3FileSystem
+      bucket: agent-files
+      region: us-east-1
     storage:
       type: storage
-      database:
-        type: plugins.builtin.resources.postgres:PostgresResource
-        host: localhost
-        port: 5432
-        name: dev_db
-        username: agent
-        setup_commands:
-          - "CREATE EXTENSION IF NOT EXISTS vector"
-      vector_store:
-        type: plugins.builtin.resources.pg_vector_store:PgVectorStore
-        dimensions: 768
-        table: embeddings
-      filesystem:
-        type: plugins.builtin.resources.s3_filesystem:S3FileSystem
-        bucket: agent-files
-        region: us-east-1
+      dependencies: [postgres, vector_store, filesystem]
 ```
 
 `MemoryResource` persists conversation history and vectors. `StorageResource` extends it with file CRUD across the configured backends.
@@ -39,11 +40,12 @@ For local experimentation you can use a file-backed DuckDB database:
 ```yaml
 plugins:
   resources:
+    db:
+      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      path: ./agent.duckdb
     storage:
       type: storage
-      database:
-        type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
-        path: ./agent.duckdb
+      dependencies: [db]
 ```
 
 You can also use `StorageResource` for a lighter setup:
@@ -51,14 +53,15 @@ You can also use `StorageResource` for a lighter setup:
 ```yaml
 plugins:
   resources:
+    db:
+      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      path: ./agent.duckdb
+    fs:
+      type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
+      base_path: ./files
     storage:
       type: storage
-      database:
-        type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
-        path: ./agent.duckdb
-      filesystem:
-        type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
-        base_path: ./files
+      dependencies: [db, fs]
 ```
 
 These configurations illustrate **Preserve All Power (7)** by enabling

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -10,6 +10,7 @@ Create a plugin class that inherits from one of the base plugin types and implem
 from pipeline.base_plugins import PromptPlugin
 from pipeline.stages import PipelineStage
 
+
 class HelloPlugin(PromptPlugin):
     stages = [PipelineStage.DO]
 
@@ -100,8 +101,9 @@ new backend, subclass `ResourcePlugin` and implement the `save_history` and
 
 ```python
 import asyncpg
-from plugins import ResourcePlugin
+
 from pipeline.stages import PipelineStage
+from plugins import ResourcePlugin
 
 
 class MyStorage(ResourcePlugin):
@@ -140,20 +142,18 @@ Several example pipelines in the `examples/` directory showcase more advanced pa
 `StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. The pipeline at `examples/pipelines/memory_composition_pipeline.py` demonstrates the same pattern using the older `MemoryResource`. `MemoryResource` now persists conversation history and vectors and is configured in [config/dev.yaml](../../config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. With the plugin configured the code looks like:
 
 ```python
-storage = StorageResource(
-    database=DuckDBDatabaseResource({"path": "./agent.duckdb"}),
-    vector_store=PgVectorStore({"table": "embeddings"}),
-    filesystem=LocalFileSystemResource({"base_path": "./files"}),
-)
+storage = StorageResource({})
+storage.database = DuckDBDatabaseResource({"path": "./agent.duckdb"})
+storage.vector_store = PgVectorStore({"table": "embeddings"})
+storage.filesystem = LocalFileSystemResource({"base_path": "./files"})
 ```
 
 `StorageResource` offers the same interface when you only need history and file storage:
 
 ```python
-storage = StorageResource(
-    database=DuckDBDatabaseResource({"path": "./agent.duckdb"}),
-    filesystem=LocalFileSystemResource({"base_path": "./files"}),
-)
+storage = StorageResource({})
+storage.database = DuckDBDatabaseResource({"path": "./agent.duckdb"})
+storage.filesystem = LocalFileSystemResource({"base_path": "./files"})
 ```
 The script at `examples/storage_resource_example.py` demonstrates this setup.
 

--- a/examples/pipelines/duckdb_pipeline.py
+++ b/examples/pipelines/duckdb_pipeline.py
@@ -40,8 +40,11 @@ def main() -> None:
     database = DuckDBDatabaseResource(
         {"path": "./agent.duckdb", "history_table": "history"}
     )
-    vector_store = DuckDBVectorStore({"table": "vectors", "dimensions": 3}, database)
-    memory = MemoryResource(database=database, vector_store=vector_store)
+    vector_store = DuckDBVectorStore({"table": "vectors", "dimensions": 3})
+    vector_store.database = database
+    memory = MemoryResource({})
+    memory.database = database
+    memory.vector_store = vector_store
 
     agent.builder.resource_registry.add("memory", memory)
     agent.builder.plugin_registry.register_plugin_for_stage(

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import asyncio
 import os
 
-
 from ..utilities import enable_plugins_namespace
 
 enable_plugins_namespace()
@@ -20,9 +19,8 @@ from pipeline.config import ConfigLoader
 from pipeline.context import PluginContext  # noqa: E402
 from plugins.builtin.resources.pg_vector_store import PgVectorStore
 from plugins.builtin.resources.postgres import PostgresResource
-from plugins.builtin.resources.sqlite_storage import (
-    SQLiteStorageResource as SQLiteDatabaseResource,
-)
+from plugins.builtin.resources.sqlite_storage import \
+    SQLiteStorageResource as SQLiteDatabaseResource
 from user_plugins.memory_resource import MemoryResource
 from user_plugins.resources import DuckDBVectorStore
 
@@ -66,7 +64,9 @@ def main() -> None:
 
     database = SQLiteDatabaseResource({"path": "./agent.db"})
     vector_store = create_vector_store()
-    memory = MemoryResource(database=database, vector_store=vector_store)
+    memory = MemoryResource({})
+    memory.database = database
+    memory.vector_store = vector_store
 
     agent.builder.resource_registry.add("memory", memory)
     agent.builder.plugin_registry.register_plugin_for_stage(

--- a/examples/storage_resource_example.py
+++ b/examples/storage_resource_example.py
@@ -17,9 +17,8 @@ from pipeline import Agent, PipelineStage, PromptPlugin
 from pipeline.context import ConversationEntry, PluginContext
 from pipeline.resources.memory_resource import MemoryResource
 from plugins.builtin.resources.local_filesystem import LocalFileSystemResource
-from plugins.builtin.resources.sqlite_storage import (
-    SQLiteStorageResource as SQLiteDatabaseResource,
-)
+from plugins.builtin.resources.sqlite_storage import \
+    SQLiteStorageResource as SQLiteDatabaseResource
 from plugins.builtin.resources.storage_resource import StorageResource
 
 
@@ -43,8 +42,10 @@ def main() -> None:
     database = SQLiteDatabaseResource({"path": "./agent.db"})
     filesystem = LocalFileSystemResource({"base_path": "./files"})
 
-    memory = MemoryResource(database=database)
-    storage = StorageResource(filesystem=filesystem)
+    memory = MemoryResource({})
+    memory.database = database
+    storage = StorageResource({})
+    storage.filesystem = filesystem
 
     agent.builder.resource_registry.add("memory", memory)
     agent.builder.resource_registry.add("storage", storage)

--- a/src/pipeline/resources/memory_resource.py
+++ b/src/pipeline/resources/memory_resource.py
@@ -70,42 +70,18 @@ class MemoryResource(ResourcePlugin, Memory):
     name = "memory"
     dependencies = ["database", "vector_store"]
 
-    def __init__(
-        self,
-        database: DatabaseResource | None = None,
-        vector_store: VectorStoreResource | None = None,
-        config: Dict | None = None,
-        *,
-        storage: DatabaseResource | None = None,
-    ) -> None:
-        """Initialize the resource.
-
-        Parameters
-        ----------
-        database:
-            Backend used to persist conversation history.
-        vector_store:
-            Backend used for similarity search.
-        config:
-            Optional configuration mapping.
-        storage:
-            Keyword-only alias for ``database`` kept for backward
-            compatibility.
-        """
+    def __init__(self, config: Dict | None = None) -> None:
+        """Initialize the resource with optional configuration."""
 
         super().__init__(config or {})
-        if storage is not None and database is None:
-            database = storage
-        elif storage is not None and storage is not database:
-            raise ValueError("'database' and 'storage' refer to different objects")
-        self.database = database
-        self.vector_store = vector_store
+        self.database: DatabaseResource | None = None
+        self.vector_store: VectorStoreResource | None = None
         self._kv: Dict[str, Any] = {}
         self._conversation_manager: ConversationManager | None = None
 
     @classmethod
     def from_config(cls, config: Dict) -> "MemoryResource":
-        return cls(None, None, config=config)
+        return cls(config=config)
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
         return None

--- a/src/plugins/builtin/resources/storage_resource.py
+++ b/src/plugins/builtin/resources/storage_resource.py
@@ -18,13 +18,9 @@ class StorageResource(ResourcePlugin):
     name = "storage"
     dependencies = ["filesystem"]
 
-    def __init__(
-        self,
-        filesystem: FileSystemResource | None = None,
-        config: Dict | None = None,
-    ) -> None:
+    def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
-        self.filesystem = filesystem
+        self.filesystem: FileSystemResource | None = None
 
     @classmethod
     def from_config(cls, config: Dict) -> "StorageResource":

--- a/tests/experiments/test_experiment_storage_resource.py
+++ b/tests/experiments/test_experiment_storage_resource.py
@@ -11,7 +11,9 @@ from plugins.builtin.resources.local_filesystem import LocalFileSystemResource
 async def make_storage(tmp_path: Path) -> StorageResource:
     fs = LocalFileSystemResource({"base_path": str(tmp_path)})
     db = InMemoryStorageResource({})
-    storage = StorageResource(database=db, filesystem=fs)
+    storage = StorageResource({})
+    storage.database = db
+    storage.filesystem = fs
     await storage.initialize()
     return storage
 

--- a/tests/integration/test_chat_history_backends.py
+++ b/tests/integration/test_chat_history_backends.py
@@ -6,16 +6,9 @@ from pathlib import Path
 import pytest
 
 from entity_config.environment import load_env
-from pipeline import (
-    ConversationEntry,
-    MetricsCollector,
-    PipelineStage,
-    PipelineState,
-    PluginContext,
-    PluginRegistry,
-    SystemRegistries,
-    ToolRegistry,
-)
+from pipeline import (ConversationEntry, MetricsCollector, PipelineStage,
+                      PipelineState, PluginContext, PluginRegistry,
+                      SystemRegistries, ToolRegistry)
 from pipeline.resources import ResourceContainer
 from pipeline.resources.memory_resource import MemoryResource
 from plugins.builtin.resources.duckdb_database import DuckDBDatabaseResource
@@ -44,7 +37,8 @@ async def run_history_test(resource):
         resource._history_table = "test_history"
         await resource.initialize()
 
-    memory = MemoryResource(database=resource)
+    memory = MemoryResource({})
+    memory.database = resource
     resources = ResourceContainer()
     await resources.add("memory", memory)
     registries = SystemRegistries(resources, ToolRegistry(), PluginRegistry())

--- a/tests/integration/test_postgres_history.py
+++ b/tests/integration/test_postgres_history.py
@@ -28,7 +28,8 @@ CONN = {
 def test_save_and_load_history(pg_env):
     async def run():
         db = PostgresResource(CONN)
-        memory = MemoryResource(database=db)
+        memory = MemoryResource({})
+        memory.database = db
         try:
             await db.initialize()
         except OSError as exc:

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -6,15 +6,9 @@ from pathlib import Path
 import pytest
 
 from entity_config.environment import load_env
-from pipeline import (
-    ConversationEntry,
-    MetricsCollector,
-    PipelineState,
-    PluginContext,
-    PluginRegistry,
-    SystemRegistries,
-    ToolRegistry,
-)
+from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
+                      PluginContext, PluginRegistry, SystemRegistries,
+                      ToolRegistry)
 from pipeline.resources import ResourceContainer
 from pipeline.resources.llm import UnifiedLLMResource
 from pipeline.resources.memory_resource import MemoryResource
@@ -57,7 +51,10 @@ def test_vector_memory_integration(pg_env):
         }
         db = PostgresResource(db_cfg)
         vm = PgVectorStore(vm_cfg)
-        memory = MemoryResource(database=db, vector_store=vm)
+        vm.database = db
+        memory = MemoryResource({})
+        memory.database = db
+        memory.vector_store = vm
         llm = UnifiedLLMResource(
             {"provider": "echo", "base_url": "http://localhost", "model": "none"}
         )

--- a/tests/test_conversation_history_plugin.py
+++ b/tests/test_conversation_history_plugin.py
@@ -1,15 +1,9 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (
-    ConversationEntry,
-    MetricsCollector,
-    PipelineState,
-    PluginContext,
-    PluginRegistry,
-    SystemRegistries,
-    ToolRegistry,
-)
+from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
+                      PluginContext, PluginRegistry, SystemRegistries,
+                      ToolRegistry)
 from pipeline.resources import ResourceContainer
 from pipeline.resources.memory_resource import MemoryResource
 from pipeline.stages import PipelineStage
@@ -22,7 +16,8 @@ async def make_context(tmp_path):
         {"path": tmp_path / "hist.duckdb", "history_table": "h"}
     )
     await db.initialize()
-    memory = MemoryResource(database=db)
+    memory = MemoryResource({})
+    memory.database = db
     state = PipelineState(
         conversation=[
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -1,17 +1,12 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (
-    PipelineStage,
-    PluginRegistry,
-    PromptPlugin,
-    SystemRegistries,
-    ToolRegistry,
-    execute_pipeline,
-)
+from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
+                      SystemRegistries, ToolRegistry, execute_pipeline)
 from pipeline.context import ConversationEntry
 from pipeline.resources import ResourceContainer
-from pipeline.resources.memory_resource import MemoryResource, SimpleMemoryResource
+from pipeline.resources.memory_resource import (MemoryResource,
+                                                SimpleMemoryResource)
 from plugins.builtin.resources.memory import Memory
 from plugins.builtin.resources.memory_storage import MemoryStorage
 
@@ -48,7 +43,8 @@ def test_memory_persists_between_runs():
 def test_save_and_load_history():
     async def run():
         storage = MemoryStorage({})
-        memory = MemoryResource(database=storage)
+        memory = MemoryResource({})
+        memory.database = storage
         history = [
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ]

--- a/tests/test_storage_resource.py
+++ b/tests/test_storage_resource.py
@@ -7,7 +7,9 @@ from plugins.builtin.resources.storage_resource import StorageResource
 
 async def make_resource(tmp_path: Path) -> StorageResource:
     fs = LocalFileSystemResource({"base_path": str(tmp_path)})
-    return StorageResource(filesystem=fs)
+    res = StorageResource({})
+    res.filesystem = fs
+    return res
 
 
 def test_store_and_load_file(tmp_path):


### PR DESCRIPTION
## Summary
- update ResourceContainer to inject dependencies after instantiation
- simplify MemoryResource and built-in resources constructors
- define dependencies explicitly in examples and configs
- update documentation for new injection pattern
- adjust unit tests for new resource API

## Testing
- `poetry run black -q src tests examples config architecture docs`
- `poetry run isort architecture/general.md docs/source/advanced_usage.md docs/source/plugin_guide.md examples/pipelines/duckdb_pipeline.py examples/pipelines/memory_composition_pipeline.py examples/storage_resource_example.py src/pipeline/resources/container.py src/pipeline/resources/memory_resource.py src/plugins/builtin/resources/duckdb_vector_store.py src/plugins/builtin/resources/pg_vector_store.py src/plugins/builtin/resources/storage_resource.py tests/experiments/test_experiment_storage_resource.py tests/integration/test_chat_history_backends.py tests/integration/test_postgres_history.py tests/integration/test_vector_memory_integration.py tests/test_conversation_history_plugin.py tests/test_memory_resource.py tests/test_storage_resource.py`
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: various missing type annotations)*
- `poetry run bandit -r src`
- `python tools/check_empty_dirs.py`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686dc10e4588832284e69a2989771399