### PR TITLE
Rename tool execution methods

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -175,7 +175,7 @@ class FailurePlugin(BasePlugin):
 ```python
 async def _execute_impl(self, context):
     # Tools execute immediately with natural async/await
-    result = await context.use_tool("calculator", expression="2+2")
+    result = await context.tool_use("calculator", expression="2+2")
     context.set_response(f"The answer is {result}")
 ```
 
@@ -186,7 +186,7 @@ async def _execute_impl(self, context):
 - Natural async/await patterns
 - No queuing complexity
 
-**Tip**: Use `context.use_tool()` to run tools directly.
+**Tip**: Use `context.tool_use()` to run tools directly.
 
 ## State Management
 
@@ -213,7 +213,7 @@ class PluginContext:
     def get_llm(self) -> LLM
     
     # Tool execution (immediate)
-    async def use_tool(self, tool_name: str, **params) -> Any
+    async def tool_use(self, tool_name: str, **params) -> Any
     
     # Response control
     def set_response(self, response: Any) -> None
@@ -320,7 +320,7 @@ if context.is_question():
     response = await context.ask_llm("Answer this question: " + context.message)
     
 if context.contains("weather", "temperature"):
-    weather = await context.use_tool("weather", location=context.location)
+    weather = await context.tool_use("weather", location=context.location)
 
 # Memory operations with semantic meaning
 memory = context.get_resource("memory")

--- a/docs/source/context.md
+++ b/docs/source/context.md
@@ -4,7 +4,7 @@
 
 - conversation history and other pipeline state
 - registered resources via `get_resource`
-- tool execution through `execute_tool`
+- tool execution through `queue_tool_use`
 - helpers for adding conversation entries and stage results
 
 Plugins receive this object inside their `_execute_impl` method.
@@ -21,7 +21,7 @@ class ExamplePlugin(PromptPlugin):
 
 - `say()` to set the pipeline response
 - `ask_llm()` to call the configured LLM
-- `use_tool()` to run a tool and wait for the result
+- `tool_use()` to run a tool and wait for the result
 
 ```python
 class MyPrompt(PromptPlugin):

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -35,7 +35,7 @@ agent = Agent()
 
 @agent.plugin
 async def weather_plugin(ctx):
-    return await ctx.use_tool("weather", city="London")
+    return await ctx.tool_use("weather", city="London")
 ```
 
 ## Loading Plugins Automatically

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -21,7 +21,7 @@ agent.tool_registry.add("search", SearchTool())
 
 @agent.plugin
 async def lookup(context):
-    return await context.use_tool("search", query="Entity Pipeline")
+    return await context.tool_use("search", query="Entity Pipeline")
 ```
 
 The `context` argument is an instance of `PluginContext`. See

--- a/examples/tools/search_weather_example.py
+++ b/examples/tools/search_weather_example.py
@@ -32,8 +32,8 @@ agent.tool_registry.add(
 @agent.plugin
 async def gather(ctx: PluginContext) -> str:
     """Run both tools and combine their output."""
-    search = await ctx.use_tool("search", query="OpenAI news")
-    weather = await ctx.use_tool("weather", location="Berlin")
+    search = await ctx.tool_use("search", query="OpenAI news")
+    weather = await ctx.tool_use("weather", location="Berlin")
     return f"{search} Weather: {weather}"
 
 

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -151,10 +151,10 @@ class PluginContext:
                 return cast(str, entry.content)
         return ""
 
-    def execute_tool(
+    def queue_tool_use(
         self, tool_name: str, params: Dict[str, Any], result_key: Optional[str] = None
     ) -> str:
-        """Queue execution of ``tool_name`` with ``params``.
+        """Queue ``tool_name`` for execution with ``params``.
 
         Returns the key where the result will be stored.
         """
@@ -289,13 +289,10 @@ class PluginContext:
         """Persist a value in pipeline metadata."""
         self.set_metadata(key, value)
 
-    async def use_tool(self, tool_name: str, **params: Any) -> Any:
-        """Run ``tool_name`` with ``params`` and return its result.
+    async def tool_use(self, tool_name: str, **params: Any) -> Any:
+        """Execute ``tool_name`` immediately and return its result."""
 
-        This helper schedules the tool call, waits for completion, and
-        then returns whatever value the tool produced.
-        """
-        result_key = self.execute_tool(tool_name, params)
+        result_key = self.queue_tool_use(tool_name, params)
         return await self._wait_for_tool_result(result_key)
 
     async def _wait_for_tool_result(self, result_key: str) -> Any:
@@ -346,7 +343,7 @@ class PluginContext:
 
     async def calculate(self, expression: str) -> Any:
         """Evaluate an arithmetic ``expression`` using the calculator tool."""
-        return await self.use_tool("calculator", expression=expression)
+        return await self.tool_use("calculator", expression=expression)
 
     def is_question(self) -> bool:
         """Return ``True`` if the user message ends with a question mark."""

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -21,7 +21,7 @@ class SleepTool(ToolPlugin):
 
 
 async def use_tool_plugin(ctx: PluginContext) -> None:
-    result = await ctx.use_tool("sleep", text="hello")
+    result = await ctx.tool_use("sleep", text="hello")
     ctx.set_response(result)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -29,7 +29,7 @@ class MetricsPlugin(PromptPlugin):
     stages = [PipelineStage.DO]
 
     async def _execute_impl(self, context):
-        await context.use_tool("echo", text="hello")
+        await context.tool_use("echo", text="hello")
         await self.call_llm(context, "hi", "test")
         context.set_response("ok")
 

--- a/tests/test_plugin_layers.py
+++ b/tests/test_plugin_layers.py
@@ -29,7 +29,7 @@ class MyTool(ToolPlugin):
 
 
 async def my_prompt(ctx: PluginContext) -> None:
-    val = await ctx.use_tool("tool", value="ok")
+    val = await ctx.tool_use("tool", value="ok")
     ctx.set_response(val)
 
 

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -26,7 +26,7 @@ async def run_search() -> str:
     await tools.add("search", SearchTool())
     registries = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
     ctx = PluginContext(state, registries)
-    return await ctx.use_tool("search", query="open source")
+    return await ctx.tool_use("search", query="open source")
 
 
 def test_search_tool_returns_result():

--- a/tests/test_tool_error_propagation.py
+++ b/tests/test_tool_error_propagation.py
@@ -24,7 +24,7 @@ class CallToolPlugin(PromptPlugin):
     stages = [PipelineStage.DO]
 
     async def _execute_impl(self, context):
-        await context.use_tool("fail")
+        await context.tool_use("fail")
 
 
 def make_registries():

--- a/tests/test_weather_api_tool.py
+++ b/tests/test_weather_api_tool.py
@@ -46,7 +46,7 @@ async def run_weather() -> dict:
     registries = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
     ctx = PluginContext(state, registries)
     try:
-        result = await ctx.use_tool("weather", location="Berlin")
+        result = await ctx.tool_use("weather", location="Berlin")
     finally:
         server.shutdown()
         thread.join()

--- a/user_plugins/prompts/chain_of_thought.py
+++ b/user_plugins/prompts/chain_of_thought.py
@@ -48,7 +48,7 @@ class ChainOfThoughtPrompt(PromptPlugin):
             )
 
             if self._needs_tools(reasoning.content):
-                await context.use_tool(
+                await context.tool_use(
                     "analysis_tool",
                     data=conversation_text,
                     reasoning_step=reasoning.content,

--- a/user_plugins/prompts/react_prompt.py
+++ b/user_plugins/prompts/react_prompt.py
@@ -71,7 +71,7 @@ class ReActPrompt(PromptPlugin):
                     metadata={"react_step": step, "type": "action"},
                 )
 
-                await context.use_tool(action_name, **params)
+                await context.tool_use(action_name, **params)
 
         context.set_response(
             "I've reached my reasoning limit without finding a definitive answer."


### PR DESCRIPTION
## Summary
- rename PluginContext.execute_tool to queue_tool_use
- rename PluginContext.use_tool to tool_use
- update docs and examples to show the new API
- update user plugins and tests with new method names

## Testing
- `poetry run pytest` *(fails: asyncio.run() cannot be called from a running event loop)*

------
https://chatgpt.com/codex/tasks/task_e_686dc1097a58832296127c61b2a8fe41