### PR TITLE
Enforce DELIVER stage response handling

### DIFF
--- a/src/pipeline/base_plugins/base.py
+++ b/src/pipeline/base_plugins/base.py
@@ -15,11 +15,9 @@ import yaml
 from pydantic import ValidationError
 
 from common_interfaces.base_plugin import BasePlugin as BasePluginInterface
-from plugins.builtin.config_models import (PLUGIN_CONFIG_MODELS,
-                                           DefaultConfigModel)
+from plugins.builtin.config_models import PLUGIN_CONFIG_MODELS, DefaultConfigModel
 
-from ..exceptions import (CircuitBreakerTripped, PipelineError,
-                          PluginExecutionError)
+from ..exceptions import CircuitBreakerTripped, PipelineError, PluginExecutionError
 from ..logging import get_logger
 from ..observability.utils import execute_with_observability
 from ..reliability import RetryPolicy

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -190,7 +190,11 @@ class PluginContext:
         return [deepcopy(entry) for entry in history]
 
     def set_response(self, response: Any) -> None:
-        """Set the pipeline's final ``response`` if not already set."""
+        """Set the pipeline's final ``response`` during the DELIVER stage."""
+
+        if self.current_stage != PipelineStage.DELIVER:
+            raise ValueError("set_response() is only valid during the DELIVER stage")
+
         state = self.__state
         if state.response is not None:
             raise ValueError("Response already set")

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -187,7 +187,7 @@ async def execute_stage(
     if state.metrics:
         state.metrics.record_stage_duration(str(stage), duration)
 
-    if stage == PipelineStage.ERROR and state.response is None:
+    if stage == PipelineStage.DELIVER and state.response is None:
         fallback = FallbackErrorPlugin({})
         context = PluginContext(state, registries)
         await fallback.execute(context)
@@ -270,7 +270,10 @@ async def execute_pipeline(
                         state.last_completed_stage = stage
 
                     if (
-                        state.response is not None
+                        (
+                            state.response is not None
+                            and state.last_completed_stage == PipelineStage.DELIVER
+                        )
                         or state.failure_info is not None
                         or state.iteration >= max_iterations
                     ):
@@ -297,6 +300,7 @@ async def execute_pipeline(
                 await execute_stage(PipelineStage.ERROR, state, registries)
                 if state_logger is not None:
                     state_logger.log(state, PipelineStage.ERROR)
+                await execute_stage(PipelineStage.DELIVER, state, registries)
             except Exception:
                 result = create_static_error_response(state.pipeline_id).to_dict()
                 return (result, state.metrics) if return_metrics else result

--- a/src/pipeline/security/validation.py
+++ b/src/pipeline/security/validation.py
@@ -30,7 +30,10 @@ class InputValidator:
         except ValidationError as exc:
             raise ValueError(str(exc)) from exc
 
-        data = instance.model_dump()
+        if hasattr(instance, "model_dump"):
+            data = instance.model_dump()
+        else:  # pragma: no cover - pydantic v1 compatibility
+            data = instance.dict()  # type: ignore[attr-defined]
         for key, value in data.items():
             if isinstance(value, str):
                 data[key] = sanitize_text(value)

--- a/src/plugins/builtin/failure/fallback_error_plugin.py
+++ b/src/plugins/builtin/failure/fallback_error_plugin.py
@@ -11,7 +11,7 @@ from pipeline.stages import PipelineStage
 class FallbackErrorPlugin(FailurePlugin):
     """Provide a generic error response."""
 
-    stages = [PipelineStage.ERROR]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         """Provide a static fallback response."""

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -21,7 +21,7 @@ class ThinkPlugin(BasePlugin):
 
 
 class RespondPlugin(BasePlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         context.set_response("ok")
@@ -34,5 +34,6 @@ def test_full_agent_pipeline():
     agent.add_plugin(ThinkPlugin())
     agent.add_plugin(RespondPlugin())
 
+    agent._runtime = agent.builder.build_runtime()
     result = asyncio.run(agent.handle("hi"))
     assert result == "ok"

--- a/tests/integration/test_pipeline_multi_provider.py
+++ b/tests/integration/test_pipeline_multi_provider.py
@@ -17,7 +17,7 @@ class FailHandler(BaseHTTPRequestHandler):
 
 
 class LLMResponder(BasePlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         response = await context.ask_llm(context.message)

--- a/tests/integration/test_stage_failures.py
+++ b/tests/integration/test_stage_failures.py
@@ -10,7 +10,7 @@ from registry import PluginRegistry, SystemRegistries, ToolRegistry
 
 
 class RespondPlugin(BasePlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         context.set_response({"message": "ok"})
@@ -47,7 +47,7 @@ def test_pipeline_recovers_from_stage_failure(
         state_file = tmp_path / "state.json"
         plugins = PluginRegistry()
         await plugins.register_plugin_for_stage(make_failing_plugin(stage), stage)
-        await plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DO)
+        await plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DELIVER)
         registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
         try:
             await execute_pipeline("hi", registries, state_file=str(state_file))

--- a/tests/performance/test_full_pipeline_benchmark.py
+++ b/tests/performance/test_full_pipeline_benchmark.py
@@ -13,7 +13,7 @@ from pipeline.resources import ResourceContainer
 
 
 class RespondPlugin:
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def execute(self, context):
         context.set_response("ok")
@@ -22,7 +22,9 @@ class RespondPlugin:
 @pytest.mark.benchmark
 def test_full_pipeline_benchmark(benchmark):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
 

--- a/tests/performance/test_pipeline_benchmark.py
+++ b/tests/performance/test_pipeline_benchmark.py
@@ -14,7 +14,7 @@ from pipeline.resources import ResourceContainer
 
 
 class NoOpPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         context.set_response("ok")
@@ -22,7 +22,9 @@ class NoOpPlugin(PromptPlugin):
 
 def _make_manager():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 

--- a/tests/pipeline/debug/test_state_logger.py
+++ b/tests/pipeline/debug/test_state_logger.py
@@ -44,7 +44,7 @@ def test_logger_and_replay(tmp_path):
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         context.set_response("ok")
@@ -52,7 +52,9 @@ class RespondPlugin(PromptPlugin):
 
 def test_execute_pipeline_logs_states(tmp_path):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
     log_file = tmp_path / "run.jsonl"

--- a/tests/pipeline/debug/test_state_manager.py
+++ b/tests/pipeline/debug/test_state_manager.py
@@ -13,7 +13,7 @@ from pipeline.resources import ResourceContainer
 
 
 class SavePlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     def __init__(self, manager: StateManager) -> None:
         super().__init__({})
@@ -27,7 +27,7 @@ class SavePlugin(PromptPlugin):
 def make_manager(manager: StateManager) -> PipelineManager:
     plugins = PluginRegistry()
     asyncio.run(
-        plugins.register_plugin_for_stage(SavePlugin(manager), PipelineStage.DO)
+        plugins.register_plugin_for_stage(SavePlugin(manager), PipelineStage.DELIVER)
     )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return PipelineManager(registries)

--- a/tests/test_agent_plugin.py
+++ b/tests/test_agent_plugin.py
@@ -20,5 +20,6 @@ def test_agent_plugin_autoclassification():
     assert any(p.name == "think_response" for p in think_plugins)
     assert any(p.name == "parse_func" for p in parse_plugins)
 
+    agent._runtime = agent.builder.build_runtime()
     result = asyncio.run(agent.run_message("hi"))
     assert result == "parsed"

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -32,9 +32,9 @@ def make_registries() -> SystemRegistries:
     plugins = PluginRegistry()
     plugin = PluginAutoClassifier.classify(
         use_tool_plugin,
-        {"stage": PipelineStage.DO, "name": "UseToolPlugin"},
+        {"stage": PipelineStage.DELIVER, "name": "UseToolPlugin"},
     )
-    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DO))
+    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DELIVER))
     return SystemRegistries(resources, tools, plugins)
 
 

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -15,7 +15,7 @@ from user_plugins.failure.error_formatter import ErrorFormatter
 
 
 class UnstablePlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         raise ValueError("boom")
@@ -26,12 +26,12 @@ def make_registries():
     asyncio.run(
         plugins.register_plugin_for_stage(
             UnstablePlugin({"failure_threshold": 2, "failure_reset_timeout": 60}),
-            PipelineStage.DO,
+            PipelineStage.DELIVER,
         )
     )
     asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
     asyncio.run(
-        plugins.register_plugin_for_stage(ErrorFormatter({}), PipelineStage.ERROR)
+        plugins.register_plugin_for_stage(ErrorFormatter({}), PipelineStage.DELIVER)
     )
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 

--- a/tests/test_cli_adapter.py
+++ b/tests/test_cli_adapter.py
@@ -15,7 +15,7 @@ from plugins.builtin.adapters.cli import CLIAdapter
 
 
 class EchoPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -24,7 +24,9 @@ class EchoPlugin(PromptPlugin):
 
 def make_adapter() -> tuple[CLIAdapter, SystemRegistries]:
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return CLIAdapter(manager), registries

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -13,7 +13,7 @@ from pipeline.resources.memory_resource import SimpleMemoryResource
 
 
 class ContinuePlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         if context.message == "start":
@@ -21,7 +21,7 @@ class ContinuePlugin(PromptPlugin):
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         if context.message == "next":
@@ -30,8 +30,12 @@ class RespondPlugin(PromptPlugin):
 
 def make_manager():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DO))
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DELIVER)
+    )
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+    )
     resources = ResourceContainer()
     asyncio.run(resources.add("memory", SimpleMemoryResource()))
     registries = SystemRegistries(resources, ToolRegistry(), plugins)

--- a/tests/test_dashboard_adapter.py
+++ b/tests/test_dashboard_adapter.py
@@ -17,7 +17,7 @@ from plugins.builtin.adapters import DashboardAdapter
 
 
 class RespPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -26,7 +26,7 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter(tmp_path: Path) -> DashboardAdapter:
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO)
+    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DELIVER)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     log_path = tmp_path / "state.log"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -40,7 +40,7 @@ class ResourceFailPlugin(PromptPlugin):
 
 
 class FallbackPlugin(FailurePlugin):
-    stages = [PipelineStage.ERROR]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         info = context.get_failure_info()
@@ -52,7 +52,7 @@ def make_registries(error_plugin, main_plugin=BoomPlugin):
     asyncio.run(plugins.register_plugin_for_stage(main_plugin({}), PipelineStage.DO))
     asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
     asyncio.run(
-        plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
+        plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.DELIVER)
     )
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -27,7 +27,7 @@ class FailPlugin(PromptPlugin):
 
 
 class ErrorPlugin(FailurePlugin):
-    stages = [PipelineStage.ERROR]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         info = context.get_failure_info()
@@ -36,7 +36,7 @@ class ErrorPlugin(FailurePlugin):
 
 
 class BadErrorPlugin(FailurePlugin):
-    stages = [PipelineStage.ERROR]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         raise RuntimeError("bad")
@@ -47,7 +47,7 @@ def make_registries(error_plugin):
     asyncio.run(plugins.register_plugin_for_stage(FailPlugin({}), PipelineStage.DO))
     asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
     asyncio.run(
-        plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
+        plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.DELIVER)
     )
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -15,7 +15,7 @@ from plugins.builtin.adapters import HTTPAdapter
 
 
 class RespPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -24,7 +24,9 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter(config=None):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return HTTPAdapter(manager, config)

--- a/tests/test_logging_adapter.py
+++ b/tests/test_logging_adapter.py
@@ -14,7 +14,7 @@ from plugins.builtin.adapters.logging import LoggingAdapter
 
 
 class EchoPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         entry = context.get_conversation_history()[0]
@@ -23,7 +23,9 @@ class EchoPlugin(PromptPlugin):
 
 def make_manager() -> PipelineManager:
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DELIVER)
+    )
     asyncio.run(
         plugins.register_plugin_for_stage(LoggingAdapter({}), PipelineStage.DELIVER)
     )

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -17,7 +17,7 @@ from plugins.builtin.resources.memory_storage import MemoryStorage
 
 
 class IncrementPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
     dependencies = ["memory"]
 
     async def _execute_impl(self, context):
@@ -30,7 +30,7 @@ class IncrementPlugin(PromptPlugin):
 def make_registries():
     plugins = PluginRegistry()
     asyncio.run(
-        plugins.register_plugin_for_stage(IncrementPlugin({}), PipelineStage.DO)
+        plugins.register_plugin_for_stage(IncrementPlugin({}), PipelineStage.DELIVER)
     )
     resources = ResourceContainer()
     asyncio.run(resources.add("memory", SimpleMemoryResource()))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -26,7 +26,7 @@ class EchoTool(ToolPlugin):
 
 
 class MetricsPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         await context.use_tool("echo", text="hello")
@@ -36,7 +36,9 @@ class MetricsPlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DELIVER)
+    )
     resources = ResourceContainer()
     asyncio.run(resources.add("llm", EchoLLM()))
     tools = ToolRegistry()

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -13,7 +13,7 @@ from pipeline.resources import ResourceContainer
 
 
 class TimedPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         await asyncio.sleep(0.05)
@@ -22,7 +22,9 @@ class TimedPlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(TimedPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(TimedPlugin({}), PipelineStage.DELIVER)
+    )
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -12,7 +12,7 @@ from pipeline.resources import ResourceContainer
 
 
 class WaitPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         await asyncio.sleep(0.05)
@@ -21,7 +21,9 @@ class WaitPlugin(PromptPlugin):
 
 def make_manager():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(WaitPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(WaitPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -17,7 +17,7 @@ from pipeline.resources import ResourceContainer
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):  # pragma: no cover - simple
         context.set_response("ok")
@@ -51,7 +51,9 @@ def test_restore_replaces_state():
 
 def test_execute_pipeline_persists_snapshots(tmp_path: Path):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     snap_dir = tmp_path / "snaps"
     result = asyncio.run(

--- a/tests/test_plugin_registry_order.py
+++ b/tests/test_plugin_registry_order.py
@@ -16,7 +16,7 @@ from pipeline.resources import ResourceContainer
 
 class First(PromptPlugin):
     priority = 30
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -27,7 +27,7 @@ class First(PromptPlugin):
 
 class Second(PromptPlugin):
     priority = 20
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -37,7 +37,7 @@ class Second(PromptPlugin):
 
 class Third(PromptPlugin):
     priority = 10
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -52,9 +52,9 @@ def _set_final_response(context):
 
 def test_plugin_priority_order_matches_execution():
     registry = PluginRegistry()
-    asyncio.run(registry.register_plugin_for_stage(First({}), PipelineStage.DO))
-    asyncio.run(registry.register_plugin_for_stage(Third({}), PipelineStage.DO))
-    asyncio.run(registry.register_plugin_for_stage(Second({}), PipelineStage.DO))
+    asyncio.run(registry.register_plugin_for_stage(First({}), PipelineStage.DELIVER))
+    asyncio.run(registry.register_plugin_for_stage(Third({}), PipelineStage.DELIVER))
+    asyncio.run(registry.register_plugin_for_stage(Second({}), PipelineStage.DELIVER))
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), registry)
     result = asyncio.run(execute_pipeline("hi", registries))
     assert result == ["third", "second", "first"]

--- a/tests/test_plugin_retry.py
+++ b/tests/test_plugin_retry.py
@@ -13,7 +13,7 @@ from user_plugins.failure.basic_logger import BasicLogger
 
 
 class FlakyPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     def __init__(self, config=None):
         super().__init__(config)
@@ -30,7 +30,7 @@ def make_registries():
     plugins = PluginRegistry()
     asyncio.run(
         plugins.register_plugin_for_stage(
-            FlakyPlugin({"max_retries": 1, "retry_delay": 0}), PipelineStage.DO
+            FlakyPlugin({"max_retries": 1, "retry_delay": 0}), PipelineStage.DELIVER
         )
     )
     asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))

--- a/tests/test_set_response_validation.py
+++ b/tests/test_set_response_validation.py
@@ -1,0 +1,24 @@
+import asyncio
+import pytest
+
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
+from pipeline.context import PluginContext
+from pipeline.state import PipelineState
+from pipeline.resources import ResourceContainer
+
+
+def test_set_response_disallowed_outside_deliver():
+    state = PipelineState(conversation=[], pipeline_id="id")
+    ctx = PluginContext(
+        state, SystemRegistries(ResourceContainer(), ToolRegistry(), PluginRegistry())
+    )
+    ctx.set_current_stage(PipelineStage.PARSE)
+    with pytest.raises(ValueError):
+        ctx.set_response("nope")
+    assert state.response is None

--- a/tests/test_state_logging.py
+++ b/tests/test_state_logging.py
@@ -44,7 +44,7 @@ def test_logger_and_replay(tmp_path):
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         context.set_response("ok")
@@ -52,7 +52,9 @@ class RespondPlugin(PromptPlugin):
 
 def test_execute_pipeline_logs_states(tmp_path):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
     log_file = tmp_path / "run.jsonl"

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -15,7 +15,7 @@ from plugins.builtin.adapters import WebSocketAdapter
 
 
 class RespPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -24,7 +24,9 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return WebSocketAdapter(manager)

--- a/user_plugins/failure/error_formatter.py
+++ b/user_plugins/failure/error_formatter.py
@@ -9,7 +9,7 @@ from pipeline.stages import PipelineStage
 class ErrorFormatter(FailurePlugin):
     """Generate a simple user message from captured failure information."""
 
-    stages = [PipelineStage.ERROR]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         info = context.get_failure_info()


### PR DESCRIPTION
## Summary
- restrict `PluginContext.set_response` to the DELIVER stage
- stop pipeline loop only when a response is produced by the DELIVER stage
- update fallback error plugin and error formatter for DELIVER usage
- call DELIVER stage after ERROR handling
- adjust tests for new DELIVER-only response rule
- add validation test for set_response
- ensure pydantic v1 compatibility in InputValidator

## Testing
- `poetry run pytest -q` *(fails: TypeError: 'Params' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_686dc106346483228aa5339f5b7df004