### PR TITLE
Update health endpoint status

### DIFF
--- a/docs/source/monitoring.md
+++ b/docs/source/monitoring.md
@@ -85,5 +85,5 @@ Create alerts in Prometheus for high latency or failures:
 
 HTTP services expose a `/health` endpoint that reports the status of every
 registered resource. The endpoint returns `{"status": "ok"}` when all resources
-report healthy and `{"status": "degraded"}` otherwise. Use this for container
+report healthy and `{"status": "error"}` otherwise. Use this for container
 liveness probes and external monitoring.

--- a/src/plugins/builtin/adapters/http.py
+++ b/src/plugins/builtin/adapters/http.py
@@ -171,7 +171,7 @@ class HTTPAdapter(AdapterPlugin):
             if registries is None:
                 return {"status": "starting"}
             report = await registries.resources.health_report()
-            status = "ok" if all(report.values()) else "degraded"
+            status = "ok" if all(report.values()) else "error"
             return {"status": status, "resources": report}
 
         if self.dashboard_enabled:


### PR DESCRIPTION
## Summary
- return `{"status": "error"}` from `/health` when any resource is unhealthy
- document the new health endpoint behavior

## Testing
- `poetry run pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686dc5f5286c83228a749cd424c22440