### PR TITLE
Fix plugin auto registration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -643,20 +643,17 @@ class MemoryResource:
 
 ## 16. Plugin Execution Order Simplification
 
-**Decision**: Remove priority-based plugin ordering and use YAML configuration order for plugin execution sequence.
+**Decision**: Plugins execute in the order defined in the YAML configuration.
 
 **Rationale**:
 - YAML order provides clear, visible execution sequence without mystery
 - Simpler mental model - "plugins run in the order I list them"
 - Easier debugging with predictable execution order
-- Eliminates unnecessary priority configuration decisions
+- Eliminates configuration ambiguity
 - "What you see is what you get" approach reduces cognitive overhead
 
 **Implementation**:
-- Remove `priority` attribute from all plugin base classes
-- Remove priority sorting logic in `PluginRegistry`
 - Register plugins in YAML configuration order or list order
-- Update plugin templates and documentation to remove priority references
 
 **Configuration Example**:
 ```yaml

--- a/architecture/architecture_tasks.md
+++ b/architecture/architecture_tasks.md
@@ -64,8 +64,4 @@
 - **Update `execute_pipeline`** to remove file-based state persistence
 
 ### 11. Plugin Execution Order Simplification
-- **Remove `priority` attribute** from all plugin base classes
-- **Remove priority sorting logic** in `PluginRegistry` 
-- **Update plugin registration** to use YAML/list order
-- **Update plugin templates** to remove priority references
-- **Update documentation** to emphasize execution order through configuration order
+- **Update plugin registration** to use YAML/list order- **Update documentation** to emphasize execution order through configuration order

--- a/src/common_interfaces/plugins.py
+++ b/src/common_interfaces/plugins.py
@@ -79,8 +79,7 @@ class PluginAutoClassifier:
             base = cast(Type, plugin_base_registry.prompt_plugin)
 
         def _default_stages(plugin_base: Type) -> list[PipelineStage]:
-            from pipeline.base_plugins import (AdapterPlugin, PromptPlugin,
-                                               ToolPlugin)
+            from pipeline.base_plugins import AdapterPlugin, PromptPlugin, ToolPlugin
 
             if issubclass(plugin_base, ToolPlugin):
                 return [PipelineStage.DO]
@@ -103,7 +102,6 @@ class PluginAutoClassifier:
         plugin_obj = plugin_base_registry.auto_plugin(
             func=plugin_func,
             stages=stages,
-            priority=priority,
             name=name,
             base_class=base,
         )


### PR DESCRIPTION
## Summary
- remove unused priority parameter from plugin autogen
- refresh plugin execution order docs

## Testing
- `poetry run pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686dc5f60ff88322b39f431027f88666