### PR TITLE
Rename stage result helpers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -441,7 +441,7 @@ class MemoryResource:
 **Implementation**: 
 - `context.set_response()` method restricted to DELIVER stage plugins only
 - Pipeline continues looping (PARSE → THINK → DO → REVIEW → DELIVER) until a DELIVER plugin calls `set_response()`
-- Earlier stages use `context.set_stage_result()` to store intermediate outputs for DELIVER plugins to access
+- Earlier stages use `context.store()` to store intermediate outputs for DELIVER plugins to access
 - Maximum iteration limit (default 5) prevents infinite loops when no DELIVER plugin sets a response
 
 **Benefits**: Ensures consistent output processing, logging, and formatting while maintaining the hybrid pipeline-state machine mental model.

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Runtime context passed to plugins during pipeline execution."""
 
 import asyncio
+import warnings
 from copy import deepcopy
 from datetime import datetime
 from typing import (
@@ -210,7 +211,7 @@ class PluginContext:
         """Return the pipeline response if set."""
         return self.__state.response
 
-    def set_stage_result(self, key: str, value: Any) -> None:
+    def store(self, key: str, value: Any) -> None:
         """Store intermediate ``value`` for the current stage under ``key``."""
         state = self.__state
         if key in state.stage_results:
@@ -222,15 +223,44 @@ class PluginContext:
             if oldest != key:
                 state.stage_results.pop(oldest, None)
 
-    def get_stage_result(self, key: str) -> Any:
-        """Retrieve a stage result stored with :meth:`set_stage_result`."""
+    def set_stage_result(
+        self, key: str, value: Any
+    ) -> None:  # pragma: no cover - deprecated
+        """Deprecated wrapper for :meth:`store`."""
+        warnings.warn(
+            "set_stage_result() is deprecated; use store()",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.store(key, value)
+
+    def load(self, key: str) -> Any:
+        """Retrieve a stage result previously stored via :meth:`store`."""
         if key not in self.__state.stage_results:
             raise KeyError(key)
         return self.__state.stage_results[key]
 
-    def has_stage_result(self, key: str) -> bool:
+    def get_stage_result(self, key: str) -> Any:  # pragma: no cover - deprecated
+        """Deprecated wrapper for :meth:`load`."""
+        warnings.warn(
+            "get_stage_result() is deprecated; use load()",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.load(key)
+
+    def has(self, key: str) -> bool:
         """Return ``True`` if ``key`` exists in stage results."""
         return key in self.__state.stage_results
+
+    def has_stage_result(self, key: str) -> bool:  # pragma: no cover - deprecated
+        """Deprecated wrapper for :meth:`has`."""
+        warnings.warn(
+            "has_stage_result() is deprecated; use has()",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.has(key)
 
     def get_metadata(self, key: str, default: Any = None) -> Any:
         """Return arbitrary metadata value previously stored."""

--- a/src/pipeline/context_helpers.py
+++ b/src/pipeline/context_helpers.py
@@ -37,7 +37,7 @@ class AdvancedContext:
             tool = self._ctx._registries.tools.get(call.name)
             if not tool:
                 result = f"Error: tool {call.name} not found"
-                self._ctx.set_stage_result(call.result_key, result)
+                self._ctx.store(call.result_key, result)
                 state.pending_tool_calls.remove(call)
                 return result
             tool = cast(Any, tool)
@@ -47,11 +47,11 @@ class AdvancedContext:
             )
             try:
                 result = await execute_tool(tool, call, state, options)
-                self._ctx.set_stage_result(call.result_key, result)
+                self._ctx.store(call.result_key, result)
                 self._ctx.record_tool_execution(call.name, call.result_key, call.source)
             except Exception as exc:  # noqa: BLE001
                 result = f"Error: {exc}"
-                self._ctx.set_stage_result(call.result_key, result)
+                self._ctx.store(call.result_key, result)
                 self._ctx.record_tool_error(call.name, str(exc))
                 state.failure_info = FailureInfo(
                     stage=str(state.current_stage),
@@ -63,6 +63,6 @@ class AdvancedContext:
                 state.pending_tool_calls.remove(call)
                 raise ToolExecutionError(call.name, exc, call.result_key)
             state.pending_tool_calls.remove(call)
-        result = self._ctx.get_stage_result(result_key)
+        result = self._ctx.load(result_key)
         state.stage_results.pop(result_key, None)
         return result

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -10,14 +10,14 @@ class ParsePlugin(BasePlugin):
     stages = [PipelineStage.PARSE]
 
     async def _execute_impl(self, context):
-        context.set_stage_result("parsed", True)
+        context.store("parsed", True)
 
 
 class ThinkPlugin(BasePlugin):
     stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context):
-        context.set_stage_result("thought", True)
+        context.store("thought", True)
 
 
 class RespondPlugin(BasePlugin):

--- a/user_plugins/prompts/chain_of_thought.py
+++ b/user_plugins/prompts/chain_of_thought.py
@@ -57,8 +57,8 @@ class ChainOfThoughtPrompt(PromptPlugin):
             if "final answer" in reasoning.content.lower():
                 break
 
-        context.set_stage_result("reasoning_complete", True)
-        context.set_stage_result("reasoning_steps", reasoning_steps)
+        context.store("reasoning_complete", True)
+        context.store("reasoning_steps", reasoning_steps)
 
     def _needs_tools(self, reasoning_text: str) -> bool:
         """Return True if ``reasoning_text`` suggests tool usage."""

--- a/user_plugins/prompts/intent_classifier.py
+++ b/user_plugins/prompts/intent_classifier.py
@@ -35,4 +35,4 @@ class IntentClassifierPrompt(PromptPlugin):
         last_message = context.get_conversation_history()[-1].content
         prompt = "Classify the user's intent in one word.\n" f"Message: {last_message}"
         response = await self.call_llm(context, prompt, purpose="intent_classification")
-        context.set_stage_result("intent", response.content)
+        context.store("intent", response.content)


### PR DESCRIPTION
## Summary
- rename stage result helpers to `store`, `load` and `has`
- update tests, user plugins, and docs
- keep backward compatibility by emitting deprecation warnings

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'plugins.builtin.conversation_manager')*

------
https://chatgpt.com/codex/tasks/task_e_686dc5f1707c8322bf9c5941de8e9984