### PR TITLE
Rename tool methods

### DIFF
--- a/docs/source/context.md
+++ b/docs/source/context.md
@@ -4,7 +4,7 @@
 
 - conversation history and other pipeline state
 - registered resources via `get_resource`
-- tool execution through `execute_tool`
+- tool execution through `queue_tool_use`
 - helpers for adding conversation entries and stage results
 
 Plugins receive this object inside their `_execute_impl` method.
@@ -21,7 +21,7 @@ class ExamplePlugin(PromptPlugin):
 
 - `say()` to set the pipeline response
 - `ask_llm()` to call the configured LLM
-- `use_tool()` to run a tool and wait for the result
+- `tool_use()` to run a tool and wait for the result
 
 ```python
 class MyPrompt(PromptPlugin):

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -36,7 +36,7 @@ agent = Agent()
 
 @agent.plugin
 async def weather_plugin(ctx):
-    return await ctx.use_tool("weather", city="London")
+    return await ctx.tool_use("weather", city="London")
 ```
 
 ## Loading Plugins Automatically

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -21,7 +21,7 @@ agent.tool_registry.add("search", SearchTool())
 
 @agent.plugin
 async def lookup(context):
-    return await context.use_tool("search", query="Entity Pipeline")
+    return await context.tool_use("search", query="Entity Pipeline")
 ```
 
 The `context` argument is an instance of `PluginContext`. See

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -21,7 +21,7 @@ class SleepTool(ToolPlugin):
 
 
 async def use_tool_plugin(ctx: PluginContext) -> None:
-    result = await ctx.use_tool("sleep", text="hello")
+    result = await ctx.tool_use("sleep", text="hello")
     ctx.set_response(result)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -29,7 +29,7 @@ class MetricsPlugin(PromptPlugin):
     stages = [PipelineStage.DO]
 
     async def _execute_impl(self, context):
-        await context.use_tool("echo", text="hello")
+        await context.tool_use("echo", text="hello")
         await self.call_llm(context, "hi", "test")
         context.set_response("ok")
 

--- a/tests/test_plugin_layers.py
+++ b/tests/test_plugin_layers.py
@@ -29,7 +29,7 @@ class MyTool(ToolPlugin):
 
 
 async def my_prompt(ctx: PluginContext) -> None:
-    val = await ctx.use_tool("tool", value="ok")
+    val = await ctx.tool_use("tool", value="ok")
     ctx.set_response(val)
 
 

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -26,7 +26,7 @@ async def run_search() -> str:
     await tools.add("search", SearchTool())
     registries = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
     ctx = PluginContext(state, registries)
-    return await ctx.use_tool("search", query="open source")
+    return await ctx.tool_use("search", query="open source")
 
 
 def test_search_tool_returns_result():

--- a/tests/test_tool_error_propagation.py
+++ b/tests/test_tool_error_propagation.py
@@ -24,7 +24,7 @@ class CallToolPlugin(PromptPlugin):
     stages = [PipelineStage.DO]
 
     async def _execute_impl(self, context):
-        await context.use_tool("fail")
+        await context.tool_use("fail")
 
 
 def make_registries():

--- a/tests/test_weather_api_tool.py
+++ b/tests/test_weather_api_tool.py
@@ -46,7 +46,7 @@ async def run_weather() -> dict:
     registries = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
     ctx = PluginContext(state, registries)
     try:
-        result = await ctx.use_tool("weather", location="Berlin")
+        result = await ctx.tool_use("weather", location="Berlin")
     finally:
         server.shutdown()
         thread.join()

--- a/user_plugins/prompts/chain_of_thought.py
+++ b/user_plugins/prompts/chain_of_thought.py
@@ -48,7 +48,7 @@ class ChainOfThoughtPrompt(PromptPlugin):
             )
 
             if self._needs_tools(reasoning.content):
-                await context.use_tool(
+                await context.tool_use(
                     "analysis_tool",
                     data=conversation_text,
                     reasoning_step=reasoning.content,

--- a/user_plugins/prompts/react_prompt.py
+++ b/user_plugins/prompts/react_prompt.py
@@ -71,7 +71,7 @@ class ReActPrompt(PromptPlugin):
                     metadata={"react_step": step, "type": "action"},
                 )
 
-                await context.use_tool(action_name, **params)
+                await context.tool_use(action_name, **params)
 
         context.set_response(
             "I've reached my reasoning limit without finding a definitive answer."


### PR DESCRIPTION
## Summary
- rename PluginContext helper methods `execute_tool` -> `queue_tool_use` and `use_tool` -> `tool_use`
- update docs and sample plugins with new method names
- update tests accordingly
- provide deprecation wrappers for old method names

## Testing
- `poetry run black src/pipeline/context.py >/tmp/black.log && tail -n 20 /tmp/black.log`
- `poetry run isort src/pipeline/context.py >/tmp/isort.log && tail -n 20 /tmp/isort.log`
- `poetry run flake8 src tests >/tmp/flake8.log && tail -n 20 /tmp/flake8.log`
- `poetry run mypy src >/tmp/mypy.log && head -n 20 /tmp/mypy.log`
- `bandit -r src >/tmp/bandit.log && tail -n 20 /tmp/bandit.log` *(fails: command not found)*
- `python tools/check_empty_dirs.py >/tmp/emptydirs.log && tail -n 20 /tmp/emptydirs.log`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml >/tmp/configdev.log && tail -n 20 /tmp/configdev.log`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml >/tmp/configprod.log && tail -n 20 /tmp/configprod.log`
- `python -m src.registry.validator >/tmp/registry.log && tail -n 20 /tmp/registry.log` *(fails: ModuleNotFoundError)*
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686dc5f29ae48322aafc71eb07ac3791