### PR TITLE
Enforce DELIVER stage for final responses

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -64,6 +64,7 @@ class ChainOfThoughtPlugin(PromptPlugin):
             if "final answer" in reasoning.content.lower():
                 break
         context.set_response(final_answer)
+        # Only plugins running in the DELIVER stage may set responses
 ```
 
 ### 3. Canonical Resource Architecture
@@ -173,7 +174,7 @@ class FailurePlugin(BasePlugin):
 async def _execute_impl(self, context):
     # Tools execute immediately with natural async/await
     result = await context.use_tool("calculator", expression="2+2")
-    context.set_response(f"The answer is {result}")
+    context.set_response(f"The answer is {result}")  # DELIVER stage only
 ```
 
 **Benefits**:
@@ -302,7 +303,7 @@ payload = ErrorResponse(
     error=info.error_message,
     message="Unable to complete request",
 ).to_dict()
-ctx.set_response(payload)
+ctx.set_response(payload)  # must be called from DELIVER stage
 ```
 
 ## Developer Experience Features

--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -68,7 +68,7 @@ When a stage fails the pipeline records a `FailureInfo` object and runs plugins 
 from pipeline.errors.response import ErrorResponse
 
 class ErrorFormatter(FailurePlugin):
-    stages = [PipelineStage.ERROR]
+    stages = [PipelineStage.DELIVER]
     async def _execute_impl(self, ctx: PluginContext) -> None:
         info = ctx.get_failure_info()
         ctx.set_response(
@@ -78,6 +78,8 @@ class ErrorFormatter(FailurePlugin):
             ).to_dict()
         )
 ```
+
+Only plugins executed in the `DELIVER` stage may invoke ``set_response``.
 
 If failure handling itself fails the framework returns a static response created by `create_static_error_response`:
 

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -15,11 +15,13 @@ from plugins import PromptPlugin
 from pipeline.stages import PipelineStage
 
 class HelloPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         context.set_response("Hello")
 ```
+
+Only plugins running in the `DELIVER` stage may call ``set_response``.
 
 Plugins may declare dependencies via the `dependencies` list and must specify the
 pipeline stages they run in. See `plugin_guide.md` for in‑depth examples.

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -192,6 +192,8 @@ class PluginContext:
     def set_response(self, response: Any) -> None:
         """Set the pipeline's final ``response`` if not already set."""
         state = self.__state
+        if state.current_stage is not PipelineStage.DELIVER:
+            raise ValueError("Only DELIVER stage can set response")
         if state.response is not None:
             raise ValueError("Response already set")
         state.response = response

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -21,7 +21,7 @@ class ThinkPlugin(BasePlugin):
 
 
 class RespondPlugin(BasePlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         context.set_response("ok")

--- a/tests/integration/test_pipeline_multi_provider.py
+++ b/tests/integration/test_pipeline_multi_provider.py
@@ -17,7 +17,7 @@ class FailHandler(BaseHTTPRequestHandler):
 
 
 class LLMResponder(BasePlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         response = await context.ask_llm(context.message)

--- a/tests/performance/test_full_pipeline_benchmark.py
+++ b/tests/performance/test_full_pipeline_benchmark.py
@@ -13,7 +13,7 @@ from pipeline.resources import ResourceContainer
 
 
 class RespondPlugin:
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def execute(self, context):
         context.set_response("ok")
@@ -22,7 +22,9 @@ class RespondPlugin:
 @pytest.mark.benchmark
 def test_full_pipeline_benchmark(benchmark):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
 

--- a/tests/performance/test_pipeline_benchmark.py
+++ b/tests/performance/test_pipeline_benchmark.py
@@ -14,7 +14,7 @@ from pipeline.resources import ResourceContainer
 
 
 class NoOpPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         context.set_response("ok")
@@ -22,7 +22,9 @@ class NoOpPlugin(PromptPlugin):
 
 def _make_manager():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -32,9 +32,9 @@ def make_registries() -> SystemRegistries:
     plugins = PluginRegistry()
     plugin = PluginAutoClassifier.classify(
         use_tool_plugin,
-        {"stage": PipelineStage.DO, "name": "UseToolPlugin"},
+        {"stage": PipelineStage.DELIVER, "name": "UseToolPlugin"},
     )
-    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DO))
+    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DELIVER))
     return SystemRegistries(resources, tools, plugins)
 
 

--- a/tests/test_cli_adapter.py
+++ b/tests/test_cli_adapter.py
@@ -15,7 +15,7 @@ from plugins.builtin.adapters.cli import CLIAdapter
 
 
 class EchoPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -24,7 +24,9 @@ class EchoPlugin(PromptPlugin):
 
 def make_adapter() -> tuple[CLIAdapter, SystemRegistries]:
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return CLIAdapter(manager), registries

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -13,7 +13,7 @@ from pipeline.resources.memory import Memory
 
 
 class ContinuePlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         if context.message == "start":
@@ -21,7 +21,7 @@ class ContinuePlugin(PromptPlugin):
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         if context.message == "next":
@@ -30,8 +30,12 @@ class RespondPlugin(PromptPlugin):
 
 def make_manager():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DO))
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DELIVER)
+    )
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+    )
     resources = ResourceContainer()
     asyncio.run(resources.add("memory", Memory()))
     registries = SystemRegistries(resources, ToolRegistry(), plugins)

--- a/tests/test_dashboard_adapter.py
+++ b/tests/test_dashboard_adapter.py
@@ -17,7 +17,7 @@ from plugins.builtin.adapters import DashboardAdapter
 
 
 class RespPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -26,7 +26,7 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter(tmp_path: Path) -> DashboardAdapter:
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO)
+    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DELIVER)
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     log_path = tmp_path / "state.log"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -40,7 +40,7 @@ class ResourceFailPlugin(PromptPlugin):
 
 
 class FallbackPlugin(FailurePlugin):
-    stages = [PipelineStage.ERROR]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         info = context.get_failure_info()
@@ -52,7 +52,7 @@ def make_registries(error_plugin, main_plugin=BoomPlugin):
     asyncio.run(plugins.register_plugin_for_stage(main_plugin({}), PipelineStage.DO))
     asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
     asyncio.run(
-        plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
+        plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.DELIVER)
     )
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 

--- a/tests/test_error_stage.py
+++ b/tests/test_error_stage.py
@@ -27,7 +27,7 @@ class FailPlugin(PromptPlugin):
 
 
 class ErrorPlugin(FailurePlugin):
-    stages = [PipelineStage.ERROR]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         info = context.get_failure_info()
@@ -36,7 +36,7 @@ class ErrorPlugin(FailurePlugin):
 
 
 class BadErrorPlugin(FailurePlugin):
-    stages = [PipelineStage.ERROR]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         raise RuntimeError("bad")
@@ -47,7 +47,7 @@ def make_registries(error_plugin):
     asyncio.run(plugins.register_plugin_for_stage(FailPlugin({}), PipelineStage.DO))
     asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
     asyncio.run(
-        plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.ERROR)
+        plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.DELIVER)
     )
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -15,7 +15,7 @@ from plugins.builtin.adapters import HTTPAdapter
 
 
 class RespPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -24,7 +24,9 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter(config=None):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return HTTPAdapter(manager, config)

--- a/tests/test_logging_adapter.py
+++ b/tests/test_logging_adapter.py
@@ -14,7 +14,7 @@ from plugins.builtin.adapters.logging import LoggingAdapter
 
 
 class EchoPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         entry = context.get_conversation_history()[0]
@@ -23,7 +23,9 @@ class EchoPlugin(PromptPlugin):
 
 def make_manager() -> PipelineManager:
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DELIVER)
+    )
     asyncio.run(
         plugins.register_plugin_for_stage(LoggingAdapter({}), PipelineStage.DELIVER)
     )

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -1,18 +1,23 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.context import ConversationEntry
 from pipeline.resources import ResourceContainer
-from pipeline.resources.memory_resource import (MemoryResource,
-                                                SimpleMemoryResource)
+from pipeline.resources.memory_resource import MemoryResource, SimpleMemoryResource
 from plugins.builtin.resources.memory import Memory
 from plugins.builtin.resources.memory_storage import MemoryStorage
 
 
 class IncrementPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
     dependencies = ["memory"]
 
     async def _execute_impl(self, context):
@@ -25,7 +30,7 @@ class IncrementPlugin(PromptPlugin):
 def make_registries():
     plugins = PluginRegistry()
     asyncio.run(
-        plugins.register_plugin_for_stage(IncrementPlugin({}), PipelineStage.DO)
+        plugins.register_plugin_for_stage(IncrementPlugin({}), PipelineStage.DELIVER)
     )
     resources = ResourceContainer()
     asyncio.run(resources.add("memory", Memory()))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -26,7 +26,7 @@ class EchoTool(ToolPlugin):
 
 
 class MetricsPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         await context.use_tool("echo", text="hello")
@@ -36,7 +36,9 @@ class MetricsPlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(MetricsPlugin({}), PipelineStage.DELIVER)
+    )
     resources = ResourceContainer()
     asyncio.run(resources.add("llm", EchoLLM()))
     tools = ToolRegistry()
@@ -53,7 +55,7 @@ def test_metrics_collected():
     assert response == "ok"
 
     data = metrics.to_dict()
-    stage = str(PipelineStage.DO)
+    stage = str(PipelineStage.DELIVER)
     plugin_key = f"{stage}:{MetricsPlugin.__name__}"
     assert plugin_key in data["plugin_durations"]
     assert plugin_key in data["llm_durations"]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -13,7 +13,7 @@ from pipeline.resources import ResourceContainer
 
 
 class TimedPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         await asyncio.sleep(0.05)
@@ -22,7 +22,9 @@ class TimedPlugin(PromptPlugin):
 
 def make_registries():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(TimedPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(TimedPlugin({}), PipelineStage.DELIVER)
+    )
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 
@@ -33,7 +35,7 @@ def test_metrics_overhead():
         execute_pipeline("hi", registries, return_metrics=True)
     )
     duration = time.time() - start
-    plugin_key = f"{PipelineStage.DO}:TimedPlugin"
+    plugin_key = f"{PipelineStage.DELIVER}:TimedPlugin"
     recorded = metrics.plugin_durations[plugin_key][0]
     assert result == "ok"
     assert recorded >= 0.05

--- a/tests/test_pipeline_manager.py
+++ b/tests/test_pipeline_manager.py
@@ -12,7 +12,7 @@ from pipeline.resources import ResourceContainer
 
 
 class WaitPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         await asyncio.sleep(0.05)
@@ -21,7 +21,9 @@ class WaitPlugin(PromptPlugin):
 
 def make_manager():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(WaitPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(WaitPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return PipelineManager(registries)
 

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -13,7 +13,7 @@ from pipeline import (
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):  # pragma: no cover - simple
         context.set_response("ok")

--- a/tests/test_plugin_layers.py
+++ b/tests/test_plugin_layers.py
@@ -41,9 +41,9 @@ def make_registries() -> SystemRegistries:
     plugins = PluginRegistry()
     plugin = PluginAutoClassifier.classify(
         my_prompt,
-        {"stage": PipelineStage.DO, "name": "MyPrompt"},
+        {"stage": PipelineStage.DELIVER, "name": "MyPrompt"},
     )
-    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DO))
+    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DELIVER))
     return SystemRegistries(resources, tools, plugins)
 
 

--- a/tests/test_plugin_registry_order.py
+++ b/tests/test_plugin_registry_order.py
@@ -15,7 +15,7 @@ from pipeline.resources import ResourceContainer
 
 
 class First(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -25,7 +25,7 @@ class First(PromptPlugin):
 
 
 class Second(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -34,7 +34,7 @@ class Second(PromptPlugin):
 
 
 class Third(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -49,9 +49,9 @@ def _set_final_response(context):
 
 def test_plugin_registration_order_matches_execution():
     registry = PluginRegistry()
-    asyncio.run(registry.register_plugin_for_stage(First({}), PipelineStage.DO))
-    asyncio.run(registry.register_plugin_for_stage(Third({}), PipelineStage.DO))
-    asyncio.run(registry.register_plugin_for_stage(Second({}), PipelineStage.DO))
+    asyncio.run(registry.register_plugin_for_stage(First({}), PipelineStage.DELIVER))
+    asyncio.run(registry.register_plugin_for_stage(Third({}), PipelineStage.DELIVER))
+    asyncio.run(registry.register_plugin_for_stage(Second({}), PipelineStage.DELIVER))
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), registry)
     result = asyncio.run(execute_pipeline("hi", registries))
     assert result == ["first", "third", "second"]
@@ -72,5 +72,5 @@ def test_initializer_preserves_yaml_order(tmp_path):
 
     initializer = SystemInitializer.from_yaml(str(path))
     plugin_reg, _, _ = asyncio.run(initializer.initialize())
-    plugins = plugin_reg.get_plugins_for_stage(PipelineStage.DO)
+    plugins = plugin_reg.get_plugins_for_stage(PipelineStage.DELIVER)
     assert [p.__class__ for p in plugins] == [Second, First, Third]

--- a/tests/test_plugin_retry.py
+++ b/tests/test_plugin_retry.py
@@ -13,7 +13,7 @@ from user_plugins.failure.basic_logger import BasicLogger
 
 
 class FlakyPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     def __init__(self, config=None):
         super().__init__(config)
@@ -30,7 +30,7 @@ def make_registries():
     plugins = PluginRegistry()
     asyncio.run(
         plugins.register_plugin_for_stage(
-            FlakyPlugin({"max_retries": 1, "retry_delay": 0}), PipelineStage.DO
+            FlakyPlugin({"max_retries": 1, "retry_delay": 0}), PipelineStage.DELIVER
         )
     )
     asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))

--- a/tests/test_set_response.py
+++ b/tests/test_set_response.py
@@ -1,0 +1,23 @@
+import pytest
+
+from pipeline import PipelineStage, PipelineState, PluginContext
+from registry import PluginRegistry, SystemRegistries, ToolRegistry
+from pipeline.resources import ResourceContainer
+
+
+def make_context(stage: PipelineStage) -> PluginContext:
+    state = PipelineState(conversation=[], pipeline_id="1", current_stage=stage)
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), PluginRegistry())
+    return PluginContext(state, registries)
+
+
+def test_set_response_allowed_in_deliver():
+    ctx = make_context(PipelineStage.DELIVER)
+    ctx.set_response("ok")
+    assert ctx.response == "ok"
+
+
+def test_set_response_fails_in_other_stage():
+    ctx = make_context(PipelineStage.DO)
+    with pytest.raises(ValueError):
+        ctx.set_response("nope")

--- a/tests/test_state_logging.py
+++ b/tests/test_state_logging.py
@@ -44,7 +44,7 @@ def test_logger_and_replay(tmp_path):
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         context.set_response("ok")
@@ -52,7 +52,9 @@ class RespondPlugin(PromptPlugin):
 
 def test_execute_pipeline_logs_states(tmp_path):
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
     log_file = tmp_path / "run.jsonl"

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -15,7 +15,7 @@ from plugins.builtin.adapters import WebSocketAdapter
 
 
 class RespPlugin(PromptPlugin):
-    stages = [PipelineStage.DO]
+    stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -24,7 +24,9 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter():
     plugins = PluginRegistry()
-    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DO))
+    asyncio.run(
+        plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DELIVER)
+    )
     registries = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     manager = PipelineManager(registries)
     return WebSocketAdapter(manager)


### PR DESCRIPTION
## Summary
- restrict `PluginContext.set_response` to only allow calling during the DELIVER stage
- adjust all plugins in tests to use DELIVER stage when finalizing responses
- document the stage restriction in docs and architecture notes
- add unit tests for new behaviour

## Testing
- `poetry install --with dev`
- `poetry run pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686dc5f041048322b1396b06e9fad80c