### PR TITLE
Fix test imports for state logger

### DIFF
--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -6,9 +6,15 @@ from pathlib import Path
 import pytest
 
 from entity_config.environment import load_env
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from pipeline.resources.llm import UnifiedLLMResource
 from pipeline.resources.memory import Memory

--- a/tests/pipeline/debug/test_state_logger.py
+++ b/tests/pipeline/debug/test_state_logger.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import datetime
 
 from pipeline import PluginRegistry, PromptPlugin, SystemRegistries, ToolRegistry
-from pipeline.debug import LogReplayer, StateLogger
+from pipeline.state_logger import LogReplayer, StateLogger
 from pipeline.pipeline import execute_pipeline
 from pipeline.resources import ResourceContainer
 from pipeline.stages import PipelineStage

--- a/tests/test_conversation_history_plugin.py
+++ b/tests/test_conversation_history_plugin.py
@@ -1,9 +1,15 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (ConversationEntry, MetricsCollector, PipelineState,
-                      PluginContext, PluginRegistry, SystemRegistries,
-                      ToolRegistry)
+from pipeline import (
+    ConversationEntry,
+    MetricsCollector,
+    PipelineState,
+    PluginContext,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+)
 from pipeline.resources import ResourceContainer
 from pipeline.resources.memory import Memory
 from pipeline.stages import PipelineStage

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -1,12 +1,17 @@
 import asyncio
 from datetime import datetime
 
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 from pipeline.context import ConversationEntry
 from pipeline.resources import ResourceContainer
-from pipeline.resources.memory_resource import (MemoryResource,
-                                                SimpleMemoryResource)
+from pipeline.resources.memory_resource import MemoryResource, SimpleMemoryResource
 from plugins.builtin.resources.memory import Memory
 from plugins.builtin.resources.memory_storage import MemoryStorage
 

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 
 from pipeline import (
     ConversationEntry,


### PR DESCRIPTION
## Summary
- add missing `Path` import in `tests/test_pipeline_state.py`
- update debug tests to reference `pipeline.state_logger`
- run `black` on tests

## Testing
- `poetry run black tests`

------
https://chatgpt.com/codex/tasks/task_e_686dcc0680288322aa312d456b9a65cb