### PR TITLE
Remove no-op cleanup pass

### DIFF
--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -80,10 +80,9 @@ class ClassRegistry:
 
 @contextmanager
 def initialization_cleanup_context():
-    try:
-        yield
-    finally:
-        pass
+    """Placeholder context manager for future initialization cleanup."""
+
+    yield
 
 
 class SystemInitializer:


### PR DESCRIPTION
## Summary
- streamline `initialization_cleanup_context`
- run formatting

## Testing
- `poetry run black src/pipeline/initializer.py --check`
- `poetry run flake8 src/pipeline/initializer.py`
- `poetry run mypy src/pipeline/initializer.py` *(fails: Missing type parameters, incompatible types)*
- `poetry run bandit -r src/pipeline/initializer.py`
- `python tools/check_empty_dirs.py`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `poetry run pytest` *(fails: ModuleNotFoundError, NameError)*
- `poetry run pytest tests/integration/ -v` *(interrupted)*
- `poetry run pytest tests/infrastructure/ -v`
- `poetry run pytest tests/performance/ -m benchmark`


------
https://chatgpt.com/codex/tasks/task_e_686dcc053bb48322b14bddada8730476