### PR TITLE
Add type hints for HTTP, CLI, and dashboard adapters

### DIFF
--- a/src/plugins/builtin/adapters/cli.py
+++ b/src/plugins/builtin/adapters/cli.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 from pipeline.base_plugins import AdapterPlugin
 from pipeline.exceptions import ResourceError
 from pipeline.manager import PipelineManager
+from pipeline.context import PluginContext
 from pipeline.pipeline import execute_pipeline
 from pipeline.security import AdapterAuthenticator
 from pipeline.stages import PipelineStage
@@ -29,7 +30,7 @@ class CLIAdapter(AdapterPlugin):
 
     def __init__(
         self,
-        manager: PipelineManager | None = None,
+        manager: PipelineManager[dict[str, Any]] | None = None,
         config: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(config)
@@ -79,5 +80,7 @@ class CLIAdapter(AdapterPlugin):
                 )
             self.logger.info("%s", response)
 
-    async def _execute_impl(self, context) -> None:  # pragma: no cover - adapter
+    async def _execute_impl(
+        self, context: PluginContext
+    ) -> None:  # pragma: no cover - adapter
         pass

--- a/src/plugins/builtin/adapters/dashboard.py
+++ b/src/plugins/builtin/adapters/dashboard.py
@@ -7,6 +7,8 @@ from collections import deque
 from pathlib import Path
 from typing import Any
 
+from pipeline.manager import PipelineManager
+
 from fastapi import Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
@@ -19,7 +21,11 @@ from tools.pipeline_viz import PipelineGraphBuilder
 class DashboardAdapter(HTTPAdapter):
     """HTTP adapter with a simple status dashboard."""
 
-    def __init__(self, manager=None, config=None) -> None:
+    def __init__(
+        self,
+        manager: PipelineManager[dict[str, Any]] | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         super().__init__(manager, config)
         templates_dir = Path(__file__).parent / "templates"
         self.templates = Jinja2Templates(directory=str(templates_dir))
@@ -31,7 +37,7 @@ class DashboardAdapter(HTTPAdapter):
         if not self.dashboard_enabled:
             return
 
-        @self.app.get("/dashboard", response_class=HTMLResponse)
+        @self.app.get("/dashboard", response_class=HTMLResponse)  # type: ignore[misc]
         async def dashboard(request: Request) -> HTMLResponse:
             count = 0
             if self.manager is not None:
@@ -46,7 +52,7 @@ class DashboardAdapter(HTTPAdapter):
                 },
             )
 
-        @self.app.get("/dashboard/transitions")
+        @self.app.get("/dashboard/transitions")  # type: ignore[misc]
         async def transitions(limit: int = 50) -> list[dict[str, Any]]:
             return self._load_transitions(limit)
 


### PR DESCRIPTION
## Summary
- add typing imports in HTTP adapter
- specify generic types for PipelineManager usage
- annotate middleware dispatch methods
- type adapter initialization arguments
- mark FastAPI route decorators with `# type: ignore[misc]`

## Testing
- `poetry run mypy src`

------
https://chatgpt.com/codex/tasks/task_e_686dcc08c5ac8322bd7c1442ae9809b3