### PR TITLE
Remove unused Optional import from memory resource

### DIFF
--- a/src/plugins/builtin/resources/memory.py
+++ b/src/plugins/builtin/resources/memory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Unified memory resource with optional persistence and search."""
 
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, cast
+from typing import Any, Dict, List, TYPE_CHECKING, cast
 
 from datetime import datetime
 


### PR DESCRIPTION
## Summary
- tidy up imports in `memory` resource

## Testing
- `poetry run black src/plugins/builtin/resources/memory.py`
- `poetry run pytest -k memory -q` *(fails: ModuleNotFoundError: No module named 'pipeline.debug')*

------
https://chatgpt.com/codex/tasks/task_e_686dcbfd9c088322a8df3b8f66f6aeb4