### PR TITLE
Update fail-fast behavior in execute_stage

### DIFF
--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -60,6 +60,10 @@ class MyTool(ToolPlugin):
 
 Base plugins include a simple circuit breaker using `failure_threshold` and `failure_reset_timeout` settings.
 
+When any plugin raises an exception the framework stops executing the rest of that stage.
+The failure is captured in `FailureInfo` and the `ERROR` stage runs immediately
+to handle the problem. No additional plugins from the failed stage are invoked.
+
 ## Error Responses and Failure Plugins
 
 When a stage fails the pipeline records a `FailureInfo` object and runs plugins assigned to the `ERROR` stage. A failure plugin can inspect the info and set a response:

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -90,7 +90,7 @@ async def execute_stage(
                 )
                 if stage != PipelineStage.ERROR:
                     await execute_stage(PipelineStage.ERROR, state, registries)
-                return
+                break
             except PluginExecutionError as exc:
                 logger.exception(
                     "Plugin execution failed",
@@ -109,7 +109,7 @@ async def execute_stage(
                 )
                 if stage != PipelineStage.ERROR:
                     await execute_stage(PipelineStage.ERROR, state, registries)
-                return
+                break
             except ToolExecutionError as exc:
                 logger.exception(
                     "Tool execution failed",
@@ -128,7 +128,7 @@ async def execute_stage(
                 )
                 if stage != PipelineStage.ERROR:
                     await execute_stage(PipelineStage.ERROR, state, registries)
-                return
+                break
             except ResourceError as exc:
                 logger.exception(
                     "Resource error",
@@ -147,7 +147,7 @@ async def execute_stage(
                 )
                 if stage != PipelineStage.ERROR:
                     await execute_stage(PipelineStage.ERROR, state, registries)
-                return
+                break
             except PipelineError as exc:
                 logger.exception(
                     "Pipeline error",
@@ -166,7 +166,7 @@ async def execute_stage(
                 )
                 if stage != PipelineStage.ERROR:
                     await execute_stage(PipelineStage.ERROR, state, registries)
-                return
+                break
             except Exception as exc:  # noqa: BLE001
                 logger.exception(
                     "Unexpected plugin exception",
@@ -188,8 +188,7 @@ async def execute_stage(
                 )
                 if stage != PipelineStage.ERROR:
                     await execute_stage(PipelineStage.ERROR, state, registries)
-                if isinstance(exc, KeyError):
-                    raise
+                break
             finally:
                 reset_request_id(token)
     duration = time.perf_counter() - start


### PR DESCRIPTION
## Summary
- enforce fail-fast execution by breaking out of a stage when any plugin fails
- clarify ERROR stage behavior in the docs

## Testing
- `poetry run black src/pipeline/pipeline.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pipeline.debug')*

------
https://chatgpt.com/codex/tasks/task_e_686dd0791ea883228367019e4c928de8