### PR TITLE
Rename tool methods

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -173,7 +173,7 @@ class FailurePlugin(BasePlugin):
 ```python
 async def _execute_impl(self, context):
     # Tools execute immediately with natural async/await
-    result = await context.use_tool("calculator", expression="2+2")
+    result = await context.tool_use("calculator", expression="2+2")
     context.set_response(f"The answer is {result}")  # DELIVER stage only
 ```
 

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -6,8 +6,17 @@ import asyncio
 import warnings
 from copy import deepcopy
 from datetime import datetime
-from typing import (TYPE_CHECKING, Any, AsyncIterator, Callable, Dict, List,
-                    Optional, TypeVar, cast)
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypeVar,
+    cast,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from common_interfaces.resources import LLM
@@ -27,8 +36,7 @@ from .context_helpers import AdvancedContext
 from .errors import ResourceError
 from .metrics import MetricsCollector
 from .stages import PipelineStage
-from .state import (ConversationEntry, FailureInfo, LLMResponse, PipelineState,
-                    ToolCall)
+from .state import ConversationEntry, FailureInfo, LLMResponse, PipelineState, ToolCall
 
 ResourceT = TypeVar("ResourceT", covariant=True)
 

--- a/src/pipeline/context_helpers.py
+++ b/src/pipeline/context_helpers.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - type check only
 from .errors import ToolExecutionError
 from .state import ConversationEntry, FailureInfo
 from .tools.base import RetryOptions
-from .tools.execution import execute_tool
+from .tools.execution import queue_tool_use
 
 
 class AdvancedContext:
@@ -46,7 +46,7 @@ class AdvancedContext:
                 delay=getattr(tool, "retry_delay", 1.0),
             )
             try:
-                result = await execute_tool(tool, call, state, options)
+                result = await queue_tool_use(tool, call, state, options)
                 self._ctx.store(call.result_key, result)
                 self._ctx.record_tool_execution(call.name, call.result_key, call.source)
             except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- rename execute_tool -> queue_tool_use
- drop old name with backward compatible wrapper
- update imports
- document new method names

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pipeline.debug')*

------
https://chatgpt.com/codex/tasks/task_e_686dd06fcbc08322bc0fcf6f203bc53e