### PR TITLE
Use store/load/has for stage results

### DIFF
--- a/architecture/architecture_tasks.md
+++ b/architecture/architecture_tasks.md
@@ -5,11 +5,11 @@
 - **Update pipeline loop logic** - Ensure only DELIVER stage responses terminate iteration
 - **Add validation error** - Clear error message when non-DELIVER plugins try to set response
 
-### 2. Stage Results Accumulation  
-- **Rename methods in `PluginContext`**:
-  - `set_stage_result()` → `store()`
-  - `get_stage_result()` → `load()` 
-  - `has_stage_result()` → `has()`
+### 2. Stage Results Accumulation
+- **Use the stage results helpers**:
+  - `store()` to add a value
+  - `load()` to read a value
+  - `has()` to check if a key exists
 - **Update all plugin examples** in docs and templates
 - **Update method documentation** and type hints
 

--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -6,8 +6,17 @@ import asyncio
 import warnings
 from copy import deepcopy
 from datetime import datetime
-from typing import (TYPE_CHECKING, Any, AsyncIterator, Callable, Dict, List,
-                    Optional, TypeVar, cast)
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypeVar,
+    cast,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from common_interfaces.resources import LLM
@@ -27,8 +36,7 @@ from .context_helpers import AdvancedContext
 from .errors import ResourceError
 from .metrics import MetricsCollector
 from .stages import PipelineStage
-from .state import (ConversationEntry, FailureInfo, LLMResponse, PipelineState,
-                    ToolCall)
+from .state import ConversationEntry, FailureInfo, LLMResponse, PipelineState, ToolCall
 
 ResourceT = TypeVar("ResourceT", covariant=True)
 
@@ -232,44 +240,15 @@ class PluginContext:
             if oldest != key:
                 state.stage_results.pop(oldest, None)
 
-    def set_stage_result(
-        self, key: str, value: Any
-    ) -> None:  # pragma: no cover - deprecated
-        """Deprecated wrapper for :meth:`store`."""
-        warnings.warn(
-            "set_stage_result() is deprecated; use store()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.store(key, value)
-
     def load(self, key: str) -> Any:
         """Retrieve a stage result previously stored via :meth:`store`."""
         if key not in self.__state.stage_results:
             raise KeyError(key)
         return self.__state.stage_results[key]
 
-    def get_stage_result(self, key: str) -> Any:  # pragma: no cover - deprecated
-        """Deprecated wrapper for :meth:`load`."""
-        warnings.warn(
-            "get_stage_result() is deprecated; use load()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.load(key)
-
     def has(self, key: str) -> bool:
         """Return ``True`` if ``key`` exists in stage results."""
         return key in self.__state.stage_results
-
-    def has_stage_result(self, key: str) -> bool:  # pragma: no cover - deprecated
-        """Deprecated wrapper for :meth:`has`."""
-        warnings.warn(
-            "has_stage_result() is deprecated; use has()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.has(key)
 
     def get_metadata(self, key: str, default: Any = None) -> Any:
         """Return arbitrary metadata value previously stored."""

--- a/tests/integration/test_stage_failures.py
+++ b/tests/integration/test_stage_failures.py
@@ -24,7 +24,7 @@ def make_failing_plugin(stage: PipelineStage):
             if not context.get_metadata("failed"):
                 context.set_metadata("failed", True)
                 raise RuntimeError("boom")
-            context.set_stage_result(str(stage), True)
+            context.store(str(stage), True)
 
     return FailingPlugin()
 


### PR DESCRIPTION
## Summary
- drop deprecated `set_stage_result`, `get_stage_result`, and `has_stage_result`
- update stage failure test
- tweak architecture task notes

## Testing
- `poetry run poe test` *(fails: ModuleNotFoundError: No module named 'pipeline.debug')*

------
https://chatgpt.com/codex/tasks/task_e_686dd06e3770832281c68c7e69d37a6b