### PR TITLE
Enforce DELIVER-only responses

### DIFF
--- a/src/pipeline/context.py
+++ b/src/pipeline/context.py
@@ -6,8 +6,17 @@ import asyncio
 import warnings
 from copy import deepcopy
 from datetime import datetime
-from typing import (TYPE_CHECKING, Any, AsyncIterator, Callable, Dict, List,
-                    Optional, TypeVar, cast)
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TypeVar,
+    cast,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from common_interfaces.resources import LLM
@@ -27,8 +36,7 @@ from .context_helpers import AdvancedContext
 from .errors import ResourceError
 from .metrics import MetricsCollector
 from .stages import PipelineStage
-from .state import (ConversationEntry, FailureInfo, LLMResponse, PipelineState,
-                    ToolCall)
+from .state import ConversationEntry, FailureInfo, LLMResponse, PipelineState, ToolCall
 
 ResourceT = TypeVar("ResourceT", covariant=True)
 
@@ -194,14 +202,12 @@ class PluginContext:
         return [deepcopy(entry) for entry in history]
 
     def set_response(self, response: Any) -> None:
-        """Set the pipeline's final ``response`` during the DELIVER stage."""
+        """Finalize the pipeline ``response`` during the DELIVER stage."""
 
         if self.current_stage != PipelineStage.DELIVER:
-            raise ValueError("set_response() is only valid during the DELIVER stage")
+            raise ValueError("Only DELIVER stage plugins may set responses")
 
         state = self.__state
-        if state.current_stage is not PipelineStage.DELIVER:
-            raise ValueError("Only DELIVER stage can set response")
         if state.response is not None:
             raise ValueError("Response already set")
         state.response = response

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -260,11 +260,13 @@ async def execute_pipeline(
                         state.last_completed_stage = stage
 
                     if (
-                        (
-                            state.response is not None
-                            and state.last_completed_stage == PipelineStage.DELIVER
-                        )
-                        or state.failure_info is not None
+                        state.response is not None
+                        and state.last_completed_stage == PipelineStage.DELIVER
+                    ):
+                        break
+
+                    if (
+                        state.failure_info is not None
                         or state.iteration >= max_iterations
                     ):
                         if (

--- a/tests/test_set_response.py
+++ b/tests/test_set_response.py
@@ -1,8 +1,8 @@
 import pytest
 
 from pipeline import PipelineStage, PipelineState, PluginContext
-from registry import PluginRegistry, SystemRegistries, ToolRegistry
 from pipeline.resources import ResourceContainer
+from registry import PluginRegistry, SystemRegistries, ToolRegistry
 
 
 def make_context(stage: PipelineStage) -> PluginContext:
@@ -19,5 +19,7 @@ def test_set_response_allowed_in_deliver():
 
 def test_set_response_fails_in_other_stage():
     ctx = make_context(PipelineStage.DO)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Only DELIVER stage plugins may set responses"
+    ):
         ctx.set_response("nope")

--- a/tests/test_set_response_validation.py
+++ b/tests/test_set_response_validation.py
@@ -1,16 +1,9 @@
-import asyncio
 import pytest
 
-from pipeline import (
-    PipelineStage,
-    PluginRegistry,
-    PromptPlugin,
-    SystemRegistries,
-    ToolRegistry,
-)
+from pipeline import PipelineStage, PluginRegistry, SystemRegistries, ToolRegistry
 from pipeline.context import PluginContext
-from pipeline.state import PipelineState
 from pipeline.resources import ResourceContainer
+from pipeline.state import PipelineState
 
 
 def test_set_response_disallowed_outside_deliver():
@@ -19,6 +12,8 @@ def test_set_response_disallowed_outside_deliver():
         state, SystemRegistries(ResourceContainer(), ToolRegistry(), PluginRegistry())
     )
     ctx.set_current_stage(PipelineStage.PARSE)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Only DELIVER stage plugins may set responses"
+    ):
         ctx.set_response("nope")
     assert state.response is None


### PR DESCRIPTION
## Summary
- restrict `PluginContext.set_response` so only DELIVER stage plugins may set a response
- only exit pipeline loop once DELIVER stage finishes and a response is set
- assert correct error message when set_response is called in other stages

## Testing
- `poetry run black tests/test_set_response_validation.py tests/test_set_response.py src/pipeline/context.py src/pipeline/pipeline.py`
- `poetry run isort tests/test_set_response_validation.py tests/test_set_response.py src/pipeline/context.py src/pipeline/pipeline.py`
- `poetry run flake8 src/pipeline/context.py src/pipeline/pipeline.py tests/test_set_response.py tests/test_set_response_validation.py`
- `poetry run mypy src/pipeline/context.py src/pipeline/pipeline.py`
- `poetry run bandit -r src/pipeline/context.py src/pipeline/pipeline.py`
- `python tools/check_empty_dirs.py`
- `poetry run python -m src.entity_config.validator --config config/dev.yaml`
- `poetry run python -m src.entity_config.validator --config config/prod.yaml`
- `pytest tests/test_set_response.py tests/test_set_response_validation.py` *(fails: ImportError: No module named 'entity_config')*

------
https://chatgpt.com/codex/tasks/task_e_686dd06d4c688322ab6374a65a77487c