### PR TITLE
Clarify plugin execution order

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ plugins:
 ```
 <!-- end config -->
 
+Plugins run sequentially in the order they appear under each stage in the YAML configuration. No priority field is used.
+
 Every plugin executes with a ``PluginContext`` which grants controlled
 access to resources, conversation history, and helper methods for calling
 tools or LLMs. This context keeps plugin logic focused while the framework

--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -30,7 +30,7 @@ and mental models stay easy to grasp.
 
 ## Design Principles
 1. Progressive disclosure: simple things stay simple, complex things are possible
-2. Async-first with predictable execution order
+2. Async-first with predictable execution order. Plugin order follows the YAML listing.
 3. Runtime reconfiguration with fail‑fast validation
 4. Clear stage boundaries and structured logging
 5. One canonical name per resource

--- a/docs/source/plugin_cheatsheet.md
+++ b/docs/source/plugin_cheatsheet.md
@@ -30,4 +30,4 @@ class ExamplePlugin(PromptPlugin):
 ```
 
 Register plugins through `Agent.add_plugin()` or in a YAML configuration file.
-Plugins run in the same order they are listed under each stage.
+Plugins run sequentially in the order listed under each stage; there is no priority.

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -90,7 +90,7 @@ plugin_dirs:
 ## Development Steps
 1. Create your plugin class and implement `_execute_impl`.
 2. Register the plugin with the `Agent` or include it in your YAML under `plugins:`.
-   Plugins execute in the order they appear in the YAML list.
+   Plugins run sequentially in the exact order listed. There is no priority field.
 3. Run `python -m src.entity_config.validator --config your.yaml` to verify configuration.
 4. Write unit tests and run `pytest` before committing changes.
 

--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -8,7 +8,7 @@ class {class_name}(AdapterPlugin):
     """Example adapter plugin."""
 
     stages = [PipelineStage.DELIVER]
-    # Execution order follows the YAML list or registration sequence
+    # Execution order follows the YAML list or registration sequence; no priority field
 
     async def _execute_impl(self, context):
         pass

--- a/src/cli/templates/failure.py
+++ b/src/cli/templates/failure.py
@@ -8,7 +8,7 @@ class {class_name}(FailurePlugin):
     """Example failure plugin."""
 
     stages = [PipelineStage.ERROR]
-    # Execution order follows the YAML list or registration sequence
+    # Execution order follows the YAML list or registration sequence; no priority field
 
     async def _execute_impl(self, context):
         pass

--- a/src/cli/templates/prompt.py
+++ b/src/cli/templates/prompt.py
@@ -8,7 +8,7 @@ class {class_name}(PromptPlugin):
     """Example prompt plugin."""
 
     stages = [PipelineStage.THINK]
-    # Execution order follows the YAML list or registration sequence
+    # Execution order follows the YAML list or registration sequence; no priority field
 
     async def _execute_impl(self, context):
         pass

--- a/src/cli/templates/resource.py
+++ b/src/cli/templates/resource.py
@@ -8,7 +8,7 @@ class {class_name}(ResourcePlugin):
     """Example resource plugin."""
 
     stages = [PipelineStage.PARSE]
-    # Execution order follows the YAML list or registration sequence
+    # Execution order follows the YAML list or registration sequence; no priority field
 
     @classmethod
     def validate_config(cls, config: dict) -> ValidationResult:

--- a/src/cli/templates/tool.py
+++ b/src/cli/templates/tool.py
@@ -10,7 +10,7 @@ class {class_name}(ToolPlugin):
     """Example tool plugin."""
 
     stages = [PipelineStage.DO]
-    # Execution order follows the YAML list or registration sequence
+    # Execution order follows the YAML list or registration sequence; no priority field
 
     async def execute_function(self, params: Dict[str, Any]) -> Any:
         return None

--- a/src/registry/registries.py
+++ b/src/registry/registries.py
@@ -88,7 +88,10 @@ class PluginRegistry:
     async def register_plugin_for_stage(
         self, plugin: BasePlugin, stage: PipelineStage | str, name: str | None = None
     ) -> None:
-        """Register ``plugin`` to execute during ``stage``."""
+        """Register ``plugin`` to execute during ``stage``.
+
+        Plugins are appended in registration order without sorting.
+        """
 
         try:
             stage_obj = PipelineStage(stage)


### PR DESCRIPTION
## Summary
- document plugin execution order follows YAML listing in README and docs
- note absence of priority in plugin templates and guide
- clarify `PluginRegistry.register_plugin_for_stage` preserves registration order

## Testing
- `poetry run black src/registry/registries.py`
- `poetry run black src/cli/templates/adapter.py src/cli/templates/failure.py src/cli/templates/prompt.py src/cli/templates/resource.py src/cli/templates/tool.py` *(fails: Cannot parse for target version Python 3.11)*
- `poetry run poe test` *(fails: ModuleNotFoundError: No module named 'pipeline.debug')*

------
https://chatgpt.com/codex/tasks/task_e_686dd07c834083229c17d43a4375fec9