### PR TITLE
Refactor resource init and docs

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -143,18 +143,23 @@ Several example pipelines in the `examples/` directory showcase more advanced pa
 `StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. The pipeline at `examples/pipelines/memory_composition_pipeline.py` demonstrates the same pattern using the older `MemoryResource`. `MemoryResource` now persists conversation history and vectors and is configured in [config/dev.yaml](../../config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. With the plugin configured the code looks like:
 
 ```python
-storage = StorageResource({})
-storage.database = DuckDBDatabaseResource({"path": "./agent.duckdb"})
-storage.vector_store = PgVectorStore({"table": "embeddings"})
-storage.filesystem = LocalFileSystemResource({"base_path": "./files"})
+resources = ResourceContainer()
+resources.register("database", DuckDBDatabaseResource, {"path": "./agent.duckdb"})
+resources.register("vector_store", PgVectorStore, {"table": "embeddings"})
+resources.register("filesystem", LocalFileSystemResource, {"base_path": "./files"})
+resources.register("storage", StorageResource, {})
+await resources.build_all()
+storage = resources.get("storage")
 ```
 
 `StorageResource` offers the same interface when you only need history and file storage:
 
 ```python
-storage = StorageResource({})
-storage.database = DuckDBDatabaseResource({"path": "./agent.duckdb"})
-storage.filesystem = LocalFileSystemResource({"base_path": "./files"})
+resources = ResourceContainer()
+resources.register("database", DuckDBDatabaseResource, {"path": "./agent.duckdb"})
+resources.register("filesystem", LocalFileSystemResource, {"base_path": "./files"})
+resources.register("storage", StorageResource, {})
+await resources.build_all()
 ```
 The script at `examples/storage_resource_example.py` demonstrates this setup.
 

--- a/src/common_interfaces/resources.py
+++ b/src/common_interfaces/resources.py
@@ -13,6 +13,7 @@ class BaseResource:
     """Minimal async resource with lifecycle hooks."""
 
     name: str = "resource"
+    dependencies: list[str] = []
 
     def __init__(self, config: Dict[str, Any] | None = None) -> None:
         self.config: Dict[str, Any] = config or {}

--- a/src/plugins/builtin/resources/memory.py
+++ b/src/plugins/builtin/resources/memory.py
@@ -25,24 +25,19 @@ class Memory(ResourcePlugin):
 
     stages = [PipelineStage.PARSE]
     name = "memory"
-    dependencies = ["database", "vector_store"]
+    dependencies: list[str] = []
 
-    def __init__(
-        self,
-        database: DatabaseResource | None = None,
-        vector_store: VectorStoreResource | None = None,
-        config: Dict | None = None,
-    ) -> None:
+    def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
-        self.database = database
-        self.vector_store = vector_store
+        self.database: DatabaseResource | None = None
+        self.vector_store: VectorStoreResource | None = None
         self._kv: Dict[str, Any] = {}
         self._conversations: Dict[str, List[ConversationEntry]] = {}
         self._conversation_manager: Memory.ConversationSession | None = None
 
     @classmethod
     def from_config(cls, config: Dict) -> "Memory":
-        return cls(None, None, config=config)
+        return cls(config=config)
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
         return None


### PR DESCRIPTION
## Summary
- add `dependencies` attribute to BaseResource
- drop dependency parameters from `Memory` resource constructor
- update plugin guide and example scripts for new injection pattern
- register resources with `ResourceContainer` in examples

## Testing
- `poetry run black examples/pipelines/vector_memory_pipeline.py examples/pipelines/duckdb_pipeline.py examples/storage_resource_example.py src/common_interfaces/resources.py src/plugins/builtin/resources/memory.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686dd07205c083229297fdd90113ab24