### PR TITLE
Clean up conversation history wrappers

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -85,7 +85,7 @@ plugins:
       type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
     conversation_history:
-      type: plugins.builtin.prompts.conversation_history:ConversationHistory
+      type: user_plugins.prompts.conversation_history:ConversationHistory
       history_table: chat_history
       stages: [parse, deliver]
     memory_retrieval:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -89,7 +89,7 @@ plugins:
       enable_reasoning: true
       max_steps: 5
     conversation_history:
-      type: plugins.builtin.prompts.conversation_history:ConversationHistory
+      type: user_plugins.prompts.conversation_history:ConversationHistory
       db_schema: public
       history_table: chat_history
       stages: [parse, deliver]

--- a/docs/source/schemas/ConversationHistory.json
+++ b/docs/source/schemas/ConversationHistory.json
@@ -1,5 +1,0 @@
-{
-  "title": "ConversationHistoryConfig",
-  "type": "object",
-  "properties": {}
-}

--- a/src/plugins/builtin/prompts/conversation_history.py
+++ b/src/plugins/builtin/prompts/conversation_history.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for :class:`ConversationHistory`."""
-
-from user_plugins.prompts.conversation_history import ConversationHistory
-
-__all__ = ["ConversationHistory"]

--- a/src/plugins/builtin/prompts/memory.py
+++ b/src/plugins/builtin/prompts/memory.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for :class:`MemoryPlugin`."""
-
-from user_plugins.prompts.memory import MemoryPlugin
-
-__all__ = ["MemoryPlugin"]


### PR DESCRIPTION
## Summary
- remove unused ConversationHistory docs
- drop wrapper modules that only re-exported user plugins
- point configuration directly at the user plugin implementation

## Testing
- `poetry run pytest tests/test_conversation_history_plugin.py::test_history_plugin_saves_conversation -q`

------
https://chatgpt.com/codex/tasks/task_e_686dd6e938888322a66b77f8b20ea16b