### PR TITLE
Clarify hot reload limits in docs

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -76,10 +76,10 @@ poetry run python src/cli.py reload-config updated.yaml
 ```
 
 The command waits for active pipelines to finish, then applies the new YAML
-configuration. Only parameter updates to **existing plugins** are hot reloadable.
-Modifying plugin stages or dependencies requires a full restart. This
-demonstrates **Dynamic Configuration Updates** for tunable values while keeping
-the system responsive.
+configuration. **Only parameter updates to existing plugins can be reloaded.**
+Any structural change—adding or removing plugins, modifying stage assignments, or
+changing dependencies—requires restarting the agent. This keeps hot reloads fast
+for tunable values while preventing inconsistent pipeline state.
 
 For a hands-on demonstration, run `examples/config_reload_example.py`:
 

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -54,9 +54,10 @@ Reload parameter values for existing plugins while the agent is running:
 poetry run python src/cli.py reload-config updated.yaml
 ```
 
-Only configuration parameters can be reloaded. Adding or removing plugins or
-changing their stages requires restarting the agent. For more on dynamic
-configuration, see [the architecture overview](../../architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure).
+Only updates to plugin parameters can be reloaded. Structural changes—adding or
+removing plugins, changing stage assignments, or altering dependencies—require a
+restart. For more on dynamic configuration see the
+[architecture overview](../../architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure).
 
 ### Using the "llm" Resource Key
 Configure a shared LLM resource in YAML:


### PR DESCRIPTION
## Summary
- update docs on runtime configuration reload to clarify that only parameter changes can be hot reloaded
- mention that structural changes require a restart

## Testing
- `poetry install --with dev`
- `poetry run black src examples tests`
- `poetry run pytest` *(fails: PluginExecutionError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6f60e0c8322bf96fedda09e1353