### PR TITLE
Update docs for Memory resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
-- ``MemoryResource`` – composite store that defaults to a DuckDB-backed database in memory and supports optional SQL/NoSQL and vector backends.
+- ``Memory`` – composite store that defaults to a DuckDB-backed database in memory and supports optional SQL/NoSQL and vector backends.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
-MemoryResource uses an in-memory DuckDB database by default, so there is no separate ``InMemoryResource``.
+Memory uses an in-memory DuckDB database by default, so there is no separate ``InMemoryResource``.
 
 StorageResource handles file CRUD and can combine multiple backends. See [docs/source/plugin_guide.md](docs/source/plugin_guide.md) for details.
 These defaults allow ``Agent()`` to process messages without any external

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -33,7 +33,7 @@ plugins:
       dependencies: [postgres, vector_store, filesystem]
 ```
 
-`MemoryResource` persists conversation history and vectors. `StorageResource` extends it with file CRUD across the configured backends.
+`Memory` persists conversation history and vectors. `StorageResource` extends it with file CRUD across the configured backends.
 
 For local experimentation you can use a file-backed DuckDB database:
 

--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -47,8 +47,8 @@ An LLM resource wraps a language model provider. Plugins can call `context.ask_l
 
 ### Memory vs Storage
 
-`MemoryResource` \u2013 composite store that defaults to a DuckDB-backed database in
-memory and supports optional SQL/NoSQL and vector backends. MemoryResource uses an
+`Memory` \u2013 composite store that defaults to a DuckDB-backed database in
+memory and supports optional SQL/NoSQL and vector backends. Memory uses an
 in-memory DuckDB database by default, so there is no separate `InMemoryResource`.
 `StorageResource` handles file CRUD across databases, vector stores, and file systems.
 

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -150,7 +150,7 @@ Several example pipelines in the `examples/` directory showcase more advanced pa
 
 ### StorageResource Composition
 
-`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. The pipeline at `examples/pipelines/memory_composition_pipeline.py` demonstrates the same pattern using the older `MemoryResource`. `MemoryResource` now persists conversation history and vectors and is configured in [config/dev.yaml](../../config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. With the plugin configured the code looks like:
+`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. The pipeline at `examples/pipelines/memory_composition_pipeline.py` demonstrates the same pattern using the unified `Memory` resource. `Memory` persists conversation history and vectors and is configured in [config/dev.yaml](../../config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. With the plugin configured the code looks like:
 
 ```python
 resources = ResourceContainer()

--- a/examples/pipelines/duckdb_pipeline.py
+++ b/examples/pipelines/duckdb_pipeline.py
@@ -48,7 +48,7 @@ def main() -> None:
         DuckDBVectorStore,
         {"table": "vectors", "dimensions": 3},
     )
-    resources.register("memory", MemoryResource, {})
+    resources.register("memory", Memory, {})
     agent.builder.plugin_registry.register_plugin_for_stage(
         SimilarityPrompt(), PipelineStage.THINK
     )

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -22,7 +22,7 @@ from plugins.builtin.resources.postgres import PostgresResource
 from plugins.builtin.resources.sqlite_storage import (
     SQLiteStorageResource as SQLiteDatabaseResource,
 )
-from user_plugins.memory_resource import MemoryResource
+from pipeline.resources.memory import Memory
 from user_plugins.resources import DuckDBVectorStore
 
 
@@ -65,7 +65,7 @@ def main() -> None:
 
     database = SQLiteDatabaseResource({"path": "./agent.db"})
     vector_store = create_vector_store()
-    memory = MemoryResource({})
+    memory = Memory()
     memory.database = database
     memory.vector_store = vector_store
 

--- a/examples/storage_resource_example.py
+++ b/examples/storage_resource_example.py
@@ -44,7 +44,7 @@ def main() -> None:
     resources.register("database", SQLiteDatabaseResource, {"path": "./agent.db"})
     resources.register("filesystem", LocalFileSystemResource, {"base_path": "./files"})
     resources.register("storage", StorageResource, {})
-    resources.register("memory", MemoryResource, {})
+    resources.register("memory", Memory, {})
 
     agent.builder.plugin_registry.register_plugin_for_stage(
         StorePrompt(), PipelineStage.THINK


### PR DESCRIPTION
## Summary
- mention unified Memory resource in README and docs
- update examples to reference `Memory`
- clean up outdated MemoryResource import

## Testing
- `poetry run black examples/pipelines/duckdb_pipeline.py examples/pipelines/memory_composition_pipeline.py examples/storage_resource_example.py`
- `poetry run pytest -q` *(fails: PluginExecutionError and other assertions)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6e4df148322b3486ee5d6485807