### PR TITLE
Update docs and templates for new context APIs

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -39,6 +39,20 @@ async def weather_plugin(ctx):
     return await ctx.tool_use("weather", city="London")
 ```
 
+Plugins share data through `store()` and `load()` and can queue additional
+tool calls:
+
+```python
+@agent.plugin
+async def summarizer(ctx):
+    if ctx.has("summary"):
+        return ctx.load("summary")
+    result_key = ctx.queue_tool_use("search", {"query": ctx.message})
+    summary = await ctx.tool_use("summarize", text=ctx.message)
+    ctx.store("summary", summary)
+    return summary
+```
+
 ### Stage Override Patterns
 
 Plugin stages are resolved in a predictable order:

--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -11,4 +11,5 @@ class {class_name}(AdapterPlugin):
     # Execution order follows the YAML list or registration sequence; no priority field
 
     async def _execute_impl(self, context):
-        pass
+        if context.has("response"):
+            await context.queue_tool_use("send", {"text": context.load("response")})

--- a/src/cli/templates/failure.py
+++ b/src/cli/templates/failure.py
@@ -11,4 +11,4 @@ class {class_name}(FailurePlugin):
     # Execution order follows the YAML list or registration sequence; no priority field
 
     async def _execute_impl(self, context):
-        pass
+        context.store("failure_info", context.get_failure_info())

--- a/src/cli/templates/prompt.py
+++ b/src/cli/templates/prompt.py
@@ -11,4 +11,10 @@ class {class_name}(PromptPlugin):
     # Execution order follows the YAML list or registration sequence; no priority field
 
     async def _execute_impl(self, context):
-        pass
+        if context.has("answer"):
+            context.say(context.load("answer"))
+            return
+
+        result = await context.tool_use("some_tool", query=context.message)
+        context.store("answer", result)
+        context.say(result)

--- a/src/cli/templates/resource.py
+++ b/src/cli/templates/resource.py
@@ -18,4 +18,4 @@ class {class_name}(ResourcePlugin):
         pass
 
     async def _execute_impl(self, context) -> None:
-        return None
+        context.queue_tool_use("refresh", {})


### PR DESCRIPTION
## Summary
- document `store`, `load`, `has`, `tool_use`, and `queue_tool_use`
- showcase state helpers in plugin guide
- update plugin templates to use new context methods

## Testing
- `poetry run black src/cli/templates`
- `poetry run pytest` *(fails: SystemError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6ea2a98832283127f32354ca8bb