### PR TITLE
Refactor example memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ When instantiated without a configuration file, ``Agent`` loads a basic set of
 plugins so the pipeline can run out of the box:
 
 - ``EchoLLMResource`` – minimal LLM resource that simply echoes prompts.
-- ``MemoryResource`` – composite store that defaults to a DuckDB-backed database in memory and supports optional SQL/NoSQL and vector backends.
+- ``Memory`` – composite store that defaults to a DuckDB-backed database in memory and supports optional SQL/NoSQL and vector backends.
 - ``SearchTool`` – wrapper around DuckDuckGo's search API.
 - ``CalculatorTool`` – safe evaluator for arithmetic expressions.
-MemoryResource uses an in-memory DuckDB database by default, so there is no separate ``InMemoryResource``.
+``Memory`` uses an in-memory DuckDB database by default, so there is no separate ``InMemoryResource``.
 
 StorageResource handles file CRUD and can combine multiple backends. See [docs/source/plugin_guide.md](docs/source/plugin_guide.md) for details.
 These defaults allow ``Agent()`` to process messages without any external

--- a/examples/pipelines/duckdb_pipeline.py
+++ b/examples/pipelines/duckdb_pipeline.py
@@ -48,7 +48,7 @@ def main() -> None:
         DuckDBVectorStore,
         {"table": "vectors", "dimensions": 3},
     )
-    resources.register("memory", MemoryResource, {})
+    resources.register("memory", Memory, {})
     agent.builder.plugin_registry.register_plugin_for_stage(
         SimilarityPrompt(), PipelineStage.THINK
     )

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -22,7 +22,7 @@ from plugins.builtin.resources.postgres import PostgresResource
 from plugins.builtin.resources.sqlite_storage import (
     SQLiteStorageResource as SQLiteDatabaseResource,
 )
-from user_plugins.memory_resource import MemoryResource
+from pipeline.resources.memory import Memory
 from user_plugins.resources import DuckDBVectorStore
 
 
@@ -65,9 +65,7 @@ def main() -> None:
 
     database = SQLiteDatabaseResource({"path": "./agent.db"})
     vector_store = create_vector_store()
-    memory = MemoryResource({})
-    memory.database = database
-    memory.vector_store = vector_store
+    memory = Memory(database=database, vector_store=vector_store)
 
     agent.builder.resource_registry.add("memory", memory)
     agent.builder.plugin_registry.register_plugin_for_stage(


### PR DESCRIPTION
## Summary
- update README to mention built-in `Memory`
- update pipeline examples to use `Memory` with vector store

## Testing
- `poetry run pytest -q` *(fails: PluginExecutionError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6ec47248322af6a54252c2d3e12