### PR TITLE
Remove unused PipelineState.restore method

### DIFF
--- a/docs/spikes/SPIKE-ERR-001.md
+++ b/docs/spikes/SPIKE-ERR-001.md
@@ -34,7 +34,7 @@ This spike investigates strategies for protecting the pipeline from repeated fai
 - **Cons**: Requires schema management and increases latency.
 
 ### 3. In-Memory Checkpointing
-- Keep a recent state copy in memory using `PipelineState.snapshot()` and restore with `restore()` if a plugin fails.
+- Keep a recent state copy in memory using `PipelineState.snapshot()` if a plugin fails.
 - **Pros**: Fastest recovery path for transient errors.
 - **Cons**: Does not help when the process is terminated.
 

--- a/src/pipeline/state.py
+++ b/src/pipeline/state.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 """Pipeline component: state."""
 
-import dataclasses
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -191,9 +190,3 @@ class PipelineState:
     def snapshot(self) -> "PipelineState":
         """Return a deep copy of the current pipeline state."""
         return deepcopy(self)
-
-    def restore(self, other: "PipelineState") -> "PipelineState":
-        """Replace all attributes with those from ``other`` and return a copy."""
-        for field_obj in dataclasses.fields(self):
-            setattr(self, field_obj.name, deepcopy(getattr(other, field_obj.name)))
-        return self.snapshot()

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -37,12 +37,3 @@ def test_snapshot_returns_deep_copy():
     snap = state.snapshot()
     snap.conversation[0].content = "bye"
     assert state.conversation[0].content == "hi"
-
-
-def test_restore_replaces_state():
-    state1 = make_state()
-    state2 = make_state()
-    state1.prompt = "changed"
-    state1.restore(state2)
-    assert state1.prompt == ""
-    assert len(state1.conversation) == 1


### PR DESCRIPTION
## Summary
- delete unused `PipelineState.restore`
- drop corresponding test
- adjust spike docs that mentioned the method

## Testing
- `poetry install --with dev`
- `poetry run pytest` *(fails: PluginExecutionError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6ef18b4832299f993b20f01cdd8