### PR TITLE
Remove unused builtin wrappers

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -58,11 +58,11 @@ plugins:
         type: pipeline.cache.memory:InMemoryCache
   tools:
     weather:
-      type: plugins.builtin.tools.weather_api_tool:WeatherApiTool
+      type: user_plugins.tools.weather_api_tool:WeatherApiTool
       api_key: "${WEATHER_API_KEY}"
       base_url: "https://api.weather.com"
     calculator:
-      type: plugins.builtin.tools.calculator_tool:CalculatorTool
+      type: user_plugins.tools.calculator_tool:CalculatorTool
   adapters:
     http:
       type: plugins.builtin.adapters.http:HTTPAdapter
@@ -85,11 +85,11 @@ plugins:
       type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
     conversation_history:
-      type: plugins.builtin.prompts.conversation_history:ConversationHistory
+      type: user_plugins.prompts.conversation_history:ConversationHistory
       history_table: chat_history
       stages: [parse, deliver]
     memory_retrieval:
-      type: plugins.builtin.prompts.memory_retrieval:MemoryRetrievalPrompt
+      type: user_plugins.prompts.memory_retrieval:MemoryRetrievalPrompt
       max_context_length: 4000
       stages: [think]
     intent_classifier:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -59,12 +59,12 @@ plugins:
         type: user_plugins.resources.cache_backends.redis:RedisCache
   tools:
     weather:
-      type: plugins.builtin.tools.weather_api_tool:WeatherApiTool
+      type: user_plugins.tools.weather_api_tool:WeatherApiTool
       api_key: "${WEATHER_API_KEY}"
       base_url: "https://api.weather.com"
       timeout: 30
     calculator:
-      type: plugins.builtin.tools.calculator_tool:CalculatorTool
+      type: user_plugins.tools.calculator_tool:CalculatorTool
       precision: 10
   adapters:
     http:
@@ -89,12 +89,12 @@ plugins:
       enable_reasoning: true
       max_steps: 5
     conversation_history:
-      type: plugins.builtin.prompts.conversation_history:ConversationHistory
+      type: user_plugins.prompts.conversation_history:ConversationHistory
       db_schema: public
       history_table: chat_history
       stages: [parse, deliver]
     memory_retrieval:
-      type: plugins.builtin.prompts.memory_retrieval:MemoryRetrievalPrompt
+      type: user_plugins.prompts.memory_retrieval:MemoryRetrievalPrompt
       max_context_length: 4000
       similarity_threshold: 0.7
       stages: [think]

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -29,11 +29,11 @@ plugins:
         type: pipeline.cache.memory:InMemoryCache
   tools:
     weather:
-      type: plugins.builtin.tools.weather_api_tool:WeatherApiTool
+      type: user_plugins.tools.weather_api_tool:WeatherApiTool
       api_key: "${WEATHER_API_KEY}"
       base_url: "https://api.weather.com"
     calculator:
-      type: plugins.builtin.tools.calculator_tool:CalculatorTool
+      type: user_plugins.tools.calculator_tool:CalculatorTool
   adapters:
     http:
       type: plugins.builtin.adapters.http:HTTPAdapter
@@ -52,7 +52,7 @@ plugins:
       type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
     memory_retrieval:
-      type: plugins.builtin.prompts.memory_retrieval:MemoryRetrievalPrompt
+      type: user_plugins.prompts.memory_retrieval:MemoryRetrievalPrompt
       max_context_length: 4000
     intent_classifier:
       type: user_plugins.prompts.intent_classifier:IntentClassifierPrompt

--- a/src/pipeline/user_plugins/tools/calculator_tool.py
+++ b/src/pipeline/user_plugins/tools/calculator_tool.py
@@ -1,5 +1,5 @@
-"""Expose the builtin :class:`CalculatorTool` for user configurations."""
+"""Provide ``CalculatorTool`` for config paths under ``user_plugins``."""
 
-from plugins.builtin.tools.calculator_tool import CalculatorTool
+from user_plugins.tools.calculator_tool import CalculatorTool
 
 __all__ = ["CalculatorTool"]

--- a/src/pipeline/user_plugins/tools/search_tool.py
+++ b/src/pipeline/user_plugins/tools/search_tool.py
@@ -1,5 +1,5 @@
-"""Expose the builtin :class:`SearchTool` for user configurations."""
+"""Provide ``SearchTool`` for config paths under ``user_plugins``."""
 
-from plugins.builtin.tools.search_tool import SearchTool
+from user_plugins.tools.search_tool import SearchTool
 
 __all__ = ["SearchTool"]

--- a/src/plugins/builtin/failure/__init__.py
+++ b/src/plugins/builtin/failure/__init__.py
@@ -1,7 +1,6 @@
-"""Failure handling plugins for logging and user-friendly errors."""
+"""Expose failure plugins from ``user_plugins`` under the builtin namespace."""
 
-from .basic_logger import BasicLogger
-from .error_formatter import ErrorFormatter
+from user_plugins.failure import BasicLogger, ErrorFormatter
 from .fallback_error_plugin import FallbackErrorPlugin
 
 __all__ = [

--- a/src/plugins/builtin/failure/basic_logger.py
+++ b/src/plugins/builtin/failure/basic_logger.py
@@ -1,5 +1,0 @@
-"""Public re-export of :class:`BasicLogger` from :mod:`user_plugins`."""
-
-from user_plugins.failure.basic_logger import BasicLogger
-
-__all__ = ["BasicLogger"]

--- a/src/plugins/builtin/failure/error_formatter.py
+++ b/src/plugins/builtin/failure/error_formatter.py
@@ -1,5 +1,0 @@
-"""Public re-export of :class:`ErrorFormatter` from :mod:`user_plugins`."""
-
-from user_plugins.failure.error_formatter import ErrorFormatter
-
-__all__ = ["ErrorFormatter"]

--- a/src/plugins/builtin/prompts/chat_history.py
+++ b/src/plugins/builtin/prompts/chat_history.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for :class:`ChatHistory`."""
-
-from user_plugins.prompts.chat_history import ChatHistory
-
-__all__ = ["ChatHistory"]

--- a/src/plugins/builtin/prompts/complex_prompt.py
+++ b/src/plugins/builtin/prompts/complex_prompt.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for :class:`ComplexPrompt`."""
-
-from user_plugins.prompts.complex_prompt import ComplexPrompt
-
-__all__ = ["ComplexPrompt"]

--- a/src/plugins/builtin/prompts/conversation_history.py
+++ b/src/plugins/builtin/prompts/conversation_history.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for :class:`ConversationHistory`."""
-
-from user_plugins.prompts.conversation_history import ConversationHistory
-
-__all__ = ["ConversationHistory"]

--- a/src/plugins/builtin/prompts/memory.py
+++ b/src/plugins/builtin/prompts/memory.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for :class:`MemoryPlugin`."""
-
-from user_plugins.prompts.memory import MemoryPlugin
-
-__all__ = ["MemoryPlugin"]

--- a/src/plugins/builtin/prompts/memory_retrieval.py
+++ b/src/plugins/builtin/prompts/memory_retrieval.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for :class:`MemoryRetrievalPrompt`."""
-
-from user_plugins.prompts.memory_retrieval import MemoryRetrievalPrompt
-
-__all__ = ["MemoryRetrievalPrompt"]

--- a/src/plugins/builtin/tools/__init__.py
+++ b/src/plugins/builtin/tools/__init__.py
@@ -1,8 +1,10 @@
-"""Compatibility re-exports for tool plugins implemented in ``user_plugins``."""
+"""Expose user tool plugins under the ``plugins.builtin`` namespace."""
 
-from .calculator_tool import CalculatorTool
-from .search_tool import SearchTool
-from .weather_api_tool import WeatherApiTool
+from user_plugins.tools import (
+    CalculatorTool,
+    SearchTool,
+    WeatherApiTool,
+)
 
 __all__ = [
     "CalculatorTool",

--- a/src/plugins/builtin/tools/calculator_tool.py
+++ b/src/plugins/builtin/tools/calculator_tool.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for the calculator tool implementation."""
-
-from user_plugins.tools.calculator_tool import CalculatorTool
-
-__all__ = ["CalculatorTool"]

--- a/src/plugins/builtin/tools/search_tool.py
+++ b/src/plugins/builtin/tools/search_tool.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for the search tool implementation."""
-
-from user_plugins.tools.search_tool import SearchTool
-
-__all__ = ["SearchTool"]

--- a/src/plugins/builtin/tools/weather_api_tool.py
+++ b/src/plugins/builtin/tools/weather_api_tool.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for the weather API tool implementation."""
-
-from user_plugins.tools.weather_api_tool import WeatherApiTool
-
-__all__ = ["WeatherApiTool"]


### PR DESCRIPTION
## Summary
- delete wrapper modules under `src/plugins/builtin` that only re-exported from `user_plugins`
- update builtin namespace `__init__` modules to import directly from `user_plugins`
- adjust wrapper modules in `src/pipeline/user_plugins`
- update example configs to reference `user_plugins` directly

## Testing
- `poetry run pytest -q` *(fails: PluginExecutionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6f45f8c83228418688fea09aec3