### PR TITLE
Refactor Memory init params

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,11 +165,10 @@ llm = UnifiedLLMResource([
     OllamaProvider(config),      # LLMResourcePlugin (fallback)
 ])
 
-# Memory Resource Composition  
-memory = Memory(
-    database=PostgresResource(config),        # DatabaseResourcePlugin
-    vector_store=PgVectorStore(config),       # VectorStoreResourcePlugin
-)
+# Memory Resource Composition
+memory = Memory(config={})
+memory.database = PostgresResource(config)        # DatabaseResourcePlugin
+memory.vector_store = PgVectorStore(config)       # VectorStoreResourcePlugin
 
 # Storage Resource Composition
 storage = Storage(

--- a/examples/pipelines/memory_composition_pipeline.py
+++ b/examples/pipelines/memory_composition_pipeline.py
@@ -65,7 +65,9 @@ def main() -> None:
 
     database = SQLiteDatabaseResource({"path": "./agent.db"})
     vector_store = create_vector_store()
-    memory = Memory(database=database, vector_store=vector_store)
+    memory = Memory(config={})
+    memory.database = database
+    memory.vector_store = vector_store
 
     agent.builder.resource_registry.add("memory", memory)
     agent.builder.plugin_registry.register_plugin_for_stage(

--- a/src/pipeline/resources/memory.py
+++ b/src/pipeline/resources/memory.py
@@ -26,22 +26,17 @@ class Memory(ResourcePlugin):
     name = "memory"
     dependencies = ["database", "vector_store"]
 
-    def __init__(
-        self,
-        database: DatabaseResource | None = None,
-        vector_store: VectorStoreResource | None = None,
-        config: Dict | None = None,
-    ) -> None:
+    def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
-        self.database = database
-        self.vector_store = vector_store
+        self.database: DatabaseResource | None = None
+        self.vector_store: VectorStoreResource | None = None
         self._kv: Dict[str, Any] = {}
         self._conversations: Dict[str, List[ConversationEntry]] = {}
         self._conversation_manager: Memory.ConversationSession | None = None
 
     @classmethod
     def from_config(cls, config: Dict) -> "Memory":
-        return cls(None, None, config=config)
+        return cls(config=config)
 
     async def _execute_impl(self, context) -> None:  # pragma: no cover - no op
         return None


### PR DESCRIPTION
## Summary
- simplify Memory resource initialization
- update memory example to assign dependencies via attributes
- adjust docs to match new initialization pattern

## Testing
- `poetry run pytest -q` *(fails: Plugin 'memory' requires 'database' but it's not registered, plus other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686dde9faff88322927cbf7ca8319af8