### PR TITLE
Use context accessors for stage results

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -94,4 +94,4 @@ async def test_tool_results_are_cached():
     await execute_pending_tools(state, registries)
 
     assert tool.calls == 1
-    assert state.stage_results["r1"] == state.stage_results["r2"]
+    assert ctx.load("r1") == ctx.load("r2")

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -67,8 +67,8 @@ def test_chain_of_thought_records_steps_and_tool_call():
         assistant_entries[1].content == "Reasoning step 1: We need to calculate result"
     )
     assert assistant_entries[2].content == "Reasoning step 2: Final answer is 42"
-    assert state.stage_results["reasoning_complete"] is True
-    assert state.stage_results["reasoning_steps"] == [
+    assert ctx.load("reasoning_complete") is True
+    assert ctx.load("reasoning_steps") == [
         "We need to calculate result",
         "Final answer is 42",
     ]

--- a/tests/test_execute_pending_tools.py
+++ b/tests/test_execute_pending_tools.py
@@ -12,6 +12,7 @@ from pipeline import (
 )
 from pipeline.resources import ResourceContainer
 from pipeline.tools.execution import execute_pending_tools
+from pipeline.context import PluginContext
 
 
 class EchoTool:
@@ -41,4 +42,5 @@ def test_execute_pending_tools_returns_mapping_by_result_key():
     results = asyncio.run(execute_pending_tools(state, registries))
 
     assert results == {"echo1": "hello"}
-    assert state.stage_results["echo1"] == "hello"
+    ctx = PluginContext(state, registries)
+    assert ctx.load("echo1") == "hello"

--- a/tests/test_intent_classifier_prompt.py
+++ b/tests/test_intent_classifier_prompt.py
@@ -39,7 +39,7 @@ def test_intent_classifier_success():
 
     asyncio.run(plugin.execute(ctx))
 
-    assert state.stage_results["intent"] == "greeting"
+    assert ctx.load("intent") == "greeting"
 
 
 def test_intent_classifier_validate_error():

--- a/tests/test_tool_registry_options.py
+++ b/tests/test_tool_registry_options.py
@@ -14,6 +14,7 @@ from pipeline import (
 )
 from pipeline.resources import ResourceContainer
 from pipeline.tools.execution import execute_pending_tools
+from pipeline.context import PluginContext
 
 
 class SleepTool:
@@ -69,6 +70,7 @@ def test_cache_ttl():
     )
     asyncio.run(execute_pending_tools(state, registries))
     assert tool.calls == 1
-    assert state.stage_results["b"] == 0
+    ctx = PluginContext(state, registries)
+    assert ctx.load("b") == 0
     key = f"{PipelineStage.DO}:sleep"
     assert key in state.metrics.tool_durations


### PR DESCRIPTION
## Summary
- update tests to rely on `PluginContext.load()` when checking stage results
- import `PluginContext` where needed

## Testing
- `poetry run pytest tests/test_execute_pending_tools.py tests/test_cache.py tests/test_tool_registry_options.py tests/test_intent_classifier_prompt.py tests/test_chain_of_thought_prompt.py -q`
- `poetry run pytest -q` *(fails: AssertionError, RuntimeError, ToolExecutionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686dedd7d2708322959676074088ace2