### PR TITLE
Enforce stable reload topology

### DIFF
--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -3,3 +3,6 @@
 :start-after: <!-- start config -->
 :end-before: <!-- end config -->
 ```
+
+Only parameter updates can be reloaded at runtime. Any addition or removal of
+plugins or resources requires restarting the agent.

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,7 +12,10 @@ from typing import Optional  # noqa: E402
 import yaml  # noqa: E402
 
 from pipeline import Agent  # noqa: E402
-from pipeline import update_plugin_configuration  # noqa: E402
+from pipeline import (
+    update_plugin_configuration,
+    validate_topology,
+)  # noqa: E402
 from pipeline.logging import get_logger  # noqa: E402
 from plugins.builtin.adapters.server import AgentServer  # noqa: E402
 
@@ -204,6 +207,11 @@ class CLI:
 
             with open(file_path, "r") as fh:
                 cfg = yaml.safe_load(fh) or {}
+
+            result = validate_topology(registries, cfg)
+            if not result.success:
+                logger.error("%s", result.error_message)
+                return 1
 
             success = True
 

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -20,7 +20,11 @@ from .base_plugins import (
     ValidationResult,
 )
 from .builder import AgentBuilder
-from .config_update import ConfigUpdateResult, update_plugin_configuration
+from .config_update import (
+    ConfigUpdateResult,
+    update_plugin_configuration,
+    validate_topology,
+)
 from .context import ConversationEntry, PluginContext, ToolCall
 from .decorators import plugin
 from .errors import create_static_error_response
@@ -78,6 +82,7 @@ __all__ = [
     "create_static_error_response",
     "ConfigUpdateResult",
     "update_plugin_configuration",
+    "validate_topology",
     "StateLogger",
     "LogReplayer",
     "Agent",
@@ -127,6 +132,7 @@ def __getattr__(name: str) -> Any:
         "create_static_error_response": "pipeline.errors",
         "ConfigUpdateResult": "pipeline.config_update",
         "update_plugin_configuration": "pipeline.config_update",
+        "validate_topology": "pipeline.config_update",
         "StateLogger": "pipeline.state_logger",
         "LogReplayer": "pipeline.state_logger",
         "ClassRegistry": "pipeline.initializer",


### PR DESCRIPTION
## Summary
- validate configuration topology before applying reloads
- surface topology validation errors in CLI
- export helper in pipeline package
- clarify restart requirements for runtime reloads
- adjust CLI reload tests

## Testing
- `poetry run black src tests`
- `poetry run pytest tests/test_cli_reload.py::test_cli_reload_success -vv`
- `poetry run pytest` *(fails: ModuleNotFoundError, plugin errors)*

------
https://chatgpt.com/codex/tasks/task_e_686dede7b9bc8322a155b4fd9fa766e6