### PR TITLE
Add built-in Chain-of-Thought and ReAct prompts

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -82,8 +82,11 @@ plugins:
       stages: [deliver]
   prompts:
     chain_of_thought:
-      type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
+      type: entity.plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
+    react:
+      type: entity.plugins.prompts.react:ReActPrompt
+      max_steps: 3
     conversation_history:
       type: user_plugins.prompts.conversation_history:ConversationHistory
       history_table: chat_history

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -85,8 +85,11 @@ plugins:
       stages: [deliver]
   prompts:
     chain_of_thought:
-      type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
+      type: entity.plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
+      max_steps: 5
+    react:
+      type: entity.plugins.prompts.react:ReActPrompt
       max_steps: 5
     conversation_history:
       type: user_plugins.prompts.conversation_history:ConversationHistory

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -49,8 +49,11 @@ plugins:
       type: plugins.builtin.adapters.logging:LoggingAdapter
   prompts:
     chain_of_thought:
-      type: user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
+      type: entity.plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
       enable_reasoning: true
+    react:
+      type: entity.plugins.prompts.react:ReActPrompt
+      max_steps: 5
     memory_retrieval:
       type: user_plugins.prompts.memory_retrieval:MemoryRetrievalPrompt
       max_context_length: 4000

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -49,8 +49,26 @@ async def summarizer(ctx):
         return ctx.load("summary")
     result_key = ctx.queue_tool_use("search", {"query": ctx.message})
     summary = await ctx.tool_use("summarize", text=ctx.message)
-    ctx.store("summary", summary)
+ctx.store("summary", summary)
     return summary
+```
+
+## Built-in Reasoning Plugins
+
+Entity provides two prompt plugins for common reasoning patterns:
+
+- `ChainOfThoughtPrompt` records intermediate thoughts and stores them with `context.store()`.
+- `ReActPrompt` alternates between reasoning and tool use, saving each step under `react_steps`.
+
+Add them in your YAML configuration:
+
+```yaml
+plugins:
+  prompts:
+    chain_of_thought:
+      type: entity.plugins.prompts.chain_of_thought:ChainOfThoughtPrompt
+    react:
+      type: entity.plugins.prompts.react:ReActPrompt
 ```
 
 ### Stage Override Patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ packages = [
     { include = "entity_config", from = "src" },
     { include = "registry", from = "src" },
     { include = "plugins", from = "src" },
+    { include = "entity", from = "src" },
     { include = "common_interfaces", from = "src" },
     { include = "tools", from = "src" },
     { include = "user_plugins" },

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -1,0 +1,1 @@
+"""Entity built-in plugins and helpers."""

--- a/src/entity/plugins/__init__.py
+++ b/src/entity/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Namespace for built-in plugins."""

--- a/src/entity/plugins/prompts/__init__.py
+++ b/src/entity/plugins/prompts/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in reasoning prompt plugins."""
+
+from .chain_of_thought import ChainOfThoughtPrompt
+from .react import ReActPrompt
+
+__all__ = ["ChainOfThoughtPrompt", "ReActPrompt"]

--- a/src/entity/plugins/prompts/chain_of_thought.py
+++ b/src/entity/plugins/prompts/chain_of_thought.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import List
+
+from pipeline.base_plugins import PromptPlugin
+from pipeline.context import ConversationEntry, PluginContext
+from pipeline.stages import PipelineStage
+
+
+class ChainOfThoughtPrompt(PromptPlugin):
+    """Incrementally reason through a problem using an LLM."""
+
+    dependencies = ["llm"]
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        conversation_text = self._latest_user_message(
+            context.get_conversation_history()
+        )
+
+        breakdown_prompt = f"Break this problem into logical steps: {conversation_text}"
+        breakdown = await self.call_llm(
+            context, breakdown_prompt, purpose="problem_breakdown"
+        )
+        context.add_conversation_entry(
+            content=f"Problem breakdown: {breakdown.content}",
+            role="assistant",
+            metadata={"reasoning_step": "breakdown"},
+        )
+
+        steps: List[str] = []
+        for step in range(int(self.config.get("max_steps", 5))):
+            reasoning_prompt = (
+                f"Reason through step {step + 1} of solving: {conversation_text}"
+            )
+            reasoning = await self.call_llm(
+                context, reasoning_prompt, purpose=f"reasoning_step_{step + 1}"
+            )
+            steps.append(reasoning.content)
+            context.add_conversation_entry(
+                content=f"Reasoning step {step + 1}: {reasoning.content}",
+                role="assistant",
+                metadata={"reasoning_step": step + 1},
+            )
+
+            if self._needs_tools(reasoning.content):
+                await context.tool_use(
+                    "analysis_tool",
+                    data=conversation_text,
+                    reasoning_step=reasoning.content,
+                )
+
+            if "final answer" in reasoning.content.lower():
+                break
+
+        context.store("reasoning_complete", True)
+        context.store("reasoning_steps", steps)
+
+    def _needs_tools(self, reasoning_text: str) -> bool:
+        indicators = ["need to calculate", "should look up", "requires analysis"]
+        return any(i in reasoning_text.lower() for i in indicators)
+
+    def _latest_user_message(self, conversation: List[ConversationEntry]) -> str:
+        user_entries = [e.content for e in conversation if e.role == "user"]
+        return user_entries[-1] if user_entries else ""

--- a/src/entity/plugins/prompts/react.py
+++ b/src/entity/plugins/prompts/react.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from pipeline.base_plugins import PromptPlugin
+from pipeline.context import ConversationEntry, PluginContext
+from pipeline.stages import PipelineStage
+
+
+class ReActPrompt(PromptPlugin):
+    """Reason and act iteratively using the ReAct pattern."""
+
+    dependencies = ["llm"]
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        max_steps = int(self.config.get("max_steps", 5))
+        conversation = context.get_conversation_history()
+        user_messages = [e.content for e in conversation if e.role == "user"]
+        question = user_messages[-1] if user_messages else "No question provided"
+
+        steps: List[Dict[str, str]] = []
+
+        for step in range(max_steps):
+            step_context = self._build_step_context(
+                context.get_conversation_history(), question
+            )
+            thought_prompt = (
+                "Think step by step about this problem:\n\n"
+                f"Context: {step_context}\n\n"
+                "What should I think about next?"
+            )
+            thought = await self.call_llm(
+                context, thought_prompt, purpose=f"react_thought_step_{step}"
+            )
+            context.add_conversation_entry(
+                content=f"Thought: {thought.content}",
+                role="assistant",
+                metadata={"react_step": step, "type": "thought"},
+            )
+            step_record: Dict[str, str] = {"thought": thought.content}
+
+            action_prompt = (
+                f'Based on my thought: "{thought.content}"\n'
+                "Should I:\n1. Take an action (specify: search, calculate, etc.)\n"
+                "2. Give a final answer\n\n"
+                'Respond with either "Action: <action_name> <parameters>" '
+                'or "Final Answer: <answer>"'
+            )
+            decision = await self.call_llm(
+                context, action_prompt, purpose=f"react_action_step_{step}"
+            )
+
+            if decision.content.startswith("Final Answer:"):
+                answer = decision.content.replace("Final Answer:", "").strip()
+                context.set_response(answer)
+                steps.append(step_record)
+                context.store("react_steps", steps)
+                return
+
+            if decision.content.startswith("Action:"):
+                action_text = decision.content.replace("Action:", "").strip()
+                action_name, params = self._parse_action(action_text)
+                step_record["action"] = action_text
+                context.add_conversation_entry(
+                    content=f"Action: {action_text}",
+                    role="assistant",
+                    metadata={"react_step": step, "type": "action"},
+                )
+                await context.tool_use(action_name, **params)
+
+            steps.append(step_record)
+
+        context.set_response(
+            "I've reached my reasoning limit without finding a definitive answer."
+        )
+        context.store("react_steps", steps)
+
+    def _build_step_context(
+        self, conversation: List[ConversationEntry], question: str
+    ) -> str:
+        parts = [f"Question: {question}"]
+        recent_entries = conversation[-10:]
+        for entry in recent_entries:
+            if entry.role == "assistant" and entry.metadata.get("type") in [
+                "thought",
+                "action",
+            ]:
+                parts.append(entry.content)
+            elif entry.role == "system" and "Tool result:" in entry.content:
+                parts.append(
+                    f"Observation: {entry.content.replace('Tool result: ', '')}"
+                )
+        return "\n".join(parts)
+
+    def _parse_action(self, action_text: str) -> Tuple[str, Dict[str, Any]]:
+        parts = action_text.split(" ", 1)
+        if len(parts) < 2:
+            return "search_tool", {"query": action_text}
+
+        action_name = parts[0].lower()
+        params_text = parts[1]
+
+        if action_name == "search":
+            return "search_tool", {"query": params_text}
+        if action_name == "calculate":
+            return "calculator_tool", {"expression": params_text}
+        return "search_tool", {"query": action_text}


### PR DESCRIPTION
## Summary
- implement `ChainOfThoughtPrompt` and `ReActPrompt` under `entity.plugins`
- register them in example configs
- document built-in reasoning plugins
- package `entity` module

## Testing
- `poetry run pytest -q tests/test_react_prompt.py tests/test_chain_of_thought_prompt.py` *(fails: ReActPrompt failed - pop from empty list)*

------
https://chatgpt.com/codex/tasks/task_e_686dedf15bf08322b17dd19d3cb0d476