### PR TITLE
Add query method to ToolRegistry

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -76,4 +76,5 @@ components_overview
 architecture
 components_overview
 plugins
+tools
 ```

--- a/docs/source/tools.md
+++ b/docs/source/tools.md
@@ -1,0 +1,15 @@
+# Tool Discovery
+
+`ToolRegistry` now exposes a lightweight `query()` method for discovering
+available tools. Plugins pass a filter function that receives the tool name and
+instance. The registry returns a dictionary of matching entries.
+
+Example:
+
+```python
+# Return tools with names starting with "search".
+search_tools = registry.tools.query(lambda n, _: n.startswith("search"))
+```
+
+Filters let prompts or other tools fetch just the plugins they care about
+without scanning the entire registry.

--- a/src/registry/registries.py
+++ b/src/registry/registries.py
@@ -6,7 +6,7 @@ import asyncio
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Callable
 
 from common_interfaces.base_plugin import BasePlugin
 from pipeline.resources.container import ResourceContainer
@@ -39,6 +39,24 @@ class ToolRegistry:
         """Return the tool registered as ``name`` if present."""
 
         return self._tools.get(name)
+
+    def query(
+        self, filter_fn: Callable[[str, Any], bool] | None = None
+    ) -> Dict[str, Any]:
+        """Return tools matching ``filter_fn``.
+
+        Parameters
+        ----------
+        filter_fn:
+            Callable receiving ``name`` and ``tool``. When provided, only
+            entries where ``filter_fn(name, tool)`` evaluates to ``True``
+            are returned.
+        """
+
+        items = list(self._tools.items())
+        if filter_fn is None:
+            return dict(items)
+        return {name: tool for name, tool in items if filter_fn(name, tool)}
 
     async def get_cached_result(self, name: str, params: Dict[str, Any]) -> Any | None:
         if self._cache_ttl is None:

--- a/tests/registry/test_thread_safety.py
+++ b/tests/registry/test_thread_safety.py
@@ -40,4 +40,4 @@ async def test_resource_and_tool_registry_thread_safety():
     )
 
     assert len(resources._resources) == 5
-    assert len(tools._tools) == 5
+    assert len(tools.query()) == 5


### PR DESCRIPTION
## Summary
- add a query method on ToolRegistry for filtered discovery
- update thread safety test to use query
- document the pattern and list it in the docs index

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686dedf1c558832296670fc601b0d9a4