### PR TITLE
Fix plugin stage resolution precedence

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -62,7 +62,7 @@ Plugin stages are resolved in a predictable order:
 3. Defaults based on plugin type (``ToolPlugin`` → ``DO``, ``PromptPlugin`` → ``THINK``, ``AdapterPlugin`` → ``PARSE`` + ``DELIVER``).
 4. Stages inferred by ``PluginAutoClassifier``.
 
-When configuration or class-defined stages override the plugin type defaults, the initializer logs a warning so you can confirm the override is intentional.
+Explicit configuration always wins. If a plugin class declares stages that differ from its type defaults the initializer emits a warning. The same warning appears when configuration overrides either the class stages or the defaults so you can double‑check the override is intentional.
 
 ## Loading Plugins Automatically
 

--- a/src/common_interfaces/plugins.py
+++ b/src/common_interfaces/plugins.py
@@ -111,6 +111,7 @@ class PluginAutoClassifier:
         plugin_obj._inferred_stages = inferred
         plugin_obj._auto_inferred_stages = inferred
         plugin_obj._type_default_stages = _default_stages(base)
+        plugin_obj._inferred = inferred
         return plugin_obj
 
     @staticmethod

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -207,18 +207,21 @@ class SystemInitializer:
 
         cfg_value = config.get("stages") or config.get("stage")
         explicit_source = None
-        attr_stages = getattr(instance, "stages", []) or []
-        attr_stages = [PipelineStage.ensure(s) for s in attr_stages]
+
+        attr_stages = [PipelineStage.ensure(s) for s in getattr(instance, "stages", [])]
         attr_explicit = getattr(instance, "_explicit_stages", False)
         auto_inferred = getattr(instance, "_auto_inferred_stages", False)
         type_defaults = self._type_default_stages(cls)
+
+        stages: list[PipelineStage] = []
+        explicit = False
 
         if cfg_value is not None:
             stages = cfg_value if isinstance(cfg_value, list) else [cfg_value]
             stages = [PipelineStage.ensure(s) for s in stages]
             explicit = True
             explicit_source = "config"
-            if attr_stages and set(stages) != set(attr_stages):
+            if attr_explicit and set(stages) != set(attr_stages):
                 logger.warning(
                     "Plugin '%s' config stages %s override class stages %s",
                     cls.__name__,
@@ -231,19 +234,12 @@ class SystemInitializer:
             explicit_source = "class"
         elif type_defaults:
             stages = type_defaults
-            explicit = False
         elif auto_inferred:
             stages = attr_stages
-            explicit = False
-        else:
-            stages = attr_stages or type_defaults
-            explicit = False
 
         if not stages:
-            stages = self._type_default_stages(cls)
-            explicit = False
+            stages = attr_stages or type_defaults
 
-        type_defaults = self._type_default_stages(cls)
         if explicit and type_defaults and set(stages) != set(type_defaults):
             source = explicit_source or "config"
             logger.warning(


### PR DESCRIPTION
## Summary
- apply explicit stage precedence order in initializer
- flag auto-generated plugins as inferred
- warn when stages override type defaults
- document stage precedence

## Testing
- `poetry run pytest tests/test_stage_precedence.py tests/test_registry_validator.py tests/test_auto_classifier_marking.py`

------
https://chatgpt.com/codex/tasks/task_e_686dede3d91c8322be52589e1b4bd0e1