### PR TITLE
Ensure YAML plugin order preserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ plugins:
 ```
 <!-- end config -->
 
-Plugins run sequentially in the order they appear under each stage in the YAML configuration. No priority field is used.
+Plugins run sequentially in the order they appear under each stage in the YAML
+configuration. The list position is the only factor controlling execution order,
+and `SystemInitializer` preserves that sequence. No priority field is used.
 
 Every plugin executes with a ``PluginContext`` which grants controlled
 access to resources, conversation history, and helper methods for calling

--- a/docs/source/plugin_cheatsheet.md
+++ b/docs/source/plugin_cheatsheet.md
@@ -30,4 +30,5 @@ class ExamplePlugin(PromptPlugin):
 ```
 
 Register plugins through `Agent.add_plugin()` or in a YAML configuration file.
-Plugins run sequentially in the order listed under each stage; there is no priority.
+The position in the list under each stage controls execution order and
+`SystemInitializer` keeps the sequence intact. There is no priority field.

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -112,7 +112,8 @@ plugin_dirs:
 ## Development Steps
 1. Create your plugin class and implement `_execute_impl`.
 2. Register the plugin with the `Agent` or include it in your YAML under `plugins:`.
-   Plugins run sequentially in the exact order listed. There is no priority field.
+   The list position determines execution order and `SystemInitializer` preserves
+   that sequence. There is no priority field.
 3. Run `python -m src.entity_config.validator --config your.yaml` to verify configuration.
 4. Write unit tests and run `pytest` before committing changes.
 

--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -8,7 +8,7 @@ class {class_name}(AdapterPlugin):
     """Example adapter plugin."""
 
     stages = [PipelineStage.DELIVER]
-    # Execution order follows the YAML list or registration sequence; no priority field
+    # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
         if context.has("response"):

--- a/src/cli/templates/failure.py
+++ b/src/cli/templates/failure.py
@@ -8,7 +8,7 @@ class {class_name}(FailurePlugin):
     """Example failure plugin."""
 
     stages = [PipelineStage.ERROR]
-    # Execution order follows the YAML list or registration sequence; no priority field
+    # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
         context.store("failure_info", context.get_failure_info())

--- a/src/cli/templates/prompt.py
+++ b/src/cli/templates/prompt.py
@@ -8,7 +8,7 @@ class {class_name}(PromptPlugin):
     """Example prompt plugin."""
 
     stages = [PipelineStage.THINK]
-    # Execution order follows the YAML list or registration sequence; no priority field
+    # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
         if context.has("answer"):

--- a/src/cli/templates/resource.py
+++ b/src/cli/templates/resource.py
@@ -8,7 +8,7 @@ class {class_name}(ResourcePlugin):
     """Example resource plugin."""
 
     stages = [PipelineStage.PARSE]
-    # Execution order follows the YAML list or registration sequence; no priority field
+    # List position controls execution order and SystemInitializer preserves it.
 
     @classmethod
     def validate_config(cls, config: dict) -> ValidationResult:

--- a/src/cli/templates/tool.py
+++ b/src/cli/templates/tool.py
@@ -10,7 +10,7 @@ class {class_name}(ToolPlugin):
     """Example tool plugin."""
 
     stages = [PipelineStage.DO]
-    # Execution order follows the YAML list or registration sequence; no priority field
+    # List position controls execution order and SystemInitializer preserves it.
 
     async def execute_function(self, params: Dict[str, Any]) -> Any:
         return None

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -31,46 +31,53 @@ class ClassRegistry:
     def __init__(self) -> None:
         self._classes: Dict[str, type[BasePlugin]] = {}
         self._configs: Dict[str, Dict] = {}
+        self._order: List[str] = []
 
     def register_class(
         self, plugin_class: type[BasePlugin], config: Dict, name: str
     ) -> None:
         self._classes[name] = plugin_class
         self._configs[name] = config
+        self._order.append(name)
 
     def has_plugin(self, name: str) -> bool:
         return name in self._classes
 
     def list_plugins(self) -> List[str]:
-        return list(self._classes.keys())
+        return list(self._order)
 
     def all_plugin_classes(self) -> Iterable[Tuple[type[BasePlugin], Dict]]:
-        for name, cls in self._classes.items():
+        for name in self._order:
+            cls = self._classes[name]
             yield cls, self._configs[name]
 
     def resource_classes(self) -> Iterable[Tuple[type, Dict]]:
         from common_interfaces.resources import Resource
 
-        for name, cls in self._classes.items():
+        for name in self._order:
+            cls = self._classes[name]
             if issubclass(cls, ResourcePlugin) or issubclass(cls, Resource):
                 yield name, cls, self._configs[name]
 
     def tool_classes(self) -> Iterable[Tuple[type[ToolPlugin], Dict]]:
-        for name, cls in self._classes.items():
+        for name in self._order:
+            cls = self._classes[name]
             if issubclass(cls, ToolPlugin):
                 yield cls, self._configs[name]
 
     def named_tool_classes(self) -> Iterable[Tuple[str, type[ToolPlugin], Dict]]:
         """Return registered tool plugin classes with their names."""
 
-        for name, cls in self._classes.items():
+        for name in self._order:
+            cls = self._classes[name]
             if issubclass(cls, ToolPlugin):
                 yield name, cls, self._configs[name]
 
     def non_resource_non_tool_classes(self) -> Iterable[Tuple[type[BasePlugin], Dict]]:
         from common_interfaces.resources import Resource
 
-        for name, cls in self._classes.items():
+        for name in self._order:
+            cls = self._classes[name]
             if (
                 not issubclass(cls, ResourcePlugin)
                 and not issubclass(cls, ToolPlugin)


### PR DESCRIPTION
## Summary
- track plugin registration order in ClassRegistry
- clarify ordering rules in documentation and templates

## Testing
- `poetry run pytest -q` *(fails: PluginExecutionError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686df1e9af5c832283c1e0891ed2307c