### PR TITLE
Remove telemetry integration

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -16,7 +16,7 @@ from pipeline import (
     update_plugin_configuration,
     validate_topology,
 )  # noqa: E402
-from pipeline.logging import get_logger  # noqa: E402
+from entity.utils.logging import get_logger  # noqa: E402
 from plugins.builtin.adapters.server import AgentServer  # noqa: E402
 
 logger = get_logger(__name__)

--- a/src/cli/plugin_tool.py
+++ b/src/cli/plugin_tool.py
@@ -18,7 +18,7 @@ from pipeline.base_plugins import PromptPlugin  # noqa: E402
 from pipeline.base_plugins import ResourcePlugin  # noqa: E402
 from pipeline.base_plugins import ToolPlugin  # noqa: E402
 from pipeline.base_plugins import AdapterPlugin, ValidationResult  # noqa: E402
-from pipeline.logging import get_logger  # noqa: E402
+from entity.utils.logging import get_logger  # noqa: E402
 
 TEMPLATE_DIR = Path(__file__).parent / "templates"
 

--- a/src/cli/plugin_tool/generate.py
+++ b/src/cli/plugin_tool/generate.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pipeline.logging import get_logger
+from entity.utils.logging import get_logger
 
 TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
 logger = get_logger(__name__)

--- a/src/cli/plugin_tool/main.py
+++ b/src/cli/plugin_tool/main.py
@@ -18,7 +18,7 @@ from pipeline.base_plugins import PromptPlugin  # noqa: E402
 from pipeline.base_plugins import ResourcePlugin  # noqa: E402
 from pipeline.base_plugins import ToolPlugin  # noqa: E402
 from pipeline.base_plugins import AdapterPlugin, ValidationResult  # noqa: E402
-from pipeline.logging import get_logger  # noqa: E402
+from entity.utils.logging import get_logger  # noqa: E402
 
 from .generate import generate_plugin  # noqa: E402
 from .utils import load_plugin  # noqa: E402

--- a/src/entity/core/builder.py
+++ b/src/entity/core/builder.py
@@ -19,7 +19,7 @@ from pipeline.base_plugins import (
     PromptPlugin,
 )
 from pipeline.interfaces import PluginAutoClassifier
-from pipeline.logging import get_logger
+from entity.utils.logging import get_logger
 from pipeline.runtime import AgentRuntime
 from pipeline.user_plugins import BasePlugin
 

--- a/src/entity/utils/logging.py
+++ b/src/entity/utils/logging.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Minimal logging helpers used across the project."""
+
+import logging
+from logging import Logger
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Configure the root logger with a simple format."""
+    level_name = level.upper()
+    log_level = logging._nameToLevel.get(level_name, logging.INFO)
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        force=True,
+    )
+
+
+def get_logger(name: str) -> Logger:
+    """Return a logger instance."""
+    return logging.getLogger(name)
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/src/entity_config/generate_template.py
+++ b/src/entity_config/generate_template.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from pipeline.logging import get_logger
+from entity.utils.logging import get_logger
 from plugins.builtin.adapters.logging_adapter import configure_logging
 
 logger = get_logger(__name__)

--- a/src/entity_config/migrate.py
+++ b/src/entity_config/migrate.py
@@ -9,7 +9,7 @@ import yaml
 
 from entity_config.models import EntityConfig, asdict
 from pipeline.config import ConfigLoader
-from pipeline.logging import get_logger
+from entity.utils.logging import get_logger
 from plugins.builtin.adapters.logging_adapter import configure_logging
 
 logger = get_logger(__name__)

--- a/src/entity_config/validator.py
+++ b/src/entity_config/validator.py
@@ -16,7 +16,7 @@ from pydantic import ValidationError  # noqa: E402
 
 from pipeline import SystemInitializer  # noqa: E402
 from pipeline.config import ConfigLoader  # noqa: E402
-from pipeline.logging import get_logger  # noqa: E402
+from entity.utils.logging import get_logger  # noqa: E402
 from plugins.builtin.adapters.logging_adapter import configure_logging  # noqa: E402
 
 from .models import EntityConfig, asdict  # noqa: E402

--- a/src/pipeline/logging.py
+++ b/src/pipeline/logging.py
@@ -2,29 +2,17 @@
 
 from __future__ import annotations
 
+"""Shims to maintain backward compatibility for logging utilities."""
 
-def configure_logging(*args, **kwargs):
-    from plugins.builtin.adapters.logging_adapter import configure_logging
-
-    return configure_logging(*args, **kwargs)
+from entity.utils.logging import configure_logging, get_logger
 
 
-def get_logger(name: str):
-    from plugins.builtin.adapters.logging_adapter import get_logger
-
-    return get_logger(name)
+def set_request_id(request_id: str):  # pragma: no cover - compatibility stub
+    return request_id
 
 
-def set_request_id(request_id: str):
-    from plugins.builtin.adapters.logging_adapter import set_request_id
-
-    return set_request_id(request_id)
-
-
-def reset_request_id(token):
-    from plugins.builtin.adapters.logging_adapter import reset_request_id
-
-    return reset_request_id(token)
+def reset_request_id(token: str) -> None:  # pragma: no cover - compatibility stub
+    pass
 
 
 __all__ = [

--- a/src/pipeline/observability/metrics.py
+++ b/src/pipeline/observability/metrics.py
@@ -1,16 +1,6 @@
 from __future__ import annotations
 
-"""Prometheus metrics integration for the Entity pipeline."""
-
-import psutil
-from prometheus_client import (
-    CollectorRegistry,
-    Counter,
-    Gauge,
-    Histogram,
-    generate_latest,
-    start_http_server,
-)
+"""Stubbed metrics integration for the Entity pipeline."""
 
 from pipeline.metrics import MetricsCollector
 
@@ -18,64 +8,16 @@ __all__ = ["MetricsServer", "MetricsServerManager"]
 
 
 class MetricsServer:
-    """Expose pipeline metrics via Prometheus."""
+    """Placeholder metrics server."""
 
-    def __init__(self, port: int = 9001) -> None:
-        self.registry = CollectorRegistry()
-        self.llm_latency = Histogram(
-            "llm_latency_seconds",
-            "Latency of LLM calls",
-            ["plugin", "stage"],
-            registry=self.registry,
-        )
-        self.llm_failures = Counter(
-            "llm_failures_total",
-            "Number of failed LLM calls",
-            ["plugin", "stage"],
-            registry=self.registry,
-        )
-        self.stage_duration = Histogram(
-            "stage_duration_seconds",
-            "Duration of each pipeline stage",
-            ["stage"],
-            registry=self.registry,
-        )
-        self.cpu_usage = Gauge(
-            "process_cpu_percent",
-            "Process CPU utilization percent",
-            registry=self.registry,
-        )
-        self.mem_usage = Gauge(
-            "process_memory_bytes",
-            "Process memory usage in bytes",
-            registry=self.registry,
-        )
-        self.dashboard_requests = Counter(
-            "dashboard_requests_total",
-            "Number of dashboard requests",
-            registry=self.registry,
-        )
-        start_http_server(port, registry=self.registry)
+    def __init__(self, port: int = 9001) -> None:  # pragma: no cover - simple init
+        self.port = port
 
-    def update(self, metrics: MetricsCollector) -> None:
-        """Update Prometheus values from ``metrics``."""
-        for key, durations in metrics.llm_durations.items():
-            stage, plugin = key.split(":", 1)
-            for d in durations:
-                self.llm_latency.labels(plugin=plugin, stage=stage).observe(d)
-        for key, count in metrics.tool_error_count.items():
-            stage, plugin = key.split(":", 1)
-            self.llm_failures.labels(plugin=plugin, stage=stage).inc(count)
-        for stage, durations in metrics.stage_durations.items():
-            for d in durations:
-                self.stage_duration.labels(stage=stage).observe(d)
-        self.cpu_usage.set(psutil.cpu_percent())
-        self.mem_usage.set(psutil.Process().memory_info().rss)
-        self.dashboard_requests.inc(metrics.dashboard_requests)
+    def update(self, metrics: MetricsCollector) -> None:  # pragma: no cover - noop
+        pass
 
-    def render(self) -> bytes:
-        """Return metrics in Prometheus text format."""
-        return generate_latest(self.registry)
+    def render(self) -> bytes:  # pragma: no cover - noop
+        return b""
 
 
 class MetricsServerManager:
@@ -85,7 +27,7 @@ class MetricsServerManager:
 
     @classmethod
     def start(cls, port: int = 9001) -> MetricsServer:
-        """Start the Prometheus metrics HTTP server if not already running."""
+        """Create the metrics server if not already running."""
 
         if cls._server is None:
             cls._server = MetricsServer(port)

--- a/src/pipeline/observability/tracing.py
+++ b/src/pipeline/observability/tracing.py
@@ -1,49 +1,32 @@
 from __future__ import annotations
 
-"""OpenTelemetry tracing helpers for the Entity pipeline."""
+"""Minimal tracing utilities used throughout the pipeline."""
 
-import os
 from contextlib import asynccontextmanager
 from typing import Any, Awaitable, Callable
 
-from opentelemetry import trace
-
-try:  # Optional dependency
-    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-except Exception:  # pragma: no cover - optional
-    OTLPSpanExporter = None  # type: ignore
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+# Telemetry integration is currently disabled. These helpers provide the same
+# interface without relying on OpenTelemetry.
 
 
-class _NullWriter:
-    """A writer that silently drops all data."""
+class _Span:  # pragma: no cover - simple placeholder
+    """No-op span object used when tracing is disabled."""
 
-    def write(self, _: str) -> None:  # pragma: no cover - simple pass-through
+    def __enter__(self) -> "_Span":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
         pass
-
-    def flush(self) -> None:  # pragma: no cover - simple pass-through
-        pass
-
-
-def _get_exporter():
-    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-    if endpoint and OTLPSpanExporter is not None:
-        return OTLPSpanExporter(endpoint=endpoint)
-    return ConsoleSpanExporter(out=_NullWriter())
-
-
-_tracer_provider = TracerProvider(resource=Resource.create({"service.name": "entity"}))
-_tracer_provider.add_span_processor(BatchSpanProcessor(_get_exporter()))
-trace.set_tracer_provider(_tracer_provider)
-_tracer = trace.get_tracer(__name__)
 
 
 @asynccontextmanager
-async def start_span(name: str):
-    with _tracer.start_as_current_span(name) as span:
+async def start_span(name: str):  # pragma: no cover - trivial
+    """Yield a no-op span to maintain tracing API compatibility."""
+    span = _Span()
+    try:
         yield span
+    finally:
+        pass
 
 
 async def traced(

--- a/src/pipeline/validation/input.py
+++ b/src/pipeline/validation/input.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, Type
 
 from pydantic import BaseModel, ValidationError
 
-from pipeline.logging import get_logger
+from entity.utils.logging import get_logger
 
 SQL_PATTERN = re.compile(r"(;|--|/\*|\b(drop|delete|insert|update)\b)", re.IGNORECASE)
 

--- a/src/plugins/resources/metrics.py
+++ b/src/plugins/resources/metrics.py
@@ -28,6 +28,7 @@ class MetricsResource(BaseResource):
         return ValidationResult.success_result()
 
     async def initialize(self) -> None:
+        """Initialize the metrics server if telemetry is enabled."""
         MetricsServerManager.start(self._port)
 
     def get_metrics(self) -> Dict[str, int]:

--- a/src/registry/validator.py
+++ b/src/registry/validator.py
@@ -16,7 +16,7 @@ if str(SRC_PATH) not in sys.path:
 from pipeline.initializer import ClassRegistry  # noqa: E402
 from pipeline.initializer import SystemInitializer  # noqa: E402
 from pipeline.initializer import import_plugin_class  # noqa: E402
-from pipeline.logging import get_logger  # noqa: E402
+from entity.utils.logging import get_logger  # noqa: E402
 from pipeline.stages import PipelineStage  # noqa: E402
 
 logger = get_logger(__name__)


### PR DESCRIPTION
## Summary
- strip tracing dependencies
- stub metrics server
- provide simplified logging utils
- use new logging helpers across the codebase

## Testing
- `poetry run black --check src/cli.py src/cli/plugin_tool.py src/cli/plugin_tool/generate.py src/cli/plugin_tool/main.py src/entity/core/builder.py src/entity/utils/logging.py src/entity_config/generate_template.py src/entity_config/migrate.py src/entity_config/validator.py src/pipeline/logging.py src/pipeline/observability/metrics.py src/pipeline/observability/tracing.py src/pipeline/validation/input.py src/plugins/resources/metrics.py src/registry/validator.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*

------
https://chatgpt.com/codex/tasks/task_e_686e547dd1c083228c5287473972080f