### PR TITLE
Validate response stage and loop

### DIFF
--- a/common_interfaces/__init__.py
+++ b/common_interfaces/__init__.py
@@ -1,0 +1,25 @@
+from importlib import import_module
+from typing import Any, Type
+
+from . import plugins
+from .base_plugin import BasePlugin
+from .resources import BaseResource
+
+__all__ = [
+    "plugins",
+    "BasePlugin",
+    "BaseResource",
+    "import_plugin_class",
+]
+
+
+def import_plugin_class(path: str) -> Type[Any]:
+    """Import a class using ``module:Class`` or ``module.Class`` notation."""
+    if ":" in path:
+        module_path, class_name = path.split(":", 1)
+    elif "." in path:
+        module_path, class_name = path.rsplit(".", 1)
+    else:
+        raise ValueError(f"Invalid plugin path: {path}")
+    module = import_module(module_path)
+    return getattr(module, class_name)

--- a/common_interfaces/base_plugin.py
+++ b/common_interfaces/base_plugin.py
@@ -1,0 +1,5 @@
+class BasePlugin:
+    """Minimal base class for plugins."""
+
+    def __init__(self, config=None):
+        self.config = config or {}

--- a/common_interfaces/plugins.py
+++ b/common_interfaces/plugins.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Type
+
+
+@dataclass
+class PluginBaseRegistry:
+    base_plugin: Type = object
+    prompt_plugin: Type = object
+    adapter_plugin: Type = object
+    auto_plugin: Type = object
+
+
+plugin_base_registry = PluginBaseRegistry()
+
+
+def configure_plugins(
+    base_plugin: Type,
+    prompt_plugin: Type,
+    adapter_plugin: Type,
+    auto_plugin: Type,
+) -> PluginBaseRegistry:
+    plugin_base_registry.base_plugin = base_plugin
+    plugin_base_registry.prompt_plugin = prompt_plugin
+    plugin_base_registry.adapter_plugin = adapter_plugin
+    plugin_base_registry.auto_plugin = auto_plugin
+    return plugin_base_registry

--- a/common_interfaces/resources.py
+++ b/common_interfaces/resources.py
@@ -1,0 +1,13 @@
+class BaseResource:
+    """Simplified resource base class used in tests."""
+
+    dependencies: list[str] = []
+
+    async def initialize(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+    async def health_check(self) -> bool:  # pragma: no cover - default ok
+        return True

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+"""Entity-specific plugin context."""
+
+from typing import Any
+
+from pipeline.context import PluginContext as _BaseContext
+from pipeline.stages import PipelineStage
+
+
+class PluginContext(_BaseContext):
+    """Extend base context with stricter response handling."""
+
+    def set_response(self, response: Any) -> None:  # noqa: D401 - clear override
+        """Finalize ``response`` only during the DELIVER stage."""
+        if self.current_stage != PipelineStage.DELIVER:
+            raise ValueError("Only DELIVER stage plugins may set responses")
+        super().set_response(response)
+
+
+__all__ = ["PluginContext"]

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, cast
 
 from entity.core.plugins import ResourcePlugin, ValidationResult
 from pipeline.manager import PipelineManager
-from pipeline.pipeline import execute_pipeline, generate_pipeline_id
 from pipeline.stages import PipelineStage
 from pipeline.state import ConversationEntry, MetricsCollector, PipelineState
 from plugins.builtin.resources.vector_store import VectorStoreResource
@@ -89,6 +88,8 @@ class Memory(ResourcePlugin):
         ) -> None:
             self._memory = memory
             self._registries = registries
+            from pipeline.pipeline import generate_pipeline_id
+
             self._pipeline_manager = pipeline_manager or PipelineManager(registries)
             self._history_limit = history_limit
             self._conversation_id = generate_pipeline_id()
@@ -114,6 +115,8 @@ class Memory(ResourcePlugin):
                 pipeline_id=self._conversation_id,
                 metrics=MetricsCollector(),
             )
+
+            from pipeline.pipeline import execute_pipeline
 
             response = cast(
                 Dict[str, Any],
@@ -148,6 +151,8 @@ class Memory(ResourcePlugin):
                     pipeline_id=self._conversation_id,
                     metrics=MetricsCollector(),
                 )
+                from pipeline.pipeline import execute_pipeline
+
                 response = cast(
                     Dict[str, Any],
                     await execute_pipeline(


### PR DESCRIPTION
## Summary
- ensure responses are only allowed during the DELIVER stage
- stop executing additional deliver plugins once a response is set
- load pipeline helpers lazily in `Memory` to avoid circular imports
- provide minimal `common_interfaces` stubs for tests

## Testing
- `poetry run pytest tests/test_pipeline_looping.py tests/test_set_response.py tests/test_set_response_validation.py -q`
- `poetry run pytest -q` *(fails: ImportError: cannot import name 'Agent' from 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_686e544b22cc8322bca501461f212e5e