### PR TITLE
Add stage result helpers in core context

### DIFF
--- a/docs/source/context.md
+++ b/docs/source/context.md
@@ -39,6 +39,16 @@ class MyPrompt(PromptPlugin):
         context.say(summary)
 ```
 
+## Stage Results
+
+Use `store()` to save intermediate data that later stages can retrieve.
+
+```python
+context.store("answer", "The Eiffel Tower is in Paris")
+if context.has("answer"):
+    result = context.load("answer")
+```
+
 ## Advanced API
 
 Some less common operations are exposed through `context.advanced`.

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Plugin context utilities for Entity plugins."""
+
+from typing import Any
+
+from pipeline.context import AdvancedContext as BaseAdvancedContext
+from pipeline.context import PluginContext as BasePluginContext
+from pipeline.state import ConversationEntry
+
+__all__ = ["PluginContext", "ConversationEntry", "AdvancedContext"]
+
+
+class PluginContext(BasePluginContext):
+    """Entity wrapper around :class:`pipeline.context.PluginContext`."""
+
+    def store(self, key: str, value: Any) -> None:
+        """Store intermediate ``value`` for the current stage under ``key``."""
+        state = self._PluginContext__state
+        if key in state.stage_results:
+            raise ValueError(f"Stage result '{key}' already set")
+        state.stage_results[key] = value
+        max_results = state.max_stage_results
+        if max_results is not None and len(state.stage_results) > max_results:
+            oldest = next(iter(state.stage_results))
+            if oldest != key:
+                state.stage_results.pop(oldest, None)
+
+    def load(self, key: str) -> Any:
+        """Retrieve a stage result previously stored via :meth:`store`."""
+        if key not in self._PluginContext__state.stage_results:
+            raise KeyError(key)
+        return self._PluginContext__state.stage_results[key]
+
+    def has(self, key: str) -> bool:
+        """Return ``True`` if ``key`` exists in stage results."""
+        return key in self._PluginContext__state.stage_results
+
+
+AdvancedContext = BaseAdvancedContext

--- a/src/entity/plugins/prompts/chain_of_thought.py
+++ b/src/entity/plugins/prompts/chain_of_thought.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import List
 
 from pipeline.base_plugins import PromptPlugin
-from pipeline.context import ConversationEntry, PluginContext
+from entity.core.context import ConversationEntry, PluginContext
 from pipeline.stages import PipelineStage
 
 

--- a/src/entity/plugins/prompts/react.py
+++ b/src/entity/plugins/prompts/react.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Tuple
 
 from pipeline.base_plugins import PromptPlugin
-from pipeline.context import ConversationEntry, PluginContext
+from entity.core.context import ConversationEntry, PluginContext
 from pipeline.stages import PipelineStage
 
 

--- a/user_plugins/examples/config_reload_example.py
+++ b/user_plugins/examples/config_reload_example.py
@@ -25,7 +25,7 @@ sys.modules.setdefault("examples.config_reload_example", sys.modules[__name__])
 from cli import CLI
 from pipeline import Agent
 from pipeline.base_plugins import PromptPlugin
-from pipeline.context import PluginContext
+from entity.core.context import PluginContext
 from pipeline.stages import PipelineStage
 
 

--- a/user_plugins/examples/failure_example.py
+++ b/user_plugins/examples/failure_example.py
@@ -15,7 +15,7 @@ from .utilities import enable_plugins_namespace
 enable_plugins_namespace()
 
 from pipeline import Agent, PipelineStage, PromptPlugin
-from pipeline.context import PluginContext
+from entity.core.context import PluginContext
 from user_plugins.failure import BasicLogger, ErrorFormatter
 
 

--- a/user_plugins/examples/pipelines/duckdb_pipeline.py
+++ b/user_plugins/examples/pipelines/duckdb_pipeline.py
@@ -14,7 +14,7 @@ from ..utilities import enable_plugins_namespace
 enable_plugins_namespace()
 
 from pipeline import Agent, PipelineStage, PromptPlugin
-from pipeline.context import PluginContext
+from entity.core.context import PluginContext
 from entity.resources.memory import Memory
 from user_plugins.resources import DuckDBDatabaseResource, DuckDBVectorStore
 

--- a/user_plugins/examples/pipelines/memory_composition_pipeline.py
+++ b/user_plugins/examples/pipelines/memory_composition_pipeline.py
@@ -16,7 +16,7 @@ enable_plugins_namespace()
 from pipeline import Agent  # noqa: E402
 from pipeline import PipelineStage, PromptPlugin  # noqa: E402
 from pipeline.config import ConfigLoader
-from pipeline.context import PluginContext  # noqa: E402
+from entity.core.context import PluginContext  # noqa: E402
 from plugins.builtin.resources.pg_vector_store import PgVectorStore
 from plugins.builtin.resources.postgres import PostgresResource
 from plugins.builtin.resources.sqlite_storage import (

--- a/user_plugins/examples/pipelines/vector_memory_pipeline.py
+++ b/user_plugins/examples/pipelines/vector_memory_pipeline.py
@@ -19,7 +19,7 @@ from entity_config.environment import load_env
 from pipeline import Agent  # noqa: E402
 from pipeline import PipelineStage, PromptPlugin  # noqa: E402
 from pipeline.config import ConfigLoader
-from pipeline.context import PluginContext  # noqa: E402
+from entity.core.context import PluginContext  # noqa: E402
 from plugins.builtin.resources.pg_vector_store import PgVectorStore  # noqa: E402
 from plugins.builtin.resources.postgres import PostgresResource  # noqa: E402
 from plugins.builtin.resources.duckdb_database import (

--- a/user_plugins/examples/storage_resource_example.py
+++ b/user_plugins/examples/storage_resource_example.py
@@ -14,7 +14,7 @@ from .utilities import enable_plugins_namespace
 enable_plugins_namespace()
 
 from pipeline import Agent, PipelineStage, PromptPlugin
-from pipeline.context import ConversationEntry, PluginContext
+from entity.core.context import ConversationEntry, PluginContext
 from entity.resources.memory import Memory
 from plugins.builtin.resources.local_filesystem import LocalFileSystemResource
 from plugins.builtin.resources.sqlite_storage import (

--- a/user_plugins/examples/tools/search_weather_example.py
+++ b/user_plugins/examples/tools/search_weather_example.py
@@ -16,7 +16,7 @@ enable_plugins_namespace()
 
 from entity_config.environment import load_env
 from pipeline import Agent
-from pipeline.context import PluginContext
+from entity.core.context import PluginContext
 from user_plugins.tools import SearchTool, WeatherApiTool
 
 load_env()


### PR DESCRIPTION
## Summary
- expose `PluginContext` helpers via new `entity.core.context`
- update example plugins to import from `entity.core.context`
- document how to store and access stage results

## Testing
- `poetry run pytest -q` *(fails: ImportError: cannot import name 'plugins' from 'common_interfaces')*

------
https://chatgpt.com/codex/tasks/task_e_686e544cc25083229b5ad32c5d3440e8