### PR TITLE
Refactor memory imports

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -21,7 +21,7 @@ plugins:
       retries: 3
       backoff: 1.0
     memory:
-      type: pipeline.resources.memory:Memory
+      type: entity.resources.memory:Memory
     vector_store:
       type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
       table: vector_mem

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -22,7 +22,7 @@ plugins:
       retries: 5
       backoff: 2.0
     memory:
-      type: pipeline.resources.memory:Memory
+      type: entity.resources.memory:Memory
     vector_store:
       type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
       table: vector_mem

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -18,7 +18,7 @@ plugins:
       base_url: "${OLLAMA_BASE_URL}"
       model: "${OLLAMA_MODEL}"
     memory:
-      type: pipeline.resources.memory:Memory
+      type: entity.resources.memory:Memory
     storage:
       type: pipeline.resources.storage_resource:StorageResource
       

--- a/tests/test_complex_prompt.py
+++ b/tests/test_complex_prompt.py
@@ -12,7 +12,7 @@ from pipeline import (
     ToolRegistry,
 )
 from entity.core.resources.container import ResourceContainer
-from pipeline.resources.memory import Memory
+from entity.resources.memory import Memory
 from user_plugins.prompts.complex_prompt import ComplexPrompt
 
 

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -9,7 +9,7 @@ from pipeline import (
     ToolRegistry,
 )
 from entity.core.resources.container import ResourceContainer
-from pipeline.resources.memory import Memory
+from entity.resources.memory import Memory
 
 
 class ContinuePlugin(PromptPlugin):

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -11,7 +11,7 @@ from pipeline import (
 )
 from pipeline.context import ConversationEntry
 from entity.core.resources.container import ResourceContainer
-from pipeline.resources.memory import Memory
+from entity.resources.memory import Memory
 from plugins.builtin.resources.memory_storage import MemoryStorage
 
 


### PR DESCRIPTION
## Summary
- point configs to entity.resources.memory
- update tests to import Memory from entity package

## Testing
- `poetry run pytest tests/test_memory_resource.py tests/test_conversation_manager.py tests/test_complex_prompt.py -q` *(fails: ModuleNotFoundError: No module named 'common_interfaces')*

------
https://chatgpt.com/codex/tasks/task_e_686e544ed20c8322b7c12aade63356af