### PR TITLE
Update template imports

### DIFF
--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -1,7 +1,7 @@
 """Template for adapter plugin."""
 
-from pipeline.base_plugins import AdapterPlugin
-from pipeline.stages import PipelineStage
+from entity.core.plugins import AdapterPlugin
+from entity.core.stages import PipelineStage
 
 
 class {class_name}(AdapterPlugin):

--- a/src/cli/templates/failure.py
+++ b/src/cli/templates/failure.py
@@ -1,7 +1,7 @@
 """Template for failure plugin."""
 
-from pipeline.base_plugins import FailurePlugin
-from pipeline.stages import PipelineStage
+from entity.core.plugins import FailurePlugin
+from entity.core.stages import PipelineStage
 
 
 class {class_name}(FailurePlugin):

--- a/src/cli/templates/prompt.py
+++ b/src/cli/templates/prompt.py
@@ -1,7 +1,7 @@
 """Template for prompt plugin."""
 
-from pipeline.base_plugins import PromptPlugin
-from pipeline.stages import PipelineStage
+from entity.core.plugins import PromptPlugin
+from entity.core.stages import PipelineStage
 
 
 class {class_name}(PromptPlugin):

--- a/src/cli/templates/resource.py
+++ b/src/cli/templates/resource.py
@@ -1,7 +1,7 @@
 """Template for resource plugin."""
 
-from pipeline.base_plugins import ResourcePlugin, ValidationResult
-from pipeline.stages import PipelineStage
+from entity.core.plugins import ResourcePlugin, ValidationResult
+from entity.core.stages import PipelineStage
 
 
 class {class_name}(ResourcePlugin):

--- a/src/cli/templates/tool.py
+++ b/src/cli/templates/tool.py
@@ -2,8 +2,8 @@
 
 from typing import Any, Dict
 
-from pipeline.base_plugins import ToolPlugin
-from pipeline.stages import PipelineStage
+from entity.core.plugins import ToolPlugin
+from entity.core.stages import PipelineStage
 
 
 class {class_name}(ToolPlugin):


### PR DESCRIPTION
## Summary
- fix import paths for plugin templates

## Testing
- `poetry run black src tests`
- `poetry run isort src/cli/templates/adapter.py src/cli/templates/resource.py src/cli/templates/tool.py src/cli/templates/prompt.py src/cli/templates/failure.py`
- `poetry run flake8 src/cli/templates/adapter.py src/cli/templates/resource.py src/cli/templates/tool.py src/cli/templates/prompt.py src/cli/templates/failure.py`
- `poetry run mypy src` *(fails: Duplicate module named "validator")*
- `poetry run bandit -r src`
- `python tools/check_empty_dirs.py` *(failed: file not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: ImportError: cannot import name 'Agent')*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: ImportError: cannot import name 'Agent')*
- `python -m src.registry.validator` *(failed: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(failed: ModuleNotFoundError: No module named 'entity_config.environment')*
- `pytest tests/integration/ -v` *(failed: ModuleNotFoundError: No module named 'entity_config.environment')*
- `pytest tests/infrastructure/ -v` *(failed: ModuleNotFoundError: No module named 'entity_config.environment')*
- `pytest tests/performance/ -m benchmark` *(failed: ModuleNotFoundError: No module named 'entity_config.environment')*


------
https://chatgpt.com/codex/tasks/task_e_686e6516b51c832291e4b255f1f169ed