### PR TITLE
Fix CLI entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 ]
 
 [tool.poetry.scripts]
-entity-cli = "src.cli:main"
+entity-cli = "entity.cli:main"
 
 
 [tool.poetry.urls]


### PR DESCRIPTION
## Summary
- point `entity-cli` to the `entity.cli` module

## Testing
- `poetry install --with dev`
- `poetry run black .`
- `poetry run isort .`
- `poetry run flake8`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `python tools/check_empty_dirs.py` *(fails: file not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.registry.validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e6514eba483228e19d0af1780a3c2