### PR TITLE
Add registry exports

### DIFF
--- a/src/registry/__init__.py
+++ b/src/registry/__init__.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+"""Registry module exports for easy access."""
+
+from .registries import PluginRegistry, SystemRegistries, ToolRegistry
+from .validator import RegistryValidator
+
+__all__ = [
+    "PluginRegistry",
+    "SystemRegistries",
+    "ToolRegistry",
+    "RegistryValidator",
+]


### PR DESCRIPTION
## Summary
- add `src/registry/__init__.py` to simplify imports

## Testing
- `poetry run black src/registry/__init__.py`
- `poetry run isort src/registry/__init__.py`
- `poetry run flake8 src/registry/__init__.py`
- `poetry run mypy src/registry/__init__.py`
- `poetry run bandit -r src/registry/__init__.py`
- `pytest tests/registry/test_validator_stage.py -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e65196234832295ec6938f65ffced