### PR TITLE
Update plugin references for CLI tool

### DIFF
--- a/src/cli/plugin_tool/main.py
+++ b/src/cli/plugin_tool/main.py
@@ -12,12 +12,12 @@ ROOT = Path(__file__).resolve().parent.parent  # noqa: E402
 if str(ROOT) not in sys.path:  # noqa: E402
     sys.path.insert(0, str(ROOT))
 
-from pipeline.base_plugins import BasePlugin  # noqa: E402
-from pipeline.base_plugins import FailurePlugin  # noqa: E402
-from pipeline.base_plugins import PromptPlugin  # noqa: E402
-from pipeline.base_plugins import ResourcePlugin  # noqa: E402
-from pipeline.base_plugins import ToolPlugin  # noqa: E402
-from pipeline.base_plugins import AdapterPlugin, ValidationResult  # noqa: E402
+from entity.core.plugins import BasePlugin  # noqa: E402
+from entity.core.plugins import FailurePlugin  # noqa: E402
+from entity.core.plugins import PromptPlugin  # noqa: E402
+from entity.core.plugins import ResourcePlugin  # noqa: E402
+from entity.core.plugins import ToolPlugin  # noqa: E402
+from entity.core.plugins import AdapterPlugin, ValidationResult  # noqa: E402
 from entity.utils.logging import get_logger  # noqa: E402
 
 from .generate import generate_plugin  # noqa: E402
@@ -237,7 +237,7 @@ class PluginToolCLI:
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 
-        from pipeline.base_plugins import PluginAutoClassifier
+        from entity.core.plugin_utils import PluginAutoClassifier
 
         found = False
         for name, obj in module.__dict__.items():

--- a/src/cli/plugin_tool/utils.py
+++ b/src/cli/plugin_tool/utils.py
@@ -5,7 +5,7 @@ import inspect
 from pathlib import Path
 from typing import Type
 
-from pipeline.base_plugins import BasePlugin
+from entity.core.plugins import BasePlugin
 
 
 def load_plugin(path: str) -> Type[BasePlugin]:


### PR DESCRIPTION
## Summary
- reference `entity.core.plugins` instead of `pipeline.base_plugins`
- load `PluginAutoClassifier` from new module

## Testing
- `poetry run black src/cli/plugin_tool/main.py src/cli/plugin_tool/utils.py`
- `poetry run isort src/cli/plugin_tool/main.py src/cli/plugin_tool/utils.py`
- `poetry run flake8 src/cli/plugin_tool/main.py src/cli/plugin_tool/utils.py`
- `poetry run mypy src/cli/plugin_tool/main.py src/cli/plugin_tool/utils.py` *(fails: Returning Any from function declared to return "int")*
- `bandit -r src` *(fails: command not found)*
- `python tools/check_empty_dirs.py` *(fails: file not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError: No module named 'plugins.builtin')*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError: No module named 'plugins.builtin')*
- `python -m src.registry.validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*


------
https://chatgpt.com/codex/tasks/task_e_686e6517b3948322b729a7553fa4ed4d