### PR TITLE
Move docs build files

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'src/docs_build/**'
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'src/docs_build/**'
 
 jobs:
   unit:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/source/conf.py
+  configuration: src/docs_build/conf.py
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:
 #    - pdf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,8 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poe.tasks]
-docs = { cmd = "sphinx-build docs/source docs/build/html" }
-docs_view = { cmd = "sphinx-autobuild docs/source docs/build/html" }
+docs = { cmd = "sphinx-build -c src/docs_build docs/source docs/build/html" }
+docs_view = { cmd = "sphinx-autobuild -c src/docs_build docs/source docs/build/html" }
 patch = { cmd = "poetry version patch" }
 _publish = { cmd = "poetry publish --build" }
 release = ["docs", "patch", "_publish"]

--- a/src/docs_build/Makefile
+++ b/src/docs_build/Makefile
@@ -3,10 +3,10 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -c .
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = source
-BUILDDIR      = build
+SOURCEDIR     = ../../docs/source
+BUILDDIR      = ../../docs/build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/src/docs_build/conf.py
+++ b/src/docs_build/conf.py
@@ -38,4 +38,4 @@ html_static_path = ["_static"]
 
 # https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html
 # autoapi_dirs = ['../../entity']
-autodoc2_packages = ["../../entity"]
+autodoc2_packages = ["../entity"]

--- a/src/docs_build/make.bat
+++ b/src/docs_build/make.bat
@@ -7,8 +7,9 @@ REM Command file for Sphinx documentation
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
-set SOURCEDIR=source
-set BUILDDIR=build
+set SPHINXOPTS=-c .
+set SOURCEDIR=..\..\docs\source
+set BUILDDIR=..\..\docs\build
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (


### PR DESCRIPTION
## Summary
- relocate Sphinx config files into `src/docs_build`
- update build scripts and tasks for the new location
- ignore `src/docs_build` in CI workflows
- point ReadTheDocs to the new configuration

## Testing
- `poetry run flake8 src tests` *(fails: F401 and F811 errors)*
- `poetry run mypy src` *(fails: several import-not-found errors)*
- `poetry run pytest -m "not integration" -v` *(fails: ModuleNotFoundError: entity_config.environment)*

------
https://chatgpt.com/codex/tasks/task_e_686e67707e988322b00e2ab6fc5d0b42