### PR TITLE
Add workflow framework

### DIFF
--- a/src/entity/workflows/__init__.py
+++ b/src/entity/workflows/__init__.py
@@ -1,0 +1,11 @@
+"""Workflow utilities."""
+
+from .base import Workflow
+from .builtin import ChainOfThoughtWorkflow, ReActWorkflow, StandardWorkflow
+
+__all__ = [
+    "Workflow",
+    "StandardWorkflow",
+    "ReActWorkflow",
+    "ChainOfThoughtWorkflow",
+]

--- a/src/entity/workflows/base.py
+++ b/src/entity/workflows/base.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Workflow definitions for pipeline execution."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+from pipeline.stages import PipelineStage
+
+
+@dataclass
+class Workflow:
+    """Map :class:`PipelineStage` to plugin names."""
+
+    stages: Dict[PipelineStage, List[str]] = field(default_factory=dict)
+
+    def __init__(
+        self, mapping: Dict[PipelineStage | str, Iterable[str]] | None = None
+    ) -> None:
+        self.stages = {}
+        if mapping:
+            for stage, plugins in mapping.items():
+                self._assign(stage, plugins)
+
+    def _assign(self, stage: PipelineStage | str, plugins: Iterable[str]) -> None:
+        stage_obj = PipelineStage.ensure(stage)
+        names = [str(p) for p in plugins]
+        if not all(names):
+            raise ValueError("Plugin names must be non-empty strings")
+        self.stages[stage_obj] = names
+
+    def to_dict(self) -> Dict[str, List[str]]:
+        return {str(stage).lower(): list(names) for stage, names in self.stages.items()}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Iterable[str]]) -> "Workflow":
+        mapping = {PipelineStage.ensure(k): list(v) for k, v in data.items()}
+        return cls(mapping)

--- a/src/entity/workflows/builtin.py
+++ b/src/entity/workflows/builtin.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Built-in workflow blueprints."""
+
+from pipeline.stages import PipelineStage
+
+from .base import Workflow
+
+
+class StandardWorkflow(Workflow):
+    """Default conversational workflow."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            {
+                PipelineStage.PARSE: ["conversation_history"],
+                PipelineStage.THINK: ["complex_prompt"],
+                PipelineStage.REVIEW: ["pii_scrubber"],
+                PipelineStage.ERROR: ["default_responder"],
+            }
+        )
+
+
+class ReActWorkflow(Workflow):
+    """Workflow using the ReAct reasoning pattern."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            {
+                PipelineStage.THINK: ["react"],
+                PipelineStage.REVIEW: ["pii_scrubber"],
+                PipelineStage.ERROR: ["default_responder"],
+            }
+        )
+
+
+class ChainOfThoughtWorkflow(Workflow):
+    """Workflow using chain-of-thought reasoning."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            {
+                PipelineStage.THINK: ["chain_of_thought"],
+                PipelineStage.REVIEW: ["pii_scrubber"],
+                PipelineStage.ERROR: ["default_responder"],
+            }
+        )


### PR DESCRIPTION
## Summary
- add Workflow class for defining stage→plugin mappings
- include built-in StandardWorkflow, ReActWorkflow, and ChainOfThoughtWorkflow
- expose the workflow classes via package init

## Testing
- `poetry run black src/entity/workflows/base.py src/entity/workflows/builtin.py src/entity/workflows/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*

------
https://chatgpt.com/codex/tasks/task_e_686e7046cfec8322897717cc124a2c66