### PR TITLE
Add Pipeline workflow class

### DIFF
--- a/src/pipeline/stages.py
+++ b/src/pipeline/stages.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Enumeration of pipeline execution stages."""
+
+from enum import IntEnum, auto
+
+
+class PipelineStage(IntEnum):
+    """Ordered pipeline stages."""
+
+    PARSE = auto()
+    THINK = auto()
+    DO = auto()
+    REVIEW = auto()
+    DELIVER = auto()
+    ERROR = auto()
+
+    def __str__(self) -> str:
+        return self.name.lower()
+
+    @classmethod
+    def from_str(cls, value: str) -> "PipelineStage":
+        try:
+            return cls[value.upper()]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Unknown stage: {value}") from exc
+
+    @classmethod
+    def ensure(cls, value: "PipelineStage | str") -> "PipelineStage":
+        if isinstance(value, cls):
+            return value
+        return cls.from_str(str(value))


### PR DESCRIPTION
## Summary
- introduce `Workflow` data class and a new `Pipeline` object
- let `Pipeline.run_message` wrap existing `execute_pipeline`
- expose `Pipeline` and `Workflow` in module exports
- add missing `PipelineStage` enum

## Testing
- `poetry run black src/pipeline/pipeline.py src/pipeline/stages.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*

------
https://chatgpt.com/codex/tasks/task_e_686e704860288322b93477ee464ff97f