### PR TITLE
Add workflow loader support

### DIFF
--- a/src/entity_config/environment.py
+++ b/src/entity_config/environment.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Environment loading utilities used in tests."""
+
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+
+def load_env(env_file: str | Path = ".env", override: bool = False) -> None:
+    """Load environment variables from ``env_file``."""
+    path = Path(env_file)
+    if path.exists():
+        load_dotenv(path, override=override)

--- a/src/pipeline/config/__init__.py
+++ b/src/pipeline/config/__init__.py
@@ -10,6 +10,7 @@ import yaml
 
 from entity_config.environment import load_env
 from entity.config.models import validate_config
+from pipeline.workflow import Workflow
 
 from .utils import interpolate_env_vars
 
@@ -18,18 +19,50 @@ class ConfigLoader:
     """Load and normalize pipeline configuration."""
 
     @staticmethod
+    def _load_workflow(workflow: Any, base: Path) -> Workflow:
+        """Return :class:`Workflow` from mapping or file path."""
+        if isinstance(workflow, Workflow):
+            return workflow
+        if isinstance(workflow, str):
+            wf_path = (
+                (base / workflow)
+                if not Path(workflow).is_absolute()
+                else Path(workflow)
+            )
+            if wf_path.suffix in {".yaml", ".yml"}:
+                wf_data = yaml.safe_load(wf_path.read_text()) or {}
+            else:
+                wf_data = json.loads(wf_path.read_text() or "{}")
+        elif isinstance(workflow, dict):
+            wf_data = workflow
+        else:
+            raise TypeError("workflow must be a path or mapping")
+        wf_data = interpolate_env_vars(wf_data)
+        return Workflow.from_dict(wf_data)
+
+    @staticmethod
     def from_yaml(path: str | Path, env_file: str = ".env") -> Dict[str, Any]:
         load_env(env_file)
-        data = yaml.safe_load(Path(path).read_text()) or {}
+        path_obj = Path(path)
+        data = yaml.safe_load(path_obj.read_text()) or {}
         data = interpolate_env_vars(data)
+        if "workflow" in data:
+            data["workflow"] = ConfigLoader._load_workflow(
+                data["workflow"], path_obj.parent
+            )
         validate_config(data)
         return data
 
     @staticmethod
     def from_json(path: str | Path, env_file: str = ".env") -> Dict[str, Any]:
         load_env(env_file)
-        data = json.loads(Path(path).read_text() or "{}")
+        path_obj = Path(path)
+        data = json.loads(path_obj.read_text() or "{}")
         data = interpolate_env_vars(data)
+        if "workflow" in data:
+            data["workflow"] = ConfigLoader._load_workflow(
+                data["workflow"], path_obj.parent
+            )
         validate_config(data)
         return data
 
@@ -37,5 +70,7 @@ class ConfigLoader:
     def from_dict(cfg: Dict[str, Any], env_file: str = ".env") -> Dict[str, Any]:
         load_env(env_file)
         data = interpolate_env_vars(dict(cfg))
+        if "workflow" in data:
+            data["workflow"] = ConfigLoader._load_workflow(data["workflow"], Path("."))
         validate_config(data)
         return data

--- a/src/pipeline/config/utils.py
+++ b/src/pipeline/config/utils.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Utility helpers for configuration loading."""
+
+import os
+import re
+from typing import Any
+
+_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def interpolate_env_vars(value: Any) -> Any:
+    """Recursively replace ``${VAR}`` with environment variables."""
+    if isinstance(value, dict):
+        return {k: interpolate_env_vars(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [interpolate_env_vars(v) for v in value]
+    if isinstance(value, str):
+        return _PATTERN.sub(lambda m: os.getenv(m.group(1), m.group(0)), value)
+    return value

--- a/src/pipeline/stages.py
+++ b/src/pipeline/stages.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Enumeration of pipeline execution stages."""
+
+from enum import Enum, auto
+
+
+class PipelineStage(Enum):
+    PARSE = auto()
+    THINK = auto()
+    DO = auto()
+    REVIEW = auto()
+    DELIVER = auto()
+    ERROR = auto()
+
+    @classmethod
+    def ensure(cls, value: "PipelineStage | str") -> "PipelineStage":
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, str):
+            try:
+                return cls[value.upper()]
+            except KeyError as exc:  # pragma: no cover - defensive
+                raise ValueError(f"Invalid stage: {value}") from exc
+        raise ValueError(f"Invalid stage: {value}")
+
+    def __str__(self) -> str:  # pragma: no cover - formatting helper
+        return self.name.lower()

--- a/src/pipeline/workflow.py
+++ b/src/pipeline/workflow.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Lightweight workflow definition utilities."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+from .stages import PipelineStage
+
+
+@dataclass
+class Workflow:
+    """Mapping of pipeline stages to plugin names."""
+
+    stages: Dict[PipelineStage, List[str]] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str | PipelineStage, Iterable[str]]) -> "Workflow":
+        mapping: Dict[PipelineStage, List[str]] = {}
+        for stage, plugins in (data or {}).items():
+            stage_obj = PipelineStage.ensure(stage)
+            if not isinstance(plugins, Iterable):
+                raise ValueError("Workflow stage values must be iterables")
+            mapping[stage_obj] = list(plugins)
+        return cls(mapping)
+
+    def to_dict(self) -> Dict[str, List[str]]:
+        return {
+            stage.name.lower(): list(plugins) for stage, plugins in self.stages.items()
+        }
+
+    def __iter__(self):  # pragma: no cover - passthrough
+        return iter(self.stages.items())

--- a/tests/config/test_workflow_roundtrip.py
+++ b/tests/config/test_workflow_roundtrip.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+import yaml
+
+from pipeline.config import ConfigLoader
+from pipeline.workflow import Workflow
+
+
+def test_workflow_roundtrip(tmp_path: Path) -> None:
+    wf_data = {"parse": ["a"], "think": ["b"], "deliver": ["c"]}
+    wf_yaml = tmp_path / "wf.yaml"
+    wf_json = tmp_path / "wf.json"
+    wf_yaml.write_text(yaml.dump(wf_data, sort_keys=False))
+    wf_json.write_text(json.dumps(wf_data))
+
+    wf_from_yaml = Workflow.from_dict(yaml.safe_load(wf_yaml.read_text()))
+    wf_from_json = Workflow.from_dict(json.loads(wf_json.read_text()))
+    assert wf_from_yaml.to_dict() == wf_data
+    assert wf_from_json.to_dict() == wf_data
+
+    cfg_yaml = tmp_path / "cfg.yml"
+    cfg_yaml.write_text(yaml.dump({"workflow": str(wf_yaml)}, sort_keys=False))
+    cfg_json = tmp_path / "cfg.json"
+    cfg_json.write_text(json.dumps({"workflow": str(wf_json)}))
+
+    loaded_yaml = ConfigLoader.from_yaml(cfg_yaml)
+    loaded_json = ConfigLoader.from_json(cfg_json)
+    loaded_dict = ConfigLoader.from_dict({"workflow": wf_data})
+
+    assert loaded_yaml["workflow"].to_dict() == wf_data
+    assert loaded_json["workflow"].to_dict() == wf_data
+    assert loaded_dict["workflow"].to_dict() == wf_data


### PR DESCRIPTION
## Summary
- define pipeline stages and workflow helper
- read workflow data in `ConfigLoader`
- add environment loader for tests
- provide env var interpolation utilities
- test workflow round-trip loading

## Testing
- `poetry run pytest tests/config/test_workflow_roundtrip.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e70505ac48322be40bfe9305fca74