### PR TITLE
Add workflow discovery utilities

### DIFF
--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Wrapper base plugin classes for the Entity framework."""
+"""Wrapper base plugin classes for the Entity framework.
 
 These classes mirror the minimal architecture described in
 ``architecture/general.md`` and avoid importing ``pipeline.base_plugins``.

--- a/src/entity/workflows/__init__.py
+++ b/src/entity/workflows/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+"""Workflow base classes and utilities."""
+
+
+class Workflow:
+    """Base workflow object describing stage order."""
+
+    stages: dict[str, list[str]] = {}
+
+
+__all__ = ["Workflow"]

--- a/src/entity/workflows/discovery.py
+++ b/src/entity/workflows/discovery.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Helpers for discovering workflow classes."""
+
+from importlib import util
+from pathlib import Path
+from types import ModuleType
+from typing import Dict, Type
+import inspect
+
+from entity.utils.logging import get_logger
+
+from . import Workflow
+
+__all__ = ["discover_workflows", "register_module_workflows"]
+
+logger = get_logger(__name__)
+
+
+def _import_module(file: Path) -> ModuleType | None:
+    try:
+        spec = util.spec_from_file_location(file.stem, file)
+        if spec and spec.loader:
+            module = util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to import workflow module %s: %s", file, exc)
+    return None
+
+
+def register_module_workflows(
+    module: ModuleType, registry: Dict[str, Type[Workflow]]
+) -> None:
+    for name, obj in vars(module).items():
+        if name.startswith("_"):
+            continue
+        if inspect.isclass(obj) and issubclass(obj, Workflow) and obj is not Workflow:
+            registry[obj.__name__] = obj
+
+
+def discover_workflows(directory: str) -> Dict[str, Type[Workflow]]:
+    """Load ``*.py`` files from ``directory`` and collect ``Workflow`` subclasses."""
+
+    registry: Dict[str, Type[Workflow]] = {}
+    for file in Path(directory).glob("*.py"):
+        if file.name.startswith("_"):
+            continue
+        module = _import_module(file)
+        if module is not None:
+            register_module_workflows(module, registry)
+    return registry

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -1,0 +1,17 @@
+from entity import Agent
+from entity.workflows import Workflow
+
+
+def test_agent_load_workflows(tmp_path):
+    path = tmp_path / "flows.py"
+    path.write_text(
+        """
+from entity.workflows import Workflow
+class Demo(Workflow):
+    pass
+"""
+    )
+    agent = Agent()
+    agent.load_workflows_from_directory(str(tmp_path))
+    assert "Demo" in agent.workflows
+    assert issubclass(agent.workflows["Demo"], Workflow)

--- a/tests/test_initializer_workflows.py
+++ b/tests/test_initializer_workflows.py
@@ -1,0 +1,19 @@
+import asyncio
+from pipeline.initializer import SystemInitializer
+from entity.workflows import Workflow
+
+
+def test_initializer_discovers_workflows(tmp_path):
+    f = tmp_path / "wf.py"
+    f.write_text(
+        """
+from entity.workflows import Workflow
+class InitFlow(Workflow):
+    pass
+"""
+    )
+    config = {"workflow_dirs": [str(tmp_path)], "plugins": {}}
+    initializer = SystemInitializer.from_dict(config)
+    asyncio.run(initializer.initialize())
+    assert "InitFlow" in initializer.workflows
+    assert issubclass(initializer.workflows["InitFlow"], Workflow)

--- a/tests/test_workflow_discovery.py
+++ b/tests/test_workflow_discovery.py
@@ -1,0 +1,16 @@
+from entity.workflows.discovery import discover_workflows
+from entity.workflows import Workflow
+
+
+def test_discover_workflows(tmp_path):
+    wf_file = tmp_path / "wf.py"
+    wf_file.write_text(
+        """
+from entity.workflows import Workflow
+class MyFlow(Workflow):
+    pass
+"""
+    )
+    workflows = discover_workflows(str(tmp_path))
+    assert "MyFlow" in workflows
+    assert issubclass(workflows["MyFlow"], Workflow)


### PR DESCRIPTION
## Summary
- support simple Workflow subclass discovery
- allow Agents and SystemInitializer to load workflows
- expose Workflow base class
- fix plugin base docstring
- add regression tests for workflow discovery

## Testing
- `poetry run black src/entity/core/agent.py src/entity/core/plugins/base.py src/pipeline/initializer.py src/entity/workflows tests/test_agent_workflows.py tests/test_initializer_workflows.py tests/test_workflow_discovery.py`
- `poetry run pytest tests/test_workflow_discovery.py tests/test_agent_workflows.py tests/test_initializer_workflows.py -q` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*

------
https://chatgpt.com/codex/tasks/task_e_686e705257788322aa9ac516719e83ff