### PR TITLE
Add dev-to-production guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Entity Pipeline Framework
+
+Build agents once and run them anywhere. The same code and configuration work
+from local prototyping to full AWS deployment. See the
+[dev-to-production guide](docs/source/dev_to_production.md) for a short
+walkthrough.

--- a/docs/source/dev_to_production.md
+++ b/docs/source/dev_to_production.md
@@ -1,0 +1,33 @@
+# From Development to Production
+
+Use the same configuration file from your laptop to the cloud. Start locally,
+containerize when ready, then deploy to AWS.
+
+## 1. Local prototyping
+
+Install dependencies and run the agent:
+
+```bash
+poetry install --with dev
+poetry run entity-cli --config config/dev.yaml
+```
+
+## 2. Containerize
+
+Build a Docker image to package your code and configuration:
+
+```bash
+docker build -t entity-agent .
+docker run -p 8000:8000 entity-agent
+```
+
+## 3. Deploy to AWS
+
+Use `AwsDeployer` or Terraform scripts to launch the container on AWS.
+For a quick demonstration:
+
+```bash
+python user_plugins/examples/bedrock_deploy.py
+```
+
+See [AWS deployment](deploy_aws.md) for details.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -38,6 +38,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [Local](deploy_local.md)
 - [Docker](deploy_docker.md)
 - [Cloud](deploy_cloud.md)
+- [Dev to production](dev_to_production.md)
 - [Production guide](deploy_production.md)
 - [Migration guide](migration_guide.md)
 
@@ -63,6 +64,7 @@ deploy_aws
 deploy_local
 deploy_docker
 deploy_cloud
+dev_to_production
 deploy_production
 migration_guide
 principle_checklist

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Wrapper base plugin classes for the Entity framework."""
+"""Wrapper base plugin classes for the Entity framework.
 
 These classes mirror the minimal architecture described in
 ``architecture/general.md`` and avoid importing ``pipeline.base_plugins``.


### PR DESCRIPTION
## Summary
- add a quick value-prop paragraph in the README
- document how to move from local dev to an AWS deployment
- link the new guide from the docs index
- fix an invalid docstring in `base.py`

## Testing
- `poetry run black src/entity/core/plugins/base.py`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*

------
https://chatgpt.com/codex/tasks/task_e_686e705f8af08322a298c54c4acecea3