### PR TITLE
Add example workflows

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -19,6 +19,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [Detailed guide](plugin_guide.md)
 - [Naming conventions](plugins.md)
 - [Developer examples](developer_examples.md)
+- [Workflows](workflows.md)
 
 ### Architecture
 - [Architecture overview](../../architecture/overview.md)
@@ -51,6 +52,7 @@ config_cheatsheet
 plugin_cheatsheet
 plugin_guide
 developer_examples
+workflows
 context
 security_config
 logging

--- a/docs/source/workflows.md
+++ b/docs/source/workflows.md
@@ -1,0 +1,35 @@
+# Example Workflows
+
+Entity provides a few ready-to-use workflow classes. Each workflow maps pipeline
+stages to plugin names. Instantiate one and pass it to `Pipeline`.
+
+```python
+from entity.workflows.examples import ChainOfThoughtWorkflow
+from pipeline import Pipeline
+
+workflow = ChainOfThoughtWorkflow()
+pipeline = Pipeline(workflow=workflow)
+```
+
+## Available Workflows
+
+### ChainOfThoughtWorkflow
+Runs the chain-of-thought reasoning plugin.
+
+```python
+from entity.workflows.examples import ChainOfThoughtWorkflow
+```
+
+### ReActWorkflow
+Uses the ReAct prompt to alternate reasoning and tool use.
+
+```python
+from entity.workflows.examples import ReActWorkflow
+```
+
+### IntentClassificationWorkflow
+Classifies user intent with a single LLM call.
+
+```python
+from entity.workflows.examples import IntentClassificationWorkflow
+```

--- a/src/entity/workflows/__init__.py
+++ b/src/entity/workflows/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Workflow base classes."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from pipeline.stages import PipelineStage
+
+
+@dataclass
+class Workflow:
+    """Mapping of pipeline stages to plugin names."""
+
+    stage_map: Dict[PipelineStage, List[str]] = field(default_factory=dict)
+
+    def get_stage_map(self) -> Dict[PipelineStage, List[str]]:
+        """Return mapping of stages to plugin names."""
+
+        return self.stage_map
+
+
+__all__ = ["Workflow"]

--- a/src/entity/workflows/examples.py
+++ b/src/entity/workflows/examples.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Example workflow classes."""
+
+from pipeline.stages import PipelineStage
+
+from . import Workflow
+
+
+class ChainOfThoughtWorkflow(Workflow):
+    """Reason through problems step by step."""
+
+    stage_map = {
+        PipelineStage.THINK: [
+            "user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt",
+        ]
+    }
+
+
+class ReActWorkflow(Workflow):
+    """Iteratively reason and act using tools."""
+
+    stage_map = {
+        PipelineStage.THINK: [
+            "user_plugins.prompts.react_prompt:ReActPrompt",
+        ]
+    }
+
+
+class IntentClassificationWorkflow(Workflow):
+    """Classify the user's intent with a single prompt."""
+
+    stage_map = {
+        PipelineStage.THINK: [
+            "user_plugins.prompts.intent_classifier:IntentClassifierPrompt",
+        ]
+    }
+
+
+__all__ = [
+    "ChainOfThoughtWorkflow",
+    "ReActWorkflow",
+    "IntentClassificationWorkflow",
+]


### PR DESCRIPTION
## Summary
- add Workflow base class and three example workflows
- document example workflows in a new docs page
- link workflows documentation from the index page

## Testing
- `poetry install --with dev`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*

------
https://chatgpt.com/codex/tasks/task_e_686e7063a43483228332fdb19ce9da1e