### PR TITLE
Add AWS startup section

### DIFF
--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -65,3 +65,23 @@ ImportError: cannot import name 'Resource' from partially initialized module 'co
 
 Once the imports are resolved, the `pytest-benchmark` plugin can capture
 timing metrics for each pipeline stage.
+
+## Zero-Config AWS Startup
+
+The framework includes helper scripts that spin up a minimal AWS stack and run a
+pipeline with almost no configuration. Run `python user_plugins/examples/bedrock_deploy.py`
+to create an S3 bucket and IAM role, then start the agent. Behavior is defined by
+a **Workflow** object:
+
+```python
+from my_workflows import QuickstartWorkflow
+from pipeline import Pipeline
+
+workflow = QuickstartWorkflow()
+pipeline = Pipeline(approach=workflow)
+```
+
+The pipeline loops through `PARSE → THINK → DO → REVIEW → DELIVER` until a
+plugin calls `set_response`, illustrating the hybrid pipeline–state machine model.
+Because the workflow defines plugin selection, you can launch on AWS without a
+YAML file and later swap in custom stages as needed.

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Wrapper base plugin classes for the Entity framework."""
+"""Base plugin classes used by the Entity framework.
 
 These classes mirror the minimal architecture described in
 ``architecture/general.md`` and avoid importing ``pipeline.base_plugins``.


### PR DESCRIPTION
## Summary
- document zero-config AWS startup in architecture docs
- fix base plugin docstring to keep black happy

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*

------
https://chatgpt.com/codex/tasks/task_e_686e7060c7b083229fa36bf78776d7ee