### PR TITLE
Add workflow CLI utilities

### DIFF
--- a/src/cli/templates/workflow_template.py
+++ b/src/cli/templates/workflow_template.py
@@ -1,0 +1,10 @@
+"""Template for workflow definition."""
+
+from pipeline import PipelineStage
+
+{workflow_name} = {
+    PipelineStage.PARSE: [],
+    PipelineStage.THINK: [],
+    PipelineStage.DO: [],
+    PipelineStage.DELIVER: [],
+}


### PR DESCRIPTION
## Summary
- add new `workflow` commands to `cli.py`
- generate workflow templates in `src/cli/templates/workflow_template.py`
- implement ASCII and Graphviz visualization options

## Testing
- `poetry run black src/cli.py src/cli/templates/workflow_template.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*

------
https://chatgpt.com/codex/tasks/task_e_686e7066f52c83228597fb1b24eae0bd