### PR TITLE
Add initial workflow tests

### DIFF
--- a/tests/integration/test_legacy_workflow_compat.py
+++ b/tests/integration/test_legacy_workflow_compat.py
@@ -1,0 +1,22 @@
+import asyncio
+import pytest
+
+from pipeline import PipelineStage
+from pipeline.base_plugins import BasePlugin
+from entity import AgentBuilder
+
+
+class ReplyPlugin(BasePlugin):
+    stages = [PipelineStage.DELIVER]
+
+    async def _execute_impl(self, context):
+        context.set_response("ok")
+
+
+@pytest.mark.integration
+def test_legacy_config_without_workflow_executes():
+    builder = AgentBuilder()
+    builder.add_plugin(ReplyPlugin({}))
+    runtime = builder.build_runtime()
+    result = asyncio.run(runtime.run_pipeline("hi"))
+    assert result == "ok"

--- a/tests/integration/test_workflow_integration.py
+++ b/tests/integration/test_workflow_integration.py
@@ -1,0 +1,18 @@
+import asyncio
+import pytest
+
+pipeline = pytest.importorskip("pipeline")
+workflow_mod = pytest.importorskip("entity.workflows.react")
+
+Pipeline = getattr(pipeline, "Pipeline", None)
+ReActWorkflow = getattr(workflow_mod, "ReActWorkflow", None)
+
+if Pipeline is None or ReActWorkflow is None:
+    pytest.skip("Workflow APIs not available", allow_module_level=True)
+
+
+@pytest.mark.integration
+def test_react_workflow_pipeline_runs():
+    runtime = Pipeline(approach=ReActWorkflow())
+    result = asyncio.run(runtime.run_pipeline("hi"))
+    assert result

--- a/tests/workflows/test_workflow_validation.py
+++ b/tests/workflows/test_workflow_validation.py
@@ -1,0 +1,15 @@
+import pytest
+
+pipeline = pytest.importorskip("pipeline")
+
+validate_topology = getattr(pipeline, "validate_topology", None)
+if validate_topology is None:
+    pytest.skip("validate_topology not available", allow_module_level=True)
+
+PipelineStage = pipeline.PipelineStage
+
+
+def test_invalid_stage_mapping_raises_error():
+    invalid = {"NOT_A_STAGE": ["noop"]}
+    with pytest.raises(Exception):
+        validate_topology(invalid)


### PR DESCRIPTION
## Summary
- test workflow stage mapping errors
- test running Pipeline with ReActWorkflow (if available)
- ensure legacy configs still run without workflows

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'entity_config.environment')*

------
https://chatgpt.com/codex/tasks/task_e_686e7064c8e08322bd32702b516d651b