### PR TITLE
Add workflow integration hints to plugin templates

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -236,7 +236,8 @@ poetry run entity-cli serve-websocket --config config/dev.yaml
 
 When implementing custom error handling, refer to
 [`user_plugins/examples/failure_example.py`](../../user_plugins/examples/failure_example.py),
-the failure plugin template at `src/cli/templates/failure.py`,
+the failure plugin template at `src/cli/templates/failure.py` (which shows how
+to register the plugin in a workflow),
 and the [error handling guide](error_handling.md).
 
 ## Troubleshooting Plugins

--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -1,4 +1,12 @@
-"""Template for adapter plugin."""
+"""Template for an adapter plugin.
+
+Adapters connect pipeline output to the outside world. Add the generated
+plugin to a workflow so it runs in the ``DELIVER`` stage:
+
+```
+workflow = {PipelineStage.DELIVER: ["MyAdapter"]}
+```
+"""
 
 from entity.core.plugins import AdapterPlugin
 from entity.core.stages import PipelineStage

--- a/src/cli/templates/failure.py
+++ b/src/cli/templates/failure.py
@@ -1,4 +1,12 @@
-"""Template for failure plugin."""
+"""Template for a failure plugin.
+
+Failure plugins run when other plugins raise an error. Integrate the
+generated plugin into a workflow as an ``ERROR`` stage handler:
+
+```
+workflow = {PipelineStage.ERROR: ["MyFailureHandler"]}
+```
+"""
 
 from entity.core.plugins import FailurePlugin
 from entity.core.stages import PipelineStage

--- a/src/cli/templates/prompt.py
+++ b/src/cli/templates/prompt.py
@@ -1,4 +1,12 @@
-"""Template for prompt plugin."""
+"""Template for a prompt plugin.
+
+Prompt plugins drive the conversation. Include the generated class in a
+workflow mapping under the ``THINK`` stage:
+
+```
+workflow = {PipelineStage.THINK: ["MyPromptPlugin"]}
+```
+"""
 
 from entity.core.plugins import PromptPlugin
 from entity.core.stages import PipelineStage

--- a/src/cli/templates/resource.py
+++ b/src/cli/templates/resource.py
@@ -1,4 +1,12 @@
-"""Template for resource plugin."""
+"""Template for a resource plugin.
+
+Resources prepare data for other plugins. Add the generated resource to a
+workflow mapping so it executes in the ``PARSE`` stage:
+
+```
+workflow = {PipelineStage.PARSE: ["MyResource"]}
+```
+"""
 
 from entity.core.plugins import ResourcePlugin, ValidationResult
 from entity.core.stages import PipelineStage

--- a/src/cli/templates/tool.py
+++ b/src/cli/templates/tool.py
@@ -1,4 +1,12 @@
-"""Template for tool plugin."""
+"""Template for a tool plugin.
+
+Tool plugins expose functions that other plugins can call. Register the
+generated tool in a workflow under the ``DO`` stage:
+
+```
+workflow = {PipelineStage.DO: ["MyTool"]}
+```
+"""
 
 from typing import Any, Dict
 


### PR DESCRIPTION
## Summary
- document how to register generated plugins in a workflow
- mention workflow integration in the plugin guide

## Testing
- `poetry install --with dev`
- `poetry run black src/cli/templates/*.py` *(fails: cannot parse templates)*
- `poetry run pytest tests/test_plugin_registry_order.py::test_plugin_registry_order -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e706730808322968eabe1c0571039