### PR TITLE
Remove deprecated registries helpers

### DIFF
--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -142,15 +142,6 @@ class Agent:
             raise PipelineError("Agent not initialized")
         return self._runtime.capabilities
 
-    # deprecated -----------------------------------------------------
-    def get_registries(self) -> SystemRegistries:  # pragma: no cover - legacy
-        warnings.warn(
-            "'get_registries' is deprecated, use 'get_capabilities' instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.get_capabilities()
-
     # ------------------------------------------------------------------
     # Compatibility helpers
     # ------------------------------------------------------------------

--- a/src/entity/core/runtime.py
+++ b/src/entity/core/runtime.py
@@ -35,18 +35,6 @@ class AgentRuntime:
     def __post_init__(self) -> None:
         self.manager = None
 
-    # ------------------------------------------------------------------
-    @property
-    def registries(self) -> SystemRegistries:  # pragma: no cover - legacy
-        """Backward compatibility alias for ``capabilities``."""
-
-        warnings.warn(
-            "'registries' is deprecated, use 'capabilities' instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.capabilities
-
     async def run_pipeline(self, message: str) -> Dict[str, Any]:
         return {"message": message}
 

--- a/src/pipeline/manager.py
+++ b/src/pipeline/manager.py
@@ -41,17 +41,6 @@ class PipelineManager(Generic[ResultT]):
     def capabilities(self) -> SystemRegistries:
         return self._capabilities
 
-    @property
-    def registries(self) -> SystemRegistries:  # pragma: no cover - legacy
-        """Backward compatibility alias for ``capabilities``."""
-
-        warnings.warn(
-            "'registries' is deprecated, use 'capabilities' instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._capabilities
-
     # ------------------------------------------------------------------
     def start_pipeline(
         self, message: str, *, max_iterations: int = 5


### PR DESCRIPTION
## Summary
- drop Agent.get_registries
- remove registries property from AgentRuntime and PipelineManager

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pipeline.base_plugins')*

------
https://chatgpt.com/codex/tasks/task_e_686e7b7c12148322ae0d8f0b76b86891