### PR TITLE
Clean up config placeholders

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -10,28 +10,28 @@ tool_registry:
 
 plugins:
   resources:
-    database:
-      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
-      path: ./dev.duckdb
-    llm:
-      type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
-      provider: ollama
-      base_url: "${OLLAMA_BASE_URL}"
-      model: "${OLLAMA_MODEL}"
-      retries: 3
-      backoff: 1.0
+    # database:
+    #   type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+    #   path: ./dev.duckdb
+    # llm:
+    #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
+    #   provider: ollama
+    #   base_url: "${OLLAMA_BASE_URL}"
+    #   model: "${OLLAMA_MODEL}"
+    #   retries: 3
+    #   backoff: 1.0
     memory:
       type: entity.resources.memory:Memory
-    vector_store:
-      type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
-      table: vector_mem
-      embedding_model:
-        name: dummy
-        dimensions: 3
-    filesystem:
-      type: plugins.builtin.resources.s3_filesystem:S3FileSystem
-      bucket: agent-files
-      region: us-east-1
+    # vector_store:
+    #   type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
+    #   table: vector_mem
+    #   embedding_model:
+    #     name: dummy
+    #     dimensions: 3
+    # filesystem:
+    #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
+    #   bucket: agent-files
+    #   region: us-east-1
     # storage:
     #   type: pipeline.resources.storage_resource:StorageResource
 #   storage:
@@ -63,22 +63,22 @@ plugins:
     calculator:
       type: user_plugins.tools.calculator_tool:CalculatorTool
   adapters:
-    http:
-      type: plugins.builtin.adapters.http:HTTPAdapter
-      stages: [parse, deliver]
-      auth_tokens:
-        - dev-secret
-      rate_limit:
-        requests: 60
-        interval: 60
-      audit_log_path: logs/audit.log
-      dashboard: true
-    cli:
-      type: plugins.builtin.adapters.cli:CLIAdapter
-      stages: [deliver]
-    logging:
-      type: plugins.builtin.adapters.logging:LoggingAdapter
-      stages: [deliver]
+    # http:
+    #   type: plugins.builtin.adapters.http:HTTPAdapter
+    #   stages: [parse, deliver]
+    #   auth_tokens:
+    #     - dev-secret
+    #   rate_limit:
+    #     requests: 60
+    #     interval: 60
+    #   audit_log_path: logs/audit.log
+    #   dashboard: true
+    # cli:
+    #   type: plugins.builtin.adapters.cli:CLIAdapter
+    #   stages: [deliver]
+    # logging:
+    #   type: plugins.builtin.adapters.logging:LoggingAdapter
+    #   stages: [deliver]
   prompts:
     chain_of_thought:
       type: entity.plugins.prompts.chain_of_thought:ChainOfThoughtPrompt

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -10,29 +10,29 @@ tool_registry:
 
 plugins:
   resources:
-    database:
-      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
-      path: ./prod.duckdb
-    llm:
-      type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
-      provider: ollama
-      base_url: "${OLLAMA_BASE_URL}"
-      model: "${OLLAMA_MODEL}"
-      temperature: 0.7
-      retries: 5
-      backoff: 2.0
+    # database:
+    #   type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+    #   path: ./prod.duckdb
+    # llm:
+    #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
+    #   provider: ollama
+    #   base_url: "${OLLAMA_BASE_URL}"
+    #   model: "${OLLAMA_MODEL}"
+    #   temperature: 0.7
+    #   retries: 5
+    #   backoff: 2.0
     memory:
       type: entity.resources.memory:Memory
-    vector_store:
-      type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
-      table: vector_mem
-      embedding_model:
-        name: dummy
-        dimensions: 3
-    filesystem:
-      type: plugins.builtin.resources.s3_filesystem:S3FileSystem
-      bucket: agent-files
-      region: us-east-1
+    # vector_store:
+    #   type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
+    #   table: vector_mem
+    #   embedding_model:
+    #     name: dummy
+    #     dimensions: 3
+    # filesystem:
+    #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
+    #   bucket: agent-files
+    #   region: us-east-1
     # storage:
     #   type: pipeline.resources.storage_resource:StorageResource
 #   storage:
@@ -66,22 +66,22 @@ plugins:
       type: user_plugins.tools.calculator_tool:CalculatorTool
       precision: 10
   adapters:
-    http:
-      type: plugins.builtin.adapters.http:HTTPAdapter
-      stages: [parse, deliver]
-      auth_tokens:
-        - ${HTTP_TOKEN}
-      rate_limit:
-        requests: 100
-        interval: 60
-      audit_log_path: logs/audit.log
-      dashboard: false
-    cli:
-      type: plugins.builtin.adapters.cli:CLIAdapter
-      stages: [deliver]
-    logging:
-      type: plugins.builtin.adapters.logging:LoggingAdapter
-      stages: [deliver]
+    # http:
+    #   type: plugins.builtin.adapters.http:HTTPAdapter
+    #   stages: [parse, deliver]
+    #   auth_tokens:
+    #     - ${HTTP_TOKEN}
+    #   rate_limit:
+    #     requests: 100
+    #     interval: 60
+    #   audit_log_path: logs/audit.log
+    #   dashboard: false
+    # cli:
+    #   type: plugins.builtin.adapters.cli:CLIAdapter
+    #   stages: [deliver]
+    # logging:
+    #   type: plugins.builtin.adapters.logging:LoggingAdapter
+    #   stages: [deliver]
   prompts:
     chain_of_thought:
       type: entity.plugins.prompts.chain_of_thought:ChainOfThoughtPrompt

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -6,21 +6,21 @@ server:
 
 plugins:
   resources:
-    database:
-      type: plugins.builtin.resources.postgres:PostgresResource
-      host: "${DB_HOST}"
-      port: 5432
-      name: "${DB_USERNAME}"
-      username: "${DB_USERNAME}"
-      password: "${DB_PASSWORD}"
-    llm:
-      provider: ollama
-      base_url: "${OLLAMA_BASE_URL}"
-      model: "${OLLAMA_MODEL}"
+    # database:
+    #   type: plugins.builtin.resources.postgres:PostgresResource
+    #   host: "${DB_HOST}"
+    #   port: 5432
+    #   name: "${DB_USERNAME}"
+    #   username: "${DB_USERNAME}"
+    #   password: "${DB_PASSWORD}"
+    # llm:
+    #   provider: ollama
+    #   base_url: "${OLLAMA_BASE_URL}"
+    #   model: "${OLLAMA_MODEL}"
     memory:
       type: entity.resources.memory:Memory
-    storage:
-      type: pipeline.resources.storage_resource:StorageResource
+    # storage:
+    #   type: pipeline.resources.storage_resource:StorageResource
       
     cache:
       type: user_plugins.resources.cache:CacheResource
@@ -34,18 +34,18 @@ plugins:
     calculator:
       type: user_plugins.tools.calculator_tool:CalculatorTool
   adapters:
-    http:
-      type: plugins.builtin.adapters.http:HTTPAdapter
-      auth_tokens:
-        - ${HTTP_TOKEN}
-      rate_limit:
-        requests: 60
-        interval: 60
-      audit_log_path: logs/audit.log
-    cli:
-      type: plugins.builtin.adapters.cli:CLIAdapter
-    logging:
-      type: plugins.builtin.adapters.logging:LoggingAdapter
+    # http:
+    #   type: plugins.builtin.adapters.http:HTTPAdapter
+    #   auth_tokens:
+    #     - ${HTTP_TOKEN}
+    #   rate_limit:
+    #     requests: 60
+    #     interval: 60
+    #   audit_log_path: logs/audit.log
+    # cli:
+    #   type: plugins.builtin.adapters.cli:CLIAdapter
+    # logging:
+    #   type: plugins.builtin.adapters.logging:LoggingAdapter
   prompts:
     chain_of_thought:
       type: entity.plugins.prompts.chain_of_thought:ChainOfThoughtPrompt

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -13,7 +13,7 @@ Use `StorageResource` with a Postgres database and optional S3 file storage:
 plugins:
   resources:
     postgres:
-      type: plugins.builtin.resources.postgres:PostgresResource
+      # type: plugins.builtin.resources.postgres:PostgresResource
       host: localhost
       port: 5432
       name: dev_db
@@ -21,11 +21,11 @@ plugins:
       setup_commands:
         - "CREATE EXTENSION IF NOT EXISTS vector"
     vector_store:
-      type: plugins.builtin.resources.pg_vector_store:PgVectorStore
+      # type: plugins.builtin.resources.pg_vector_store:PgVectorStore
       dimensions: 768
       table: embeddings
     filesystem:
-      type: plugins.builtin.resources.s3_filesystem:S3FileSystem
+      # type: plugins.builtin.resources.s3_filesystem:S3FileSystem
       bucket: agent-files
       region: us-east-1
     storage:
@@ -41,7 +41,7 @@ For local experimentation you can use a file-backed DuckDB database:
 plugins:
   resources:
     db:
-      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      # type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
       path: ./agent.duckdb
     storage:
       type: storage
@@ -54,10 +54,10 @@ You can also use `StorageResource` for a lighter setup:
 plugins:
   resources:
     db:
-      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      # type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
       path: ./agent.duckdb
     fs:
-      type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
+      # type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
       base_path: ./files
     storage:
       type: storage

--- a/docs/source/config_cheatsheet.md
+++ b/docs/source/config_cheatsheet.md
@@ -15,7 +15,7 @@ workflow:
 plugins:
   resources:
     database:
-      type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
+      # type: plugins.builtin.resources.sqlite_storage:SQLiteStorageResource
       path: ./entity.db
     llm:
       provider: openai
@@ -25,7 +25,7 @@ plugins:
       type: user_plugins.prompts.simple:SimplePrompt
   adapters:
     http:
-      type: plugins.builtin.adapters.http:HTTPAdapter
+      # type: plugins.builtin.adapters.http:HTTPAdapter
       stages: [parse, deliver]
 ```
 

--- a/docs/source/dashboard.md
+++ b/docs/source/dashboard.md
@@ -10,7 +10,7 @@ Enable the adapter in your YAML configuration:
 plugins:
   adapters:
     dashboard:
-      type: plugins.builtin.adapters.dashboard:DashboardAdapter
+      # type: plugins.builtin.adapters.dashboard:DashboardAdapter
       stages: [parse, deliver]
       dashboard: true
       state_log_path: ./state.log

--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -4,20 +4,20 @@ The easiest way to capture structured logs is using ``LoggingAdapter``. Add it
 to your ``adapters`` configuration or initialize it directly:
 
 ```python
-from plugins.builtin.adapters.logging import LoggingAdapter
+# from plugins.builtin.adapters.logging import LoggingAdapter
 
-adapter = LoggingAdapter()
+# adapter = LoggingAdapter()
 ```
 
 To configure logging globally, call ``configure_logging`` from
 ``plugins.builtin.adapters.logging_adapter``:
 
 ```python
-from plugins.builtin.adapters.logging_adapter import configure_logging, get_logger
+# from plugins.builtin.adapters.logging_adapter import configure_logging, get_logger
 
-configure_logging(level="INFO", json_enabled=True)
-logger = get_logger(__name__)
-logger.info("Logging configured")
+# configure_logging(level="INFO", json_enabled=True)
+# logger = get_logger(__name__)
+# logger.info("Logging configured")
 ```
 
 Set the ``ENTITY_LOG_PATH`` environment variable to route logs to a file.

--- a/docs/source/migration_guide.md
+++ b/docs/source/migration_guide.md
@@ -15,7 +15,7 @@ exist in the `plugins.builtin` package. For example:
 from experiments.storage.resource import StorageResource
 
 # New
-from plugins.builtin.resources.storage import StorageResource
+# from plugins.builtin.resources.storage import StorageResource  # placeholder
 ```
 
 ## 2. Check Configuration Files

--- a/docs/source/security.md
+++ b/docs/source/security.md
@@ -2,10 +2,10 @@
 
 This project can run plugins inside isolated Docker containers. Each plugin must
 provide a `plugin.toml` manifest defining required resources and runtime limits.
-The :class:`plugins.builtin.infrastructure.sandbox.DockerSandboxRunner` applies CPU and memory limits
+The :class:`plugins.builtin.infrastructure.sandbox.DockerSandboxRunner` applies CPU and memory limits *(placeholder implementation)*
 based on the manifest and verifies the plugin signature before execution. The
 runner uses :class:`infrastructure.DockerInfrastructure` so you can also build
 a Docker image for your agent.
 
-To validate manifests outside of runtime, use :class:`plugins.builtin.infrastructure.sandbox.PluginAuditor`.
+To validate manifests outside of runtime, use :class:`plugins.builtin.infrastructure.sandbox.PluginAuditor` *(placeholder)*.
 It checks requested resources against a whitelist and reports any violations.

--- a/docs/source/security_config.md
+++ b/docs/source/security_config.md
@@ -10,7 +10,7 @@ Adapters accept a mapping of tokens to allowed roles. For example:
 plugins:
   adapters:
     http:
-      type: plugins.builtin.adapters.http:HTTPAdapter
+      # type: plugins.builtin.adapters.http:HTTPAdapter
       auth_tokens:
         admin-token: ["http"]
 ```


### PR DESCRIPTION
## Summary
- comment unused plugin references in configs
- mark missing adapters and resources in docs

## Testing
- `poetry run poe validate` *(fails: ModuleNotFoundError: No module named 'pipeline.errors')*

------
https://chatgpt.com/codex/tasks/task_e_686e7b80dc1483229528ffee33fc1399