### PR TITLE
Deprecate PipelineManager docs

### DIFF
--- a/docs/source/api_reference.md
+++ b/docs/source/api_reference.md
@@ -3,6 +3,10 @@
 This section is generated from the project source using autodoc. Every public
 module is documented directly from its docstrings.
 
+!!! warning "Deprecated modules"
+    ``PipelineManager`` and ``pipeline.runtime`` are deprecated. Use
+    ``entity.Agent`` or ``entity.core.runtime.AgentRuntime`` instead.
+
 ::: entity
     options:
         members: true

--- a/src/pipeline/manager.py
+++ b/src/pipeline/manager.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-"""Compatibility wrapper delegating to :class:`AgentRuntime`."""
+"""Deprecated wrapper delegating to :class:`AgentRuntime`.
+
+This class exists solely for backward compatibility. Prefer using
+``entity.Agent`` or ``entity.core.runtime.AgentRuntime`` directly. It will be
+removed in a future release.
+"""
 
 import asyncio
 from typing import Any, Generic, Optional, TypeVar, cast

--- a/src/pipeline/runtime.py
+++ b/src/pipeline/runtime.py
@@ -1,4 +1,8 @@
-"""Compatibility wrapper for the core AgentRuntime."""
+"""Deprecated shim exposing :class:`AgentRuntime`.
+
+Import :class:`entity.core.runtime.AgentRuntime` or use ``entity.Agent``
+instead. This module will be removed in a future release.
+"""
 
 from entity.core.runtime import AgentRuntime
 


### PR DESCRIPTION
## Summary
- mark `PipelineManager` and `pipeline.runtime` as deprecated
- add note in API reference

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e7b85da888322878d2aa37d8956ff