### PR TITLE
Add cache and memory helpers

### DIFF
--- a/docs/source/context.md
+++ b/docs/source/context.md
@@ -4,7 +4,7 @@
 
 - conversation history and other pipeline state
 - registered resources via `get_resource`
-- intermediate values with `store()`, `load()`, and `has()`
+- temporary data with `cache()`, `recall()`, and `has()`
 - tool execution through `tool_use()` and `queue_tool_use()`
 - helpers for adding conversation entries
 
@@ -22,7 +22,7 @@ class ExamplePlugin(PromptPlugin):
 
 - `say()` to set the pipeline response
 - `ask_llm()` to call the configured LLM
-- `store()`, `load()`, and `has()` for sharing data between stages
+- `cache()`, `recall()`, and `has()` for sharing data between stages
 - `tool_use()` to run a tool and wait for the result
 - `queue_tool_use()` to defer tool execution until later
 
@@ -30,23 +30,23 @@ class ExamplePlugin(PromptPlugin):
 class MyPrompt(PromptPlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         if context.has("summary"):
-            context.say(context.load("summary"))
+            context.say(context.recall("summary"))
             return
 
         summary = await context.tool_use("summarize", text=context.message)
-        context.store("summary", summary)
+        context.cache("summary", summary)
         context.queue_tool_use("log_summary", {"text": summary})
         context.say(summary)
 ```
 
 ## Stage Results
 
-Use `store()` to save intermediate data that later stages can retrieve.
+Use `cache()` to save intermediate data that later stages can retrieve.
 
 ```python
-context.store("answer", "The Eiffel Tower is in Paris")
+context.cache("answer", "The Eiffel Tower is in Paris")
 if context.has("answer"):
-    result = context.load("answer")
+    result = context.recall("answer")
 ```
 
 ## Advanced API

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -39,17 +39,17 @@ async def weather_plugin(ctx):
     return await ctx.tool_use("weather", city="London")
 ```
 
-Plugins share data through `store()` and `load()` and can queue additional
+Plugins share data through `cache()` and `recall()` and can queue additional
 tool calls:
 
 ```python
 @agent.plugin
 async def summarizer(ctx):
     if ctx.has("summary"):
-        return ctx.load("summary")
+        return ctx.recall("summary")
     result_key = ctx.queue_tool_use("search", {"query": ctx.message})
     summary = await ctx.tool_use("summarize", text=ctx.message)
-ctx.store("summary", summary)
+ctx.cache("summary", summary)
     return summary
 ```
 
@@ -57,7 +57,7 @@ ctx.store("summary", summary)
 
 Entity provides two prompt plugins for common reasoning patterns:
 
-- `ChainOfThoughtPrompt` records intermediate thoughts and stores them with `context.store()`.
+- `ChainOfThoughtPrompt` records intermediate thoughts and stores them with `context.cache()`.
 - `ReActPrompt` alternates between reasoning and tool use, saving each step under `react_steps`.
 
 Add them in your YAML configuration:

--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -20,4 +20,4 @@ class {class_name}(AdapterPlugin):
 
     async def _execute_impl(self, context):
         if context.has("response"):
-            await context.queue_tool_use("send", {"text": context.load("response")})
+            await context.queue_tool_use("send", {"text": context.recall("response")})

--- a/src/cli/templates/failure.py
+++ b/src/cli/templates/failure.py
@@ -19,4 +19,4 @@ class {class_name}(FailurePlugin):
     # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
-        context.store("failure_info", context.get_failure_info())
+        context.cache("failure_info", context.get_failure_info())

--- a/src/cli/templates/prompt.py
+++ b/src/cli/templates/prompt.py
@@ -20,9 +20,9 @@ class {class_name}(PromptPlugin):
 
     async def _execute_impl(self, context):
         if context.has("answer"):
-            context.say(context.load("answer"))
+            context.say(context.recall("answer"))
             return
 
         result = await context.tool_use("some_tool", query=context.message)
-        context.store("answer", result)
+        context.cache("answer", result)
         context.say(result)

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -21,11 +21,21 @@ class Memory(ResourcePlugin):
     async def _execute_impl(self, context: Any) -> None:  # noqa: D401, ARG002
         return None
 
-    def get(self, key: str, default: Any | None = None) -> Any:
+    # ------------------------------------------------------------------
+    # Key-value helpers
+    # ------------------------------------------------------------------
+
+    def memory(self, key: str, default: Any | None = None) -> Any:
+        """Retrieve a persisted value."""
         return self._kv.get(key, default)
 
-    def set(self, key: str, value: Any) -> None:
+    def remember(self, key: str, value: Any) -> None:
+        """Persist ``value`` for later retrieval."""
         self._kv[key] = value
+
+    # Backwards compatibility
+    get = memory
+    set = remember
 
     def clear(self) -> None:
         self._kv.clear()

--- a/user_plugins/examples/pipelines/duckdb_pipeline.py
+++ b/user_plugins/examples/pipelines/duckdb_pipeline.py
@@ -35,11 +35,11 @@ class SimilarityPrompt(PromptPlugin):
 
     async def _execute_impl(self, ctx: PluginContext) -> None:
         memory: Memory = ctx.get_resource("memory")
-        await memory.save_conversation(ctx.pipeline_id, ctx.get_conversation_history())
+        await memory.save_conversation(ctx.pipeline_id, ctx.conversation())
         if memory.vector_store:
             await memory.vector_store.add_embedding(ctx.message)
             similar = await memory.search_similar(ctx.message, 1)
-            ctx.add_conversation_entry(f"Similar entries: {similar}", role="assistant")
+            ctx.say(f"Similar entries: {similar}")
 
 
 async def build_registries(workflow: dict[PipelineStage, List]) -> SystemRegistries:

--- a/user_plugins/examples/pipelines/memory_composition_pipeline.py
+++ b/user_plugins/examples/pipelines/memory_composition_pipeline.py
@@ -42,10 +42,8 @@ class StorePrompt(PromptPlugin):
 
     async def _execute_impl(self, context: PluginContext) -> None:
         memory: Memory = context.get_resource("memory")
-        await memory.save_conversation(
-            context.pipeline_id, context.get_conversation_history()
-        )
-        context.add_conversation_entry("Conversation stored", role="assistant")
+        await memory.save_conversation(context.pipeline_id, context.conversation())
+        context.say("Conversation stored")
 
 
 def create_vector_store() -> PgVectorStore | DuckDBVectorStore:

--- a/user_plugins/examples/pipelines/vector_memory_pipeline.py
+++ b/user_plugins/examples/pipelines/vector_memory_pipeline.py
@@ -37,12 +37,10 @@ class ComplexPrompt(PromptPlugin):
         if memory.vector_store:
             await memory.vector_store.add_embedding("greeting")
             similar = await memory.search_similar("greeting", 1)
-            context.add_conversation_entry(
-                f"Similar entries: {similar}", role="assistant"
-            )
+            context.say(f"Similar entries: {similar}")
         llm = context.get_llm()
         response = await llm.generate("Respond to the user using stored context.")
-        context.add_conversation_entry(response, role="assistant")
+        context.say(response)
 
 
 def create_database_config() -> Tuple[type, Dict]:

--- a/user_plugins/prompts/chain_of_thought.py
+++ b/user_plugins/prompts/chain_of_thought.py
@@ -18,17 +18,14 @@ class ChainOfThoughtPrompt(PromptPlugin):
     stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        conversation_text = self._get_conversation_text(
-            context.get_conversation_history()
-        )
+        conversation_text = self._get_conversation_text(context.conversation())
 
         breakdown_prompt = f"Break this problem into logical steps: {conversation_text}"
         breakdown = await self.call_llm(
             context, breakdown_prompt, purpose="problem_breakdown"
         )
-        context.add_conversation_entry(
-            content=f"Problem breakdown: {breakdown.content}",
-            role="assistant",
+        context.say(
+            f"Problem breakdown: {breakdown.content}",
             metadata={"reasoning_step": "breakdown"},
         )
 
@@ -41,9 +38,8 @@ class ChainOfThoughtPrompt(PromptPlugin):
                 context, reasoning_prompt, purpose=f"reasoning_step_{step + 1}"
             )
             reasoning_steps.append(reasoning.content)
-            context.add_conversation_entry(
-                content=f"Reasoning step {step + 1}: {reasoning.content}",
-                role="assistant",
+            context.say(
+                f"Reasoning step {step + 1}: {reasoning.content}",
                 metadata={"reasoning_step": step + 1},
             )
 
@@ -57,8 +53,8 @@ class ChainOfThoughtPrompt(PromptPlugin):
             if "final answer" in reasoning.content.lower():
                 break
 
-        context.store("reasoning_complete", True)
-        context.store("reasoning_steps", reasoning_steps)
+        context.cache("reasoning_complete", True)
+        context.cache("reasoning_steps", reasoning_steps)
 
     def _needs_tools(self, reasoning_text: str) -> bool:
         """Return True if ``reasoning_text`` suggests tool usage."""

--- a/user_plugins/prompts/complex_prompt.py
+++ b/user_plugins/prompts/complex_prompt.py
@@ -36,7 +36,7 @@ class ComplexPrompt(PromptPlugin):
         history_text = "\n".join(f"{h.role}: {h.content}" for h in history)
 
         last_message = ""
-        for entry in reversed(context.get_conversation_history()):
+        for entry in reversed(context.conversation()):
             if entry.role == "user":
                 last_message = entry.content
                 break
@@ -57,13 +57,10 @@ class ComplexPrompt(PromptPlugin):
 
         response = await self.call_llm(context, prompt, purpose="complex_prompt")
 
-        context.add_conversation_entry(
-            content=response.content,
-            role="assistant",
+        context.say(
+            response.content,
             metadata={"source": "complex_prompt"},
         )
         context.set_response(response.content)
         if memory:
-            await memory.save_conversation(
-                context.pipeline_id, context.get_conversation_history()
-            )
+            await memory.save_conversation(context.pipeline_id, context.conversation())

--- a/user_plugins/prompts/intent_classifier.py
+++ b/user_plugins/prompts/intent_classifier.py
@@ -32,7 +32,7 @@ class IntentClassifierPrompt(PromptPlugin):
         return ValidationResult.success_result()
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        last_message = context.get_conversation_history()[-1].content
+        last_message = context.conversation()[-1].content
         prompt = "Classify the user's intent in one word.\n" f"Message: {last_message}"
         response = await self.call_llm(context, prompt, purpose="intent_classification")
-        context.store("intent", response.content)
+        context.cache("intent", response.content)

--- a/user_plugins/prompts/pii_scrubber.py
+++ b/user_plugins/prompts/pii_scrubber.py
@@ -22,9 +22,7 @@ class PIIScrubberPrompt(PromptPlugin):
     )
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        new_history = [
-            self._scrub_entry(entry) for entry in context.get_conversation_history()
-        ]
+        new_history = [self._scrub_entry(entry) for entry in context.conversation()]
         context.advanced.replace_conversation_history(new_history)
         if context.has_response():
             context.update_response(self._scrub_value)


### PR DESCRIPTION
## Summary
- update context with cache/recall and remember/memory helpers
- add matching helpers to Memory resource
- refactor plugins and examples to use new methods
- document new PluginContext verbs

## Testing
- `poetry run pytest tests/test_memory_resource.py -k test_memory_persists_between_runs -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e7b879d5c8322b31fe895d42e0e72