### PR TITLE
Add load and has helpers to PluginContext

### DIFF
--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -39,8 +39,8 @@ async def weather_plugin(ctx):
     return await ctx.tool_use("weather", city="London")
 ```
 
-Plugins share data through `store()` and `load()` and can queue additional
-tool calls:
+Plugins share data through `store()`, `load()`, and `has()` and can queue additional
+tool calls. `load()` accepts an optional default value when the key is missing:
 
 ```python
 @agent.plugin

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -41,5 +41,15 @@ class PluginContext:
     def store(self, key: str, value: Any) -> None:
         self._store[key] = value
 
+    def load(self, key: str, default: Any | None = None) -> Any:
+        """Return ``key`` from the internal store or ``default`` when missing."""
+
+        return self._store.get(key, default)
+
+    def has(self, key: str) -> bool:
+        """Return ``True`` when ``key`` is stored."""
+
+        return key in self._store
+
     def set_response(self, value: Any) -> None:
         self.response = value


### PR DESCRIPTION
## Summary
- implement `load` and `has` helpers in `PluginContext`
- document these new helpers in the plugin guide

## Testing
- `poetry run pytest -q` *(fails: ImportError while importing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686e7b76feb083228c405ab1dc6bc5ec