### PR TITLE
Simplify PluginContext state helpers

### DIFF
--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -1,24 +1,24 @@
 import asyncio
 
 import pytest
-from pipeline import PipelineStage
-from pipeline.base_plugins import BasePlugin
 
 from entity import Agent
+from pipeline import PipelineStage
+from pipeline.base_plugins import BasePlugin
 
 
 class ParsePlugin(BasePlugin):
     stages = [PipelineStage.PARSE]
 
     async def _execute_impl(self, context):
-        context.store("parsed", True)
+        context.cache("parsed", True)
 
 
 class ThinkPlugin(BasePlugin):
     stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context):
-        context.store("thought", True)
+        context.cache("thought", True)
 
 
 class RespondPlugin(BasePlugin):

--- a/tests/integration/test_stage_failures.py
+++ b/tests/integration/test_stage_failures.py
@@ -3,14 +3,14 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
+
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.state_logger import LogReplayer, StateLogger
 from pipeline import PipelineStage, execute_pipeline
 from pipeline.base_plugins import BasePlugin
 from pipeline.pipeline import generate_pipeline_id
 from pipeline.resources import ResourceContainer
 from pipeline.state import ConversationEntry, MetricsCollector, PipelineState
-from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
-
-from entity.core.state_logger import LogReplayer, StateLogger
 
 
 class RespondPlugin(BasePlugin):
@@ -28,7 +28,7 @@ def make_failing_plugin(stage: PipelineStage):
             if not context.get_metadata("failed"):
                 context.set_metadata("failed", True)
                 raise RuntimeError("boom")
-            context.store(str(stage), True)
+            context.cache(str(stage), True)
 
     return FailingPlugin()
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pipeline.context as context_module
+from entity.core.resources.container import ResourceContainer
 from pipeline import (
     ConversationEntry,
     MetricsCollector,
@@ -16,8 +17,6 @@ from pipeline.cache import InMemoryCache
 from pipeline.state import ToolCall
 from pipeline.tools.execution import execute_pending_tools
 from plugins.builtin.resources.llm_base import LLM
-
-from entity.core.resources.container import ResourceContainer
 from user_plugins.resources.cache import CacheResource
 
 context_module.LLM = LLM
@@ -95,4 +94,4 @@ async def test_tool_results_are_cached():
     await execute_pending_tools(state, capabilities)
 
     assert tool.calls == 1
-    assert ctx.load("r1") == ctx.load("r2")
+    assert ctx.recall("r1") == ctx.recall("r2")

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import datetime
 
+from entity.core.resources.container import ResourceContainer
 from pipeline import (
     ConversationEntry,
     MetricsCollector,
@@ -10,8 +11,6 @@ from pipeline import (
     SystemRegistries,
     ToolRegistry,
 )
-
-from entity.core.resources.container import ResourceContainer
 from user_plugins.prompts.chain_of_thought import ChainOfThoughtPrompt
 
 
@@ -68,8 +67,8 @@ def test_chain_of_thought_records_steps_and_tool_call():
         assistant_entries[1].content == "Reasoning step 1: We need to calculate result"
     )
     assert assistant_entries[2].content == "Reasoning step 2: Final answer is 42"
-    assert ctx.load("reasoning_complete") is True
-    assert ctx.load("reasoning_steps") == [
+    assert ctx.recall("reasoning_complete") is True
+    assert ctx.recall("reasoning_steps") == [
         "We need to calculate result",
         "Final answer is 42",
     ]

--- a/tests/test_execute_pending_tools.py
+++ b/tests/test_execute_pending_tools.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import datetime
 
+from entity.core.resources.container import ResourceContainer
 from pipeline import (
     ConversationEntry,
     MetricsCollector,
@@ -12,8 +13,6 @@ from pipeline import (
 )
 from pipeline.context import PluginContext
 from pipeline.tools.execution import execute_pending_tools
-
-from entity.core.resources.container import ResourceContainer
 
 
 class EchoTool:
@@ -46,4 +45,4 @@ def test_execute_pending_tools_returns_mapping_by_result_key():
 
     assert results == {"echo1": "hello"}
     ctx = PluginContext(state, capabilities)
-    assert ctx.load("echo1") == "hello"
+    assert ctx.recall("echo1") == "hello"

--- a/tests/test_intent_classifier_prompt.py
+++ b/tests/test_intent_classifier_prompt.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import datetime
 
+from entity.core.resources.container import ResourceContainer
 from pipeline import (
     ConversationEntry,
     MetricsCollector,
@@ -10,8 +11,6 @@ from pipeline import (
     SystemRegistries,
     ToolRegistry,
 )
-
-from entity.core.resources.container import ResourceContainer
 from user_plugins.prompts.intent_classifier import IntentClassifierPrompt
 
 
@@ -40,7 +39,7 @@ def test_intent_classifier_success():
 
     asyncio.run(plugin.execute(ctx))
 
-    assert ctx.load("intent") == "greeting"
+    assert ctx.recall("intent") == "greeting"
 
 
 def test_intent_classifier_validate_error():

--- a/tests/test_tool_registry_options.py
+++ b/tests/test_tool_registry_options.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from datetime import datetime
 
+from entity.core.resources.container import ResourceContainer
 from pipeline import (
     ConversationEntry,
     MetricsCollector,
@@ -14,8 +15,6 @@ from pipeline import (
 )
 from pipeline.context import PluginContext
 from pipeline.tools.execution import execute_pending_tools
-
-from entity.core.resources.container import ResourceContainer
 
 
 class SleepTool:
@@ -72,6 +71,6 @@ def test_cache_ttl():
     asyncio.run(execute_pending_tools(state, capabilities))
     assert tool.calls == 1
     ctx = PluginContext(state, capabilities)
-    assert ctx.load("b") == 0
+    assert ctx.recall("b") == 0
     key = f"{PipelineStage.DO}:sleep"
     assert key in state.metrics.tool_durations


### PR DESCRIPTION
## Summary
- clean up PluginContext helpers
- switch tests to `cache`/`recall`

## Testing
- `poetry run flake8 src/entity/core/context.py tests/test_cache.py tests/test_execute_pending_tools.py tests/test_chain_of_thought_prompt.py tests/test_intent_classifier_prompt.py tests/test_tool_registry_options.py tests/integration/test_stage_failures.py tests/integration/test_full_pipeline.py`
- `poetry run mypy src/entity/core/context.py` *(fails: Returning Any from function declared to return "str" and other issues)*
- `bandit -r src` *(fails: command not found)*
- `python tools/check_empty_dirs.py` *(fails: file not found)*
- `poetry run pytest -k ""` *(fails: many errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ea1b0c47c8322b796bee34ee00837