### PR TITLE
Replace JSON schema usage with Pydantic

### DIFF
--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -103,9 +103,6 @@ def asdict(model: BaseModel) -> Dict[str, Any]:
     return model.model_dump()
 
 
-CONFIG_SCHEMA = EntityConfig.model_json_schema()
-
-
 def validate_config(data: Dict[str, Any]) -> None:
     """Validate ``data`` by instantiating :class:`EntityConfig`."""
 
@@ -123,7 +120,6 @@ __all__ = [
     "ServerConfig",
     "ToolRegistryConfig",
     "EntityConfig",
-    "CONFIG_SCHEMA",
     "validate_config",
     "asdict",
 ]


### PR DESCRIPTION
## Summary
- drop unused `CONFIG_SCHEMA` constant
- validate metrics resource config with a Pydantic model

## Testing
- `poetry run flake8 src/entity/config/models.py src/plugins/resources/metrics.py`
- `poetry run mypy src/entity/config/models.py src/plugins/resources/metrics.py` *(fails: Cannot find implementation or library stub for module named "plugins.resources.base")*
- `poetry run bandit -r src/entity/config/models.py src/plugins/resources/metrics.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686ea1cc51708322be9274cbf16792e6