### PR TITLE
Fix plugin ordering docs and registries

### DIFF
--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -30,7 +30,7 @@ and mental models stay easy to grasp.
 
 ## Design Principles
 1. Progressive disclosure: simple things stay simple, complex things are possible
-2. Async-first with predictable execution order. Plugin order follows the YAML listing.
+2. Async-first with predictable execution order. YAML order determines plugin execution.
 3. Runtime reconfiguration with fail‑fast validation
 4. Clear stage boundaries and structured logging
 5. One canonical name per resource

--- a/docs/source/plugin_cheatsheet.md
+++ b/docs/source/plugin_cheatsheet.md
@@ -30,5 +30,5 @@ class ExamplePlugin(PromptPlugin):
 ```
 
 Register plugins through `Agent.add_plugin()` or in a YAML configuration file.
-The position in the list under each stage controls execution order and
-`SystemInitializer` keeps the sequence intact. There is no priority field.
+YAML order determines execution order and `SystemInitializer` keeps the
+sequence intact. There is no priority field.

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -130,8 +130,8 @@ plugin_dirs:
 ## Development Steps
 1. Create your plugin class and implement `_execute_impl`.
 2. Register the plugin with the `Agent` or include it in your YAML under `plugins:`.
-   The list position determines execution order and `SystemInitializer` preserves
-   that sequence. There is no priority field.
+   YAML order determines execution order and `SystemInitializer` preserves that
+   sequence. There is no priority field.
 3. Validate the YAML using `SystemInitializer.from_yaml("your.yaml")`.
 4. Write unit tests and run `pytest` before committing changes.
 

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -412,4 +412,5 @@ class SystemInitializer:
                         f"Available: {available}"
                     )
 
-        graph.topological_sort()
+        # DependencyGraph may enforce valid dependencies but should not reorder
+        # plugins. Execution strictly follows YAML order.

--- a/src/registry/registries.py
+++ b/src/registry/registries.py
@@ -136,9 +136,9 @@ class PluginRegistry:
                 self._dependents.setdefault(dep, []).append(plugin)
 
     def get_plugins_for_stage(self, stage: PipelineStage) -> List[BasePlugin]:
-        """Return list of plugins registered for ``stage``."""
+        """Return plugins for ``stage`` in registration order."""
 
-        return self._stage_plugins.get(stage, [])
+        return list(self._stage_plugins.get(stage, []))
 
     def list_plugins(self) -> List[BasePlugin]:
         plugins: List[BasePlugin] = []


### PR DESCRIPTION
## Summary
- clarify YAML order controls plugin execution
- document that SystemInitializer won't reorder plugins
- maintain plugin registration order in PluginRegistry

## Testing
- `poetry run black .`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pipeline.metrics')*

------
https://chatgpt.com/codex/tasks/task_e_686ea1d029cc8322aef1554f3a2fb8df