### PR TITLE
Remove pipeline cross imports

### DIFF
--- a/src/entity/core/builder.py
+++ b/src/entity/core/builder.py
@@ -19,10 +19,10 @@ from entity.core.plugins.base import (
     BasePlugin as BasePluginType,
     PromptPlugin,
 )
-from pipeline.interfaces import PluginAutoClassifier
-from pipeline.stages import PipelineStage
+from .plugin_utils import PluginAutoClassifier
+from .stages import PipelineStage
 from entity.utils.logging import get_logger
-from pipeline.runtime import AgentRuntime
+from .runtime import AgentRuntime
 from entity.core.plugins.base import BasePlugin
 
 logger = get_logger(__name__)

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -6,15 +6,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pipeline.stages import PipelineStage
-from pipeline.state import PipelineState, ToolCall, ConversationEntry
-
-
-@dataclass
-class ConversationEntry:
-    content: str
-    role: str
-    metadata: Dict[str, Any] | None = None
+from .stages import PipelineStage
+from .state import ConversationEntry, PipelineState, ToolCall
 
 
 class PluginContext:

--- a/src/entity/core/plugins/__init__.py
+++ b/src/entity/core/plugins/__init__.py
@@ -9,15 +9,7 @@ from .base import (
     PromptPlugin,
     ResourcePlugin,
     ToolPlugin,
-)
-from pipeline.validation import ValidationResult
-from .base import (
-    AdapterPlugin,
-    BasePlugin,
-    FailurePlugin,
-    PromptPlugin,
-    ResourcePlugin,
-    ToolPlugin,
+    ValidationResult,
 )
 
 __all__ = [

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -13,8 +13,8 @@ from typing import Any, Dict, List
 import asyncio
 import time
 
-from pipeline.logging import get_logger
-from pipeline.stages import PipelineStage
+from entity.utils.logging import get_logger
+from ..stages import PipelineStage
 
 
 class ToolExecutionError(Exception):

--- a/src/entity/core/stages.py
+++ b/src/entity/core/stages.py
@@ -1,5 +1,35 @@
 """Stage enumeration for plugin execution."""
 
-from pipeline.stages import PipelineStage
+from __future__ import annotations
+
+from enum import IntEnum, auto
+
+
+class PipelineStage(IntEnum):
+    """Ordered pipeline stages."""
+
+    PARSE = auto()
+    THINK = auto()
+    DO = auto()
+    REVIEW = auto()
+    DELIVER = auto()
+    ERROR = auto()
+
+    def __str__(self) -> str:
+        return self.name.lower()
+
+    @classmethod
+    def from_str(cls, value: str) -> "PipelineStage":
+        try:
+            return cls[value.upper()]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Unknown stage: {value}") from exc
+
+    @classmethod
+    def ensure(cls, value: "PipelineStage | str") -> "PipelineStage":
+        if isinstance(value, cls):
+            return value
+        return cls.from_str(str(value))
+
 
 __all__ = ["PipelineStage"]


### PR DESCRIPTION
## Summary
- clean up `entity.core` to not depend on the legacy `pipeline` package
- rework `Agent` to use `Workflow` directly
- import helpers from local modules in `builder` and `context`
- provide minimal classes for registry validation
- embed `PipelineStage` enum directly

## Testing
- `poetry run pytest` *(fails: FileNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ea1d02a788322b034e355c5acb265