### PR TITLE
Add queued tool execution and metrics

### DIFF
--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -53,6 +53,9 @@ class BasePlugin:
         start = time.perf_counter()
         response = await context.call_llm(context, prompt, purpose=purpose)
         duration = time.perf_counter() - start
+        if context.get_failure_info() is None and hasattr(context._state, "metrics"):
+            key = f"{context.current_stage}:{self.__class__.__name__}:{purpose}"
+            context._state.metrics.record_llm_duration(key, duration)
         self.logger.info(
             "LLM call completed",
             extra={

--- a/src/pipeline/metrics.py
+++ b/src/pipeline/metrics.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class MetricsCollector:
+    """Collect timing and count metrics."""
+
+    stage_durations: Dict[str, float] = field(default_factory=dict)
+    plugin_durations: Dict[str, List[float]] = field(default_factory=dict)
+    llm_durations: Dict[str, List[float]] = field(default_factory=dict)
+    llm_call_count: Dict[str, int] = field(default_factory=dict)
+    tool_durations: Dict[str, List[float]] = field(default_factory=dict)
+    tool_execution_count: Dict[str, int] = field(default_factory=dict)
+    pipeline_durations: List[float] = field(default_factory=list)
+
+    def record_stage_duration(self, stage: str, duration: float) -> None:
+        self.stage_durations[stage] = duration
+
+    def record_plugin_duration(self, plugin: str, duration: float) -> None:
+        self.plugin_durations.setdefault(plugin, []).append(duration)
+
+    def record_llm_duration(self, key: str, duration: float) -> None:
+        self.llm_durations.setdefault(key, []).append(duration)
+        self.llm_call_count[key] = self.llm_call_count.get(key, 0) + 1
+
+    def record_tool_duration(self, key: str, duration: float) -> None:
+        self.tool_durations.setdefault(key, []).append(duration)
+        self.tool_execution_count[key] = self.tool_execution_count.get(key, 0) + 1
+
+    def record_pipeline_duration(self, duration: float) -> None:
+        self.pipeline_durations.append(duration)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "stage_durations": self.stage_durations,
+            "plugin_durations": self.plugin_durations,
+            "llm_durations": self.llm_durations,
+            "llm_call_count": self.llm_call_count,
+            "tool_durations": self.tool_durations,
+            "tool_execution_count": self.tool_execution_count,
+            "pipeline_durations": self.pipeline_durations,
+        }

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -122,8 +122,14 @@ async def execute_stage(
             context.set_current_stage(stage)
             await registries.validators.validate(stage, context)
             token = set_request_id(state.pipeline_id)
+            plugin_name = registries.plugins.get_plugin_name(plugin)
+            start_plugin = time.perf_counter()
             try:
                 await plugin.execute(context)
+                plugin_duration = time.perf_counter() - start_plugin
+                if state.metrics:
+                    key = f"{stage}:{plugin_name}"
+                    state.metrics.record_plugin_duration(key, plugin_duration)
                 if stage == PipelineStage.DELIVER and state.response is not None:
                     break
                 if state.pending_tool_calls:

--- a/src/pipeline/tools/execution.py
+++ b/src/pipeline/tools/execution.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict
+
+from entity.core.plugins.base import ToolExecutionError
+from entity.core.state import ToolCall
+from pipeline.state import PipelineState, MetricsCollector
+from entity.core.registries import SystemRegistries
+
+
+async def execute_pending_tools(
+    state: PipelineState, registries: SystemRegistries
+) -> Dict[str, Any]:
+    """Run queued tools respecting registry options."""
+    results: Dict[str, Any] = {}
+    if not state.pending_tool_calls:
+        return results
+    tools = registries.tools
+    sem = asyncio.Semaphore(tools.concurrency_limit)
+
+    async def run_call(call: ToolCall) -> None:
+        cached = await tools.get_cached_result(call.name, call.params)
+        if cached is not None:
+            result = cached
+            duration = 0.0
+        else:
+            tool = tools.get(call.name)
+            if tool is None:
+                raise ToolExecutionError(f"Tool '{call.name}' not found")
+            start = time.perf_counter()
+            async with sem:
+                result = await tool.execute_function(call.params)
+            duration = time.perf_counter() - start
+            await tools.cache_result(call.name, call.params, result)
+        results[call.result_key] = result
+        state.stage_results[call.result_key] = result
+        if state.metrics:
+            key = f"{state.current_stage}:{call.name}"
+            state.metrics.record_tool_duration(key, duration)
+
+    await asyncio.gather(*(run_call(c) for c in list(state.pending_tool_calls)))
+    return results

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -84,14 +84,10 @@ async def test_tool_results_are_cached():
     tool = FakeTool()
     await capabilities.tools.add("fake", tool)
 
-    state.pending_tool_calls.append(
-        ToolCall(name="fake", params={"x": 2}, result_key="r1")
-    )
+    await ctx.queue_tool_use("fake", result_key="r1", x=2)
     await execute_pending_tools(state, capabilities)
 
-    state.pending_tool_calls.append(
-        ToolCall(name="fake", params={"x": 2}, result_key="r2")
-    )
+    await ctx.queue_tool_use("fake", result_key="r2", x=2)
     await execute_pending_tools(state, capabilities)
 
     assert tool.calls == 1

--- a/tests/test_execute_pending_tools.py
+++ b/tests/test_execute_pending_tools.py
@@ -29,9 +29,6 @@ def make_state():
         pipeline_id="1",
         metrics=MetricsCollector(),
     )
-    state.pending_tool_calls.append(
-        ToolCall(name="echo", params={"text": "hello"}, result_key="echo1")
-    )
     return state
 
 
@@ -41,6 +38,8 @@ def test_execute_pending_tools_returns_mapping_by_result_key():
         ResourceContainer(), ToolRegistry(), PluginRegistry()
     )
     asyncio.run(capabilities.tools.add("echo", EchoTool()))
+    ctx = PluginContext(state, capabilities)
+    asyncio.run(ctx.queue_tool_use("echo", result_key="echo1", text="hello"))
 
     results = asyncio.run(execute_pending_tools(state, capabilities))
 


### PR DESCRIPTION
## Summary
- add metrics module and queued tool execution helper
- capture plugin, tool, and LLM durations in metrics
- extend `PluginContext` with `queue_tool_use`, `say`, and `conversation`
- update pipeline to track per-plugin durations
- update tests to use queueing API

## Testing
- `poetry install --with dev`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686ea1d044cc8322bdfbb3fb528c7c66