### PR TITLE
Improve stage resolution and validation

### DIFF
--- a/src/entity/core/plugin_utils.py
+++ b/src/entity/core/plugin_utils.py
@@ -66,19 +66,7 @@ class PluginAutoClassifier:
             )
 
         hints = user_hints or {}
-        try:
-            source = inspect.getsource(plugin_func)
-        except OSError:
-            source = ""
-
-        if any(k in source for k in ["think", "reason", "analyze"]):
-            base = cast(Type, plugin_base_registry.prompt_plugin)
-        elif any(k in source for k in ["parse", "validate", "check"]):
-            base = cast(Type, plugin_base_registry.adapter_plugin)
-        elif any(k in source for k in ["return", "response", "answer"]):
-            base = cast(Type, plugin_base_registry.prompt_plugin)
-        else:
-            base = cast(Type, plugin_base_registry.prompt_plugin)
+        base = cast(Type, plugin_base_registry.prompt_plugin)
 
         from .plugins.base import AdapterPlugin, PromptPlugin, ToolPlugin
 
@@ -92,14 +80,15 @@ class PluginAutoClassifier:
             return []
 
         explicit = False
-        inferred = True
+        inferred = False
         stages = _default_stages(base)
         if "stage" in hints or "stages" in hints:
             hint = hints.get("stages") or hints.get("stage")
             stages = hint if isinstance(hint, list) else [hint]
             stages = [PipelineStage.from_str(str(s)) for s in stages]
             explicit = True
-            inferred = False
+        else:
+            inferred = True
 
         name = hints.get("name", plugin_func.__name__)
 

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -154,16 +154,11 @@ def test_stage_override_warning(caplog):
         async def _execute_impl(self, context):
             pass
 
-    initializer = SystemInitializer()
-    plugin = OverridePrompt({})
+    registry = ClassRegistry()
 
     caplog.set_level(logging.WARNING, logger="pipeline.initializer")
     logging.getLogger("pipeline.initializer").addHandler(caplog.handler)
-    initializer._resolve_plugin_stages(
-        OverridePrompt,
-        plugin,
-        {"stage": PipelineStage.DO},
-    )
+    registry._resolve_plugin_stages(OverridePrompt, {"stage": PipelineStage.DO})
 
     assert any(
         "override type defaults" in record.getMessage()


### PR DESCRIPTION
## Summary
- simplify `PluginAutoClassifier` heuristics
- validate plugin stage declarations at registration
- log overrides in `ClassRegistry._resolve_plugin_stages`
- adjust registry validator and stage checks tests

## Testing
- `poetry run pytest -q` *(fails: FileNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ea1d3c9908322930a28b85227013f