### PR TITLE
Enable parameterized workflow blueprints

### DIFF
--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -77,11 +77,13 @@ a **Workflow** object:
 from my_workflows import QuickstartWorkflow
 from pipeline import Pipeline
 
-workflow = QuickstartWorkflow()
+workflow = QuickstartWorkflow(prompt="my_prompts:QuickstartPrompt")
 pipeline = Pipeline(approach=workflow)
 ```
 
 The pipeline loops through `PARSE → THINK → DO → REVIEW → DELIVER` until a
 plugin calls `set_response`, illustrating the hybrid pipeline–state machine model.
 Because the workflow defines plugin selection, you can launch on AWS without a
-YAML file and later swap in custom stages as needed.
+YAML file and later swap in custom stages as needed. Pass different plugin
+arguments when creating the workflow to reuse the same class across
+environments.

--- a/docs/source/workflows.md
+++ b/docs/source/workflows.md
@@ -1,13 +1,16 @@
 # Example Workflows
 
 Entity provides a few ready-to-use workflow classes. Each workflow maps pipeline
-stages to plugin names. Instantiate one and pass it to `Pipeline`.
+stages to plugin names. Workflows act as blueprints; supply your own plugin
+names when instantiating them and reuse the class across environments.
 
 ```python
 from entity.workflows.examples import ChainOfThoughtWorkflow
 from pipeline import Pipeline
 
-workflow = ChainOfThoughtWorkflow()
+workflow = ChainOfThoughtWorkflow(
+    prompt="user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt"
+)
 pipeline = Pipeline(workflow=workflow)
 ```
 
@@ -18,6 +21,9 @@ Runs the chain-of-thought reasoning plugin.
 
 ```python
 from entity.workflows.examples import ChainOfThoughtWorkflow
+workflow = ChainOfThoughtWorkflow(
+    prompt="user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt"
+)
 ```
 
 ### ReActWorkflow
@@ -25,6 +31,7 @@ Uses the ReAct prompt to alternate reasoning and tool use.
 
 ```python
 from entity.workflows.examples import ReActWorkflow
+workflow = ReActWorkflow(prompt="user_plugins.prompts.react_prompt:ReActPrompt")
 ```
 
 ### IntentClassificationWorkflow
@@ -32,4 +39,7 @@ Classifies user intent with a single LLM call.
 
 ```python
 from entity.workflows.examples import IntentClassificationWorkflow
+workflow = IntentClassificationWorkflow(
+    prompt="user_plugins.prompts.intent_classifier:IntentClassifierPrompt"
+)
 ```

--- a/src/entity/workflows/base.py
+++ b/src/entity/workflows/base.py
@@ -3,24 +3,28 @@ from __future__ import annotations
 """Workflow definitions for pipeline execution."""
 
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List
+from typing import ClassVar, Dict, Iterable, List
 
 from pipeline.stages import PipelineStage
 
 
 @dataclass
 class Workflow:
-    """Map :class:`PipelineStage` to plugin names."""
+    """Reusable mapping from :class:`PipelineStage` to plugin names."""
 
+    stage_map: ClassVar[Dict[PipelineStage | str, Iterable[str]]] = {}
     stages: Dict[PipelineStage, List[str]] = field(default_factory=dict)
 
     def __init__(
-        self, mapping: Dict[PipelineStage | str, Iterable[str]] | None = None
+        self,
+        mapping: Dict[PipelineStage | str, Iterable[str]] | None = None,
+        **params: str,
     ) -> None:
         self.stages = {}
-        if mapping:
-            for stage, plugins in mapping.items():
-                self._assign(stage, plugins)
+        mapping = mapping or self.stage_map
+        for stage, plugins in (mapping or {}).items():
+            formatted = [str(p).format(**params) for p in plugins]
+            self._assign(stage, formatted)
 
     def _assign(self, stage: PipelineStage | str, plugins: Iterable[str]) -> None:
         stage_obj = PipelineStage.ensure(stage)
@@ -31,6 +35,10 @@ class Workflow:
 
     def to_dict(self) -> Dict[str, List[str]]:
         return {str(stage).lower(): list(names) for stage, names in self.stages.items()}
+
+    def copy(self, **params: str) -> "Workflow":
+        """Return a new workflow with updated parameters."""
+        return self.__class__(mapping=self.stages, **params)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Iterable[str]]) -> "Workflow":

--- a/src/entity/workflows/builtin.py
+++ b/src/entity/workflows/builtin.py
@@ -10,38 +10,29 @@ from .base import Workflow
 class StandardWorkflow(Workflow):
     """Default conversational workflow."""
 
-    def __init__(self) -> None:
-        super().__init__(
-            {
-                PipelineStage.PARSE: ["conversation_history"],
-                PipelineStage.THINK: ["complex_prompt"],
-                PipelineStage.REVIEW: ["pii_scrubber"],
-                PipelineStage.ERROR: ["default_responder"],
-            }
-        )
+    stage_map = {
+        PipelineStage.PARSE: ["conversation_history"],
+        PipelineStage.THINK: ["complex_prompt"],
+        PipelineStage.REVIEW: ["pii_scrubber"],
+        PipelineStage.ERROR: ["default_responder"],
+    }
 
 
 class ReActWorkflow(Workflow):
     """Workflow using the ReAct reasoning pattern."""
 
-    def __init__(self) -> None:
-        super().__init__(
-            {
-                PipelineStage.THINK: ["react"],
-                PipelineStage.REVIEW: ["pii_scrubber"],
-                PipelineStage.ERROR: ["default_responder"],
-            }
-        )
+    stage_map = {
+        PipelineStage.THINK: ["react"],
+        PipelineStage.REVIEW: ["pii_scrubber"],
+        PipelineStage.ERROR: ["default_responder"],
+    }
 
 
 class ChainOfThoughtWorkflow(Workflow):
     """Workflow using chain-of-thought reasoning."""
 
-    def __init__(self) -> None:
-        super().__init__(
-            {
-                PipelineStage.THINK: ["chain_of_thought"],
-                PipelineStage.REVIEW: ["pii_scrubber"],
-                PipelineStage.ERROR: ["default_responder"],
-            }
-        )
+    stage_map = {
+        PipelineStage.THINK: ["chain_of_thought"],
+        PipelineStage.REVIEW: ["pii_scrubber"],
+        PipelineStage.ERROR: ["default_responder"],
+    }

--- a/src/entity/workflows/examples.py
+++ b/src/entity/workflows/examples.py
@@ -10,31 +10,37 @@ from . import Workflow
 class ChainOfThoughtWorkflow(Workflow):
     """Reason through problems step by step."""
 
-    stage_map = {
-        PipelineStage.THINK: [
-            "user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt",
-        ]
-    }
+    stage_map = {PipelineStage.THINK: ["{prompt}"]}
+
+    def __init__(
+        self,
+        prompt: str = "user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt",
+    ) -> None:
+        super().__init__(prompt=prompt)
 
 
 class ReActWorkflow(Workflow):
     """Iteratively reason and act using tools."""
 
-    stage_map = {
-        PipelineStage.THINK: [
-            "user_plugins.prompts.react_prompt:ReActPrompt",
-        ]
-    }
+    stage_map = {PipelineStage.THINK: ["{prompt}"]}
+
+    def __init__(
+        self,
+        prompt: str = "user_plugins.prompts.react_prompt:ReActPrompt",
+    ) -> None:
+        super().__init__(prompt=prompt)
 
 
 class IntentClassificationWorkflow(Workflow):
     """Classify the user's intent with a single prompt."""
 
-    stage_map = {
-        PipelineStage.THINK: [
-            "user_plugins.prompts.intent_classifier:IntentClassifierPrompt",
-        ]
-    }
+    stage_map = {PipelineStage.THINK: ["{prompt}"]}
+
+    def __init__(
+        self,
+        prompt: str = "user_plugins.prompts.intent_classifier:IntentClassifierPrompt",
+    ) -> None:
+        super().__init__(prompt=prompt)
 
 
 __all__ = [

--- a/tests/test_workflow_discovery.py
+++ b/tests/test_workflow_discovery.py
@@ -14,3 +14,20 @@ class MyFlow(Workflow):
     workflows = discover_workflows(str(tmp_path))
     assert "MyFlow" in workflows
     assert issubclass(workflows["MyFlow"], Workflow)
+
+
+def test_discover_multiple_files(tmp_path):
+    (tmp_path / "a.py").write_text(
+        "from entity.workflows import Workflow\nclass A(Workflow):\n    pass"
+    )
+    (tmp_path / "b.py").write_text(
+        "class IgnoreMe: pass\nfrom entity.workflows import Workflow\nclass B(Workflow):\n    pass"
+    )
+    workflows = discover_workflows(str(tmp_path))
+    assert set(workflows) == {"A", "B"}
+
+
+def test_discover_ignores_import_errors(tmp_path):
+    (tmp_path / "broken.py").write_text("raise Exception('boom')")
+    workflows = discover_workflows(str(tmp_path))
+    assert workflows == {}


### PR DESCRIPTION
## Summary
- allow `Workflow` blueprints to accept parameters
- convert built-in workflows to class level `stage_map`
- add placeholders to example workflows
- expand workflow discovery tests
- document workflow reuse with parameterization

## Testing
- `poetry run pytest tests/test_workflow_discovery.py`

------
https://chatgpt.com/codex/tasks/task_e_686ea1d5291c8322a906c234c0094f1e