### PR TITLE
Update docs for new plugin import path and config models

### DIFF
--- a/docs/source/config_cheatsheet.md
+++ b/docs/source/config_cheatsheet.md
@@ -29,6 +29,25 @@ plugins:
       stages: [parse, deliver]
 ```
 
+The same configuration can be expressed programmatically:
+
+```python
+from entity.config.models import EntityConfig, PluginsSection, PluginConfig
+
+config = EntityConfig(
+    server={"host": "0.0.0.0", "port": 8000},
+    workflow={"parse": ["http"], "think": ["main"], "deliver": ["http"]},
+    plugins=PluginsSection(
+        resources={
+            "database": PluginConfig(path="./entity.db"),
+            "llm": PluginConfig(provider="openai", model="gpt-4"),
+        },
+        prompts={"main": PluginConfig(type="user_plugins.prompts.simple:SimplePrompt")},
+        adapters={"http": PluginConfig(stages=["parse", "deliver"])},
+    ),
+)
+```
+
 Use `poetry run entity-cli --config config.yaml` to start the agent.
 This example references a plugin under the `user_plugins` package to
 show how custom modules can be loaded.

--- a/docs/source/migration_guide.md
+++ b/docs/source/migration_guide.md
@@ -31,7 +31,7 @@ poetry run entity-cli --config your.yaml
 ## 3. Validate Plugins
 
 If you wrote custom plugins during the experimental phase, make sure they inherit
-from the current base classes in `pipeline.base_plugins`. Then update the
+from the current base classes in `entity.core.plugins`. Then update the
 `stages` list to use values from `pipeline.stages.PipelineStage`.
 
 ## 4. Verify Stored Data

--- a/docs/source/module_map.md
+++ b/docs/source/module_map.md
@@ -2,11 +2,11 @@
 
 This document describes the key modules and their responsibilities after consolidating the base plugin classes.
 
-## `pipeline.base_plugins`
+## `entity.core.plugins`
 All abstract plugin base classes live in this module. Other packages import from here rather than maintaining duplicates.
 
 ## `plugins`
 Concrete plugin implementations organized by type. The package re-exports the base classes for backward compatibility but no longer defines them.
 
 ## `pipeline`
-The package root exposes the public API. It imports base classes from `pipeline.base_plugins` and re-exports them as convenience symbols alongside utility functions, capabilities and managers.
+The package root exposes the public API. It imports base classes from `entity.core.plugins` and re-exports them as convenience symbols alongside utility functions, capabilities and managers.

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -7,7 +7,7 @@ The Entity framework is built around extensible plugins. Plugins run during spec
 Create a plugin class that inherits from one of the base plugin types and implement `_execute_impl`:
 
 ```python
-from pipeline.base_plugins import PromptPlugin
+from entity.core.plugins import PromptPlugin
 from pipeline.stages import PipelineStage
 
 
@@ -132,7 +132,8 @@ plugin_dirs:
 2. Register the plugin with the `Agent` or include it in your YAML under `plugins:`.
    The list position determines execution order and `SystemInitializer` preserves
    that sequence. There is no priority field.
-3. Validate the YAML using `SystemInitializer.from_yaml("your.yaml")`.
+3. Validate the configuration with `entity.config.EntityConfig` or
+   load a YAML file using `SystemInitializer.from_yaml("your.yaml")`.
 4. Write unit tests and run `pytest` before committing changes.
 
 ## Implementing Storage Backends

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -11,6 +11,23 @@ Run an agent from a YAML configuration file:
 entity-cli --config config.yaml
 ```
 
+### Programmatic Configuration
+Build the same configuration in Python using the models from
+`entity.config`:
+
+```python
+from entity.config.models import EntityConfig, PluginsSection, PluginConfig
+
+config = EntityConfig(
+    workflow={"think": ["main"], "deliver": ["http"]},
+    plugins=PluginsSection(
+        prompts={"main": PluginConfig(type="user_plugins.prompts.simple:SimplePrompt")},
+        adapters={"http": PluginConfig(type="plugins.builtin.adapters.http:HTTPAdapter", stages=["parse", "deliver"])},
+        resources={"llm": PluginConfig(provider="openai", model="gpt-4")},
+    ),
+)
+```
+
 ### Using the SearchTool
 Register `SearchTool` and call it from your plugin:
 

--- a/docs/source/workflows.md
+++ b/docs/source/workflows.md
@@ -33,3 +33,27 @@ Classifies user intent with a single LLM call.
 ```python
 from entity.workflows.examples import IntentClassificationWorkflow
 ```
+
+## Custom Workflow with Memory
+
+Define a workflow programmatically and store conversation data using the
+`memory` resource:
+
+```python
+from entity.workflows import Workflow
+from pipeline.stages import PipelineStage
+
+workflow = Workflow(
+    {
+        PipelineStage.PARSE: ["conversation_history"],
+        PipelineStage.THINK: ["main"],
+        PipelineStage.DELIVER: ["http"],
+    }
+)
+
+@agent.plugin
+async def remember(ctx):
+    history = ctx.memory("history", [])
+    history.append(ctx.message)
+    ctx.remember("history", history)
+```


### PR DESCRIPTION
## Summary
- replace outdated `pipeline.base_plugins` imports with `entity.core.plugins`
- describe validation using `EntityConfig`
- add programmatic configuration examples
- document custom workflow with memory resource

## Testing
- `poetry install --with dev`
- `poetry run pytest -q` *(fails: FileNotFoundError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ea1d56a248322b42cbd314fb387b1