### PR TITLE
Expose agent entrypoints

### DIFF
--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["core"]
+__all__ = ["core", "Agent", "AgentBuilder"]
 
 
 def __getattr__(name: str):
@@ -10,4 +10,12 @@ def __getattr__(name: str):
         from . import core as _core
 
         return _core
+    if name == "Agent":
+        from .core.agent import Agent as _Agent
+
+        return _Agent
+    if name == "AgentBuilder":
+        from .core.builder import AgentBuilder as _AgentBuilder
+
+        return _AgentBuilder
     raise AttributeError(name)


### PR DESCRIPTION
## Summary
- re-export `Agent` and `AgentBuilder` from the package root
- keep lazy loading for heavy imports

## Testing
- `poetry run pytest -q` *(fails: FileNotFoundError and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ea1f95e8c8322b59dbee38c4a21aa