### PR TITLE
Expose Workflow in pipeline module

### DIFF
--- a/src/pipeline/workflow.py
+++ b/src/pipeline/workflow.py
@@ -5,9 +5,12 @@ from typing import Mapping, Iterable, Optional
 
 from entity.core.builder import AgentBuilder
 from entity.core.runtime import AgentRuntime
+from entity.workflows.base import Workflow
 from .stages import PipelineStage
 
 WorkflowMapping = Mapping[PipelineStage | str, Iterable[str]]
+
+__all__ = ["Pipeline", "Workflow"]
 
 
 @dataclass
@@ -15,7 +18,7 @@ class Pipeline:
     """Simple pipeline wrapper holding builder and workflow."""
 
     builder: AgentBuilder = field(default_factory=AgentBuilder)
-    workflow: Optional[WorkflowMapping] = None
+    workflow: Optional[Workflow | WorkflowMapping] = None
 
     def build_runtime(self) -> AgentRuntime:
         """Build an AgentRuntime using the stored builder and workflow."""


### PR DESCRIPTION
## Summary
- re-export `Workflow` in `pipeline.workflow`
- expose `Pipeline` and `Workflow` through `__all__`
- allow `Pipeline` to accept a `Workflow` instance

## Testing
- `poetry run black src/pipeline/workflow.py`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pipeline.metrics')*

------
https://chatgpt.com/codex/tasks/task_e_686ea1f9af78832285b4483b3711d80a