### PR TITLE
Add pipeline resource module exports

### DIFF
--- a/src/pipeline/resources/__init__.py
+++ b/src/pipeline/resources/__init__.py
@@ -1,0 +1,12 @@
+"""Convenience imports for pipeline resources."""
+
+from .container import ResourceContainer
+
+from .memory import Memory  # noqa: F401
+from .llm import UnifiedLLMResource  # noqa: F401
+
+__all__ = [
+    "ResourceContainer",
+    "Memory",
+    "UnifiedLLMResource",
+]

--- a/src/pipeline/resources/llm.py
+++ b/src/pipeline/resources/llm.py
@@ -1,0 +1,43 @@
+"""Unified LLM resource stub used in tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import httpx
+
+
+@dataclass
+class _Provider:
+    name: str
+    config: Dict[str, Any]
+
+    async def generate(self, prompt: str) -> str:
+        if self.name == "gemini":
+            url = f"{self.config['base_url'].rstrip('/')}/v1beta/models/{self.config['model']}:generateContent?key={self.config['api_key']}"
+            data = {"contents": [{"parts": [{"text": prompt}]}]}
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(url, json=data)
+            return resp.json()["candidates"][0]["content"]["parts"][0]["text"]
+        if self.name == "claude":
+            url = f"{self.config['base_url'].rstrip('/')}/v1/messages"
+            data = {
+                "model": self.config["model"],
+                "messages": [{"role": "user", "content": prompt}],
+            }
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(url, json=data)
+            return resp.json()["content"][0]["text"]
+        # Echo and other providers simply return the prompt
+        return prompt
+
+
+class UnifiedLLMResource:
+    """Simplified multi-provider LLM wrapper."""
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        self._providers = [_Provider(config.get("provider", ""), config)]
+
+    async def generate(self, prompt: str) -> str:
+        return await self._providers[0].generate(prompt)

--- a/src/pipeline/resources/memory.py
+++ b/src/pipeline/resources/memory.py
@@ -1,0 +1,30 @@
+"""Pipeline memory resource wrappers."""
+
+from __future__ import annotations
+
+from entity.resources.memory import Memory as _Memory
+from pipeline.pipeline import execute_pipeline
+from entity.core.registries import SystemRegistries
+
+
+class Conversation:
+    """Simple conversation helper for tests."""
+
+    def __init__(self, capabilities: SystemRegistries) -> None:
+        self._caps = capabilities
+
+    async def process_request(self, message: str):
+        result = await execute_pipeline(message, self._caps)
+        while isinstance(result, dict) and result.get("type") == "continue_processing":
+            next_msg = result.get("message", "")
+            result = await execute_pipeline(next_msg, self._caps)
+        return result
+
+
+class Memory(_Memory):
+    """Expose start_conversation on top of base Memory."""
+
+    def start_conversation(
+        self, capabilities: SystemRegistries, _manager: object | None = None
+    ) -> Conversation:
+        return Conversation(capabilities)


### PR DESCRIPTION
## Summary
- expose ResourceContainer via new pipeline.resources package
- add pipeline.resources.memory wrapper for conversations
- create a minimal UnifiedLLMResource stub for tests

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686ea1faf2508322ab1b9101667dce0d