### PR TITLE
Add pipeline exceptions wrapper

### DIFF
--- a/src/pipeline/exceptions.py
+++ b/src/pipeline/exceptions.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Pipeline exceptions and reliability errors."""
+
+from .errors import (
+    PipelineError,
+    PluginContextError,
+    PluginExecutionError,
+    ResourceError,
+    ToolExecutionError,
+    StageExecutionError,
+    ErrorResponse,
+    create_static_error_response,
+)
+
+
+class CircuitBreakerTripped(PipelineError):
+    """Raised when a circuit breaker is open and execution is blocked."""
+
+
+class MaxIterationsExceeded(PipelineError):
+    """Raised when the pipeline runs more iterations than allowed."""
+
+
+__all__ = [
+    "PipelineError",
+    "PluginContextError",
+    "PluginExecutionError",
+    "ResourceError",
+    "ToolExecutionError",
+    "StageExecutionError",
+    "ErrorResponse",
+    "create_static_error_response",
+    "CircuitBreakerTripped",
+    "MaxIterationsExceeded",
+]


### PR DESCRIPTION
## Summary
- expose reliability exception types for pipeline
- re-export core error classes via `pipeline.exceptions`

## Testing
- `poetry run pytest tests/integration/test_reliability.py::test_circuit_breaker_trips -q` *(fails: ModuleNotFoundError: No module named 'pipeline.reliability')*

------
https://chatgpt.com/codex/tasks/task_e_686ea1fe4a148322b235824cd7e19aec