### PR TITLE
Add plugin helper interface exports

### DIFF
--- a/src/pipeline/interfaces.py
+++ b/src/pipeline/interfaces.py
@@ -1,0 +1,7 @@
+from entity.core.plugin_utils import (
+    PluginAutoClassifier,
+    configure_plugins,
+    import_plugin_class,
+)
+
+__all__ = ["PluginAutoClassifier", "configure_plugins", "import_plugin_class"]


### PR DESCRIPTION
## Summary
- add `pipeline.interfaces` to re-export plugin utilities

## Testing
- `poetry run pytest` *(fails: 75 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ea2009d0c8322a0071a63a5ade246