### PR TITLE
Add registry initializer

### DIFF
--- a/src/registry/__init__.py
+++ b/src/registry/__init__.py
@@ -1,0 +1,5 @@
+"""Registry helpers exposed for easy import."""
+
+from .registries import PluginRegistry, ToolRegistry, SystemRegistries
+
+__all__ = ["PluginRegistry", "ToolRegistry", "SystemRegistries"]


### PR DESCRIPTION
## Summary
- add `src/registry/__init__.py`
- expose `PluginRegistry`, `ToolRegistry`, and `SystemRegistries`

## Testing
- `poetry run black .`
- `poetry run pytest` *(fails: FileNotFoundError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ea2011fd08322801b2e7aca1a0e31