### PR TITLE
Add stub builtin resources and adapters

### DIFF
--- a/src/plugins/builtin/adapters/__init__.py
+++ b/src/plugins/builtin/adapters/__init__.py
@@ -1,0 +1,13 @@
+"""Built-in adapter stubs."""
+
+from .http_adapter import HTTPAdapter
+from .cli import CLIAdapter
+from .websocket import WebSocketAdapter
+from .dashboard import DashboardAdapter
+
+__all__ = [
+    "HTTPAdapter",
+    "CLIAdapter",
+    "WebSocketAdapter",
+    "DashboardAdapter",
+]

--- a/src/plugins/builtin/adapters/cli.py
+++ b/src/plugins/builtin/adapters/cli.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from entity.core.plugins import AdapterPlugin
+from pipeline.stages import PipelineStage
+
+
+class CLIAdapter(AdapterPlugin):
+    """Placeholder CLI adapter."""
+
+    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
+
+    def __init__(self, manager: Any, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.manager = manager
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def serve(self, capabilities: Any) -> None:  # pragma: no cover - stub
+        return None

--- a/src/plugins/builtin/adapters/dashboard.py
+++ b/src/plugins/builtin/adapters/dashboard.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from entity.core.plugins import AdapterPlugin
+from pipeline.stages import PipelineStage
+
+
+class DashboardAdapter(AdapterPlugin):
+    """Placeholder dashboard adapter."""
+
+    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
+
+    def __init__(self, manager: Any, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.manager = manager
+        self.app = object()
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def serve(self, capabilities: Any) -> None:  # pragma: no cover - stub
+        return None

--- a/src/plugins/builtin/adapters/http_adapter.py
+++ b/src/plugins/builtin/adapters/http_adapter.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from entity.core.plugins import AdapterPlugin
+from pipeline.stages import PipelineStage
+
+
+class HTTPAdapter(AdapterPlugin):
+    """Placeholder HTTP adapter."""
+
+    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
+
+    def __init__(self, manager: Any, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.manager = manager
+        self.app = object()
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None

--- a/src/plugins/builtin/adapters/websocket.py
+++ b/src/plugins/builtin/adapters/websocket.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from entity.core.plugins import AdapterPlugin
+from pipeline.stages import PipelineStage
+
+
+class WebSocketAdapter(AdapterPlugin):
+    """Placeholder WebSocket adapter."""
+
+    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
+
+    def __init__(self, manager: Any, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.manager = manager
+        self.app = object()
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def serve(self, capabilities: Any) -> None:  # pragma: no cover - stub
+        return None

--- a/src/plugins/builtin/resources/__init__.py
+++ b/src/plugins/builtin/resources/__init__.py
@@ -10,6 +10,8 @@ from .duckdb_vector_store import DuckDBVectorStore
 from .filesystem import FileSystemResource
 from .llm_base import LLM
 from .llm_resource import LLMResource
+from .postgres import PostgresResource
+from .echo_llm import EchoLLMResource
 from .local_filesystem import LocalFileSystemResource
 from .memory_filesystem import MemoryFileSystem
 from .metrics import MetricsResource
@@ -28,10 +30,12 @@ __all__ = [
     "Resource",
     "BaseResource",
     "LLMResource",
+    "EchoLLMResource",
     "StructuredLogging",
     "MetricsResource",
     "DuckDBDatabaseResource",
     "PgVectorStore",
+    "PostgresResource",
     "MemoryFileSystem",
     "DuckDBVectorStore",
     "LocalFileSystemResource",

--- a/src/plugins/builtin/resources/echo_llm.py
+++ b/src/plugins/builtin/resources/echo_llm.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from pipeline.state import LLMResponse
+
+from .llm_resource import LLMResource
+
+
+class EchoLLMResource(LLMResource):
+    """LLM that simply echoes the prompt."""
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+
+    async def generate(self, prompt: str) -> LLMResponse:
+        return LLMResponse(content=prompt)

--- a/src/plugins/builtin/resources/llm_base.py
+++ b/src/plugins/builtin/resources/llm_base.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class LLMResponse:
+    """Simple container for LLM output."""
+
+    content: str
+
+
+class LLM:
+    """Placeholder LLM type used in tests."""
+
+    pass

--- a/src/plugins/builtin/resources/llm_resource.py
+++ b/src/plugins/builtin/resources/llm_resource.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from html import escape
+from typing import Any, Dict
+
+from entity.core.plugins import ResourcePlugin
+from pipeline.state import LLMResponse
+
+
+class LLMResource(ResourcePlugin):
+    """Base class for simple LLM resources."""
+
+    name = "llm"
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def generate(self, prompt: str) -> LLMResponse:
+        """Return an ``LLMResponse`` for ``prompt``."""
+        return LLMResponse(content=prompt)
+
+    async def call_llm(self, prompt: str, *, sanitize: bool = False) -> str:
+        """Helper used in tests to call ``generate`` with optional sanitization."""
+        if sanitize:
+            prompt = escape(prompt)
+        result = await self.generate(prompt)
+        return getattr(result, "content", str(result))

--- a/src/plugins/builtin/resources/pg_vector_store.py
+++ b/src/plugins/builtin/resources/pg_vector_store.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from entity.core.plugins import ResourcePlugin
+
+
+class PgVectorStore(ResourcePlugin):
+    """Placeholder pgvector-based store."""
+
+    name = "pg_vector_store"
+    dependencies = ["database"]
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self._db: Any = None
+        self.database: Any = None
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def initialize(self) -> None:
+        self._db = self.database
+
+    async def add_embedding(self, text: str) -> None:  # pragma: no cover - stub
+        return None
+
+    async def query_similar(self, query: str, k: int = 5) -> List[str]:  # noqa: D401
+        return []

--- a/src/plugins/builtin/resources/postgres.py
+++ b/src/plugins/builtin/resources/postgres.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, Dict
+
+from entity.core.plugins import ResourcePlugin
+
+
+class _DummyConn:
+    async def execute(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+class _DummyPool:
+    async def acquire(self) -> _DummyConn:
+        return _DummyConn()
+
+    async def release(self, _conn: _DummyConn) -> None:
+        return None
+
+    async def close(self) -> None:  # pragma: no cover - placeholder
+        return None
+
+
+class PostgresResource(ResourcePlugin):
+    """Minimal Postgres resource stub used in tests."""
+
+    name = "postgres"
+    stages: list = []
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self._pool = _DummyPool()
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def initialize(self) -> None:
+        return None
+
+    @asynccontextmanager
+    async def connection(self) -> Any:
+        conn = await self._pool.acquire()
+        try:
+            yield conn
+        finally:
+            await self._pool.release(conn)


### PR DESCRIPTION
## Summary
- implement minimal LLM and Postgres resource stubs
- add echo LLM resource and pg_vector store stub
- create placeholder adapters

## Testing
- `poetry run black src/plugins/builtin/resources/llm_base.py src/plugins/builtin/resources/llm_resource.py src/plugins/builtin/resources/postgres.py src/plugins/builtin/resources/pg_vector_store.py src/plugins/builtin/resources/echo_llm.py src/plugins/builtin/adapters/*.py src/plugins/builtin/adapters/__init__.py src/plugins/builtin/resources/__init__.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ea203e9908322a6877b06fdda66b8