### PR TITLE
Enforce DELIVER-only response setting

### DIFF
--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -7,7 +7,8 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pipeline.stages import PipelineStage
-from pipeline.state import PipelineState, ToolCall, ConversationEntry
+from pipeline.state import ConversationEntry, PipelineState, ToolCall
+from pipeline.errors import PluginContextError
 
 
 @dataclass
@@ -146,5 +147,7 @@ class PluginContext:
 
     def set_response(self, value: Any) -> None:
         if self.current_stage is not PipelineStage.DELIVER:
-            raise ValueError("Only DELIVER stage plugins may set responses")
+            raise PluginContextError(
+                f"set_response may only be called in DELIVER stage, not {self.current_stage}"
+            )
         self._state.response = value

--- a/tests/test_set_response.py
+++ b/tests/test_set_response.py
@@ -1,6 +1,7 @@
 import asyncio
 import pytest
 from pipeline import PipelineStage, PipelineState, PluginContext, PromptPlugin
+from pipeline.errors import PluginContextError
 from registry import PluginRegistry, SystemRegistries, ToolRegistry
 
 from entity.core.resources.container import ResourceContainer
@@ -23,7 +24,8 @@ def test_set_response_allowed_in_deliver():
 def test_set_response_fails_in_other_stage():
     ctx = make_context(PipelineStage.DO)
     with pytest.raises(
-        ValueError, match="Only DELIVER stage plugins may set responses"
+        PluginContextError,
+        match="set_response may only be called in DELIVER stage",
     ):
         ctx.set_response("nope")
 
@@ -38,5 +40,5 @@ class EarlyPlugin(PromptPlugin):
 def test_plugin_cannot_set_response_before_deliver():
     ctx = make_context(PipelineStage.DO)
     plugin = EarlyPlugin({})
-    with pytest.raises(ValueError):
+    with pytest.raises(PluginContextError):
         asyncio.run(plugin.execute(ctx))

--- a/tests/test_set_response_validation.py
+++ b/tests/test_set_response_validation.py
@@ -1,6 +1,7 @@
 import pytest
 from pipeline import PipelineStage, PluginRegistry, SystemRegistries, ToolRegistry
 from pipeline.context import PluginContext
+from pipeline.errors import PluginContextError
 from pipeline.state import PipelineState
 
 from entity.core.resources.container import ResourceContainer
@@ -13,7 +14,8 @@ def test_set_response_disallowed_outside_deliver():
     )
     ctx.set_current_stage(PipelineStage.PARSE)
     with pytest.raises(
-        ValueError, match="Only DELIVER stage plugins may set responses"
+        PluginContextError,
+        match="set_response may only be called in DELIVER stage",
     ):
         ctx.set_response("nope")
     assert state.response is None


### PR DESCRIPTION
## Summary
- raise `PluginContextError` when plugins call `set_response` outside `DELIVER`
- adjust tests for the stricter error type

## Testing
- `poetry run pytest tests/test_set_response.py tests/test_set_response_validation.py tests/test_pipeline_looping.py -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ebd42aaa083228bd35c81858ffc75