### PR TITLE
Fix imports in test_full_pipeline

### DIFF
--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -5,8 +5,6 @@ from pipeline import PipelineStage
 from entity.core.plugins import BasePlugin
 
 from entity import Agent
-from pipeline import PipelineStage
-from pipeline.base_plugins import BasePlugin
 
 
 class ParsePlugin(BasePlugin):


### PR DESCRIPTION
## Summary
- remove duplicate `PipelineStage` import
- reference `BasePlugin` from `entity.core.plugins`

## Testing
- `poetry run pytest tests/integration/test_full_pipeline.py::test_full_agent_pipeline -q` *(fails: ModuleNotFoundError: No module named 'entity.core.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_686ec36f4214832298aa8563e335d1f3