### PR TITLE
Remove duplicate asyncio import

### DIFF
--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 """Minimal plugin context objects."""
 
 import asyncio
+import time
 from dataclasses import dataclass
 from datetime import datetime
-import time
 from typing import Any, Dict, List, Optional
-import asyncio
 
 from pipeline.stages import PipelineStage
 from pipeline.state import ConversationEntry, PipelineState


### PR DESCRIPTION
## Summary
- clean up double import in `context.py`

## Testing
- `poetry run black src/entity/core/context.py`
- `poetry run isort src/entity/core/context.py`
- `poetry run flake8 src/entity/core/context.py` *(fails: F401, F821)*
- `poetry run mypy src/entity/core/context.py` *(fails: missing names)*
- `poetry run bandit -r src/entity/core/context.py`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError)*
- `python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_686ec36c82bc832292885e0276c427fa