### PR TITLE
Refactor plugin imports

### DIFF
--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -21,7 +21,7 @@ from entity.workflows.discovery import (
     register_module_workflows,
 )
 
-from .base_plugins import BasePlugin, ResourcePlugin, ToolPlugin
+from entity.core.plugins import BasePlugin, ResourcePlugin, ToolPlugin
 from .defaults import DEFAULT_CONFIG
 from .logging import configure_logging, get_logger
 from .stages import PipelineStage
@@ -94,7 +94,7 @@ class ClassRegistry:
     def _type_default_stages(self, cls: type[BasePlugin]) -> List[PipelineStage]:
         """Return default stages for the given plugin class."""
 
-        from .base_plugins import AdapterPlugin, PromptPlugin
+        from entity.core.plugins import AdapterPlugin, PromptPlugin
 
         if issubclass(cls, ToolPlugin):
             return [PipelineStage.DO]
@@ -313,7 +313,7 @@ class SystemInitializer:
     def _type_default_stages(self, cls: type[BasePlugin]) -> List[PipelineStage]:
         """Return default stages for the given plugin class."""
 
-        from .base_plugins import AdapterPlugin, PromptPlugin
+        from entity.core.plugins import AdapterPlugin, PromptPlugin
 
         if issubclass(cls, ToolPlugin):
             return [PipelineStage.DO]

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -1,12 +1,9 @@
 import asyncio
 
 import pytest
-from pipeline import PipelineStage
-from entity.core.plugins import BasePlugin
-
 from entity import Agent
+from entity.core.plugins import BasePlugin
 from pipeline import PipelineStage
-from pipeline.base_plugins import BasePlugin
 
 
 class ParsePlugin(BasePlugin):


### PR DESCRIPTION
## Summary
- replace `.base_plugins` imports with `entity.core.plugins`
- clean up `test_full_pipeline` imports
- run Black on the files touched

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_686ec369d8448322af633389a95731f4