### PR TITLE
Fix docs to drop old pipeline references

### DIFF
--- a/docs/source/api_reference.md
+++ b/docs/source/api_reference.md
@@ -3,8 +3,6 @@
 This section is generated from the project source using autodoc. Every public
 module is documented directly from its docstrings.
 
-!!! warning "Deprecated modules"
-    ``PipelineManager`` is deprecated. Use ``entity.Agent`` instead.
 
 ::: entity
     options:

--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -4,16 +4,16 @@ The easiest way to capture structured logs is using ``LoggingAdapter``. Add it
 to your ``adapters`` configuration or initialize it directly:
 
 ```python
-# from plugins.builtin.adapters.logging import LoggingAdapter
+# from entity.plugins.builtin.adapters.logging import LoggingAdapter
 
 # adapter = LoggingAdapter()
 ```
 
 To configure logging globally, call ``configure_logging`` from
-``plugins.builtin.adapters.logging_adapter``:
+``entity.plugins.builtin.adapters.logging_adapter``:
 
 ```python
-# from plugins.builtin.adapters.logging_adapter import configure_logging, get_logger
+# from entity.plugins.builtin.adapters.logging_adapter import configure_logging, get_logger
 
 # configure_logging(level="INFO", json_enabled=True)
 # logger = get_logger(__name__)

--- a/docs/source/migration_guide.md
+++ b/docs/source/migration_guide.md
@@ -15,7 +15,7 @@ exist in the `plugins.builtin` package. For example:
 from experiments.storage.resource import StorageResource
 
 # New
-# from plugins.builtin.resources.storage import StorageResource  # placeholder
+# from entity.plugins.builtin.resources.storage import StorageResource  # placeholder
 ```
 
 ## 2. Check Configuration Files
@@ -32,7 +32,7 @@ poetry run entity-cli --config your.yaml
 
 If you wrote custom plugins during the experimental phase, make sure they inherit
 from the current base classes in `entity.core.plugins`. Then update the
-`stages` list to use values from `pipeline.stages.PipelineStage`.
+`stages` list to use values from `entity.core.stages.PipelineStage`.
 
 ## 4. Verify Stored Data
 

--- a/docs/source/plugin_cheatsheet.md
+++ b/docs/source/plugin_cheatsheet.md
@@ -13,8 +13,8 @@ All plugins declare their `stages` and any `dependencies`.
 
 ## Skeleton
 ```python
-from plugins import PromptPlugin
-from pipeline.stages import PipelineStage
+from entity.core.plugins import PromptPlugin
+from entity.core.stages import PipelineStage
 
 class ExamplePlugin(PromptPlugin):
     dependencies = ["database", "llm"]

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -8,7 +8,7 @@ Create a plugin class that inherits from one of the base plugin types and implem
 
 ```python
 from entity.core.plugins import PromptPlugin
-from pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 
 class HelloPlugin(PromptPlugin):
@@ -21,7 +21,7 @@ class HelloPlugin(PromptPlugin):
 Register the plugin with an `Agent` instance:
 
 ```python
-from pipeline import Agent
+from entity import Agent
 
 agent = Agent()
 agent.add_plugin(HelloPlugin({}))
@@ -144,8 +144,8 @@ new backend, subclass `ResourcePlugin` and implement the `save_history` and
 ```python
 import asyncpg
 
-from pipeline.stages import PipelineStage
-from plugins import ResourcePlugin
+from entity.core.stages import PipelineStage
+from entity.core.plugins import ResourcePlugin
 
 
 class MyStorage(ResourcePlugin):

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -11,8 +11,8 @@ function and registered through configuration or the `Agent` API.
 
 ## Basic Pattern
 ```python
-from plugins import PromptPlugin
-from pipeline.stages import PipelineStage
+from entity.core.plugins import PromptPlugin
+from entity.core.stages import PipelineStage
 
 class HelloPlugin(PromptPlugin):
     stages = [PipelineStage.DELIVER]

--- a/docs/source/workflows.md
+++ b/docs/source/workflows.md
@@ -51,7 +51,7 @@ Define a workflow programmatically and store conversation data using the
 
 ```python
 from entity.workflows import Workflow
-from pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 workflow = Workflow(
     {


### PR DESCRIPTION
## Summary
- remove outdated PipelineManager warning from API reference
- update docs to import from `entity` rather than `pipeline`

## Testing
- `poetry run black src tests`
- `poetry run pytest` *(fails: FileNotFoundError during tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ec35b4af08322a6905d716eb5c220