### PR TITLE
Remove metrics helper functions

### DIFF
--- a/src/pipeline/observability/__init__.py
+++ b/src/pipeline/observability/__init__.py
@@ -1,16 +1,9 @@
-from .metrics import (
-    MetricsServer,
-    MetricsServerManager,
-    start_metrics_server,
-    get_metrics_server,
-)
+from .metrics import MetricsServer, MetricsServerManager
 from .tracing import start_span, traced
 
 __all__ = [
     "MetricsServer",
     "MetricsServerManager",
-    "start_metrics_server",
-    "get_metrics_server",
     "start_span",
     "traced",
 ]

--- a/src/pipeline/observability/metrics.py
+++ b/src/pipeline/observability/metrics.py
@@ -38,15 +38,3 @@ class MetricsServerManager:
         """Return the active :class:`MetricsServer` instance if running."""
 
         return cls._server
-
-
-def start_metrics_server(port: int = 9001) -> MetricsServer:
-    """Backward-compatible wrapper for :meth:`MetricsServerManager.start`."""
-
-    return MetricsServerManager.start(port)
-
-
-def get_metrics_server() -> MetricsServer | None:
-    """Backward-compatible wrapper for :meth:`MetricsServerManager.get`."""
-
-    return MetricsServerManager.get()


### PR DESCRIPTION
## Summary
- drop `start_metrics_server` and `get_metrics_server`
- expose metrics manager directly from `pipeline.observability`

## Testing
- `poetry install --with dev`
- `poetry run pytest` *(fails: 66 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ec359c3708322b22c691a1e6ccc48