### PR TITLE
Remove obsolete request-id logging

### DIFF
--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -23,7 +23,7 @@ from entity.workflows.discovery import (
 
 from .base_plugins import BasePlugin, ResourcePlugin, ToolPlugin
 from .defaults import DEFAULT_CONFIG
-from .logging import configure_logging, get_logger
+from entity.utils.logging import configure_logging, get_logger
 from .stages import PipelineStage
 from .workflow import Workflow
 

--- a/src/pipeline/logging.py
+++ b/src/pipeline/logging.py
@@ -2,22 +2,7 @@
 
 from __future__ import annotations
 
-"""Shims to maintain backward compatibility for logging utilities."""
-
 from entity.utils.logging import configure_logging, get_logger
 
 
-def set_request_id(request_id: str):  # pragma: no cover - compatibility stub
-    return request_id
-
-
-def reset_request_id(token: str) -> None:  # pragma: no cover - compatibility stub
-    pass
-
-
-__all__ = [
-    "configure_logging",
-    "get_logger",
-    "set_request_id",
-    "reset_request_id",
-]
+__all__ = ["configure_logging", "get_logger"]

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -25,7 +25,7 @@ from .exceptions import (
     ResourceError,
     ToolExecutionError,
 )
-from .logging import get_logger, reset_request_id, set_request_id
+from entity.utils.logging import get_logger
 from .manager import PipelineManager
 from .metrics import MetricsCollector
 from .observability.metrics import MetricsServerManager
@@ -121,7 +121,6 @@ async def execute_stage(
             context = PluginContext(state, registries)
             context.set_current_stage(stage)
             await registries.validators.validate(stage, context)
-            token = set_request_id(state.pipeline_id)
             plugin_name = registries.plugins.get_plugin_name(plugin)
             start_plugin = time.perf_counter()
             try:
@@ -241,8 +240,6 @@ async def execute_stage(
                     error_message=message,
                     original_exception=exc,
                 )
-            finally:
-                reset_request_id(token)
             if state.failure_info:
                 break
         if state.failure_info and stage != PipelineStage.ERROR:


### PR DESCRIPTION
## Summary
- remove compatibility layer from pipeline logging helpers
- call core logging helpers directly
- drop unused request id logic

## Testing
- `poetry run pytest` *(fails: FileNotFoundError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ec354ba0483229055595451fc6abb