### PR TITLE
Remove deprecated registries parameter

### DIFF
--- a/src/entity/core/runtime.py
+++ b/src/entity/core/runtime.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Dict
-import warnings
 
 from .registries import SystemRegistries
 
@@ -14,21 +13,7 @@ class _AgentRuntime:
     capabilities: SystemRegistries
     manager: Any = field(init=False)
 
-    def __init__(
-        self,
-        capabilities: SystemRegistries | None = None,
-        *,
-        registries: SystemRegistries | None = None,
-    ) -> None:
-        if capabilities is None and registries is not None:
-            warnings.warn(
-                "'registries' is deprecated, use 'capabilities' instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            capabilities = registries
-        if capabilities is None:
-            raise TypeError("capabilities is required")
+    def __init__(self, capabilities: SystemRegistries) -> None:
         self.capabilities = capabilities
         self.__post_init__()
 

--- a/src/pipeline/manager.py
+++ b/src/pipeline/manager.py
@@ -8,9 +8,8 @@ removed in a future release.
 """
 
 import asyncio
-from typing import Any, Generic, Optional, TypeVar, cast
+from typing import Generic, TypeVar, cast
 
-import warnings
 
 from entity.core.runtime import _AgentRuntime
 from entity.core.state_logger import StateLogger
@@ -24,20 +23,10 @@ class PipelineManager(Generic[ResultT]):
 
     def __init__(
         self,
-        capabilities: Optional[SystemRegistries] = None,
+        capabilities: SystemRegistries,
         *,
         state_logger: StateLogger | None = None,
-        **kwargs: Any,
     ) -> None:
-        if capabilities is None and "registries" in kwargs:
-            warnings.warn(
-                "'registries' is deprecated, use 'capabilities' instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            capabilities = kwargs.pop("registries")
-        if kwargs:
-            raise TypeError(f"Unexpected arguments: {', '.join(kwargs)}")
         self._runtime = _AgentRuntime(capabilities, state_logger=state_logger)
         self._capabilities = self._runtime.capabilities
 


### PR DESCRIPTION
## Summary
- drop `registries` argument from pipeline executor, runtime and manager
- pass capabilities explicitly

## Testing
- `poetry run pytest` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686ec35846a483229663a22e202d3fef