### PR TITLE
Update legacy workflow test

### DIFF
--- a/tests/integration/test_legacy_workflow_compat.py
+++ b/tests/integration/test_legacy_workflow_compat.py
@@ -15,7 +15,7 @@ class ReplyPlugin(BasePlugin):
 
 @pytest.mark.integration
 def test_legacy_config_without_workflow_executes():
-    builder = _AgentBuilder()
+    builder = AgentBuilder()
     builder.add_plugin(ReplyPlugin({}))
     runtime = builder.build_runtime()
     result = asyncio.run(runtime.run_pipeline("hi"))


### PR DESCRIPTION
## Summary
- update old builder call to use `AgentBuilder`

## Testing
- `poetry run pytest tests/integration/test_legacy_workflow_compat.py -k legacy_config_without_workflow_executes -q` *(fails: ImportError: cannot import name 'AgentBuilder')*

------
https://chatgpt.com/codex/tasks/task_e_686ecc832eec83229d8be04778989597