### PR TITLE
Fix missing imports in integration test

### DIFF
--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -1,6 +1,8 @@
 import asyncio
 
 import pytest
+from entity.core.plugins import BasePlugin
+from pipeline import PipelineStage
 from entity import Agent
 
 


### PR DESCRIPTION
## Summary
- ensure `test_full_pipeline` imports BasePlugin and PipelineStage

## Testing
- `poetry run black tests/integration/test_full_pipeline.py`
- `poetry run pytest tests/integration/test_full_pipeline.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686ecc8147308322b5f24623bf1395ce