### PR TITLE
Fix doc formatting

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1045,4 +1045,5 @@ This architecture maintains your existing stateless execution model while provid
 - .env credential interpolation
 - `ConversationHistory` data schema
 - `MetricsCollector` and telemetry
-- `core` versus `community` plugin separation- Import paths / circular imports
+- `core` versus `community` plugin separation
+- Import paths / circular imports

--- a/architecture/architecture_tasks.md
+++ b/architecture/architecture_tasks.md
@@ -62,5 +62,6 @@
 - **Add structured logging** for stage completion with full context using `StateLogger`
 - **Clean up state serialization utilities** if no longer needed elsewhere
 - **Update `execute_pipeline`** to remove file-based state persistence
-
-### 11. Plugin Execution Order Simplification- **Update plugin registration** to use YAML/list order- **Update documentation** to emphasize execution order through configuration order
+### 11. Plugin Execution Order Simplification
+- **Update plugin registration** to use YAML/list order
+- **Update documentation** to emphasize execution order through configuration order


### PR DESCRIPTION
## Summary
- correct Plugin Execution Order Simplification section formatting
- clean up final bullet list in architecture doc

## Testing
- `poetry run black --check src tests` *(fails: would reformat files)*
- `poetry run isort src tests --check-only` *(fails: imports not sorted)*
- `poetry run flake8 src tests` *(fails: F401, F821, etc.)*
- `poetry run mypy src` *(fails: found 241 errors)*
- `bandit -r src` *(fails: command not found)*
- `python tools/check_empty_dirs.py` *(fails: file not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError)*
- `python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError: 'dotenv')*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError: 'dotenv')*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError: 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError: 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686ef985fcf08322a0caa409bdef5307