### PR TITLE
Remove old state args

### DIFF
--- a/docs/source/state_logging.md
+++ b/docs/source/state_logging.md
@@ -12,4 +12,18 @@ Each entry is saved as JSON Lines with timestamp, pipeline id and stage. Replay 
 poetry run entity-cli replay-log states.jsonl
 ```
 
+
+You can also log states programmatically using :class:`StateLogger`:
+
+```python
+from entity.core.state_logger import StateLogger
+from pipeline.pipeline import execute_pipeline
+
+logger = StateLogger("states.jsonl")
+result = asyncio.run(execute_pipeline("hi", capabilities, state_logger=logger))
+logger.close()
+```
+
+Old `state_file` and `snapshots_dir` parameters were removed. Use the logger instead to capture state transitions.
+
 This prints the stored states with a short delay allowing you to inspect the pipeline flow.

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -15,7 +15,7 @@ from .stages import PipelineStage
 
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
-    from .state import FailureInfo, LLMResponse, PipelineState
+    from entity.core.state import FailureInfo, LLMResponse, PipelineState
 
 __all__ = [
     "PipelineStage",
@@ -55,6 +55,7 @@ __all__ = [
     "Agent",
     "AgentRuntime",
     "Pipeline",
+    "Workflow",
     "execute_with_observability",
 ]
 
@@ -71,8 +72,11 @@ def __getattr__(name: str) -> Any:
         "SystemInitializer",
         "initialization_cleanup_context",
     }:
-        from entity.core.registries import (PluginRegistry, SystemRegistries,
-                                            ToolRegistry)
+        from entity.core.registries import (
+            PluginRegistry,
+            SystemRegistries,
+            ToolRegistry,
+        )
         from entity.core.resources.container import ResourceContainer
 
         from .initializer import (
@@ -94,6 +98,7 @@ def __getattr__(name: str) -> Any:
     heavy_imports = {
         "Agent": "pipeline.agent",
         "Pipeline": "pipeline.workflow",
+        "Workflow": "pipeline.pipeline",
         "execute_pipeline": "pipeline.pipeline",
         "create_default_response": "pipeline.pipeline",
         "create_static_error_response": "pipeline.errors",

--- a/src/pipeline/workflow.py
+++ b/src/pipeline/workflow.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Mapping, Iterable, Optional
+from typing import Iterable, Mapping, Optional
 
 from entity.core.builder import _AgentBuilder
 from entity.core.runtime import AgentRuntime
+from entity.workflows.base import Workflow as BaseWorkflow
+
 from .stages import PipelineStage
 
 WorkflowMapping = Mapping[PipelineStage | str, Iterable[str]]
+
+Workflow = BaseWorkflow
 
 __all__ = ["Pipeline", "Workflow"]
 


### PR DESCRIPTION
## Summary
- clean up state snapshot support in PipelineManager
- drop deprecated registries fallback in execute_pipeline
- expose Workflow and fix workflow module
- document new StateLogger usage

## Testing
- `poetry run black src/pipeline/manager.py src/pipeline/pipeline.py`
- `poetry run isort src/pipeline/manager.py src/pipeline/pipeline.py`
- `poetry run flake8 src/pipeline/__init__.py src/pipeline/manager.py src/pipeline/pipeline.py src/pipeline/workflow.py`
- `poetry run mypy src/pipeline/__init__.py src/pipeline/manager.py src/pipeline/pipeline.py src/pipeline/workflow.py`
- `poetry run bandit -r src`
- `poetry run pytest tests/pipeline -q` *(fails: ModuleNotFoundError: No module named 'pipeline.defaults')*

------
https://chatgpt.com/codex/tasks/task_e_686ef97a210c8322a17465c0fd4b715b