### PR TITLE
Introduce store/load utilities

### DIFF
--- a/docs/source/context.md
+++ b/docs/source/context.md
@@ -4,7 +4,7 @@
 
 - conversation history and other pipeline state
 - registered resources via `get_resource`
-- temporary data with `cache()`, `recall()`, and `has()`
+- temporary data with `store()`, `load()`, and `has()`
 - tool execution through `tool_use()` and `queue_tool_use()`
 - helpers for adding conversation entries
 
@@ -22,7 +22,7 @@ class ExamplePlugin(PromptPlugin):
 
 - `say()` to set the pipeline response
 - `ask_llm()` to call the configured LLM
-- `cache()`, `recall()`, and `has()` for sharing data between stages
+- `store()`, `load()`, and `has()` for sharing data between stages
 - `tool_use()` to run a tool and wait for the result
 - `queue_tool_use()` to defer tool execution until later
 
@@ -30,23 +30,23 @@ class ExamplePlugin(PromptPlugin):
 class MyPrompt(PromptPlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         if context.has("summary"):
-            context.say(context.recall("summary"))
+            context.say(context.load("summary"))
             return
 
         summary = await context.tool_use("summarize", text=context.message)
-        context.cache("summary", summary)
+        context.store("summary", summary)
         context.queue_tool_use("log_summary", {"text": summary})
         context.say(summary)
 ```
 
 ## Stage Results
 
-Use `cache()` to save intermediate data that later stages can retrieve.
+Use `store()` to save intermediate data that later stages can retrieve.
 
 ```python
-context.cache("answer", "The Eiffel Tower is in Paris")
+context.store("answer", "The Eiffel Tower is in Paris")
 if context.has("answer"):
-    result = context.recall("answer")
+    result = context.load("answer")
 ```
 
 ## Advanced API

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -39,17 +39,17 @@ async def weather_plugin(ctx):
     return await ctx.tool_use("weather", city="London")
 ```
 
-Plugins share data through `cache()` and `recall()` and can queue additional
+Plugins share data through `store()` and `load()` and can queue additional
 tool calls:
 
 ```python
 @agent.plugin
 async def summarizer(ctx):
     if ctx.has("summary"):
-        return ctx.recall("summary")
+        return ctx.load("summary")
     result_key = ctx.queue_tool_use("search", {"query": ctx.message})
     summary = await ctx.tool_use("summarize", text=ctx.message)
-ctx.cache("summary", summary)
+ctx.store("summary", summary)
     return summary
 ```
 
@@ -57,7 +57,7 @@ ctx.cache("summary", summary)
 
 Entity provides two prompt plugins for common reasoning patterns:
 
-- `ChainOfThoughtPrompt` records intermediate thoughts and stores them with `context.cache()`.
+- `ChainOfThoughtPrompt` records intermediate thoughts and stores them with `context.store()`.
 - `ReActPrompt` alternates between reasoning and tool use, saving each step under `react_steps`.
 
 Add them in your YAML configuration:

--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -20,4 +20,4 @@ class {class_name}(AdapterPlugin):
 
     async def _execute_impl(self, context):
         if context.has("response"):
-            await context.queue_tool_use("send", {"text": context.recall("response")})
+            await context.queue_tool_use("send", {"text": context.load("response")})

--- a/src/cli/templates/failure.py
+++ b/src/cli/templates/failure.py
@@ -19,4 +19,4 @@ class {class_name}(FailurePlugin):
     # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
-        context.cache("failure_info", context.get_failure_info())
+        context.store("failure_info", context.get_failure_info())

--- a/src/cli/templates/prompt.py
+++ b/src/cli/templates/prompt.py
@@ -20,9 +20,9 @@ class {class_name}(PromptPlugin):
 
     async def _execute_impl(self, context):
         if context.has("answer"):
-            context.say(context.recall("answer"))
+            context.say(context.load("answer"))
             return
 
         result = await context.tool_use("some_tool", query=context.message)
-        context.cache("answer", result)
+        context.store("answer", result)
         context.say(result)

--- a/src/entity/plugins/prompts/chain_of_thought.py
+++ b/src/entity/plugins/prompts/chain_of_thought.py
@@ -49,8 +49,8 @@ class ChainOfThoughtPrompt(PromptPlugin):
             if "final answer" in reasoning.content.lower():
                 break
 
-        context.cache("reasoning_complete", True)
-        context.cache("reasoning_steps", steps)
+        context.store("reasoning_complete", True)
+        context.store("reasoning_steps", steps)
 
     def _needs_tools(self, reasoning_text: str) -> bool:
         indicators = ["need to calculate", "should look up", "requires analysis"]

--- a/src/entity/plugins/prompts/react.py
+++ b/src/entity/plugins/prompts/react.py
@@ -52,7 +52,7 @@ class ReActPrompt(PromptPlugin):
                 answer = decision.content.replace("Final Answer:", "").strip()
                 context.set_response(answer)
                 steps.append(step_record)
-                context.cache("react_steps", steps)
+                context.store("react_steps", steps)
                 return
 
             if decision.content.startswith("Action:"):
@@ -70,7 +70,7 @@ class ReActPrompt(PromptPlugin):
         context.set_response(
             "I've reached my reasoning limit without finding a definitive answer."
         )
-        context.cache("react_steps", steps)
+        context.store("react_steps", steps)
 
     def _build_step_context(
         self, conversation: List[ConversationEntry], question: str

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -8,14 +8,14 @@ class ParsePlugin(BasePlugin):
     stages = [PipelineStage.PARSE]
 
     async def _execute_impl(self, context):
-        context.cache("parsed", True)
+        context.store("parsed", True)
 
 
 class ThinkPlugin(BasePlugin):
     stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context):
-        context.cache("thought", True)
+        context.store("thought", True)
 
 
 class RespondPlugin(BasePlugin):

--- a/tests/integration/test_stage_failures.py
+++ b/tests/integration/test_stage_failures.py
@@ -28,7 +28,7 @@ def make_failing_plugin(stage: PipelineStage):
             if not context.get_metadata("failed"):
                 context.set_metadata("failed", True)
                 raise RuntimeError("boom")
-            context.cache(str(stage), True)
+            context.store(str(stage), True)
 
     return FailingPlugin()
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -87,4 +87,4 @@ async def test_tool_results_are_cached():
     await execute_pending_tools(state, capabilities)
 
     assert tool.calls == 1
-    assert ctx.recall("r1") == ctx.recall("r2")
+    assert ctx.load("r1") == ctx.load("r2")

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -67,8 +67,8 @@ def test_chain_of_thought_records_steps_and_tool_call():
         assistant_entries[1].content == "Reasoning step 1: We need to calculate result"
     )
     assert assistant_entries[2].content == "Reasoning step 2: Final answer is 42"
-    assert ctx.recall("reasoning_complete") is True
-    assert ctx.recall("reasoning_steps") == [
+    assert ctx.load("reasoning_complete") is True
+    assert ctx.load("reasoning_steps") == [
         "We need to calculate result",
         "Final answer is 42",
     ]

--- a/tests/test_execute_pending_tools.py
+++ b/tests/test_execute_pending_tools.py
@@ -41,4 +41,4 @@ def test_execute_pending_tools_returns_mapping_by_result_key():
 
     assert results == {"echo1": "hello"}
     ctx = PluginContext(state, capabilities)
-    assert ctx.recall("echo1") == "hello"
+    assert ctx.load("echo1") == "hello"

--- a/tests/test_intent_classifier_prompt.py
+++ b/tests/test_intent_classifier_prompt.py
@@ -39,7 +39,7 @@ def test_intent_classifier_success():
 
     asyncio.run(plugin.execute(ctx))
 
-    assert ctx.recall("intent") == "greeting"
+    assert ctx.load("intent") == "greeting"
 
 
 def test_intent_classifier_validate_error():

--- a/tests/test_tool_registry_options.py
+++ b/tests/test_tool_registry_options.py
@@ -64,6 +64,6 @@ def test_cache_ttl():
     asyncio.run(execute_pending_tools(state, capabilities))
     assert tool.calls == 1
     ctx = PluginContext(state, capabilities)
-    assert ctx.recall("b") == 0
+    assert ctx.load("b") == 0
     key = f"{PipelineStage.DO}:sleep"
     assert key in state.metrics.tool_durations

--- a/user_plugins/prompts/chain_of_thought.py
+++ b/user_plugins/prompts/chain_of_thought.py
@@ -54,8 +54,8 @@ class ChainOfThoughtPrompt(PromptPlugin):
             if "final answer" in reasoning.content.lower():
                 break
 
-        context.cache("reasoning_complete", True)
-        context.cache("reasoning_steps", reasoning_steps)
+        context.store("reasoning_complete", True)
+        context.store("reasoning_steps", reasoning_steps)
 
     def _needs_tools(self, reasoning_text: str) -> bool:
         """Return True if ``reasoning_text`` suggests tool usage."""

--- a/user_plugins/prompts/intent_classifier.py
+++ b/user_plugins/prompts/intent_classifier.py
@@ -35,4 +35,4 @@ class IntentClassifierPrompt(PromptPlugin):
         last_message = context.conversation()[-1].content
         prompt = "Classify the user's intent in one word.\n" f"Message: {last_message}"
         response = await self.call_llm(context, prompt, purpose="intent_classification")
-        context.cache("intent", response.content)
+        context.store("intent", response.content)


### PR DESCRIPTION
## Summary
- add `store`, `load`, and `has` methods for stage results
- switch plugins and pipeline utilities to the new helpers
- update docs and template examples
- adjust tests for the new API

## Testing
- `poetry run flake8 src tests` *(fails: F401, F821, E501 and others)*
- `poetry run mypy src` *(fails: found 240 errors)*
- `bandit -r src` *(fails: command not found)*
- `python tools/check_empty_dirs.py` *(fails: file not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686ef961eb24832285c0ce17342f815e