### PR TITLE
docs: correct architecture references

### DIFF
--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -1,6 +1,6 @@
 # Component Overview
 
-This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](../../architecture/overview.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](../../config/dev.yaml).
+This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](../../architecture/general.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](../../config/dev.yaml).
 
 ## Pipelines and Stages
 
@@ -62,7 +62,7 @@ Multiple adapters may run during the `deliver` stage. Each adapter receives the 
 
 ## Putting It Together
 
-Pipelines, plugins, and adapters form the execution engine. Resources supply capabilities like LLMs, memory, and storage. The [architecture document](../../architecture/overview.md) shows how these pieces fit together.
+Pipelines, plugins, and adapters form the execution engine. Resources supply capabilities like LLMs, memory, and storage. The [architecture document](../../architecture/general.md) shows how these pieces fit together.
 
 ## Agent, Builder, and Runtime
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -22,7 +22,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [Workflows](workflows.md)
 
 ### Architecture
-- [Architecture overview](../../architecture/overview.md)
+- [Architecture overview](../../architecture/general.md)
 - [Components overview](components_overview.md)
 - [Deliver-stage adapters](components_overview.md#deliver-stage-adapters)
 


### PR DESCRIPTION
## Summary
- fix architecture links in Components and index docs

## Testing
- `poetry run black .`
- `poetry run pytest -q` *(fails: FileNotFoundError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_686f0d9df9108322b65fe09cb4b5a9ef