### PR TITLE
docs: correct autodoc package path

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,4 +38,4 @@ html_static_path = ["_static"]
 
 # https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html
 # autoapi_dirs = ['../../entity']
-autodoc2_packages = ["../entity"]
+autodoc2_packages = ["../../src/entity"]


### PR DESCRIPTION
## Summary
- fix autodoc2 path in Sphinx config
- silence Sphinx static path warning by adding `_static` directory

## Testing
- `poetry run pytest -q` *(fails: FileNotFoundError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_686f0d9c14548322ab7a653e93bc69aa