### PR TITLE
Update docs headings

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -1,8 +1,4 @@
-```{include} ../../README.md
-:relative-images:
-:start-after: <!-- start advanced_usage -->
-:end-before: <!-- end advanced_usage -->
-```
+# Advanced Usage
 
 ### Composing Storage Backends
 

--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -1,8 +1,4 @@
-```{include} ../../README.md
-:relative-images:
-:start-after: <!-- start config -->
-:end-before: <!-- end config -->
-```
+# Configuration
 
 Only parameter updates can be reloaded at runtime. Any addition or removal of
 plugins or resources requires restarting the agent.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -2,12 +2,6 @@
 
 Welcome to the Entity Pipeline framework. These pages explain how to configure an agent, write plugins, and deploy the system.
 
-```{include} ../../README.md
-:relative-images:
-:start-after: <!-- start quick_start -->
-:end-before: <!-- end quick_start -->
-```
-
 ## Documentation Map
 
 ### Getting Started

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -1,8 +1,4 @@
-```{include} ../../README.md
-:relative-images:
-:start-after: <!-- start quick_start -->
-:end-before: <!-- end quick_start -->
-```
+# Quick Start
 
 ### CLI Usage
 Run an agent from a YAML configuration file:


### PR DESCRIPTION
## Summary
- remove README includes from docs
- add new H1 headings for Quick Start, Configuration, and Advanced Usage

## Testing
- `poetry run pytest tests/test_agent.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686f0d9a494483229a65dafbaed75bed