### PR TITLE
Fix docs links

### DIFF
--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -1,6 +1,6 @@
 # Component Overview
 
-This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](../../architecture/overview.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](../../config/dev.yaml).
+This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](https://github.com/Ladvien/entity/blob/main/architecture/general.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](https://github.com/Ladvien/entity/blob/main/config/dev.yaml).
 
 ## Pipelines and Stages
 
@@ -62,7 +62,7 @@ Multiple adapters may run during the `deliver` stage. Each adapter receives the 
 
 ## Putting It Together
 
-Pipelines, plugins, and adapters form the execution engine. Resources supply capabilities like LLMs, memory, and storage. The [architecture document](../../architecture/overview.md) shows how these pieces fit together.
+Pipelines, plugins, and adapters form the execution engine. Resources supply capabilities like LLMs, memory, and storage. The [architecture document](https://github.com/Ladvien/entity/blob/main/architecture/general.md) shows how these pieces fit together.
 
 ## Agent, Builder, and Runtime
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -22,7 +22,7 @@ Welcome to the Entity Pipeline framework. These pages explain how to configure a
 - [Workflows](workflows.md)
 
 ### Architecture
-- [Architecture overview](../../architecture/overview.md)
+- [Architecture overview](https://github.com/Ladvien/entity/blob/main/architecture/general.md)
 - [Components overview](components_overview.md)
 - [Deliver-stage adapters](components_overview.md#deliver-stage-adapters)
 

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -183,7 +183,7 @@ Several example pipelines once lived in ``user_plugins/examples`` to showcase mo
 
 ### StorageResource Composition
 
-`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. Memory persists conversation history and vectors and is configured in [config/dev.yaml](../../config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. With the plugin configured the code looks like:
+`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. Memory persists conversation history and vectors and is configured in [config/dev.yaml](https://github.com/Ladvien/entity/blob/main/config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. With the plugin configured the code looks like:
 
 ```python
 resources = ResourceContainer()

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -76,7 +76,7 @@ poetry run entity-cli reload-config updated.yaml
 Only updates to plugin parameters can be reloaded. Structural changes—adding or
 removing plugins, changing stage assignments, or altering dependencies—require a
 restart. For more on dynamic configuration see the
-[architecture overview](../../architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure).
+[architecture overview](https://github.com/Ladvien/entity/blob/main/architecture/general.md#%F0%9F%94%84-reconfigurable-agent-infrastructure).
 
 ### Using the "llm" Resource Key
 Configure a shared LLM resource in YAML:

--- a/tests/performance/test_full_pipeline_benchmark.py
+++ b/tests/performance/test_full_pipeline_benchmark.py
@@ -3,8 +3,13 @@ import asyncio
 import pytest
 
 from entity.core.resources.container import ResourceContainer
-from pipeline import (PipelineStage, PluginRegistry, SystemRegistries,
-                      ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 
 
 class RespondPlugin:

--- a/tests/performance/test_pipeline_benchmark.py
+++ b/tests/performance/test_pipeline_benchmark.py
@@ -3,8 +3,14 @@ import asyncio
 import pytest
 
 from entity.core.resources.container import ResourceContainer
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 
 
 class NoOpPlugin(PromptPlugin):

--- a/tests/test_cli_adapter.py
+++ b/tests/test_cli_adapter.py
@@ -4,8 +4,13 @@ from typing import Any
 
 from entity.core.resources.container import ResourceContainer
 from entity.core.runtime import _AgentRuntime
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from plugins.builtin.adapters.cli import CLIAdapter
 
 

--- a/tests/test_config_update.py
+++ b/tests/test_config_update.py
@@ -1,9 +1,16 @@
 import asyncio
 
 from entity.core.resources.container import ResourceContainer
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, ValidationResult,
-                      execute_pipeline, update_plugin_configuration)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    ValidationResult,
+    execute_pipeline,
+    update_plugin_configuration,
+)
 
 
 class TestReconfigPlugin(PromptPlugin):

--- a/tests/test_dashboard_adapter.py
+++ b/tests/test_dashboard_adapter.py
@@ -6,8 +6,13 @@ import httpx
 
 from entity.core.resources.container import ResourceContainer
 from entity.core.runtime import _AgentRuntime
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from plugins.builtin.adapters import DashboardAdapter
 
 

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -4,8 +4,13 @@ import httpx
 
 from entity.core.resources.container import ResourceContainer
 from entity.core.runtime import _AgentRuntime
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from plugins.builtin.adapters import HTTPAdapter
 
 

--- a/tests/test_logging_adapter.py
+++ b/tests/test_logging_adapter.py
@@ -3,8 +3,14 @@ import logging
 
 from entity.core.resources.container import ResourceContainer
 from entity.core.runtime import _AgentRuntime
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry, execute_pipeline)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+    execute_pipeline,
+)
 
 
 class LoggingAdapter(PromptPlugin):

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -4,8 +4,13 @@ from fastapi.testclient import TestClient
 
 from entity.core.resources.container import ResourceContainer
 from entity.core.runtime import _AgentRuntime
-from pipeline import (PipelineStage, PluginRegistry, PromptPlugin,
-                      SystemRegistries, ToolRegistry)
+from pipeline import (
+    PipelineStage,
+    PluginRegistry,
+    PromptPlugin,
+    SystemRegistries,
+    ToolRegistry,
+)
 from plugins.builtin.adapters import WebSocketAdapter
 
 


### PR DESCRIPTION
## Summary
- link to architecture docs with GitHub URLs
- fix reference to config/dev.yaml
- format Python files

## Testing
- `poetry run black .`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686f0da31eec832288b6eb5466862a0f