### PR TITLE
Add drag-and-drop plugin visualizer

### DIFF
--- a/docs/source/_static/plugin_visualizer.css
+++ b/docs/source/_static/plugin_visualizer.css
@@ -1,0 +1,19 @@
+.pipeline {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.stage {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  width: 200px;
+}
+
+.plugin {
+  background: #f7f7f7;
+  border: 1px solid #ddd;
+  margin: 0.25rem 0;
+  padding: 0.25rem;
+  cursor: move;
+}

--- a/docs/source/_static/plugin_visualizer.js
+++ b/docs/source/_static/plugin_visualizer.js
@@ -1,0 +1,94 @@
+var PluginVisualizer = (() => {
+  var __create = Object.create;
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __getProtoOf = Object.getPrototypeOf;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
+    get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
+  }) : x)(function(x) {
+    if (typeof require !== "undefined") return require.apply(this, arguments);
+    throw Error('Dynamic require of "' + x + '" is not supported');
+  });
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+    // If the importer is in node compatibility mode or this is not an ESM
+    // file that has been converted to a CommonJS file using a Babel-
+    // compatible transform (i.e. "__esModule" has not been set), then set
+    // "default" to the CommonJS "module.exports" for node compatibility.
+    isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+    mod
+  ));
+  var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+  // docs/src/components/PluginVisualizer.tsx
+  var PluginVisualizer_exports = {};
+  __export(PluginVisualizer_exports, {
+    initVisualizer: () => initVisualizer
+  });
+  var import_react = __toESM(__require("react"));
+  var import_client = __toESM(__require("react-dom/client"));
+  var defaultPipeline = {
+    SETUP: ["LoadConfig", "InitMemory"],
+    DO: ["Reason", "Plan"],
+    DELIVER: ["Respond"]
+  };
+  var PluginVisualizer = () => {
+    const [pipeline, setPipeline] = (0, import_react.useState)(defaultPipeline);
+    const [dragInfo, setDragInfo] = (0, import_react.useState)(null);
+    const handleDragStart = (stage, index) => (e) => {
+      setDragInfo({ stage, index });
+      e.dataTransfer.effectAllowed = "move";
+    };
+    const handleDrop = (stage, index) => (e) => {
+      e.preventDefault();
+      if (!dragInfo) return;
+      const plugin = pipeline[dragInfo.stage][dragInfo.index];
+      const newPipeline = { ...pipeline };
+      newPipeline[dragInfo.stage] = newPipeline[dragInfo.stage].filter((_, i) => i !== dragInfo.index);
+      if (index === void 0) {
+        newPipeline[stage].push(plugin);
+      } else {
+        newPipeline[stage].splice(index, 0, plugin);
+      }
+      setPipeline(newPipeline);
+      setDragInfo(null);
+    };
+    const handleDragOver = (e) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+    };
+    return /* @__PURE__ */ import_react.default.createElement("div", { className: "pipeline" }, Object.entries(pipeline).map(([stage, plugins]) => /* @__PURE__ */ import_react.default.createElement("div", { key: stage, className: "stage", onDragOver: handleDragOver, onDrop: handleDrop(stage) }, /* @__PURE__ */ import_react.default.createElement("h3", null, stage), plugins.map((plugin, index) => /* @__PURE__ */ import_react.default.createElement(
+      "div",
+      {
+        key: `${stage}-${plugin}-${index}`,
+        className: "plugin",
+        draggable: true,
+        onDragStart: handleDragStart(stage, index),
+        onDrop: handleDrop(stage, index),
+        onDragOver: handleDragOver
+      },
+      plugin
+    )))));
+  };
+  function initVisualizer(elementId) {
+    const container = document.getElementById(elementId);
+    if (!container) return;
+    const root = import_client.default.createRoot(container);
+    root.render(/* @__PURE__ */ import_react.default.createElement(PluginVisualizer, null));
+  }
+  initVisualizer("plugin-visualizer");
+  return __toCommonJS(PluginVisualizer_exports);
+})();

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,6 +19,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",  # Adds links to different sections of document
     "autodoc2",
     "sphinxcontrib.mermaid",
+    "plugin_visualizer_extension",
 ]
 
 

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -239,4 +239,9 @@ When implementing custom error handling, see the failure plugin template at
 - **Missing dependency** – ensure the plugin name appears in `plugins.resources` or `plugins.tools`.
 - **Runtime errors** – run with `LOG_LEVEL=DEBUG` to see the full traceback.
 
+## Visualize Plugin Pipeline
+The following widget lets you experiment with plugin ordering across stages.
+
+.. plugin-visualizer::
+
 

--- a/docs/source/plugin_visualizer_extension.py
+++ b/docs/source/plugin_visualizer_extension.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from sphinx.application import Sphinx
+
+
+class PluginVisualizerDirective(Directive):
+    has_content = False
+
+    def run(self) -> list[nodes.Node]:
+        return [nodes.raw("", '<div id="plugin-visualizer"></div>', format="html")]
+
+
+def setup(app: Sphinx) -> dict[str, str | bool | int]:
+    app.add_js_file("https://unpkg.com/react@18/umd/react.development.js")
+    app.add_js_file("https://unpkg.com/react-dom@18/umd/react-dom.development.js")
+    app.add_css_file("plugin_visualizer.css")
+    app.add_js_file("plugin_visualizer.js")
+    app.add_directive("plugin-visualizer", PluginVisualizerDirective)
+    return {"version": "0.1"}

--- a/docs/src/components/PluginVisualizer.tsx
+++ b/docs/src/components/PluginVisualizer.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom/client';
+
+interface Pipeline {
+  [stage: string]: string[];
+}
+
+const defaultPipeline: Pipeline = {
+  SETUP: ['LoadConfig', 'InitMemory'],
+  DO: ['Reason', 'Plan'],
+  DELIVER: ['Respond'],
+};
+
+interface DragInfo {
+  stage: string;
+  index: number;
+}
+
+const PluginVisualizer: React.FC = () => {
+  const [pipeline, setPipeline] = useState<Pipeline>(defaultPipeline);
+  const [dragInfo, setDragInfo] = useState<DragInfo | null>(null);
+
+  const handleDragStart = (stage: string, index: number) => (e: React.DragEvent<HTMLDivElement>) => {
+    setDragInfo({ stage, index });
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDrop = (stage: string, index?: number) => (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (!dragInfo) return;
+    const plugin = pipeline[dragInfo.stage][dragInfo.index];
+    const newPipeline: Pipeline = { ...pipeline };
+    newPipeline[dragInfo.stage] = newPipeline[dragInfo.stage].filter((_, i) => i !== dragInfo.index);
+    if (index === undefined) {
+      newPipeline[stage].push(plugin);
+    } else {
+      newPipeline[stage].splice(index, 0, plugin);
+    }
+    setPipeline(newPipeline);
+    setDragInfo(null);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  };
+
+  return (
+    <div className="pipeline">
+      {Object.entries(pipeline).map(([stage, plugins]) => (
+        <div key={stage} className="stage" onDragOver={handleDragOver} onDrop={handleDrop(stage)}>
+          <h3>{stage}</h3>
+          {plugins.map((plugin, index) => (
+            <div
+              key={`${stage}-${plugin}-${index}`}
+              className="plugin"
+              draggable
+              onDragStart={handleDragStart(stage, index)}
+              onDrop={handleDrop(stage, index)}
+              onDragOver={handleDragOver}
+            >
+              {plugin}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export function initVisualizer(elementId: string): void {
+  const container = document.getElementById(elementId);
+  if (!container) return;
+  const root = ReactDOM.createRoot(container);
+  root.render(<PluginVisualizer />);
+}
+
+initVisualizer('plugin-visualizer');


### PR DESCRIPTION
## Summary
- create `PluginVisualizer` React component
- integrate the widget into the docs via a Sphinx extension
- embed the visualizer on the plugin guide page

## Testing
- `poetry run black .`
- `poetry run pytest -m "not integration" -v` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_686f11eb516c83229c1394a6425ee6ef