### PR TITLE
Add architecture diagrams to docs

### DIFF
--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -28,6 +28,9 @@ be overridden by passing a different value for `max_iterations` to
 Every resource is registered under a single name so configuration remains small
 and mental models stay easy to grasp.
 
+## Plugin Lifecycle and Pipeline Stages
+.. mermaid:: diagrams/plugin_lifecycle.mmd
+
 ## Design Principles
 1. Progressive disclosure: simple things stay simple, complex things are possible
 2. Async-first with predictable execution order. YAML order determines plugin execution.
@@ -46,15 +49,8 @@ standard input and output.
 For additional diagrams and examples see the ADRs in `docs/adr/`.
 
 ## Framework Overview Diagram
-```mermaid
-flowchart LR
-    A[User Input] --> B[Input Adapter]
-    B --> C[Processing Pipeline]
-    C --> D[Resource Container]
-    C --> E[Tool Registry]
-    C --> F[Plugins]
-    C --> G[Response]
-```
+.. mermaid:: diagrams/overall_architecture.mmd
+
 
 ## Benchmark Results
 The performance suite currently fails to run due to circular import errors.

--- a/docs/source/deploy_production.md
+++ b/docs/source/deploy_production.md
@@ -4,6 +4,8 @@ This document describes a minimal production setup for running the Entity Pipeli
 It assumes you already tested your configuration locally and want to move it to a
 reliable environment. Provide your own `Dockerfile` for building the image.
 
+.. mermaid:: diagrams/deployment_patterns.mmd
+
 ## Container Image
 
 Build a Docker image containing your plugins and configuration:

--- a/docs/source/dev_to_production.md
+++ b/docs/source/dev_to_production.md
@@ -3,6 +3,9 @@
 Use the same configuration file from your laptop to the cloud. Start locally,
 containerize when ready, then deploy to AWS.
 
+## Deployment Patterns
+.. mermaid:: diagrams/deployment_patterns.mmd
+
 ## 1. Local prototyping
 
 Install dependencies and run the agent:

--- a/docs/source/diagrams/deployment_patterns.mmd
+++ b/docs/source/diagrams/deployment_patterns.mmd
@@ -1,0 +1,4 @@
+flowchart TB
+    Local[Local Machine] --> Docker[Docker Container]
+    Docker --> Cloud[Cloud Service]
+    Cloud --> Scale[Scaled Production]

--- a/docs/source/diagrams/overall_architecture.mmd
+++ b/docs/source/diagrams/overall_architecture.mmd
@@ -1,0 +1,14 @@
+flowchart TD
+    User((User)) --> |input| Adapter[Input Adapter]
+    Adapter --> Pipeline[Processing Pipeline]
+    Pipeline --> Resources[Resource Container]
+    Pipeline --> Tools[Tool Registry]
+    Pipeline --> Plugins[Plugins]
+    Pipeline --> Stages{Pipeline Stages}
+    Stages --> Parse[Parse]
+    Stages --> Think[Think]
+    Stages --> Do[Do]
+    Stages --> Review[Review]
+    Stages --> Deliver[Deliver]
+    Stages --> Error[Error]
+    Deliver --> Output((Response))

--- a/docs/source/diagrams/plugin_lifecycle.mmd
+++ b/docs/source/diagrams/plugin_lifecycle.mmd
@@ -1,0 +1,9 @@
+flowchart LR
+    Init[Agent Startup] --> Load[Load Plugins]
+    Load --> Validate[Validate Configuration]
+    Validate --> Parse[Run Parse Stage]
+    Parse --> Think[Run Think Stage]
+    Think --> Do[Run Do Stage]
+    Do --> Review[Run Review Stage]
+    Review --> Deliver[Run Deliver Stage]
+    Deliver --> Teardown[Teardown Plugins]


### PR DESCRIPTION
## Summary
- show architecture and plugin lifecycle diagrams in docs
- illustrate deployment patterns

## Testing
- `poetry run black src tests`
- `poetry run pytest -m "not integration" -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686f11eac5c08322875f8d8777a6e283