### PR TITLE
Fix developer examples doc

### DIFF
--- a/docs/source/developer_examples.md
+++ b/docs/source/developer_examples.md
@@ -1,7 +1,29 @@
 # Developer Examples
 
-The repository previously included a set of demonstration scripts under
-``user_plugins/examples``. Those examples have been removed to simplify the code
-base, but the documentation still references them for historical context.
+This project no longer bundles the old `user_plugins/examples` directory. The docs now include a minimal example so you can experiment quickly.
 
+## Minimal Pipeline
+
+Create a simple agent that echoes input back through the HTTP adapter:
+
+```python
+from entity.core.agent import Agent
+from plugins.builtin.adapters.http import HTTPAdapter
+from plugins.builtin.prompts.echo import EchoPrompt
+
+agent = Agent()
+agent.add_plugin(EchoPrompt())
+agent.add_plugin(HTTPAdapter(stages=["parse", "deliver"]))
+
+if __name__ == "__main__":
+    agent.run()
+```
+
+Run the agent with:
+
+```bash
+poetry run python src/main.py
+```
+
+For additional pipeline recipes, see the example projects linked in the README.
 

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -179,7 +179,7 @@ methods, enabling a consistent storage interface across resources.
 
 ## Example Pipelines
 
-Several example pipelines once lived in ``user_plugins/examples`` to showcase more advanced patterns.
+Additional pipelines are available in a dedicated examples repository.
 
 ### StorageResource Composition
 
@@ -222,7 +222,7 @@ Those scripts were good starting points when designing plugins. One example show
 
 ### Adapter and Failure Examples
 
-Short examples also demonstrated adapter usage and basic failure handling.
+Other examples cover adapter usage and basic failure handling.
 They exposed an ``Agent`` through a command line interface. Use ``entity-cli``
 to run the agent interactively or over a WebSocket connection:
 


### PR DESCRIPTION
## Summary
- update developer examples doc to include a minimal code snippet
- remove stale references to `user_plugins/examples` from the plugin guide

## Testing
- `poetry install --with dev`
- `poetry run poe test` *(fails: FileNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686f11e8f1c08322a57a3733e025464b