### PR TITLE
Add plugin marketplace docs and CLI stub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Here’s a cleaned-up and deduplicated version of your `CONTRIBUTING.md` section
 
 Thank you for helping improve the Entity Pipeline Framework!
 
+See [Contribution Guidelines](docs/source/contribution_guidelines.md) for project standards.
+
 Start by setting up your development environment:
 
 ```bash

--- a/docs/source/contribution_guidelines.md
+++ b/docs/source/contribution_guidelines.md
@@ -1,0 +1,18 @@
+# Contribution Guidelines
+
+These guidelines help keep the codebase consistent and maintainable.
+
+## Coding Standards
+- Format all Python files with `black`.
+- Keep classes small and focused on a single responsibility.
+- Favor clear names and straightforward control flow.
+
+## Development Workflow
+- Install dependencies with `poetry install --with dev`.
+- Run the quality checks listed in `CONTRIBUTING.md` before committing.
+- Add tests for new features or bug fixes.
+
+## Code Review
+- Explain the purpose of your change in the pull request description.
+- Respond to review feedback promptly.
+- Remove obsolete code rather than leaving it commented out.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -46,6 +46,8 @@ config
 config_cheatsheet
 plugin_cheatsheet
 plugin_guide
+plugin_marketplace
+contribution_guidelines
 developer_examples
 workflows
 context

--- a/docs/source/plugin_marketplace.md
+++ b/docs/source/plugin_marketplace.md
@@ -1,0 +1,19 @@
+# Plugin Marketplace
+
+The plugin marketplace lets developers share and discover plugins for the Entity framework.
+
+## Sharing Plugins
+- Package your plugin with a standard `pyproject.toml` and upload it to the community registry.
+- Include usage examples and a detailed description so others know what your plugin does.
+
+## Installing from the Marketplace
+- Use `pip install your-plugin` or future `entity-cli` commands to add a plugin to your project.
+- Installed packages can then be referenced in your configuration just like local plugins.
+
+## Rating and Reviews
+- Marketplace users can rate plugins on a five-star scale and leave feedback.
+- Ratings help highlight well-maintained plugins and signal potential issues.
+
+## Searching the Marketplace
+- A planned command `entity-cli search-plugin <name>` will query the registry and list matching plugins.
+- The command will print each plugin's description and average rating.

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -64,6 +64,8 @@ class EntityCLI:
         sub.add_parser("run", help="Start the agent")
         sub.add_parser("serve-websocket", help="Start the agent via WebSocket")
         sub.add_parser("verify", help="Load plugins and exit")
+        search = sub.add_parser("search-plugin", help="Search the plugin marketplace")
+        search.add_argument("name")
         replay = sub.add_parser("replay-log", help="Replay a state log file")
         replay.add_argument("file")
         reload_p = sub.add_parser(
@@ -149,6 +151,9 @@ class EntityCLI:
         if cmd == "verify":
             assert self.args.config is not None
             return self._verify_plugins(self.args.config)
+        if cmd == "search-plugin":
+            assert self.args.name is not None
+            return self._search_plugin(self.args.name)
         if cmd == "workflow":
             return self._handle_workflow()
         if cmd == "replay-log":
@@ -310,6 +315,11 @@ class EntityCLI:
         if not found:
             logger.error("No async plugin functions found in %s", path)
             return 1
+        return 0
+
+    def _search_plugin(self, name: str) -> int:
+        """Placeholder for future plugin marketplace search."""
+        logger.info("search-plugin '%s' is not implemented yet", name)
         return 0
 
     @staticmethod


### PR DESCRIPTION
## Summary
- document plugin marketplace usage
- define contribution guidelines
- link guidelines from CONTRIBUTING
- add placeholder `search-plugin` CLI command

## Testing
- `poetry run black .`
- `poetry run pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686f11f11838832287c44d421896d206