### PR TITLE
Implement create-agent CLI command

### DIFF
--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -7,6 +7,13 @@ Run an agent from a YAML configuration file:
 entity-cli --config config.yaml
 ```
 
+Scaffold a minimal agent project:
+
+```bash
+entity-cli create-agent my_agent
+cd my_agent && python src/main.py
+```
+
 ### Programmatic Configuration
 Build the same configuration in Python using the models from
 `entity.config`:

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,6 +1,13 @@
 """Compatibility imports for the unified CLI."""
 
-from entity.cli import EntityCLI as CLI, main
+from importlib import import_module
+
+
+def __getattr__(name: str):
+    if name in {"CLI", "main"}:
+        module = import_module("entity.cli")
+        return module.EntityCLI if name == "CLI" else module.main
+    raise AttributeError(name)
 
 
 __all__ = ["CLI", "main"]

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional, cast, Mapping, Iterable
 
 from .builder import _AgentBuilder
-from .exceptions import PipelineError
+from pipeline.exceptions import PipelineError
 from .registries import PluginRegistry, SystemRegistries
 from .runtime import AgentRuntime
 from pipeline.workflow import Pipeline, WorkflowMapping

--- a/tests/test_cli_create_agent.py
+++ b/tests/test_cli_create_agent.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+import yaml
+
+
+def test_create_agent(tmp_path):
+    dest = tmp_path / "agent"
+    result = subprocess.run(
+        [sys.executable, "-m", "entity.cli", "create-agent", str(dest)],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert (dest / "src" / "main.py").exists()
+    config_path = dest / "config" / "dev.yaml"
+    assert config_path.exists()
+    cfg = yaml.safe_load(config_path.read_text())
+    assert cfg["server"]["port"] == 8000


### PR DESCRIPTION
## Summary
- add lazy imports in `cli` package to avoid circular import
- update `EntityCLI` with `create-agent` command
- fix agent module path
- scaffold new agent projects via CLI
- document create-agent usage in quick start
- add tests for new command

## Testing
- `poetry run pytest tests/test_cli_entrypoint.py tests/test_cli_create_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_686f11e880bc8322bea7ced374f44f5e