### PR TITLE
Add runnable agent examples

### DIFF
--- a/docs/source/developer_examples.md
+++ b/docs/source/developer_examples.md
@@ -1,7 +1,13 @@
 # Developer Examples
 
-The repository previously included a set of demonstration scripts under
-``user_plugins/examples``. Those examples have been removed to simplify the code
-base, but the documentation still references them for historical context.
+This repository ships a few self-contained example agents under ``examples/``.
+
+| Example | Description |
+| ------- | ----------- |
+| ``basic_agent`` | Minimal echo agent |
+| ``intermediate_agent`` | Chain-of-thought reasoning with an echo LLM |
+| ``advanced_agent`` | ReAct loop using the calculator tool |
+
+Run any example with ``poetry run python examples/<name>/main.py``.
 
 

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -7,6 +7,9 @@ Run an agent from a YAML configuration file:
 entity-cli --config config.yaml
 ```
 
+Ready-made agents live in the new `examples/` directory. Run them with
+`poetry run python examples/<name>/main.py` to see the framework in action.
+
 ### Programmatic Configuration
 Build the same configuration in Python using the models from
 `entity.config`:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Example Agents
+
+Each subdirectory contains a small agent showcasing a different feature level.
+
+- **basic_agent** – echoes the user's message.
+- **intermediate_agent** – runs a chain-of-thought prompt with an echo LLM.
+- **advanced_agent** – demonstrates a ReAct loop with tool usage.
+
+Run any example with:
+
+```bash
+poetry run python examples/<name>/main.py
+```

--- a/examples/advanced_agent/README.md
+++ b/examples/advanced_agent/README.md
@@ -1,0 +1,7 @@
+# Advanced Agent
+
+This example demonstrates a ReAct-style loop with the built-in calculator tool.
+
+```bash
+poetry run python examples/advanced_agent/main.py
+```

--- a/examples/advanced_agent/main.py
+++ b/examples/advanced_agent/main.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from user_plugins.tools.calculator_tool import CalculatorTool
+from entity.core.plugins import PromptPlugin, ResourcePlugin
+from entity.core.context import PluginContext
+from pipeline.stages import PipelineStage
+from datetime import datetime
+
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.resources.container import ResourceContainer
+from pipeline.pipeline import execute_pipeline, generate_pipeline_id
+from pipeline.state import ConversationEntry, MetricsCollector, PipelineState
+
+
+class EchoLLMResource(ResourcePlugin):
+    """LLM resource that echoes the prompt."""
+
+    async def generate(self, prompt: str) -> Any:
+        return {"content": prompt}
+
+
+class ReActPrompt(PromptPlugin):
+    """Very small ReAct style prompt."""
+
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        question = next(
+            (e.content for e in context.conversation() if e.role == "user"), ""
+        )
+        tool_result = await context.tool_use("calc", expression="2+2")
+        context.say(f"Thinking about {question} using tool result {tool_result}")
+
+
+class FinalResponder(PromptPlugin):
+    """Return the last assistant message."""
+
+    stages = [PipelineStage.DELIVER]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        assistant = [e.content for e in context.conversation() if e.role == "assistant"]
+        context.set_response(assistant[-1] if assistant else "")
+
+
+async def main() -> None:
+    resources = ResourceContainer()
+    resources.register("llm", EchoLLMResource, {})
+    await resources.build_all()
+
+    tools = ToolRegistry()
+    await tools.add("calc", CalculatorTool())
+
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(
+        ReActPrompt({"max_steps": 2}), PipelineStage.THINK, "react"
+    )
+    await plugins.register_plugin_for_stage(
+        FinalResponder(), PipelineStage.DELIVER, "final"
+    )
+
+    caps = SystemRegistries(resources=resources, tools=tools, plugins=plugins)
+
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(
+                content="What is 2 + 2?", role="user", timestamp=datetime.now()
+            )
+        ],
+        pipeline_id=generate_pipeline_id(),
+        metrics=MetricsCollector(),
+    )
+    result: dict[str, Any] = await execute_pipeline("What is 2 + 2?", caps, state=state)
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/basic_agent/README.md
+++ b/examples/basic_agent/README.md
@@ -1,0 +1,7 @@
+# Basic Agent
+
+This minimal example echoes whatever the user says.
+
+```bash
+poetry run python examples/basic_agent/main.py
+```

--- a/examples/basic_agent/main.py
+++ b/examples/basic_agent/main.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from pathlib import Path
+import sys
+
+from entity.core.plugins import PromptPlugin
+from entity.core.context import PluginContext
+from pipeline.stages import PipelineStage
+from datetime import datetime
+
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.resources.container import ResourceContainer
+from pipeline.pipeline import execute_pipeline, generate_pipeline_id
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from pipeline.state import ConversationEntry, MetricsCollector, PipelineState
+
+
+class EchoPrompt(PromptPlugin):
+    """Return the last user message."""
+
+    stages = [PipelineStage.DELIVER]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        last_message = ""
+        for entry in reversed(context.conversation()):
+            if entry.role == "user":
+                last_message = entry.content
+                break
+        context.set_response(f"You said: {last_message}")
+
+
+async def main() -> None:
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(EchoPrompt(), PipelineStage.DELIVER, "echo")
+
+    resources = ResourceContainer()
+    await resources.build_all()
+
+    caps = SystemRegistries(resources=resources, tools=ToolRegistry(), plugins=plugins)
+
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(content="Hello", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id=generate_pipeline_id(),
+        metrics=MetricsCollector(),
+    )
+    result: dict[str, Any] = await execute_pipeline("Hello", caps, state=state)
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/intermediate_agent/README.md
+++ b/examples/intermediate_agent/README.md
@@ -1,0 +1,7 @@
+# Intermediate Agent
+
+This example uses a simple chain-of-thought prompt and an echo LLM resource.
+
+```bash
+poetry run python examples/intermediate_agent/main.py
+```

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from pathlib import Path
+import sys
+
+from entity.core.plugins import PromptPlugin, ResourcePlugin
+from entity.core.context import PluginContext
+from pipeline.stages import PipelineStage
+from datetime import datetime
+
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.resources.container import ResourceContainer
+from pipeline.pipeline import execute_pipeline, generate_pipeline_id
+from pipeline.state import ConversationEntry, MetricsCollector, PipelineState
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+
+class EchoLLMResource(ResourcePlugin):
+    """LLM resource that echoes the prompt."""
+
+    async def generate(self, prompt: str) -> Any:
+        return {"content": prompt}
+
+
+class ChainOfThoughtPrompt(PromptPlugin):
+    """Simple reasoning plugin."""
+
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        user = next((e.content for e in context.conversation() if e.role == "user"), "")
+        context.say(f"Thought about: {user}")
+
+
+class FinalResponder(PromptPlugin):
+    """Send the last assistant message as the response."""
+
+    stages = [PipelineStage.DELIVER]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        assistant_messages = [
+            e.content for e in context.conversation() if e.role == "assistant"
+        ]
+        context.set_response(assistant_messages[-1] if assistant_messages else "")
+
+
+async def main() -> None:
+    resources = ResourceContainer()
+    resources.register("llm", EchoLLMResource, {})
+    await resources.build_all()
+
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(
+        ChainOfThoughtPrompt({"max_steps": 1}), PipelineStage.THINK, "cot"
+    )
+    await plugins.register_plugin_for_stage(
+        FinalResponder(), PipelineStage.DELIVER, "final"
+    )
+
+    caps = SystemRegistries(resources=resources, tools=ToolRegistry(), plugins=plugins)
+
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(
+                content="Explain the sky", role="user", timestamp=datetime.now()
+            )
+        ],
+        pipeline_id=generate_pipeline_id(),
+        metrics=MetricsCollector(),
+    )
+    result: dict[str, Any] = await execute_pipeline(
+        "Explain the sky", caps, state=state
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -1,0 +1,21 @@
+import subprocess
+import sys
+
+import pytest
+
+EXAMPLES = [
+    "examples/basic_agent/main.py",
+    "examples/intermediate_agent/main.py",
+    "examples/advanced_agent/main.py",
+]
+
+
+@pytest.mark.examples
+@pytest.mark.parametrize("script", EXAMPLES)
+def test_example_runs(script):
+    result = subprocess.run(
+        ["poetry", "run", "python", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- create basic, intermediate and advanced example agents
- test that each example starts with `poetry run`
- reference examples in quick start and developer docs

## Testing
- `poetry run pytest tests/examples/test_examples.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f11efc4b88322921e6732e6dac950