### PR TITLE
Add UnifiedLLMResource plugin export

### DIFF
--- a/src/plugins/builtin/resources/llm/unified.py
+++ b/src/plugins/builtin/resources/llm/unified.py
@@ -1,0 +1,3 @@
+from pipeline.resources.llm import UnifiedLLMResource
+
+__all__ = ["UnifiedLLMResource"]


### PR DESCRIPTION
## Summary
- provide `plugins.builtin.resources.llm.unified.UnifiedLLMResource`
- keep existing exports in `pipeline.resources`

## Testing
- `poetry run black src/plugins/builtin/resources/llm/unified.py`
- `poetry run flake8 src/plugins/builtin/resources/llm/unified.py`
- `poetry run mypy src/plugins/builtin/resources/llm/unified.py`
- `poetry run pytest tests/test_gemini_resource.py::test_generate_sends_prompt_and_returns_text -q` *(fails: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_686fed9a62d083229a1294f0ed1d2e04