### PR TITLE
Add simple in-memory cache

### DIFF
--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -57,6 +57,7 @@ __all__ = [
     "Pipeline",
     "Workflow",
     "execute_with_observability",
+    "InMemoryCache",
 ]
 
 

--- a/src/pipeline/cache.py
+++ b/src/pipeline/cache.py
@@ -1,0 +1,35 @@
+"""Simple in-memory cache used in tests."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class _CacheEntry:
+    value: Any
+    expires_at: float | None
+
+
+class InMemoryCache:
+    """Minimal cache storing values in-process."""
+
+    def __init__(self) -> None:
+        self._data: Dict[str, _CacheEntry] = {}
+
+    def set(self, key: str, value: Any, ttl: Optional[float] = None) -> None:
+        """Store ``value`` for ``key`` with optional ``ttl`` in seconds."""
+        expires_at = time.monotonic() + ttl if ttl is not None else None
+        self._data[key] = _CacheEntry(value, expires_at)
+
+    def get(self, key: str) -> Any | None:
+        """Return cached value if present and not expired."""
+        entry = self._data.get(key)
+        if entry is None:
+            return None
+        if entry.expires_at is not None and entry.expires_at < time.monotonic():
+            del self._data[key]
+            return None
+        return entry.value

--- a/user_plugins/resources/__init__.py
+++ b/user_plugins/resources/__init__.py
@@ -1,3 +1,5 @@
 """User resource package."""
 
-__all__: list[str] = []
+from .cache import CacheResource
+
+__all__ = ["CacheResource"]

--- a/user_plugins/resources/cache.py
+++ b/user_plugins/resources/cache.py
@@ -1,0 +1,34 @@
+"""Simple cache resource used in tests."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from entity.core.plugins import ResourcePlugin
+from pipeline.cache import InMemoryCache
+
+
+class CacheResource(ResourcePlugin):
+    """Resource wrapper around :class:`InMemoryCache`."""
+
+    name = "cache"
+    stages: list = []
+
+    def __init__(
+        self, backend: InMemoryCache | None = None, config: Dict | None = None
+    ) -> None:
+        super().__init__(config or {})
+        self.backend = backend or InMemoryCache()
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def get_cached_result(self, name: str, params: Dict[str, Any]) -> Any | None:
+        key = f"{name}:{sorted(params.items())}"
+        return self.backend.get(key)
+
+    async def cache_result(
+        self, name: str, params: Dict[str, Any], result: Any, ttl: float | None = None
+    ) -> None:
+        key = f"{name}:{sorted(params.items())}"
+        self.backend.set(key, result, ttl)


### PR DESCRIPTION
## Summary
- implement `InMemoryCache` with optional TTL
- expose cache in `pipeline.__init__`
- create `CacheResource` and export it in user plugins

## Testing
- `poetry run pytest tests/test_cache.py -q` *(fails: ModuleNotFoundError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_686fed985f8c832285dd2270835e10c5