### PR TITLE
Clean up builtin resource exports

### DIFF
--- a/src/plugins/builtin/resources/__init__.py
+++ b/src/plugins/builtin/resources/__init__.py
@@ -1,46 +1,15 @@
 """Resource implementations shipped with the framework."""
 
-from .base import BaseResource, Resource
-from .bedrock import BedrockResource
-from entity.core.resources.container import ResourceContainer
-from .database import DatabaseResource
-from .dsl import ResourceDef, ResourceGraph
-from .duckdb_database import DuckDBDatabaseResource
-from .duckdb_vector_store import DuckDBVectorStore
-from .filesystem import FileSystemResource
+from .echo_llm import EchoLLMResource
 from .llm_base import LLM
 from .llm_resource import LLMResource
-from .postgres import PostgresResource
-from .echo_llm import EchoLLMResource
-from .local_filesystem import LocalFileSystemResource
-from .memory_filesystem import MemoryFileSystem
-from .metrics import MetricsResource
 from .pg_vector_store import PgVectorStore
-from .s3_filesystem import S3FileSystem
-from .structured_logging import StructuredLogging
-from .vector_store import VectorStore, VectorStoreResource
+from .postgres import PostgresResource
 
 __all__ = [
     "LLM",
-    "DatabaseResource",
-    "FileSystemResource",
-    "VectorStore",
-    "VectorStoreResource",
-    "ResourceContainer",
-    "Resource",
-    "BaseResource",
     "LLMResource",
     "EchoLLMResource",
-    "StructuredLogging",
-    "MetricsResource",
-    "DuckDBDatabaseResource",
     "PgVectorStore",
     "PostgresResource",
-    "MemoryFileSystem",
-    "DuckDBVectorStore",
-    "LocalFileSystemResource",
-    "S3FileSystem",
-    "BedrockResource",
-    "ResourceDef",
-    "ResourceGraph",
 ]


### PR DESCRIPTION
## Summary
- streamline builtin resource imports
- list only existing resources in `__all__`

## Testing
- `poetry run python -c 'import plugins.builtin.resources'`
- `poetry run black src/plugins/builtin/resources/__init__.py`
- `poetry run isort src/plugins/builtin/resources/__init__.py`
- `poetry run flake8 src tests`
- `poetry run mypy src`
- `bandit -r src` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m entity.core.registry_validator --config config/dev.yaml` *(fails: AttributeError)
- `poetry run pytest` *(fails: 14 errors during collection)*
- `python tools/check_empty_dirs.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fed93b8988322849a6a0a9f4ee618