### PR TITLE
Add plugin error response helper

### DIFF
--- a/src/pipeline/errors.py
+++ b/src/pipeline/errors.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any
+
+from entity.core.state import FailureInfo
+from pipeline.stages import PipelineStage
 
 
 class PipelineError(Exception):
@@ -9,7 +13,19 @@ class PipelineError(Exception):
 
 
 class PluginContextError(PipelineError):
-    pass
+    """Raised when plugin preconditions fail."""
+
+    def __init__(
+        self,
+        stage: "PipelineStage",
+        plugin_name: str,
+        message: str,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.stage = stage
+        self.plugin_name = plugin_name
+        self.context = context or {}
 
 
 class PluginExecutionError(PipelineError):
@@ -28,22 +44,38 @@ class ToolExecutionError(PipelineError):
 
 
 class StageExecutionError(PipelineError):
-    pass
+    """Raised when an error occurs while executing a pipeline stage."""
+
+    def __init__(
+        self,
+        stage: "PipelineStage",
+        message: str,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.stage = stage
+        self.context = context or {}
 
 
 @dataclass
 class ErrorResponse:
+    """Standard structure returned when a plugin fails."""
+
     error: str
     message: str
     error_id: str | None = None
+    plugin: str | None = None
+    stage: str | None = None
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
     type: str = "error"
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "error": self.error,
             "message": self.message,
             "error_id": self.error_id,
+            "plugin": self.plugin,
+            "stage": self.stage,
             "timestamp": self.timestamp,
             "type": self.type,
         }
@@ -58,6 +90,19 @@ def create_static_error_response(pipeline_id: str) -> ErrorResponse:
     )
 
 
+def create_error_response(pipeline_id: str, info: FailureInfo) -> ErrorResponse:
+    """Return an error response populated with plugin failure details."""
+
+    return ErrorResponse(
+        error=info.error_message,
+        message="Unable to process request",
+        error_id=pipeline_id,
+        plugin=info.plugin_name,
+        stage=info.stage,
+        type="plugin_error",
+    )
+
+
 __all__ = [
     "PipelineError",
     "PluginContextError",
@@ -67,4 +112,5 @@ __all__ = [
     "ToolExecutionError",
     "ErrorResponse",
     "create_static_error_response",
+    "create_error_response",
 ]

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -15,12 +15,8 @@ from typing import Any, Dict
 
 from entity.core.context import PluginContext
 from entity.core.registries import PluginRegistry, SystemRegistries
-from entity.core.state import (
-    ConversationEntry,
-    FailureInfo,
-    MetricsCollector,
-    PipelineState,
-)
+from entity.core.state import ConversationEntry, FailureInfo, MetricsCollector
+from pipeline.state import PipelineState
 from entity.core.state_logger import StateLogger
 from entity.utils.logging import get_logger
 

--- a/user_plugins/failure/basic_logger.py
+++ b/user_plugins/failure/basic_logger.py
@@ -21,7 +21,7 @@ class BasicLogger(FailurePlugin):
         try:
             info = context.get_failure_info()
             if info is not None:
-                snapshot = info.context_snapshot
+                snapshot = getattr(info, "context_snapshot", None)
                 logger.error(
                     "Pipeline failure encountered",
                     extra={
@@ -29,8 +29,10 @@ class BasicLogger(FailurePlugin):
                         "plugin": info.plugin_name,
                         "error": info.error_message,
                         "type": info.error_type,
-                        "pipeline_id": context.request_id,
-                        "retry_count": context.state.iteration,
+                        "pipeline_id": context.pipeline_id,
+                        "retry_count": getattr(
+                            getattr(context, "_state", None), "iteration", 0
+                        ),
                         **({"context_snapshot": snapshot} if snapshot else {}),
                     },
                 )


### PR DESCRIPTION
## Summary
- include plugin and stage data on `ErrorResponse`
- export new helper `create_error_response`
- update basic failure logger to avoid missing attrs
- ensure pipeline imports extended `PipelineState`
- adapt context tool usage to optional caching helpers

## Testing
- `poetry run mypy src/pipeline/errors.py src/pipeline/pipeline.py`
- `pydocstyle src/pipeline/errors.py src/pipeline/pipeline.py`
- `poetry run pytest tests/test_error_handling.py tests/test_tool_error_propagation.py tests/test_circuit_breaker.py -q` *(fails: AssertionError in two tests)*

------
https://chatgpt.com/codex/tasks/task_e_686fed95f1448322993d74652f0e9cce