### PR TITLE
Add DuckDB database resource

### DIFF
--- a/src/plugins/builtin/resources/__init__.py
+++ b/src/plugins/builtin/resources/__init__.py
@@ -5,6 +5,7 @@ from .llm_base import LLM
 from .llm_resource import LLMResource
 from .pg_vector_store import PgVectorStore
 from .postgres import PostgresResource
+from .duckdb_database import DuckDBDatabaseResource
 
 __all__ = [
     "LLM",
@@ -12,4 +13,5 @@ __all__ = [
     "EchoLLMResource",
     "PgVectorStore",
     "PostgresResource",
+    "DuckDBDatabaseResource",
 ]

--- a/src/plugins/builtin/resources/duckdb_database.py
+++ b/src/plugins/builtin/resources/duckdb_database.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, Dict, Iterator
+
+import duckdb
+
+from entity.core.plugins import ResourcePlugin
+
+
+class DuckDBDatabaseResource(ResourcePlugin):
+    """DuckDB-backed database resource."""
+
+    name = "duckdb_database"
+    stages: list = []
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.path: str = self.config.get("path", ":memory:")
+        self._conn: duckdb.DuckDBPyConnection | None = None
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def initialize(self) -> None:
+        """Open the database connection."""
+        self._conn = duckdb.connect(self.path)
+
+    @asynccontextmanager
+    async def connection(self) -> Iterator[duckdb.DuckDBPyConnection]:
+        """Yield a connection to execute queries."""
+        if self._conn is None:
+            self._conn = duckdb.connect(self.path)
+        try:
+            yield self._conn
+        finally:
+            pass
+
+    async def shutdown(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None


### PR DESCRIPTION
## Summary
- implement `DuckDBDatabaseResource` for duckdb-backed storage
- export the new resource in builtin resources package

## Testing
- `poetry run pytest` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ff512967883228ebfad40c4a4a27c