### PR TITLE
Configure default database resource

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -10,9 +10,9 @@ tool_registry:
 
 plugins:
   resources:
-    # database:
-    #   type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
-    #   path: ./dev.duckdb
+    database:
+      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      path: ./agent.duckdb
     # llm:
     #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
     #   provider: ollama
@@ -22,6 +22,7 @@ plugins:
     #   backoff: 1.0
     memory:
       type: entity.resources.memory:Memory
+      dependencies: [database]
     # vector_store:
     #   type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
     #   table: vector_mem

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -10,9 +10,9 @@ tool_registry:
 
 plugins:
   resources:
-    # database:
-    #   type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
-    #   path: ./prod.duckdb
+    database:
+      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      path: ./agent.duckdb
     # llm:
     #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
     #   provider: ollama
@@ -23,6 +23,7 @@ plugins:
     #   backoff: 2.0
     memory:
       type: entity.resources.memory:Memory
+      dependencies: [database]
     # vector_store:
     #   type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
     #   table: vector_mem

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -6,20 +6,16 @@ server:
 
 plugins:
   resources:
-    # database:
-    #   type: plugins.builtin.resources.postgres:PostgresResource
-    #   host: "${DB_HOST}"
-    #   port: 5432
-    #   name: "${DB_USERNAME}"
-    #   username: "${DB_USERNAME}"
-    #   password: "${DB_PASSWORD}"
+    database:
+      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      path: ./agent.duckdb
     # llm:
     #   provider: ollama
     #   base_url: "${OLLAMA_BASE_URL}"
     #   model: "${OLLAMA_MODEL}"
     memory:
       type: entity.resources.memory:Memory
-      dependencies: []
+      dependencies: [database]
     # storage:
     #   type: pipeline.resources.storage_resource:StorageResource
   tools:

--- a/examples/advanced_agent/main.py
+++ b/examples/advanced_agent/main.py
@@ -15,6 +15,8 @@ from datetime import datetime
 
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
 from entity.core.resources.container import ResourceContainer
+from plugins.builtin.resources.duckdb_database import DuckDBDatabaseResource
+from entity.resources.memory import Memory
 from pipeline.pipeline import execute_pipeline, generate_pipeline_id
 from pipeline.state import ConversationEntry, MetricsCollector, PipelineState
 
@@ -51,6 +53,9 @@ class FinalResponder(PromptPlugin):
 
 async def main() -> None:
     resources = ResourceContainer()
+    Memory.dependencies = ["database"]
+    resources.register("database", DuckDBDatabaseResource, {"path": "./agent.duckdb"})
+    resources.register("memory", Memory, {})
     resources.register("llm", EchoLLMResource, {})
     await resources.build_all()
 

--- a/examples/basic_agent/main.py
+++ b/examples/basic_agent/main.py
@@ -12,6 +12,8 @@ from datetime import datetime
 
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
 from entity.core.resources.container import ResourceContainer
+from plugins.builtin.resources.duckdb_database import DuckDBDatabaseResource
+from entity.resources.memory import Memory
 from pipeline.pipeline import execute_pipeline, generate_pipeline_id
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
@@ -37,6 +39,9 @@ async def main() -> None:
     await plugins.register_plugin_for_stage(EchoPrompt(), PipelineStage.DELIVER, "echo")
 
     resources = ResourceContainer()
+    Memory.dependencies = ["database"]
+    resources.register("database", DuckDBDatabaseResource, {"path": "./agent.duckdb"})
+    resources.register("memory", Memory, {})
     await resources.build_all()
 
     caps = SystemRegistries(resources=resources, tools=ToolRegistry(), plugins=plugins)

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -12,6 +12,8 @@ from datetime import datetime
 
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
 from entity.core.resources.container import ResourceContainer
+from plugins.builtin.resources.duckdb_database import DuckDBDatabaseResource
+from entity.resources.memory import Memory
 from pipeline.pipeline import execute_pipeline, generate_pipeline_id
 from pipeline.state import ConversationEntry, MetricsCollector, PipelineState
 
@@ -49,6 +51,9 @@ class FinalResponder(PromptPlugin):
 
 async def main() -> None:
     resources = ResourceContainer()
+    Memory.dependencies = ["database"]
+    resources.register("database", DuckDBDatabaseResource, {"path": "./agent.duckdb"})
+    resources.register("memory", Memory, {})
     resources.register("llm", EchoLLMResource, {})
     await resources.build_all()
 


### PR DESCRIPTION
## Summary
- configure DuckDB database resource in dev, prod, and template configs
- ensure memory depends on database
- update example agents to register database and memory resources

## Testing
- `poetry run black config examples/basic_agent/main.py examples/intermediate_agent/main.py examples/advanced_agent/main.py`
- `poetry run isort src tests --check` *(fails: imports not sorted)*
- `poetry run flake8 src tests` *(fails: command not found)*
- `poetry run mypy src` *(fails: found 184 errors)*
- `bandit -r src` *(fails: command not found)*
- `python tools/check_empty_dirs.py` *(fails: file not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError)*
- `python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError)*
- `pytest tests/integration/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/infrastructure/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/performance/ -m benchmark` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686ff51607c48322b83dba1204aed143