### PR TITLE
Document in-memory DuckDB default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 [![Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://entity.readthedocs.io/en/latest/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Entity lets you craft agent pipelines using a single configuration file. The same YAML works locally and in production, so iteration stays simple.
+Entity lets you craft agent pipelines using a single configuration file. The same YAML works locally and in production, so iteration stays simple. By default the agent stores conversation data in an in-memory DuckDB database so you can try things instantly.
 
 ## Key Features
 - Three-layer plugin system for progressive complexity
 - Hot-reloadable YAML config with validation
 - Stateless workers that scale horizontally
 - Unified memory resource for chat, search, and storage
+- In-memory DuckDB backend for quick local testing
 
 Check the [hero landing page](https://entity.readthedocs.io/en/latest/) for a visual overview.
 

--- a/architecture/5_minute_start.md
+++ b/architecture/5_minute_start.md
@@ -1,0 +1,5 @@
+# 5-Minute Start
+
+The framework aims to get developers experimenting in minutes. The default `Memory` resource automatically configures DuckDB in memory so no database setup is required. This choice trades durability for speed during early exploration. Because DuckDB runs in the same process, the agent can start, store conversation history, and run tools without external dependencies.
+
+For production deployments you can switch to Postgres or any other supported backend by updating the `memory` configuration in your YAML file. The in-memory DuckDB setup is kept small so new users can try the agent with a single command.

--- a/docs/adr/0003-five-minute-start.md
+++ b/docs/adr/0003-five-minute-start.md
@@ -1,0 +1,14 @@
+# ADR 0003: Five-Minute Start Default
+
+## Status
+Accepted
+
+## Context
+Early experimentation should require no external services. A persistent database often slows first-time users. DuckDB runs in-process and can operate entirely in memory.
+
+## Decision
+The default `memory` resource uses DuckDB in memory so new users can launch an agent with a single command. This configuration provides conversation history and vector search without installing a database server.
+
+## Consequences
+- Quick local demos and tutorials do not require additional infrastructure.
+- Data is ephemeral; production setups should replace the memory configuration with a durable backend such as Postgres.

--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -1,7 +1,9 @@
 # Architecture Overview
 
 The Entity Pipeline Framework uses a single execution pipeline with explicit
-stages. Plugins implement each stage and provide reusable behavior.
+stages. Plugins implement each stage and provide reusable behavior. The default
+agent stores conversations in a DuckDB database that runs entirely in memory so
+you can start experimenting without setting up external services.
 
 ## Pipeline Stages
 - **parse** – validate input and load context

--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -1,6 +1,6 @@
 # Component Overview
 
-This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](https://github.com/Ladvien/entity/blob/main/architecture/general.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](https://github.com/Ladvien/entity/blob/main/config/dev.yaml).
+This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](https://github.com/Ladvien/entity/blob/main/architecture/general.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](https://github.com/Ladvien/entity/blob/main/config/dev.yaml). The sample configuration stores history in an in-memory DuckDB database so you can experiment immediately.
 
 ## Pipelines and Stages
 

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -9,7 +9,7 @@ Ready-made agents live in the new `examples/` directory. Run them with
 
 ### Programmatic Configuration
 Build the same configuration in Python using the models from
-`entity.config`:
+`entity.config`. The `Memory` resource sets up an in-memory DuckDB database by default so no database server is required:
 
 ```python
 from entity.config.models import EntityConfig, PluginsSection, PluginConfig
@@ -19,7 +19,10 @@ config = EntityConfig(
     plugins=PluginsSection(
         prompts={"main": PluginConfig(type="user_plugins.prompts.simple:SimplePrompt")},
         adapters={"http": PluginConfig(type="plugins.builtin.adapters.http:HTTPAdapter", stages=["parse", "deliver"])},
-        resources={"llm": PluginConfig(provider="openai", model="gpt-4")},
+        resources={
+            "llm": PluginConfig(provider="openai", model="gpt-4"),
+            "memory": PluginConfig(type="entity.resources.memory:Memory"),
+        },
     ),
 )
 ```
@@ -52,6 +55,8 @@ curl -X POST -H "Content-Type: application/json" \
 ```
 
 You should see a simple reply from the example pipeline.
+
+The generated configuration stores conversation history in an in-memory DuckDB database. You can switch to a file-based or server database later by editing `config/dev.yaml`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- highlight default DuckDB-based memory
- mention quick-start database in quick_start, architecture, components
- add "5-minute start" ADR and section in architecture docs

## Testing
- `poetry run black src/entity/resources/memory.py`
- `poetry run pytest` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ff5174f0c8322af5a3d0824fec780