### PR TITLE
Update docs for default DuckDB usage

### DIFF
--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -2,14 +2,31 @@
 
 ### Composing Storage Backends
 
-PostgreSQL's `pgvector` extension allows vector similarity search for embeddings.
-Use `StorageResource` with a Postgres database and optional S3 file storage:
+Local development uses a file-backed DuckDB database by default, so you can
+experiment without running an external server. `StorageResource` composes the
+database and optional file system into a single interface:
 
 ```yaml
 plugins:
   resources:
+    db:
+      type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+      path: ./agent.duckdb
+    fs:
+      type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
+      base_path: ./files
+    storage:
+      type: storage
+      dependencies: [db, fs]
+```
+
+`Memory` persists conversation history and vectors. `StorageResource` extends it with file CRUD across the configured backends.
+Upgrade to a Postgres-backed setup when you need a production database with `pgvector`:
+```yaml
+plugins:
+  resources:
     postgres:
-      # type: plugins.builtin.resources.postgres:PostgresResource
+      type: plugins.builtin.resources.postgres:PostgresResource
       host: localhost
       port: 5432
       name: dev_db
@@ -17,11 +34,11 @@ plugins:
       setup_commands:
         - "CREATE EXTENSION IF NOT EXISTS vector"
     vector_store:
-      # type: plugins.builtin.resources.pg_vector_store:PgVectorStore
+      type: plugins.builtin.resources.pg_vector_store:PgVectorStore
       dimensions: 768
       table: embeddings
     filesystem:
-      # type: plugins.builtin.resources.s3_filesystem:S3FileSystem
+      type: plugins.builtin.resources.s3_filesystem:S3FileSystem
       bucket: agent-files
       region: us-east-1
     storage:
@@ -29,35 +46,18 @@ plugins:
       dependencies: [postgres, vector_store, filesystem]
 ```
 
-`Memory` persists conversation history and vectors. `StorageResource` extends it with file CRUD across the configured backends.
-
-For local experimentation you can use a file-backed DuckDB database:
-
-```yaml
-plugins:
-  resources:
-    db:
-      # type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
-      path: ./agent.duckdb
-    storage:
-      type: storage
-      dependencies: [db]
-```
 
 You can also use `StorageResource` for a lighter setup:
 
 ```yaml
 plugins:
   resources:
-    db:
-      # type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
-      path: ./agent.duckdb
-    fs:
-      # type: plugins.builtin.resources.local_filesystem:LocalFileSystemResource
-      base_path: ./files
-    storage:
-      type: storage
-      dependencies: [db, fs]
+      db:
+        type: plugins.builtin.resources.duckdb_database:DuckDBDatabaseResource
+        path: ./agent.duckdb
+      storage:
+        type: storage
+        dependencies: [db]
 ```
 
 These configurations illustrate **Preserve All Power (7)** by enabling

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -183,7 +183,7 @@ Additional pipelines are available in a dedicated examples repository.
 
 ### StorageResource Composition
 
-`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. Memory persists conversation history and vectors and is configured in [config/dev.yaml](https://github.com/Ladvien/entity/blob/main/config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. With the plugin configured the code looks like:
+`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. Memory persists conversation history and vectors and is configured in [config/dev.yaml](https://github.com/Ladvien/entity/blob/main/config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. The scaffold's `dev.yaml` already registers `DuckDBDatabaseResource`, so local development works out of the box. With the plugin configured the code looks like:
 
 ```python
 resources = ResourceContainer()
@@ -243,5 +243,4 @@ When implementing custom error handling, see the failure plugin template at
 The following widget lets you experiment with plugin ordering across stages.
 
 .. plugin-visualizer::
-
 


### PR DESCRIPTION
## Summary
- update advanced usage to showcase DuckDB first
- mention Postgres upgrade path
- note that dev scaffold already registers DuckDB in plugin guide

## Testing
- `poetry run black src tests`
- `poetry run pytest` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686ff517fbac832294aad5a22991aa25