### PR TITLE
Add duckdb memory example

### DIFF
--- a/docs/source/tutorial_first_pipeline.md
+++ b/docs/source/tutorial_first_pipeline.md
@@ -22,3 +22,15 @@ curl -X POST -H "Content-Type: application/json" \
 ```
 
 The response comes from the default EchoLLMResource.
+
+Run the DuckDB memory example to see persistence:
+
+```bash
+poetry run python examples/duckdb_memory_agent/main.py
+```
+
+After running it twice inspect the `agent.duckdb` file:
+
+```bash
+duckdb agent.duckdb "SELECT * FROM kv;"
+```

--- a/examples/duckdb_memory_agent/README.md
+++ b/examples/duckdb_memory_agent/README.md
@@ -1,0 +1,14 @@
+# DuckDB Memory Agent
+
+This example runs a minimal pipeline with a DuckDB-backed memory resource.
+It increments a counter on each request and persists it to `agent.duckdb`.
+
+```bash
+poetry run python examples/duckdb_memory_agent/main.py
+```
+
+Run the script twice and inspect the database file:
+
+```bash
+duckdb agent.duckdb "SELECT * FROM kv;"
+```

--- a/examples/duckdb_memory_agent/main.py
+++ b/examples/duckdb_memory_agent/main.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from typing import Any, List
+
+import duckdb
+
+from entity.core.plugins import PromptPlugin, ResourcePlugin
+from entity.core.context import PluginContext
+from entity.core.state import ConversationEntry
+from pipeline.stages import PipelineStage
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.resources.container import ResourceContainer
+from pipeline.pipeline import execute_pipeline, generate_pipeline_id
+from pipeline.state import PipelineState, MetricsCollector
+
+
+class DuckDBMemory(ResourcePlugin):
+    """Simple DuckDB-backed memory."""
+
+    name = "memory"
+    stages: list[str] = []
+
+    def __init__(self, config: dict | None = None) -> None:
+        super().__init__(config or {})
+        path = self.config.get("path", "agent.duckdb")
+        self._conn = duckdb.connect(path)
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS history ("
+            "conversation_id TEXT, role TEXT, content TEXT, timestamp TEXT)"
+        )
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - resource
+        return None
+
+    def remember(self, key: str, value: Any) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO kv VALUES (?, ?)",
+            (key, json.dumps(value)),
+        )
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        row = self._conn.execute(
+            "SELECT value FROM kv WHERE key = ?",
+            (key,),
+        ).fetchone()
+        return json.loads(row[0]) if row else default
+
+    def clear(self) -> None:
+        self._conn.execute("DELETE FROM kv")
+
+    async def save_conversation(
+        self, conversation_id: str, history: List[ConversationEntry]
+    ) -> None:
+        self._conn.execute(
+            "DELETE FROM history WHERE conversation_id = ?",
+            (conversation_id,),
+        )
+        for entry in history:
+            self._conn.execute(
+                "INSERT INTO history VALUES (?, ?, ?, ?)",
+                (
+                    conversation_id,
+                    entry.role,
+                    entry.content,
+                    entry.timestamp.isoformat(),
+                ),
+            )
+
+    async def load_conversation(self, conversation_id: str) -> List[ConversationEntry]:
+        rows = self._conn.execute(
+            "SELECT role, content, timestamp FROM history WHERE conversation_id = ? "
+            "ORDER BY timestamp",
+            (conversation_id,),
+        ).fetchall()
+        return [
+            ConversationEntry(
+                role=row[0],
+                content=row[1],
+                timestamp=datetime.fromisoformat(row[2]),
+            )
+            for row in rows
+        ]
+
+
+class IncrementPrompt(PromptPlugin):
+    """Increment a counter stored in memory."""
+
+    stages = [PipelineStage.DELIVER]
+    dependencies = ["memory"]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        memory: DuckDBMemory = context.get_resource("memory")  # type: ignore[assignment]
+        count = memory.get("count", 0) + 1
+        memory.remember("count", count)
+        context.set_response(f"Count: {count}")
+
+
+async def main() -> None:
+    resources = ResourceContainer()
+    resources.register("memory", DuckDBMemory, {"path": "agent.duckdb"})
+    await resources.build_all()
+
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(
+        IncrementPrompt({}), PipelineStage.DELIVER, "increment"
+    )
+
+    caps = SystemRegistries(resources=resources, tools=ToolRegistry(), plugins=plugins)
+
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id=generate_pipeline_id(),
+        metrics=MetricsCollector(),
+    )
+    first = await execute_pipeline("hi", caps, state=state)
+
+    state2 = PipelineState(
+        conversation=[
+            ConversationEntry(content="again", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id=generate_pipeline_id(),
+        metrics=MetricsCollector(),
+    )
+    second = await execute_pipeline("again", caps, state=state2)
+
+    print(first)
+    print(second)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `duckdb_memory_agent` example showing persistent memory
- document running the example and inspecting the `agent.duckdb` file

## Testing
- `poetry run isort --check src tests` *(fails: imports incorrectly sorted)*
- `poetry run flake8 src tests` *(fails: F401/F821 etc.)*
- `poetry run mypy src` *(fails: found errors in 37 files)*
- `bandit -r src` *(command not found)*
- `python tools/check_empty_dirs.py` *(failed: file not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/integration/ -v` *(failed: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/infrastructure/ -v` *(failed: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/performance/ -m benchmark` *(failed: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_686ff51b77708322879a8b92876dafa5