### PR TITLE
Update dynamic import path for resource container

### DIFF
--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -73,18 +73,18 @@ def test_health_report():
 # Resource pool tests using dynamic import to avoid package path issues
 root = Path(__file__).resolve().parents[1]
 spec = importlib.util.spec_from_file_location(
-    "plugins.builtin.resources.container",
-    root / "src" / "plugins" / "builtin" / "resources" / "container.py",
+    "entity.core.resources.container",
+    root / "src" / "entity" / "core" / "resources" / "container.py",
 )
 
 _orig_pipeline = sys.modules.get("pipeline")
-_orig_resources = sys.modules.get("plugins.builtin.resources")
+_orig_resources = sys.modules.get("entity.core.resources")
 
 module = importlib.util.module_from_spec(spec)
-sys.modules["plugins.builtin.resources.container"] = module
+sys.modules["entity.core.resources.container"] = module
 try:
     sys.modules["pipeline"] = ModuleType("pipeline")
-    sys.modules["plugins.builtin.resources"] = ModuleType("plugins.builtin.resources")
+    sys.modules["entity.core.resources"] = ModuleType("entity.core.resources")
     spec.loader.exec_module(module)  # type: ignore[arg-type]
 finally:
     if _orig_pipeline is not None:
@@ -93,9 +93,9 @@ finally:
         sys.modules.pop("pipeline", None)
 
     if _orig_resources is not None:
-        sys.modules["plugins.builtin.resources"] = _orig_resources
+        sys.modules["entity.core.resources"] = _orig_resources
     else:
-        sys.modules.pop("plugins.builtin.resources", None)
+        sys.modules.pop("entity.core.resources", None)
 
 ResourceContainerDynamic = module.ResourceContainer
 


### PR DESCRIPTION
## Summary
- point `tests/test_resource_container.py` at `entity.core.resources.container`

## Testing
- `poetry run black tests/test_resource_container.py`
- `poetry run pytest tests/test_resource_container.py`

------
https://chatgpt.com/codex/tasks/task_e_6870153a2d2083229d15518bf48d5415