### PR TITLE
Expose cli package in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ package-mode = true
 
 packages = [
     { include = "entity", from = "src" },
+    { include = "cli", from = "src" },
 ]
 
 [tool.poetry.scripts]


### PR DESCRIPTION
## Summary
- expose the `cli` module in the packages list of `pyproject.toml`

## Testing
- `poetry install --with dev`
- `poetry run python - <<'EOF'
import cli
print(cli.__package__)
EOF`
- `poetry run pytest` *(fails: FileNotFoundError: container.py, ImportError: AgentBuilder)*

------
https://chatgpt.com/codex/tasks/task_e_6870153abf2c83228778ed6a46408f31