### PR TITLE
Update resource paths in docs and configs

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -339,7 +339,7 @@ relevant_context = await memory.get_memory(context.message)  # Similarity search
 plugins:
   resources:
     llm:
-      type: pipeline.resources.llm.unified:UnifiedLLMResource
+      type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
       provider: ollama
       model: llama3:8b
       base_url: http://localhost:11434
@@ -355,7 +355,7 @@ plugins:
         dimensions: 768
         
     storage:
-      type: pipeline.resources.storage_resource:StorageResource
+      type: plugins.builtin.resources.storage_resource:StorageResource
       filesystem:
         type: plugins.builtin.resources.s3_filesystem:S3FileSystem
         bucket: agent-files

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -34,9 +34,9 @@ plugins:
     #   bucket: agent-files
     #   region: us-east-1
     # storage:
-    #   type: pipeline.resources.storage_resource:StorageResource
+    #   type: plugins.builtin.resources.storage_resource:StorageResource
 #   storage:
-#     type: pipeline.resources.storage_resource:StorageResource
+#     type: plugins.builtin.resources.storage_resource:StorageResource
 #     database:
 #       type: plugins.builtin.resources.postgres:PostgresResource
 #       host: localhost

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -35,9 +35,9 @@ plugins:
     #   bucket: agent-files
     #   region: us-east-1
     # storage:
-    #   type: pipeline.resources.storage_resource:StorageResource
+    #   type: plugins.builtin.resources.storage_resource:StorageResource
 #   storage:
-#     type: pipeline.resources.storage_resource:StorageResource
+#     type: plugins.builtin.resources.storage_resource:StorageResource
 #     database:
 #       type: plugins.builtin.resources.postgres:PostgresResource
 #       host: prod-db.example.com

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -17,7 +17,7 @@ plugins:
       type: entity.resources.memory:Memory
       dependencies: [database]
     # storage:
-    #   type: pipeline.resources.storage_resource:StorageResource
+    #   type: plugins.builtin.resources.storage_resource:StorageResource
   tools:
     weather:
       type: user_plugins.tools.weather_api_tool:WeatherApiTool


### PR DESCRIPTION
## Summary
- point docs to `plugins.builtin.resources.*`
- fix commented config examples to match new resource namespace

## Testing
- `poetry run black .`
- `poetry run pytest -q` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68701c77767c8322938b110d5b864ac8