### PR TITLE
Remove legacy context methods

### DIFF
--- a/architecture/general.md
+++ b/architecture/general.md
@@ -298,7 +298,7 @@ STATIC_ERROR_RESPONSE = {
 ```python
 from pipeline.errors.response import ErrorResponse
 
-info = ctx.get_failure_info()
+info = ctx.failure_info
 payload = ErrorResponse(
     error=info.error_message,
     message="Unable to complete request",

--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -60,7 +60,7 @@ from pipeline.errors.response import ErrorResponse
 class ErrorFormatter(FailurePlugin):
     stages = [PipelineStage.DELIVER]
     async def _execute_impl(self, ctx: PluginContext) -> None:
-        info = ctx.get_failure_info()
+        info = ctx.failure_info
         ctx.set_response(
             ErrorResponse(
                 error=info.error_message,
@@ -111,7 +111,7 @@ class BasicLogger(FailurePlugin):
     stages = [PipelineStage.ERROR]
 
     async def _execute_impl(self, ctx: PluginContext) -> None:
-        info = ctx.get_failure_info()
+        info = ctx.failure_info
         logging.error(
             "Stage %s plugin %s failed: %s",
             info.stage,

--- a/src/cli/templates/failure.py
+++ b/src/cli/templates/failure.py
@@ -19,4 +19,4 @@ class {class_name}(FailurePlugin):
     # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
-        context.store("failure_info", context.get_failure_info())
+        context.store("failure_info", context.failure_info)

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -7,9 +7,9 @@ import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pipeline.stages import PipelineStage
-from pipeline.errors import PluginContextError
 from entity.core.state import ConversationEntry, PipelineState
+from pipeline.errors import PluginContextError
+from pipeline.stages import PipelineStage
 
 
 class PluginContext:
@@ -145,10 +145,6 @@ class PluginContext:
         """Return ``True`` if ``key`` exists in stage results."""
         return key in self._state.stage_results
 
-    # Backwards compatibility
-    cache = store
-    recall = load
-
     # ------------------------------------------------------------------
     # Persistent memory helpers
     # ------------------------------------------------------------------
@@ -172,11 +168,6 @@ class PluginContext:
 
     @property
     def failure_info(self) -> Any:
-        """Return information about the most recent failure."""
-        return self._state.failure_info
-
-    # Backwards compatibility
-    def get_failure_info(self) -> Any:
         """Return information about the most recent failure."""
         return self._state.failure_info
 

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -7,11 +7,9 @@ These classes mirror the minimal architecture described in
 They offer a small, easy to understand surface for plugin authors.
 """
 
-from dataclasses import dataclass
-from typing import Any, Dict, List, Type
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type
 
 from entity.utils.logging import get_logger
 
@@ -60,7 +58,7 @@ class BasePlugin:
         start = time.perf_counter()
         response = await context.call_llm(context, prompt, purpose=purpose)
         duration = time.perf_counter() - start
-        if context.get_failure_info() is None and hasattr(context._state, "metrics"):
+        if context.failure_info is None and hasattr(context._state, "metrics"):
             key = f"{context.current_stage}:{self.__class__.__name__}:{purpose}"
             context._state.metrics.record_llm_duration(key, duration)
         self.logger.info(

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -44,7 +44,7 @@ class FallbackPlugin(FailurePlugin):
     stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context):
-        info = context.get_failure_info()
+        info = context.failure_info
         context.set_response({"error": info.error_message})
 
 

--- a/tests/test_pipeline_looping.py
+++ b/tests/test_pipeline_looping.py
@@ -48,7 +48,7 @@ class RecordFailurePlugin(FailurePlugin):
         self.store = store
 
     async def _execute_impl(self, context):
-        info = context.get_failure_info()
+        info = context.failure_info
         if info:
             self.store.append(info)
 

--- a/user_plugins/failure/basic_logger.py
+++ b/user_plugins/failure/basic_logger.py
@@ -19,7 +19,7 @@ class BasicLogger(FailurePlugin):
     async def _execute_impl(self, context: PluginContext) -> Any:
         logger = logging.getLogger(self.__class__.__name__)
         try:
-            info = context.get_failure_info()
+            info = context.failure_info
             if info is not None:
                 snapshot = getattr(info, "context_snapshot", None)
                 logger.error(

--- a/user_plugins/failure/default_responder.py
+++ b/user_plugins/failure/default_responder.py
@@ -15,7 +15,7 @@ class DefaultResponder(FailurePlugin):
     stages = [PipelineStage.ERROR]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        info = context.get_failure_info()
+        info = context.failure_info
         if info is None:
             context.set_response(
                 create_static_error_response(context.pipeline_id).to_dict()

--- a/user_plugins/failure/error_formatter.py
+++ b/user_plugins/failure/error_formatter.py
@@ -15,7 +15,7 @@ class ErrorFormatter(FailurePlugin):
     stages = [PipelineStage.DELIVER]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        info = context.get_failure_info()
+        info = context.failure_info
         if info is None:
             context.set_response(create_static_error_response(context.pipeline_id))
             return


### PR DESCRIPTION
## Summary
- remove cache/recall aliases and get_failure_info
- update failure handling helpers to use failure_info property
- reference store/load/failure_info in docs

## Testing
- `poetry run isort src tests`
- `poetry run flake8 src tests` *(fails: F401, F821, etc.)*
- `poetry run mypy src` *(fails: found 188 errors)*
- `poetry run bandit -r src`
- `pytest tests/test_pipeline_looping.py tests/test_error_handling.py -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68701c7407d88322b26bf005b1dfdaf1