### PR TITLE
Remove agent plugin registry properties

### DIFF
--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 """Pipeline component: agent."""
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional, cast, Mapping, Iterable
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, cast
+
+from pipeline.exceptions import PipelineError
+from pipeline.workflow import Pipeline, WorkflowMapping
 
 from .builder import _AgentBuilder
-from pipeline.exceptions import PipelineError
 from .registries import PluginRegistry, SystemRegistries
 from .runtime import AgentRuntime
-from pipeline.workflow import Pipeline, WorkflowMapping
 
 
 @dataclass
@@ -111,8 +112,9 @@ class Agent:
     ) -> "Agent":
         """Instantiate an agent from a YAML/JSON path or mapping."""
 
-        from pathlib import Path
         import asyncio
+        from pathlib import Path
+
         from pipeline.initializer import SystemInitializer
 
         if isinstance(cfg, Mapping):
@@ -170,18 +172,3 @@ class Agent:
         if self._runtime is None:
             raise PipelineError("Agent not initialized")
         return self._runtime.capabilities
-
-    # ------------------------------------------------------------------
-    # Compatibility helpers
-    # ------------------------------------------------------------------
-    @property
-    def plugin_registry(self) -> "PluginRegistry":  # pragma: no cover - passthrough
-        if self._runtime is not None:
-            return self._runtime.capabilities.plugins
-        return self.builder.plugin_registry
-
-    @property
-    def plugins(self) -> "PluginRegistry":  # pragma: no cover - passthrough
-        if self._runtime is not None:
-            return self._runtime.capabilities.plugins
-        return self.builder.plugin_registry

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,6 +1,5 @@
-from pipeline import PipelineStage, PromptPlugin
-
 from entity import Agent
+from pipeline import PipelineStage, PromptPlugin
 
 
 def test_plugin_decorator_registration():
@@ -10,7 +9,7 @@ def test_plugin_decorator_registration():
     async def hello(context):
         return "hi"
 
-    do_plugins = agent.plugin_registry.get_plugins_for_stage(PipelineStage.DO)
+    do_plugins = agent.builder.plugin_registry.get_plugins_for_stage(PipelineStage.DO)
     assert any(p.name == "hello" for p in do_plugins)
 
 
@@ -25,5 +24,7 @@ def test_add_plugin():
     agent = Agent()
     plugin = ExamplePlugin()
     agent.add_plugin(plugin)
-    think_plugins = agent.plugin_registry.get_plugins_for_stage(PipelineStage.THINK)
+    think_plugins = agent.builder.plugin_registry.get_plugins_for_stage(
+        PipelineStage.THINK
+    )
     assert plugin in think_plugins

--- a/tests/test_agent_from_directory.py
+++ b/tests/test_agent_from_directory.py
@@ -1,8 +1,7 @@
 import logging
 
-from pipeline import PipelineStage
-
 from entity import Agent
+from pipeline import PipelineStage
 
 
 def test_from_directory_import_error(tmp_path, caplog):
@@ -17,7 +16,7 @@ async def hi_plugin(ctx):\n    return 'hi'\n"""
     bad.write_text("import nonexistent_module")
 
     agent = Agent.from_directory(str(tmp_path))
-    plugins = agent.plugins.get_plugins_for_stage(PipelineStage.DO)
+    plugins = agent.builder.plugin_registry.get_plugins_for_stage(PipelineStage.DO)
     assert any(p.name == "hi_plugin" for p in plugins)
     assert not any(p.name == "bad" for p in plugins)
     assert any("Failed to import plugin module" in r.message for r in caplog.records)
@@ -47,7 +46,7 @@ class BadClass:
     )
 
     agent = Agent.from_directory(str(tmp_path))
-    plugins = agent.plugins.get_plugins_for_stage(PipelineStage.DO)
+    plugins = agent.builder.plugin_registry.get_plugins_for_stage(PipelineStage.DO)
 
     names = {getattr(p, "name", p.__class__.__name__) for p in plugins}
     classes = {p.__class__.__name__ for p in plugins}

--- a/tests/test_agent_from_package.py
+++ b/tests/test_agent_from_package.py
@@ -1,8 +1,7 @@
 import logging
 
-from pipeline import PipelineStage
-
 from entity import Agent
+from pipeline import PipelineStage
 
 
 def test_from_package_import_error(tmp_path, caplog, monkeypatch):
@@ -15,7 +14,7 @@ def test_from_package_import_error(tmp_path, caplog, monkeypatch):
 
     monkeypatch.syspath_prepend(str(tmp_path))
     agent = Agent.from_package("pkg")
-    plugins = agent.plugins.get_plugins_for_stage(PipelineStage.DO)
+    plugins = agent.builder.plugin_registry.get_plugins_for_stage(PipelineStage.DO)
     assert any(p.name == "ok_plugin" for p in plugins)
     assert not any(p.name == "bad" for p in plugins)
     assert any("Failed to import plugin module" in r.message for r in caplog.records)
@@ -55,7 +54,7 @@ async def sub_plugin(ctx):
 
     monkeypatch.syspath_prepend(str(tmp_path))
     agent = Agent.from_package("pkg2")
-    plugins = agent.plugins.get_plugins_for_stage(PipelineStage.DO)
+    plugins = agent.builder.plugin_registry.get_plugins_for_stage(PipelineStage.DO)
 
     names = {getattr(p, "name", p.__class__.__name__) for p in plugins}
     classes = {p.__class__.__name__ for p in plugins}

--- a/tests/test_core_plugin_registry_order.py
+++ b/tests/test_core_plugin_registry_order.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import yaml
 
 from entity.core.agent import Agent
@@ -63,5 +64,7 @@ def test_agent_initializer_preserves_yaml_order(tmp_path):
 
     agent = Agent(config_path=str(path))
     asyncio.run(agent._ensure_runtime())
-    plugins = agent.plugins.get_plugins_for_stage(PipelineStage.DELIVER)
+    plugins = agent.runtime.capabilities.plugins.get_plugins_for_stage(
+        PipelineStage.DELIVER
+    )
     assert [p.__class__ for p in plugins] == [Second, First, Third]


### PR DESCRIPTION
## Summary
- remove deprecated `plugin_registry` and `plugins` accessors from `Agent`
- update unit tests to reference the builder or runtime plugin registry directly

## Testing
- `poetry run isort src/entity/core/agent.py tests/test_agent.py tests/test_agent_from_package.py tests/test_agent_from_directory.py tests/test_core_plugin_registry_order.py`
- `poetry run flake8 src/entity/core/agent.py tests/test_agent.py tests/test_agent_from_package.py tests/test_agent_from_directory.py tests/test_core_plugin_registry_order.py` *(fails: F401, F821)*
- `poetry run mypy src/entity/core/agent.py tests/test_agent.py tests/test_agent_from_package.py tests/test_agent_from_directory.py tests/test_core_plugin_registry_order.py` *(fails: several errors)*
- `bandit -r src` *(fails: command not found)*
- `python tools/check_empty_dirs.py` *(fails: No such file or directory)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `pytest tests/test_agent.py tests/test_agent_from_package.py tests/test_agent_from_directory.py tests/test_core_plugin_registry_order.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68701c746d8483228ce0d000e75ec1ec