### PR TITLE
Remove redundant defaults

### DIFF
--- a/src/pipeline/defaults.py
+++ b/src/pipeline/defaults.py
@@ -1,7 +1,0 @@
-from __future__ import annotations
-
-from typing import Any
-
-DEFAULT_CONFIG: dict[str, Any] = {}
-
-__all__ = ["DEFAULT_CONFIG"]


### PR DESCRIPTION
## Summary
- delete unused `defaults.py`
- simplify SystemInitializer config handling

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.plugin_tool')*

------
https://chatgpt.com/codex/tasks/task_e_68701fb881c8832291e01263025de7a6