### PR TITLE
Remove metrics collector

### DIFF
--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -61,8 +61,8 @@ Example output:
 ImportError: cannot import name 'Resource' from partially initialized module 'entity.core.resources'
 ```
 
-Once the imports are resolved, the `pytest-benchmark` plugin can capture
-timing metrics for each pipeline stage.
+Once the imports are resolved, the `pytest-benchmark` plugin can measure
+pipeline stage timings.
 
 ## Zero-Config AWS Startup
 

--- a/docs/source/deploy_production.md
+++ b/docs/source/deploy_production.md
@@ -39,7 +39,7 @@ the orchestrator can restart the container on failures.
 
 For horizontal scaling you can run multiple agent replicas behind a load
 balancer. Use a shared database and file store so each instance has access to
-conversation history and uploaded files. Enable monitoring and metrics (see
+conversation history and uploaded files. Enable tracing (see
 `monitoring.md`) to gain visibility into resource usage.
 
 

--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -45,8 +45,7 @@ correlated across stages. Tool executions follow the same pattern. When a tool
 starts, finishes or fails, a structured log entry is emitted describing the
 result.
 
-Metrics are recorded alongside these logs. Duration and error counts are stored
-in ``context.metrics``.
+Metrics collection has been removed. Only structured logs are emitted.
 
 For production deployments, `config/logging_prod.yaml` contains a recommended
 configuration enabling JSON formatted logs and file rotation.

--- a/docs/source/monitoring.md
+++ b/docs/source/monitoring.md
@@ -1,6 +1,6 @@
 # Monitoring the Pipeline
 
-This guide shows how to collect metrics and traces from an Entity deployment.
+This guide explains how to enable tracing for an Entity deployment.
 
 
 ## OpenTelemetry Tracing

--- a/docs/source/principle_checklist.md
+++ b/docs/source/principle_checklist.md
@@ -5,7 +5,7 @@ Before submitting a pull request, ensure your changes honor the framework's desi
 - [ ] **Progressive Disclosure (1)** - keep simple use cases simple.
 - [ ] **Fail-Fast Validation (15)** - validate configuration and dependencies early.
 - [ ] **Intuitive Mental Models (21)** - maintain easy to follow APIs and stages.
-- [ ] **Observable by Design (16)** - add structured logs or metrics when applicable.
+- [ ] **Observable by Design (16)** - add structured logs when applicable.
 - [ ] **Explicit Stage Assignment (17)** - declare plugin stages clearly.
 
 Run the programmatic checks in `AGENTS.md` to confirm compliance.

--- a/examples/advanced_agent/main.py
+++ b/examples/advanced_agent/main.py
@@ -18,7 +18,7 @@ from entity.core.resources.container import ResourceContainer
 from plugins.builtin.resources.duckdb_database import DuckDBDatabaseResource
 from entity.resources.memory import Memory
 from pipeline.pipeline import execute_pipeline, generate_pipeline_id
-from pipeline.state import ConversationEntry, MetricsCollector, PipelineState
+from pipeline.state import ConversationEntry, PipelineState
 
 
 class EchoLLMResource(ResourcePlugin):
@@ -79,7 +79,6 @@ async def main() -> None:
             )
         ],
         pipeline_id=generate_pipeline_id(),
-        metrics=MetricsCollector(),
     )
     result: dict[str, Any] = await execute_pipeline("What is 2 + 2?", caps, state=state)
     print(result)

--- a/examples/basic_agent/main.py
+++ b/examples/basic_agent/main.py
@@ -17,7 +17,7 @@ from entity.resources.memory import Memory
 from pipeline.pipeline import execute_pipeline, generate_pipeline_id
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
-from pipeline.state import ConversationEntry, MetricsCollector, PipelineState
+from pipeline.state import ConversationEntry, PipelineState
 
 
 class EchoPrompt(PromptPlugin):
@@ -51,7 +51,6 @@ async def main() -> None:
             ConversationEntry(content="Hello", role="user", timestamp=datetime.now())
         ],
         pipeline_id=generate_pipeline_id(),
-        metrics=MetricsCollector(),
     )
     result: dict[str, Any] = await execute_pipeline("Hello", caps, state=state)
     print(result)

--- a/examples/duckdb_memory_agent/main.py
+++ b/examples/duckdb_memory_agent/main.py
@@ -14,7 +14,7 @@ from pipeline.stages import PipelineStage
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
 from entity.core.resources.container import ResourceContainer
 from pipeline.pipeline import execute_pipeline, generate_pipeline_id
-from pipeline.state import PipelineState, MetricsCollector
+from pipeline.state import PipelineState
 
 
 class DuckDBMemory(ResourcePlugin):
@@ -118,7 +118,6 @@ async def main() -> None:
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ],
         pipeline_id=generate_pipeline_id(),
-        metrics=MetricsCollector(),
     )
     first = await execute_pipeline("hi", caps, state=state)
 
@@ -127,7 +126,6 @@ async def main() -> None:
             ConversationEntry(content="again", role="user", timestamp=datetime.now())
         ],
         pipeline_id=generate_pipeline_id(),
-        metrics=MetricsCollector(),
     )
     second = await execute_pipeline("again", caps, state=state2)
 

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -15,7 +15,7 @@ from entity.core.resources.container import ResourceContainer
 from plugins.builtin.resources.duckdb_database import DuckDBDatabaseResource
 from entity.resources.memory import Memory
 from pipeline.pipeline import execute_pipeline, generate_pipeline_id
-from pipeline.state import ConversationEntry, MetricsCollector, PipelineState
+from pipeline.state import ConversationEntry, PipelineState
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
@@ -74,7 +74,6 @@ async def main() -> None:
             )
         ],
         pipeline_id=generate_pipeline_id(),
-        metrics=MetricsCollector(),
     )
     result: dict[str, Any] = await execute_pipeline(
         "Explain the sky", caps, state=state

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -107,9 +107,7 @@ class PluginContext:
             duration = time.perf_counter() - start
             if cache_result:
                 await cache_result(name, params, result)
-        if self._state.metrics:
-            key = f"{self.current_stage}:{name}"
-            self._state.metrics.record_tool_duration(key, duration)
+        # Tool duration metrics removed
         return result
 
     async def queue_tool_use(

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -58,9 +58,6 @@ class BasePlugin:
         start = time.perf_counter()
         response = await context.call_llm(context, prompt, purpose=purpose)
         duration = time.perf_counter() - start
-        if context.failure_info is None and hasattr(context._state, "metrics"):
-            key = f"{context.current_stage}:{self.__class__.__name__}:{purpose}"
-            context._state.metrics.record_llm_duration(key, duration)
         self.logger.info(
             "LLM call completed",
             extra={

--- a/src/entity/core/state.py
+++ b/src/entity/core/state.py
@@ -26,18 +26,6 @@ class ToolCall:
 
 
 @dataclass
-class MetricsCollector:
-    stage_durations: Dict[str, float] = field(default_factory=dict)
-
-    def record_stage_duration(self, stage: str, duration: float) -> None:
-        self.stage_durations[stage] = duration
-
-    def record_pipeline_duration(self, _duration: float) -> None:  # noqa: D401, ARG002
-        """No-op placeholder."""
-        pass
-
-
-@dataclass
 class PipelineState:
     conversation: List[ConversationEntry]
     response: Any = None
@@ -50,7 +38,6 @@ class PipelineState:
     iteration: int = 0
     current_stage: Optional[PipelineStage] = None
     last_completed_stage: Optional[PipelineStage] = None
-    metrics: MetricsCollector = field(default_factory=MetricsCollector)
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/src/pipeline/state.py
+++ b/src/pipeline/state.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-from entity.core.state import (
-    ConversationEntry,
-    FailureInfo,
-    LLMResponse,
-    MetricsCollector,
-)
+from entity.core.state import ConversationEntry, FailureInfo, LLMResponse
 from entity.core.state import PipelineState as CoreState
 from entity.core.state import ToolCall
 
@@ -16,7 +11,6 @@ __all__ = [
     "ConversationEntry",
     "FailureInfo",
     "LLMResponse",
-    "MetricsCollector",
     "PipelineState",
     "ToolCall",
 ]

--- a/src/pipeline/tools/execution.py
+++ b/src/pipeline/tools/execution.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 from entity.core.plugins import ToolExecutionError
 from entity.core.state import ToolCall
-from pipeline.state import PipelineState, MetricsCollector
+from pipeline.state import PipelineState
 from entity.core.context import PluginContext
 from entity.core.registries import SystemRegistries
 
@@ -38,9 +38,6 @@ async def execute_pending_tools(
             await tools.cache_result(call.name, call.params, result)
         results[call.result_key] = result
         context.store(call.result_key, result)
-        if state.metrics:
-            key = f"{state.current_stage}:{call.name}"
-            state.metrics.record_tool_duration(key, duration)
 
     await asyncio.gather(*(run_call(c) for c in list(state.pending_tool_calls)))
     return results

--- a/tests/integration/test_stage_failures.py
+++ b/tests/integration/test_stage_failures.py
@@ -10,7 +10,7 @@ from pipeline import PipelineStage, execute_pipeline
 from entity.core.plugins import BasePlugin
 from pipeline.pipeline import generate_pipeline_id
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import ConversationEntry, MetricsCollector, PipelineState
+from entity.core.state import ConversationEntry, PipelineState
 
 
 class RespondPlugin(BasePlugin):
@@ -61,7 +61,6 @@ def test_pipeline_recovers_from_stage_failure(
                 ConversationEntry(content="hi", role="user", timestamp=datetime.now())
             ],
             pipeline_id=generate_pipeline_id(),
-            metrics=MetricsCollector(),
         )
 
         await execute_pipeline("hi", capabilities, state_logger=logger, state=state)

--- a/tests/integration/test_vector_memory_integration.py
+++ b/tests/integration/test_vector_memory_integration.py
@@ -7,7 +7,6 @@ import pytest
 
 from entity.config.environment import load_env
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from entity.resources.memory import Memory
 from pipeline import (
     ConversationEntry,
@@ -98,7 +97,6 @@ def test_vector_memory_integration(pg_env):
                 )
             ],
             pipeline_id="conv1",
-            metrics=MetricsCollector(),
         )
         ctx = PluginContext(state, capabilities)
         plugin = ComplexPrompt({"k": 1})

--- a/tests/security/test_stage_input_validator.py
+++ b/tests/security/test_stage_input_validator.py
@@ -4,7 +4,6 @@ import asyncio
 from datetime import datetime
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from pipeline import (
     ConversationEntry,
     PipelineStage,
@@ -29,7 +28,6 @@ def test_validator_runs_before_plugin():
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
     )
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(DummyPlugin(), PipelineStage.DO))

--- a/tests/test_call_llm_logging.py
+++ b/tests/test_call_llm_logging.py
@@ -2,7 +2,6 @@ import asyncio
 from datetime import datetime
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from pipeline import (
     ConversationEntry,
     PipelineStage,
@@ -29,7 +28,6 @@ def make_context(llm) -> PluginContext:
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ],
         pipeline_id="123",
-        metrics=MetricsCollector(),
         current_stage=PipelineStage.THINK,
     )
     resources = ResourceContainer()

--- a/tests/test_chain_of_thought_prompt.py
+++ b/tests/test_chain_of_thought_prompt.py
@@ -2,7 +2,6 @@ import asyncio
 from datetime import datetime
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from pipeline import (
     ConversationEntry,
     PipelineState,
@@ -37,7 +36,6 @@ def make_context(llm: FakeLLM):
             )
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
     )
     resources = ResourceContainer()
     tools = ToolRegistry()

--- a/tests/test_claude_resource.py
+++ b/tests/test_claude_resource.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 
-from entity.core.state import MetricsCollector
 from pipeline import PipelineState, PluginContext, SystemInitializer, SystemRegistries
 from plugins.builtin.resources.llm.unified import UnifiedLLMResource
 
@@ -48,6 +47,6 @@ def test_context_get_llm_with_provider():
     }
     initializer = SystemInitializer.from_dict(cfg)
     plugin_reg, resource_reg, tool_reg, _ = asyncio.run(initializer.initialize())
-    state = PipelineState(conversation=[], pipeline_id="1", metrics=MetricsCollector())
+    state = PipelineState(conversation=[], pipeline_id="1")
     ctx = PluginContext(state, SystemRegistries(resource_reg, tool_reg, plugin_reg))
     assert isinstance(ctx.get_llm(), UnifiedLLMResource)

--- a/tests/test_complex_prompt.py
+++ b/tests/test_complex_prompt.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from unittest.mock import AsyncMock
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from entity.resources.memory import Memory
 from pipeline import (
     ConversationEntry,
@@ -44,7 +43,6 @@ def make_context(llm, memory):
             ConversationEntry(content="hello", role="user", timestamp=datetime.now())
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
     )
     resources = ResourceContainer()
     asyncio.run(resources.add("llm", llm))

--- a/tests/test_execute_pending_tools.py
+++ b/tests/test_execute_pending_tools.py
@@ -23,7 +23,6 @@ def make_state():
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
     )
     return state
 

--- a/tests/test_execute_stage.py
+++ b/tests/test_execute_stage.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import pytest
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from pipeline import (
     ConversationEntry,
     PipelineStage,
@@ -36,7 +35,6 @@ def make_state():
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ],
         pipeline_id="123",
-        metrics=MetricsCollector(),
     )
 
 

--- a/tests/test_gemini_resource.py
+++ b/tests/test_gemini_resource.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 
-from entity.core.state import MetricsCollector
 from pipeline import PipelineState, PluginContext, SystemInitializer, SystemRegistries
 from plugins.builtin.resources.llm.unified import UnifiedLLMResource
 
@@ -45,6 +44,6 @@ def test_context_get_llm_with_provider():
     }
     initializer = SystemInitializer.from_dict(cfg)
     plugin_reg, resource_reg, tool_reg, _ = asyncio.run(initializer.initialize())
-    state = PipelineState(conversation=[], pipeline_id="1", metrics=MetricsCollector())
+    state = PipelineState(conversation=[], pipeline_id="1")
     ctx = PluginContext(state, SystemRegistries(resource_reg, tool_reg, plugin_reg))
     assert isinstance(ctx.get_llm(), UnifiedLLMResource)

--- a/tests/test_intent_classifier_prompt.py
+++ b/tests/test_intent_classifier_prompt.py
@@ -2,7 +2,6 @@ import asyncio
 from datetime import datetime
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from pipeline import (
     ConversationEntry,
     PipelineState,
@@ -25,7 +24,6 @@ def make_context(llm: FakeLLM):
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
     )
     resources = ResourceContainer()
     asyncio.run(resources.add("llm", llm))

--- a/tests/test_llm_helpers.py
+++ b/tests/test_llm_helpers.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import pytest
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from pipeline import (
     ConversationEntry,
     PipelineStage,
@@ -29,7 +28,6 @@ def make_context(llm=None) -> PluginContext:
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
     )
     resources = ResourceContainer()
     if llm is not None:

--- a/tests/test_pii_scrubber_plugin.py
+++ b/tests/test_pii_scrubber_plugin.py
@@ -2,7 +2,6 @@ import asyncio
 from datetime import datetime
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from pipeline import (
     ConversationEntry,
     PipelineState,
@@ -24,7 +23,6 @@ def make_context():
             )
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
     )
     state.response = "Contact admin@example.com at (123) 456-7890"
     capabilities = SystemRegistries(

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from entity.core.state import MetricsCollector
 from pipeline import ConversationEntry, PipelineStage, PipelineState, PromptPlugin
 
 
@@ -17,7 +16,6 @@ def make_state() -> PipelineState:
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ],
         pipeline_id="123",
-        metrics=MetricsCollector(),
     )
 
 

--- a/tests/test_react_prompt.py
+++ b/tests/test_react_prompt.py
@@ -2,7 +2,6 @@ import asyncio
 from datetime import datetime
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from pipeline import (
     ConversationEntry,
     PipelineState,
@@ -33,7 +32,6 @@ def make_context(llm: FakeLLM):
             )
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
     )
     resources = ResourceContainer()
     tools = ToolRegistry()

--- a/tests/test_search_tool.py
+++ b/tests/test_search_tool.py
@@ -2,7 +2,6 @@ import asyncio
 from datetime import datetime
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from pipeline import (
     ConversationEntry,
     PipelineState,
@@ -20,7 +19,6 @@ async def run_search() -> str:
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
     )
     tools = ToolRegistry()
     await tools.add("search", SearchTool())

--- a/tests/test_tool_registry_options.py
+++ b/tests/test_tool_registry_options.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from entity.core.resources.container import ResourceContainer
 from entity.core.state import (
     ConversationEntry,
-    MetricsCollector,
     PipelineState,
     ToolCall,
 )
@@ -30,7 +29,6 @@ def _make_state() -> PipelineState:
             ConversationEntry(content="hi", role="user", timestamp=datetime.now()),
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
         current_stage=PipelineStage.DO,
     )
 
@@ -65,5 +63,4 @@ def test_cache_ttl():
     assert tool.calls == 1
     ctx = PluginContext(state, capabilities)
     assert ctx.load("b") == 0
-    key = f"{PipelineStage.DO}:sleep"
-    assert key in state.metrics.tool_durations
+    # Removed metrics check since metrics have been deprecated

--- a/tests/test_weather_api_tool.py
+++ b/tests/test_weather_api_tool.py
@@ -4,7 +4,6 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
 
 from entity.core.resources.container import ResourceContainer
-from entity.core.state import MetricsCollector
 from pipeline import (
     ConversationEntry,
     PipelineState,
@@ -38,7 +37,6 @@ async def run_weather() -> dict:
             ConversationEntry(content="hi", role="user", timestamp=datetime.now())
         ],
         pipeline_id="1",
-        metrics=MetricsCollector(),
     )
     tools = ToolRegistry()
     tool = WeatherApiTool({"base_url": base_url, "api_key": "x"})


### PR DESCRIPTION
## Summary
- drop `MetricsCollector` class
- strip metrics from pipeline execution and plugin context
- adjust examples and tests to stop passing metrics
- remove metrics references from documentation

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870257c7da08322b79e48cf11a36be6