### PR TITLE
Add merge artifact scan to migration docs

### DIFF
--- a/docs/source/migration_guide.md
+++ b/docs/source/migration_guide.md
@@ -52,3 +52,12 @@ as needed.
 
 By following these steps you can remove all deprecated experimental features and
 rely on the stable interfaces going forward.
+## 5. Check for Merge Artifacts
+
+After merging branches, search the repository for Git conflict markers before running the test suite. A quick scan prevents leftover markers from slipping into main:
+
+```bash
+grep -R "<<<<<<<" -n
+```
+
+Once the search returns no results, run `poetry run pytest` to ensure the repository state is sound.


### PR DESCRIPTION
## Summary
- document scanning for merge conflict markers in the migration guide
- confirm commit `fa36185c` and surrounding merges are clean

## Testing
- `poetry run pytest -q` *(fails: 86 failed, 79 passed, 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6870257e54448322abf72cc206f123bd