### PR TITLE
Remove tool registry cache_ttl

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -6,7 +6,6 @@ server:
 
 tool_registry:
   concurrency_limit: 5
-  cache_ttl: 300
 
 plugins:
   resources:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -6,7 +6,6 @@ server:
 
 tool_registry:
   concurrency_limit: 10
-  cache_ttl: 600
 
 plugins:
   resources:

--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -75,7 +75,6 @@ class ToolRegistryConfig(BaseModel):
     """Options controlling tool execution."""
 
     concurrency_limit: int = 5
-    cache_ttl: int | None = None
 
 
 class EntityConfig(BaseModel):

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -440,8 +440,7 @@ class SystemInitializer:
             # Phase 3.5: register tools
             tr_cfg = self.config.get("tool_registry", {})
             tool_registry = self.tool_registry_cls(
-                concurrency_limit=tr_cfg.get("concurrency_limit", 5),
-                cache_ttl=tr_cfg.get("cache_ttl"),
+                concurrency_limit=tr_cfg.get("concurrency_limit", 5)
             )
             for name, cls, config in registry.named_tool_classes():
                 instance = cls(config)

--- a/tests/test_tool_registry_options.py
+++ b/tests/test_tool_registry_options.py
@@ -49,21 +49,3 @@ def test_concurrency_limit():
     duration = time.time() - start
     assert tool.calls == 4
     assert duration >= 0.2
-
-
-def test_cache_ttl():
-    state = _make_state()
-    tool = SleepTool()
-    tools = ToolRegistry(cache_ttl=5)
-    asyncio.run(tools.add("sleep", tool))
-    capabilities = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
-    ctx = PluginContext(state, capabilities)
-    asyncio.run(ctx.queue_tool_use("sleep", result_key="a", delay=0))
-    asyncio.run(execute_pending_tools(state, capabilities))
-    asyncio.run(ctx.queue_tool_use("sleep", result_key="b", delay=0))
-    asyncio.run(execute_pending_tools(state, capabilities))
-    assert tool.calls == 1
-    ctx = PluginContext(state, capabilities)
-    assert ctx.load("b") == 0
-    key = f"{PipelineStage.DO}:sleep"
-    assert key in state.metrics.tool_durations


### PR DESCRIPTION
## Summary
- drop cache_ttl from dev and prod YAML configs
- remove cache_ttl field from configuration models
- update initializer to no longer expect cache_ttl
- clean up tool registry option tests

## Testing
- `poetry run pytest -q tests/test_tool_registry_options.py` *(fails: ToolRegistry.__init__() got an unexpected keyword argument 'concurrency_limit')*

------
https://chatgpt.com/codex/tasks/task_e_6870257ed5288322b17d83236b5d31e0