### PR TITLE
Enforce final response stage check

### DIFF
--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -19,6 +19,7 @@ class PluginContext:
         self._state = state
         self._registries = registries
         self._memory = getattr(registries.resources, "memory", None)
+        self._plugin_name: str | None = None
 
     # ------------------------------------------------------------------
     @property
@@ -27,6 +28,13 @@ class PluginContext:
 
     def set_current_stage(self, stage: PipelineStage) -> None:
         self._state.current_stage = stage
+
+    def set_current_plugin(self, name: str) -> None:
+        self._plugin_name = name
+
+    @property
+    def current_plugin(self) -> str | None:
+        return self._plugin_name
 
     @property
     def pipeline_id(self) -> str:
@@ -172,6 +180,8 @@ class PluginContext:
     def set_response(self, value: Any) -> None:
         if self.current_stage is not PipelineStage.DELIVER:
             raise PluginContextError(
-                f"set_response may only be called in DELIVER stage, not {self.current_stage}"
+                self.current_stage,
+                self.current_plugin or "unknown",
+                f"set_response may only be called in DELIVER stage, not {self.current_stage}",
             )
         self._state.response = value

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -115,9 +115,10 @@ async def execute_stage(
         for plugin in stage_plugins:
             context = PluginContext(state, registries)
             context.set_current_stage(stage)
+            name = registries.plugins.get_plugin_name(plugin)
+            context.set_current_plugin(name)
             if registries.validators is not None:
                 await registries.validators.validate(stage, context)
-            registries.plugins.get_plugin_name(plugin)
             try:
                 await plugin.execute(context)
                 if stage == PipelineStage.DELIVER and state.response is not None:


### PR DESCRIPTION
## Summary
- record plugin name during execution
- include stage & plugin name when `set_response` is called outside `DELIVER`

## Testing
- `poetry run pytest tests/test_set_response.py tests/test_set_response_validation.py -q`
- `poetry run pytest -q` *(fails: Plugin 'b' has invalid stage values, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6870e661a948832293f98d011f7c06ed