### PR TITLE
Add server helpers to Agent interface

### DIFF
--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 """Pipeline component: agent."""
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterable, Mapping, Optional, cast
+from typing import Any, Callable, Dict, Mapping, Optional, cast
 
 from pipeline.exceptions import PipelineError
-from pipeline.workflow import Pipeline, WorkflowMapping
+from pipeline.workflow import Pipeline
 
 from .builder import _AgentBuilder
-from .registries import PluginRegistry, SystemRegistries
+from .registries import SystemRegistries
 from .runtime import AgentRuntime
 
 
@@ -172,3 +172,30 @@ class Agent:
         if self._runtime is None:
             raise PipelineError("Agent not initialized")
         return self._runtime.capabilities
+
+    async def serve_http(self, **config: Any) -> None:
+        """Run the agent via the built-in HTTP adapter."""
+
+        await self._ensure_runtime()
+        from plugins.builtin.adapters.server import AgentServer
+
+        server = AgentServer(self.runtime)
+        await server.serve_http(**config)
+
+    async def serve_websocket(self, **config: Any) -> None:
+        """Run the agent via the built-in WebSocket adapter."""
+
+        await self._ensure_runtime()
+        from plugins.builtin.adapters.server import AgentServer
+
+        server = AgentServer(self.runtime)
+        await server.serve_websocket(**config)
+
+    async def serve_cli(self, **config: Any) -> None:
+        """Run the agent via the built-in CLI adapter."""
+
+        await self._ensure_runtime()
+        from plugins.builtin.adapters.server import AgentServer
+
+        server = AgentServer(self.runtime)
+        await server.serve_cli(**config)

--- a/src/plugins/builtin/adapters/__init__.py
+++ b/src/plugins/builtin/adapters/__init__.py
@@ -4,10 +4,12 @@ from .http_adapter import HTTPAdapter
 from .cli import CLIAdapter
 from .websocket import WebSocketAdapter
 from .dashboard import DashboardAdapter
+from .server import AgentServer
 
 __all__ = [
     "HTTPAdapter",
     "CLIAdapter",
     "WebSocketAdapter",
     "DashboardAdapter",
+    "AgentServer",
 ]

--- a/src/plugins/builtin/adapters/server.py
+++ b/src/plugins/builtin/adapters/server.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Simplistic server facade for built-in adapters."""
+
+from typing import Any
+
+from entity.core.runtime import AgentRuntime
+
+from .cli import CLIAdapter
+from .http_adapter import HTTPAdapter
+from .websocket import WebSocketAdapter
+
+
+class AgentServer:
+    """Expose adapter-based serving helpers."""
+
+    def __init__(self, runtime: AgentRuntime) -> None:
+        self.runtime = runtime
+
+    async def serve_http(self, **config: Any) -> None:
+        adapter = HTTPAdapter(self.runtime.manager, config)
+        await adapter.serve(self.runtime.capabilities)
+
+    async def serve_websocket(self, **config: Any) -> None:
+        adapter = WebSocketAdapter(self.runtime.manager, config)
+        await adapter.serve(self.runtime.capabilities)
+
+    async def serve_cli(self, **config: Any) -> None:
+        adapter = CLIAdapter(self.runtime.manager, config)
+        await adapter.serve(self.runtime.capabilities)


### PR DESCRIPTION
## Summary
- expose built-in `AgentServer` facade
- hook HTTP, WebSocket, and CLI serving methods to `Agent`

## Testing
- `poetry run pytest -q` *(fails: PluginContextError missing parameters)*

------
https://chatgpt.com/codex/tasks/task_e_6870e67a3cc48322a0c80fcc33b01baf