### PR TITLE
Refactor workflow separation

### DIFF
--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -32,24 +32,9 @@ from .exceptions import (
 from .observability.tracing import start_span
 from .stages import PipelineStage
 from .tools.execution import execute_pending_tools
+from .workflow import Workflow
 
 logger = get_logger(__name__)
-
-
-@dataclass
-class Workflow:
-    """Simple stage to plugin name mapping."""
-
-    stage_map: dict[PipelineStage, list[str]]
-
-    @classmethod
-    def from_dict(cls, data: Dict[Any, Any]) -> "Workflow":
-        mapping: dict[PipelineStage, list[str]] = {}
-        for stage, plugins in data.items():
-            stage_enum = PipelineStage.ensure(stage)
-            names = plugins if isinstance(plugins, list) else [plugins]
-            mapping[stage_enum] = [str(p) for p in names]
-        return cls(mapping)
 
 
 class Pipeline:

--- a/src/pipeline/workflow.py
+++ b/src/pipeline/workflow.py
@@ -27,19 +27,3 @@ class Pipeline:
         """Build an AgentRuntime using the stored builder and workflow."""
 
         return self.builder.build_runtime(workflow=self.workflow)
-
-
-@dataclass
-class Workflow:
-    """Mapping of pipeline stages to plugin names."""
-
-    stage_map: WorkflowMapping
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Iterable[str]]) -> "Workflow":
-        mapping: dict[PipelineStage, list[str]] = {}
-        for stage, plugins in data.items():
-            stage_enum = PipelineStage.ensure(stage)
-            names = list(plugins)
-            mapping[stage_enum] = [str(p) for p in names]
-        return cls(mapping)


### PR DESCRIPTION
## Summary
- alias pipeline workflow to entity workflow base
- import this alias in `pipeline.Pipeline`

## Testing
- `poetry run pytest -q` *(fails: PluginContextError.__init__() missing 2 required positional arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6870e67d16a88322ac8341585ad8f2fd