### PR TITLE
Update doc: add Layer 0 to plugin progression

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -313,8 +313,9 @@ This taxonomy provides a clear mental model for developers while maintaining the
 **Decision**: Maintain current 3-layer structure with improved transitions and guided discovery.
 
 **Layer Structure**:
+- **Layer 0**: Zero-config quick start (see [Layer 0: Zero-Config Developer Experience](#27-layer-0-zero-config-developer-experience))
 - **Layer 1**: Function decorators (`@agent.plugin`) with auto-classification
-- **Layer 2**: Class-based plugins with explicit control  
+- **Layer 2**: Class-based plugins with explicit control
 - **Layer 3**: Advanced plugins with sophisticated pipeline access
 
 **Enhancements**:


### PR DESCRIPTION
## Summary
- integrate Layer 0 into the plugin abstraction bullets

## Testing
- `poetry install --with dev`
- `black .`
- `pytest -n auto` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6870e658e5f0832296d0ccc3eb6688e8