### PR TITLE
Improve analyze-plugin output

### DIFF
--- a/src/cli/plugin_tool/main.py
+++ b/src/cli/plugin_tool/main.py
@@ -246,7 +246,18 @@ class PluginToolCLI:
             if inspect.iscoroutinefunction(obj):
                 plugin = PluginAutoClassifier.classify(obj)
                 stages = ", ".join(str(s) for s in plugin.stages)
-                logger.info("%s -> %s", name, stages)
+
+                reasons: list[str] = []
+                if getattr(plugin, "_explicit_stages", False):
+                    reasons.append("explicit hints")
+                else:
+                    if getattr(plugin, "_auto_inferred_stages", False):
+                        reasons.append("source heuristics")
+                    if plugin.stages == getattr(plugin, "_type_default_stages", []):
+                        reasons.append("type defaults")
+                reason = ", ".join(reasons) if reasons else "unknown"
+
+                logger.info("%s -> %s (%s)", name, stages, reason)
                 found = True
 
         if not found:

--- a/tests/test_plugin_tool_analyze.py
+++ b/tests/test_plugin_tool_analyze.py
@@ -1,0 +1,21 @@
+import logging
+
+from cli.plugin_tool.main import PluginToolArgs, PluginToolCLI
+
+
+def _create_tmp_plugin(tmp_path):
+    file = tmp_path / "sample.py"
+    file.write_text("""async def foo(ctx):\n    return 'hi'\n""")
+    return file
+
+
+def test_analyze_plugin_reports_reason(tmp_path, caplog):
+    path = _create_tmp_plugin(tmp_path)
+    cli = PluginToolCLI.__new__(PluginToolCLI)
+    cli.args = PluginToolArgs(command="analyze-plugin", path=str(path))
+    caplog.set_level(logging.INFO)
+    result = cli._analyze_plugin()
+    assert result == 0
+    messages = [r.message for r in caplog.records if "foo ->" in r.message]
+    assert messages
+    assert "source heuristics" in messages[0]


### PR DESCRIPTION
## Summary
- enhance analyze-plugin output with reasons for stage inference
- add regression test for analyze-plugin

## Testing
- `poetry run isort --check src tests` *(fails: imports not sorted)*
- `poetry run flake8 src tests` *(fails: F401, F821, etc.)*
- `poetry run mypy src` *(fails: found 161 errors)*
- `bandit -r src` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6870eb61a0dc83228ca08a59c3ee8c26