### PR TITLE
Add docs for plugin analysis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Check the [hero landing page](https://entity.readthedocs.io/en/latest/) for a vi
 poetry run entity-cli --config config/dev.yaml
 ```
 
-See the [Quick Start](docs/source/quick_start.md) for step-by-step setup or browse the [full documentation](https://entity.readthedocs.io/en/latest/).
+See the [Quick Start](docs/source/quick_start.md) for step-by-step setup or browse the [full documentation](https://entity.readthedocs.io/en/latest/). For plugin inspection see the [Analyze Plugin Functions](docs/source/plugin_guide.md#analyze-plugin-functions) section.

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -240,6 +240,22 @@ poetry run entity-cli serve-websocket --config config/dev.yaml
 When implementing custom error handling, see the failure plugin template at
 `src/cli/templates/failure.py` and the [error handling guide](error_handling.md).
 
+## Analyze Plugin Functions
+
+Use the plugin analysis tool to see which pipeline stages a plain async function
+would run under. The tool relies on ``PluginAutoClassifier`` to infer the best
+plugin wrapper.
+
+```bash
+poetry run python src/cli/plugin_tool/main.py analyze-plugin path/to/plugin.py
+```
+
+Example output:
+
+```text
+INFO     greet -> THINK
+```
+
 ## Troubleshooting Plugins
 - **Plugin not executing** – confirm the `stages` list contains the desired pipeline stage.
 - **Missing dependency** – ensure the plugin name appears in `plugins.resources` or `plugins.tools`.


### PR DESCRIPTION
## Summary
- document the `analyze-plugin` helper in the plugin guide
- point README to the new documentation

## Testing
- `poetry run black . --check`
- `poetry run pytest -q` *(fails: Plugin 'b' has invalid stage values and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870eb60f5388322bde84f8786cd8ae1