### PR TITLE
Add circuit breaker tuning docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -438,9 +438,12 @@ class BasePlugin:
 
 **Circuit Breaker Integration**:
 - Database connections: 3 failures = circuit open
-- External APIs: 5 failures = circuit open  
+- External APIs: 5 failures = circuit open
 - File systems: 2 failures = circuit open
 - All failures surface with full technical details for debugging
+
+For configuration examples see
+[Tuning Circuit Breaker Thresholds](docs/source/error_handling.md#tuning-circuit-breaker-thresholds).
 
 **Developer Experience Features**:
 - CLI validation tools: `poetry run entity-cli validate --config config.yaml`

--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -50,6 +50,26 @@ When any plugin raises an exception the framework stops executing the rest of th
 The failure is captured in `FailureInfo` and the `ERROR` stage runs immediately
 to handle the problem. No additional plugins from the failed stage are invoked.
 
+## Tuning Circuit Breaker Thresholds
+
+You can modify circuit breaker limits directly in plugin configuration. The
+`init_failure_threshold` option controls how many initialization attempts are
+allowed before the startup breaker opens.
+
+```yaml
+plugins:
+  - db:
+      type: Postgres
+      failure_threshold: 5
+      failure_reset_timeout: 120
+      init_failure_threshold: 2
+```
+
+Shorter reset windows speed up feedback during development, while production
+deployments usually set higher thresholds. See
+[Architecture Section 5](../ARCHITECTURE.md#5-error-handling-and-validation-fail-fast-with-multi-layered-validation)
+for the design rationale.
+
 ## Error Responses and Failure Plugins
 
 When a stage fails the pipeline records a `FailureInfo` object and runs plugins assigned to the `ERROR` stage. These plugins can attempt recovery, log the error or present a fallback message. A common pattern is to convert the failure info into a user-facing error response:


### PR DESCRIPTION
## Summary
- document how to tune circuit breaker thresholds
- show an example with the initialization breaker
- reference the tuning guide from the architecture overview

## Testing
- `poetry install --with dev`
- `poetry run black src tests`

------
https://chatgpt.com/codex/tasks/task_e_6871061cde64832284b6f7b1dc1dba2e