### PR TITLE
Remove outdated validator hooks docs

### DIFF
--- a/docs/source/security_config.md
+++ b/docs/source/security_config.md
@@ -17,14 +17,6 @@ plugins:
 
 Each adapter validates the provided bearer token and ensures the role is allowed.
 
-## Input Validation Hooks
-
-Register callbacks on `SystemRegistries.validators` to inspect or modify the
-`PluginContext` before each stage plugin runs.
-
-```python
-capabilities.validators.register(PipelineStage.PARSE, my_validator)
-```
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary
- remove the old validator hooks section from the security docs

## Testing
- `poetry run black src tests`
- `poetry run pytest` *(fails: NameError: user_id is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6871066a39048322b7ab75f4bd4c13cd