### PR TITLE
Validate queued tool use

### DIFF
--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -133,6 +133,8 @@ class PluginContext:
         self, name: str, *, result_key: str | None = None, **params: Any
     ) -> str:
         """Queue ``name`` for later execution and return its result key."""
+        if self._registries.tools.get(name) is None:
+            raise ValueError(f"Tool '{name}' not found")
         if result_key is None:
             result_key = f"{name}_{len(self._state.pending_tool_calls)}"
         self._state.pending_tool_calls.append(

--- a/tests/test_context_queue_tool_use.py
+++ b/tests/test_context_queue_tool_use.py
@@ -1,0 +1,26 @@
+import asyncio
+from datetime import datetime
+
+import pytest
+from entity.core.resources.container import ResourceContainer
+from entity.core.state import ConversationEntry, PipelineState
+from entity.core.context import PluginContext
+from pipeline import PluginRegistry, SystemRegistries, ToolRegistry
+
+
+def _make_context() -> PluginContext:
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(content="hi", role="user", timestamp=datetime.now())
+        ],
+        pipeline_id="1",
+    )
+    caps = SystemRegistries(ResourceContainer(), ToolRegistry(), PluginRegistry())
+    return PluginContext(state, caps)
+
+
+@pytest.mark.unit
+def test_queue_tool_use_unknown_tool():
+    ctx = _make_context()
+    with pytest.raises(ValueError):
+        asyncio.run(ctx.queue_tool_use("missing"))


### PR DESCRIPTION
## Summary
- verify queued tools exist before queuing
- test queuing an unknown tool raises ValueError

## Testing
- `poetry run pytest tests/test_context_queue_tool_use.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68710713d7188322a2737e6a2d6fcd61