### PR TITLE
Add dependencies attribute to builtin resources

### DIFF
--- a/src/plugins/builtin/resources/duckdb_database.py
+++ b/src/plugins/builtin/resources/duckdb_database.py
@@ -13,6 +13,7 @@ class DuckDBDatabaseResource(ResourcePlugin):
 
     name = "duckdb_database"
     stages: list = []
+    dependencies: list[str] = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/plugins/builtin/resources/echo_llm.py
+++ b/src/plugins/builtin/resources/echo_llm.py
@@ -10,6 +10,8 @@ from .llm_resource import LLMResource
 class EchoLLMResource(LLMResource):
     """LLM that simply echoes the prompt."""
 
+    dependencies: list[str] = []
+
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
 

--- a/src/plugins/builtin/resources/llm_resource.py
+++ b/src/plugins/builtin/resources/llm_resource.py
@@ -11,6 +11,7 @@ class LLMResource(ResourcePlugin):
     """Base class for simple LLM resources."""
 
     name = "llm"
+    dependencies: list[str] = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/plugins/builtin/resources/postgres.py
+++ b/src/plugins/builtin/resources/postgres.py
@@ -27,6 +27,7 @@ class PostgresResource(ResourcePlugin):
 
     name = "postgres"
     stages: list = []
+    dependencies: list[str] = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})


### PR DESCRIPTION
## Summary
- declare `dependencies: list[str] = []` on DuckDBDatabaseResource, PostgresResource, LLMResource and EchoLLMResource
- run formatting and tests

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'cli.plugin_tool')*

------
https://chatgpt.com/codex/tasks/task_e_68710720b4cc8322bd486d0ad209b1a9