### PR TITLE
Improve docs for queued tools

### DIFF
--- a/docs/source/context.md
+++ b/docs/source/context.md
@@ -49,6 +49,19 @@ if context.has("answer"):
     result = context.load("answer")
 ```
 
+## Queued Tool Results
+
+`queue_tool_use()` returns a key that identifies the pending call. The pipeline
+executes queued tools after the stage completes and stores each result under its
+key. Use `context.load(result_key)` in a later stage to read the value.
+
+```python
+result_key = context.queue_tool_use("search", query="open source ai")
+
+# Later, after queued tools run
+search_results = context.load(result_key)
+```
+
 ## Advanced API
 
 Some less common operations are exposed through `context.advanced`.

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -49,9 +49,32 @@ async def summarizer(ctx):
         return ctx.load("summary")
     result_key = ctx.queue_tool_use("search", {"query": ctx.message})
     summary = await ctx.tool_use("summarize", text=ctx.message)
-ctx.store("summary", summary)
+    ctx.store("summary", summary)
     return summary
 ```
+
+Queued tools run after the stage completes. Their results are stored using the
+returned key and can be loaded later:
+
+```python
+@agent.plugin
+async def follow_up(ctx):
+    key = ctx.queue_tool_use("search", {"query": ctx.message})
+    await ctx.tool_use("summarize", text=ctx.message)
+    ctx.say(ctx.load(key))
+```
+
+### ToolRegistry Options
+
+Tools are managed by ``ToolRegistry`` which exposes two knobs:
+
+* ``concurrency_limit`` – maximum number of queued tools that execute in
+  parallel.
+* ``cache_ttl`` – time-to-live in seconds for cached tool results. Calls with the
+  same parameters return the cached result while valid.
+
+Specify these options in your YAML configuration or when constructing
+``Agent`` programmatically.
 
 ## Built-in Reasoning Plugins
 


### PR DESCRIPTION
## Summary
- explain retrieving queued tool results in `context.load`
- show how ToolRegistry controls concurrency and caching
- give example of retrieving queued tool result

## Testing
- `poetry run black src tests`
- `PYTHONPATH=docs/source poetry run poe docs`


------
https://chatgpt.com/codex/tasks/task_e_687107153d4483228bb9698ff2478fac