### PR TITLE
Check merge commit for conflicts

### DIFF
--- a/docs/source/migration_guide.md
+++ b/docs/source/migration_guide.md
@@ -61,3 +61,9 @@ grep -R "<<<<<<<" -n
 ```
 
 Once the search returns no results, run `poetry run pytest` to ensure the repository state is sound.
+
+For historical merges such as `fa36185c`, verify there are no embedded markers by inspecting the commit directly:
+
+```bash
+git show fa36185c | grep '<<<<<<<' || echo "clean"
+```


### PR DESCRIPTION
## Summary
- document how to verify merge commits for leftover conflict markers

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'cli.plugin_tool')*

------
https://chatgpt.com/codex/tasks/task_e_687106f3979883228f0838e830c3749c