### PR TITLE
Remove deprecated tool caching

### DIFF
--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Minimal plugin context objects."""
 
 import asyncio
-import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -114,19 +113,7 @@ class PluginContext:
         tool = self._registries.tools.get(name)
         if tool is None:
             raise ValueError(f"Tool '{name}' not found")
-        get_cached = getattr(self._registries.tools, "get_cached_result", None)
-        cache_result = getattr(self._registries.tools, "cache_result", None)
-        cached = await get_cached(name, params) if get_cached else None
-        if cached is not None:
-            result = cached
-            duration = 0.0
-        else:
-            start = time.perf_counter()
-            result = await tool.execute_function(params)
-            duration = time.perf_counter() - start
-            if cache_result:
-                await cache_result(name, params, result)
-        # Tool duration metrics removed
+        result = await tool.execute_function(params)
         return result
 
     async def queue_tool_use(

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List
-import time
 
 
 class PluginRegistry:
@@ -43,17 +42,11 @@ class PluginRegistry:
 
 
 class ToolRegistry:
-    """Store registered tools with basic caching and discovery."""
+    """Store registered tools and handle discovery."""
 
-    def __init__(
-        self, *, concurrency_limit: int = 5, cache_ttl: int | None = None
-    ) -> None:
+    def __init__(self, *, concurrency_limit: int = 5) -> None:
         self._tools: Dict[str, Callable[..., Awaitable[Any]]] = {}
         self.concurrency_limit = concurrency_limit
-        self.cache_ttl = cache_ttl
-        self._cache: Dict[tuple[str, frozenset[tuple[str, Any]]], tuple[Any, float]] = (
-            {}
-        )
 
     async def add(self, name: str, tool: Callable[..., Awaitable[Any]]) -> None:
         self._tools[name] = tool
@@ -77,27 +70,6 @@ class ToolRegistry:
                 if any(i in t.lower() for t in getattr(v, "intents", []))
             ]
         return items
-
-    async def get_cached_result(self, name: str, params: Dict[str, Any]) -> Any | None:
-        if self.cache_ttl is None:
-            return None
-        key = (name, frozenset(params.items()))
-        item = self._cache.get(key)
-        if not item:
-            return None
-        result, timestamp = item
-        if time.time() - timestamp > self.cache_ttl:
-            self._cache.pop(key, None)
-            return None
-        return result
-
-    async def cache_result(
-        self, name: str, params: Dict[str, Any], result: Any
-    ) -> None:
-        if self.cache_ttl is None:
-            return
-        key = (name, frozenset(params.items()))
-        self._cache[key] = (result, time.time())
 
 
 @dataclass

--- a/src/pipeline/tools/execution.py
+++ b/src/pipeline/tools/execution.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from typing import Any, Dict
 
 from entity.core.plugins import ToolExecutionError
@@ -23,19 +22,11 @@ async def execute_pending_tools(
     context = PluginContext(state, registries)
 
     async def run_call(call: ToolCall) -> None:
-        cached = await tools.get_cached_result(call.name, call.params)
-        if cached is not None:
-            result = cached
-            duration = 0.0
-        else:
-            tool = tools.get(call.name)
-            if tool is None:
-                raise ToolExecutionError(f"Tool '{call.name}' not found")
-            start = time.perf_counter()
-            async with sem:
-                result = await tool.execute_function(call.params)
-            duration = time.perf_counter() - start
-            await tools.cache_result(call.name, call.params, result)
+        tool = tools.get(call.name)
+        if tool is None:
+            raise ToolExecutionError(f"Tool '{call.name}' not found")
+        async with sem:
+            result = await tool.execute_function(call.params)
         results[call.result_key] = result
         context.store(call.result_key, result)
 

--- a/tests/test_tool_registry_options.py
+++ b/tests/test_tool_registry_options.py
@@ -47,20 +47,3 @@ def test_concurrency_limit():
     duration = time.time() - start
     assert tool.calls == 4
     assert duration >= 0.2
-
-
-def test_cache_ttl():
-    state = _make_state()
-    tool = SleepTool()
-    tools = ToolRegistry(cache_ttl=5)
-    asyncio.run(tools.add("sleep", tool))
-    capabilities = SystemRegistries(ResourceContainer(), tools, PluginRegistry())
-    ctx = PluginContext(state, capabilities)
-    asyncio.run(ctx.queue_tool_use("sleep", result_key="a", delay=0))
-    asyncio.run(execute_pending_tools(state, capabilities))
-    asyncio.run(ctx.queue_tool_use("sleep", result_key="b", delay=0))
-    asyncio.run(execute_pending_tools(state, capabilities))
-    assert tool.calls == 1
-    ctx = PluginContext(state, capabilities)
-    assert ctx.load("b") == 0
-    # Removed metrics check since metrics have been deprecated


### PR DESCRIPTION
## Summary
- drop cache options from ToolRegistry
- clean up context helpers and tool execution flow
- delete cache tests

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'cli.plugin_tool')*

------
https://chatgpt.com/codex/tasks/task_e_687106f1e0e08322bd91e092de706d57