### PR TITLE
Add PipelineWorker

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -484,6 +484,7 @@ class PipelineWorker:
         await memory.save_conversation(pipeline_id, state.conversation)
         return result
 ```
+Implemented in `src/entity/worker/pipeline_worker.py`.
 
 **Resource Implementation**:
 ```python

--- a/src/entity/worker/pipeline_worker.py
+++ b/src/entity/worker/pipeline_worker.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from entity.core.registries import SystemRegistries
+from entity.core.state import ConversationEntry
+from pipeline.pipeline import execute_pipeline
+from pipeline.state import PipelineState
+
+
+class PipelineWorker:
+    """Stateless executor that runs a pipeline for a conversation."""
+
+    def __init__(self, registries: SystemRegistries) -> None:
+        self.registries = registries
+
+    async def run_stages(self, state: PipelineState) -> Any:
+        """Delegate pipeline execution to the existing driver."""
+        # user_message is ignored when ``state`` is provided
+        return await execute_pipeline("", self.registries, state=state)
+
+    async def execute_pipeline(self, pipeline_id: str, message: str) -> Any:
+        """Process ``message`` using the pipeline identified by ``pipeline_id``."""
+        memory = self.registries.resources.get("memory")
+        conversation = await memory.load_conversation(pipeline_id)
+        conversation.append(
+            ConversationEntry(content=message, role="user", timestamp=datetime.now())
+        )
+        state = PipelineState(conversation=conversation, pipeline_id=pipeline_id)
+        result = await self.run_stages(state)
+        await memory.save_conversation(pipeline_id, state.conversation)
+        return result

--- a/tests/worker/test_pipeline_worker.py
+++ b/tests/worker/test_pipeline_worker.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.resources.container import ResourceContainer
+from entity.resources.memory import Memory
+from entity.worker.pipeline_worker import PipelineWorker
+from pipeline.base_plugins import PromptPlugin
+from pipeline.stages import PipelineStage
+
+
+class RespondPlugin(PromptPlugin):
+    stages = [PipelineStage.DELIVER]
+
+    async def _execute_impl(self, context):  # pragma: no cover - trivial
+        context.set_response("ok")
+
+
+async def build_worker() -> PipelineWorker:
+    resources = ResourceContainer()
+    await resources.add("memory", Memory())
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+    regs = SystemRegistries(resources, ToolRegistry(), plugins)
+    return PipelineWorker(regs)
+
+
+def test_worker_keeps_no_state_between_calls():
+    async def run():
+        worker = await build_worker()
+        memory = worker.registries.resources.get("memory")
+        await worker.execute_pipeline("1", "hello")
+        convo1 = await memory.load_conversation("1")
+        assert convo1 and convo1[-1].content == "hello"
+        assert vars(worker) == {"registries": worker.registries}
+
+        await worker.execute_pipeline("2", "bye")
+        convo2 = await memory.load_conversation("2")
+        assert convo2 and convo2[-1].content == "bye"
+        assert vars(worker) == {"registries": worker.registries}
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- implement stateless `PipelineWorker`
- add tests to confirm workers don't hold conversation data
- link worker implementation from ARCHITECTURE docs

## Testing
- `poetry run black src/entity/worker/pipeline_worker.py tests/worker/test_pipeline_worker.py`
- `poetry run isort src/entity/worker/pipeline_worker.py tests/worker/test_pipeline_worker.py`
- `poetry run flake8 src/entity/worker/pipeline_worker.py tests/worker/test_pipeline_worker.py`
- `poetry run mypy src` *(fails: several errors)*
- `bandit -r src/entity/worker/pipeline_worker.py` *(fails: command not found)*
- `python tools/check_empty_dirs.py` *(fails: file not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68710706d18c83229cf2869583ef7852