### PR TITLE
Fix docs about memory defaults

### DIFF
--- a/architecture/5_minute_start.md
+++ b/architecture/5_minute_start.md
@@ -1,5 +1,5 @@
 # 5-Minute Start
 
-The framework aims to get developers experimenting in minutes. The default `Memory` resource automatically configures DuckDB in memory so no database setup is required. This choice trades durability for speed during early exploration. Because DuckDB runs in the same process, the agent can start, store conversation history, and run tools without external dependencies.
+The framework aims to get developers experimenting in minutes. The default `Memory` resource stores data only in memory so no database setup is required. This choice trades durability for speed during early exploration. Use a custom resource such as DuckDB when you need to persist history.
 
-For production deployments you can switch to Postgres or any other supported backend by updating the `memory` configuration in your YAML file. The in-memory DuckDB setup is kept small so new users can try the agent with a single command.
+For production deployments you can switch to Postgres or any other supported backend by updating the `memory` configuration in your YAML file. The ephemeral setup keeps the quick start simple, but you will want a persistent backend before moving to production.

--- a/architecture/general.md
+++ b/architecture/general.md
@@ -126,9 +126,9 @@ storage = StorageResource({})
 storage.filesystem = S3FileSystem(bucket="agent-files")
 ```
 
-MemoryResource \u2013 composite store that defaults to a DuckDB-backed database
-in memory and supports optional SQL/NoSQL and vector backends. MemoryResource
-uses an in-memory DuckDB database by default, so there is no separate
+MemoryResource \u2013 composite store that keeps data in memory by default and
+supports optional SQL/NoSQL and vector backends. Use a custom resource such as
+the DuckDB example when persistence is required. There is no separate
 `InMemoryResource`.
 
 ## Plugin System Details

--- a/docs/adr/0003-five-minute-start.md
+++ b/docs/adr/0003-five-minute-start.md
@@ -4,10 +4,10 @@
 Accepted
 
 ## Context
-Early experimentation should require no external services. A persistent database often slows first-time users. DuckDB runs in-process and can operate entirely in memory.
+Early experimentation should require no external services. A persistent database often slows first-time users, so the default memory plugin uses an in-process dictionary. DuckDB remains available for lightweight persistence.
 
 ## Decision
-The default `memory` resource uses DuckDB in memory so new users can launch an agent with a single command. This configuration provides conversation history and vector search without installing a database server.
+The default `memory` resource keeps data in memory only. New users can launch an agent with a single command, but history is lost on restart. The DuckDB example shows how to add simple persistence without running a server.
 
 ## Consequences
 - Quick local demos and tutorials do not require additional infrastructure.

--- a/docs/source/advanced_usage.md
+++ b/docs/source/advanced_usage.md
@@ -2,7 +2,7 @@
 
 ### Composing Storage Backends
 
-Local development uses a file-backed DuckDB database by default, so you can
+The examples use a file-backed DuckDB database for local development, so you can
 experiment without running an external server. `StorageResource` composes the
 database and optional file system into a single interface:
 

--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -2,8 +2,8 @@
 
 The Entity Pipeline Framework uses a single execution pipeline with explicit
 stages. Plugins implement each stage and provide reusable behavior. The default
-agent stores conversations in a DuckDB database that runs entirely in memory so
-you can start experimenting without setting up external services.
+agent keeps conversations only in memory. Use a custom resource such as the
+DuckDB example when you need persistence.
 
 ## Pipeline Stages
 - **parse** – validate input and load context

--- a/docs/source/components_overview.md
+++ b/docs/source/components_overview.md
@@ -1,6 +1,6 @@
 # Component Overview
 
-This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](https://github.com/Ladvien/entity/blob/main/architecture/general.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](https://github.com/Ladvien/entity/blob/main/config/dev.yaml). The sample configuration stores history in an in-memory DuckDB database so you can experiment immediately.
+This page explains the main building blocks of the Entity Pipeline framework. Use it alongside the [architecture overview](https://github.com/Ladvien/entity/blob/main/architecture/general.md), [plugin guide](plugin_guide.md) and [plugin cheat sheet](plugin_cheatsheet.md). A working configuration is available in [`config/dev.yaml`](https://github.com/Ladvien/entity/blob/main/config/dev.yaml). The sample configuration stores history only in memory so you can experiment immediately.
 
 ## Pipelines and Stages
 
@@ -47,10 +47,10 @@ An LLM resource wraps a language model provider. Plugins can call `context.ask_l
 
 ### Memory vs Storage
 
-`Memory` \u2013 composite store that defaults to a DuckDB-backed database in
-memory and supports optional SQL/NoSQL and vector backends. Memory uses an
-in-memory DuckDB database by default, so there is no separate `InMemoryResource`.
-`StorageResource` handles file CRUD across databases, vector stores, and file systems.
+`Memory` \u2013 composite store that keeps data in memory by default. Use a
+custom resource such as the DuckDB example when you need to persist history.
+There is no separate `InMemoryResource`. `StorageResource` handles file CRUD
+across databases, vector stores, and file systems.
 
 ## Adapters
 

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -183,7 +183,7 @@ Additional pipelines are available in a dedicated examples repository.
 
 ### StorageResource Composition
 
-`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. Memory persists conversation history and vectors and is configured in [config/dev.yaml](https://github.com/Ladvien/entity/blob/main/config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. The scaffold's `dev.yaml` already registers `DuckDBDatabaseResource`, so local development works out of the box. With the plugin configured the code looks like:
+`StorageResource` composes `DatabaseResource`, `VectorStoreResource`, and `FileSystemResource` behind one interface for handling files. Memory persists conversation history and vectors and is configured in [config/dev.yaml](https://github.com/Ladvien/entity/blob/main/config/dev.yaml). Use `StorageResource` when your plugins need to create or read files. The scaffold's `dev.yaml` registers `DuckDBDatabaseResource` for this purpose, so local development works out of the box. With the plugin configured the code looks like:
 
 ```python
 resources = ResourceContainer()

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -9,7 +9,8 @@ Ready-made agents live in the new `examples/` directory. Run them with
 
 ### Programmatic Configuration
 Build the same configuration in Python using the models from
-`entity.config`. The `Memory` resource sets up an in-memory DuckDB database by default so no database server is required:
+`entity.config`. The `Memory` resource is ephemeral by default; use a custom
+resource such as the DuckDB example if you need to persist history:
 
 ```python
 from entity.config.models import EntityConfig, PluginsSection, PluginConfig
@@ -56,7 +57,9 @@ curl -X POST -H "Content-Type: application/json" \
 
 You should see a simple reply from the example pipeline.
 
-The generated configuration stores conversation history in an in-memory DuckDB database. You can switch to a file-based or server database later by editing `config/dev.yaml`.
+The generated configuration keeps conversation history only in memory. To
+persist data across runs, register a custom resource like the DuckDB example and
+update `config/dev.yaml`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- clarify that Memory resource is ephemeral
- update docs to recommend DuckDB for persistence

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.plugin_tool')*

------
https://chatgpt.com/codex/tasks/task_e_68710775862c8322a574085ac1291bae