### PR TITLE
Remove context snapshot logging

### DIFF
--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -62,7 +62,6 @@ fields:
 * ``error`` – human readable message
 * ``pipeline_id`` – unique identifier for the run
 * ``retry_count`` – current iteration count
-* ``context_snapshot`` – serialized pipeline state if available
 
 These fields provide enough information to correlate failures with pipeline
 state and retry attempts.

--- a/user_plugins/failure/basic_logger.py
+++ b/user_plugins/failure/basic_logger.py
@@ -21,7 +21,6 @@ class BasicLogger(FailurePlugin):
         try:
             info = context.failure_info
             if info is not None:
-                snapshot = getattr(info, "context_snapshot", None)
                 logger.error(
                     "Pipeline failure encountered",
                     extra={
@@ -33,7 +32,6 @@ class BasicLogger(FailurePlugin):
                         "retry_count": getattr(
                             getattr(context, "_state", None), "iteration", 0
                         ),
-                        **({"context_snapshot": snapshot} if snapshot else {}),
                     },
                 )
             else:


### PR DESCRIPTION
## Summary
- drop context_snapshot field from `BasicLogger`
- remove doc references to context_snapshot

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.plugin_tool')*

------
https://chatgpt.com/codex/tasks/task_e_6871077425b48322ba43626ca1a57e8f