### PR TITLE
Add request_id alias and update logging

### DIFF
--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -44,6 +44,11 @@ class PluginContext:
         return self._state.pipeline_id
 
     @property
+    def request_id(self) -> str:
+        """Alias for ``pipeline_id`` for compatibility with logging."""
+        return self.pipeline_id
+
+    @property
     def user_id(self) -> str:
         return self._user_id
 

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -1,0 +1,15 @@
+from entity.core.resources.container import ResourceContainer
+from entity.core.state import PipelineState
+from pipeline import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.context import PluginContext
+
+
+def make_context() -> PluginContext:
+    state = PipelineState(conversation=[], pipeline_id="pid")
+    registries = SystemRegistries(ResourceContainer(), ToolRegistry(), PluginRegistry())
+    return PluginContext(state, registries)
+
+
+def test_request_id_matches_pipeline_id():
+    ctx = make_context()
+    assert ctx.request_id == ctx.pipeline_id

--- a/user_plugins/failure/basic_logger.py
+++ b/user_plugins/failure/basic_logger.py
@@ -29,7 +29,7 @@ class BasicLogger(FailurePlugin):
                         "plugin": info.plugin_name,
                         "error": info.error_message,
                         "type": info.error_type,
-                        "pipeline_id": context.pipeline_id,
+                        "pipeline_id": context.request_id,
                         "retry_count": getattr(
                             getattr(context, "_state", None), "iteration", 0
                         ),


### PR DESCRIPTION
## Summary
- expose `context.request_id` as alias of `pipeline_id`
- log using `context.request_id` in `BasicLogger`
- verify new property in unit test

## Testing
- `poetry run pytest -q tests/test_request_id.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.plugin_tool')*

------
https://chatgpt.com/codex/tasks/task_e_6871076ee4b0832282cad5e5b2e721c8