### PR TITLE
Add pipeline context snapshot to FailureInfo

### DIFF
--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -62,7 +62,7 @@ fields:
 * ``error`` – human readable message
 * ``pipeline_id`` – unique identifier for the run
 * ``retry_count`` – current iteration count
-* ``context_snapshot`` – serialized pipeline state if available
+* ``context_snapshot`` – serialized pipeline state (always present but may be empty)
 
 These fields provide enough information to correlate failures with pipeline
 state and retry attempts.

--- a/src/entity/core/state.py
+++ b/src/entity/core/state.py
@@ -81,6 +81,7 @@ class FailureInfo:
     error_message: str
     original_exception: Exception | None = None
     timestamp: datetime = field(default_factory=datetime.now)
+    context_snapshot: dict[str, Any] | None = None
 
 
 @dataclass

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -31,7 +31,6 @@ from .exceptions import (
 )
 from .observability.tracing import start_span
 from .stages import PipelineStage
-from .workflow import Workflow
 from .tools.execution import execute_pending_tools
 from .workflow import Workflow
 
@@ -136,6 +135,7 @@ async def execute_stage(
                     error_type="circuit_breaker",
                     error_message=str(exc),
                     original_exception=exc,
+                    context_snapshot=state.to_dict(),
                 )
             except PluginExecutionError as exc:
                 logger.exception(
@@ -152,6 +152,7 @@ async def execute_stage(
                     error_type=exc.original_exception.__class__.__name__,
                     error_message=str(exc.original_exception),
                     original_exception=exc.original_exception,
+                    context_snapshot=state.to_dict(),
                 )
             except ToolExecutionError as exc:
                 logger.exception(
@@ -168,6 +169,7 @@ async def execute_stage(
                     error_type=exc.original_exception.__class__.__name__,
                     error_message=str(exc.original_exception),
                     original_exception=exc.original_exception,
+                    context_snapshot=state.to_dict(),
                 )
             except ResourceError as exc:
                 logger.exception(
@@ -184,6 +186,7 @@ async def execute_stage(
                     error_type=exc.__class__.__name__,
                     error_message=str(exc),
                     original_exception=exc,
+                    context_snapshot=state.to_dict(),
                 )
             except PipelineError as exc:
                 logger.exception(
@@ -200,6 +203,7 @@ async def execute_stage(
                     error_type=exc.__class__.__name__,
                     error_message=str(exc),
                     original_exception=exc,
+                    context_snapshot=state.to_dict(),
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.exception(
@@ -219,6 +223,7 @@ async def execute_stage(
                     error_type=exc.__class__.__name__,
                     error_message=message,
                     original_exception=exc,
+                    context_snapshot=state.to_dict(),
                 )
             if state.failure_info:
                 break
@@ -305,6 +310,7 @@ async def execute_pipeline(
                             original_exception=RuntimeError(
                                 "max iteration limit reached"
                             ),
+                            context_snapshot=state.to_dict(),
                         )
                     break
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,5 +1,7 @@
 import asyncio
 
+from entity.core.resources.container import ResourceContainer
+from entity.core.state import FailureInfo
 from pipeline import (
     FailurePlugin,
     PipelineStage,
@@ -20,9 +22,6 @@ from pipeline.errors import (
     create_error_response,
     create_static_error_response,
 )
-from entity.core.state import FailureInfo
-
-from entity.core.resources.container import ResourceContainer
 from user_plugins.failure.basic_logger import BasicLogger
 
 

--- a/tests/test_pipeline_looping.py
+++ b/tests/test_pipeline_looping.py
@@ -1,6 +1,8 @@
 import asyncio
 from typing import Optional
 
+from entity.core.resources.container import ResourceContainer
+from entity.core.state import FailureInfo, PipelineState
 from pipeline import (
     FailurePlugin,
     PipelineStage,
@@ -10,9 +12,6 @@ from pipeline import (
     ToolRegistry,
     execute_pipeline,
 )
-from entity.core.state import FailureInfo, PipelineState
-
-from entity.core.resources.container import ResourceContainer
 
 
 class CountingDeliverPlugin(PromptPlugin):
@@ -94,3 +93,4 @@ def test_max_iterations_triggers_error():
     assert state.iteration == 2
     assert failures
     assert failures[0].error_type == "max_iterations"
+    assert failures[0].context_snapshot == state.to_dict()

--- a/user_plugins/failure/basic_logger.py
+++ b/user_plugins/failure/basic_logger.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from entity.core.plugins import FailurePlugin
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from entity.core.context import PluginContext
+
 from pipeline.stages import PipelineStage
 
 
@@ -21,7 +21,6 @@ class BasicLogger(FailurePlugin):
         try:
             info = context.failure_info
             if info is not None:
-                snapshot = getattr(info, "context_snapshot", None)
                 logger.error(
                     "Pipeline failure encountered",
                     extra={
@@ -33,7 +32,7 @@ class BasicLogger(FailurePlugin):
                         "retry_count": getattr(
                             getattr(context, "_state", None), "iteration", 0
                         ),
-                        **({"context_snapshot": snapshot} if snapshot else {}),
+                        "context_snapshot": info.context_snapshot,
                     },
                 )
             else:


### PR DESCRIPTION
## Summary
- add `context_snapshot` to `FailureInfo`
- include snapshot in all FailureInfo instances in the pipeline
- simplify `BasicLogger` to always log the snapshot
- document that snapshots are always present in failure logs
- check snapshot in tests

## Testing
- `poetry run flake8 src tests`
- `poetry run mypy src` *(fails: ModuleNotFoundError: 'entity', many errors)*
- `bandit -r src` *(fails: command not found)*
- `python tools/check_empty_dirs.py` *(fails: file not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine not awaited)*
- `python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError: 'entity')*
- `poetry run pytest` *(fails: ModuleNotFoundError: 'cli.plugin_tool')*
- `poetry run pytest tests/integration/ -v` *(fails: multiple assertion and attribute errors)*
- `poetry run pytest tests/infrastructure/ -v` *(fails: directory not found)*
- `poetry run pytest tests/performance/ -m benchmark` *(fails: NameError: 'user_id')*

------
https://chatgpt.com/codex/tasks/task_e_6871076be7808322a7c5a30521ff2da8