### PR TITLE
Use container DependencyGraph in pipeline

### DIFF
--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -16,7 +16,7 @@ from entity.core.resources.container import ResourceContainer
 from entity.utils.logging import configure_logging, get_logger
 from entity.workflows.discovery import discover_workflows, register_module_workflows
 from pipeline.config import ConfigLoader
-from pipeline.utils import DependencyGraph
+from entity.core.resources.container import DependencyGraph
 from pipeline.reliability import CircuitBreaker
 from pipeline.exceptions import CircuitBreakerTripped
 

--- a/src/pipeline/utils/__init__.py
+++ b/src/pipeline/utils/__init__.py
@@ -1,9 +1,5 @@
-class DependencyGraph:
-    def __init__(self, graph):
-        self.graph = graph
+"""Utility helpers used by the pipeline package."""
 
-    def topological_sort(self):  # pragma: no cover - simple stub
-        return list(self.graph)
-
+from entity.core.resources.container import DependencyGraph
 
 __all__ = ["DependencyGraph"]


### PR DESCRIPTION
## Summary
- expose DependencyGraph from the main utilities module
- import DependencyGraph directly from entity.core.resources.container

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.plugin_tool')*

------
https://chatgpt.com/codex/tasks/task_e_68710725d4288322b7589bfada892264