### PR TITLE
Add optional dependency support

### DIFF
--- a/docs/source/plugin_cheatsheet.md
+++ b/docs/source/plugin_cheatsheet.md
@@ -29,6 +29,14 @@ class ExamplePlugin(PromptPlugin):
         pass
 ```
 
+Add ``?`` to mark a dependency optional:
+
+```python
+class MaybeVector(PromptPlugin):
+    dependencies = ["vector_store?"]
+    stages = [PipelineStage.PARSE]
+```
+
 Register plugins through `Agent.add_plugin()` or in a YAML configuration file.
 YAML order determines execution order and `SystemInitializer` keeps the
 sequence intact. There is no priority field.

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -119,6 +119,15 @@ class = "my_pkg.calc:CalculatorTool"
 During initialization the discovered entries are merged into the config and
 their dependencies validated automatically.
 
+Append a ``?`` to a dependency name to mark it optional. Missing optional
+dependencies are injected as ``None`` instead of raising an error:
+
+```toml
+[tool.entity.plugins.prompts.optional]
+class = "my_pkg.opt:OptionalPrompt"
+dependencies = ["vector_store?"]
+```
+
 ### External Plugin Repositories
 
 Plugins can live in their own repositories. Add the repository path to

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,65 @@
+import asyncio
+
+from entity.core.resources.container import ResourceContainer
+from entity.core.plugins import ResourcePlugin, PromptPlugin
+from entity.core.stages import PipelineStage
+from entity.core.registry_validator import RegistryValidator
+import yaml
+
+
+class OptionalRes(ResourcePlugin):
+    stages = [PipelineStage.PARSE]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class DependentRes(ResourcePlugin):
+    stages = [PipelineStage.PARSE]
+    dependencies = ["optional?"]
+
+    def __init__(self, config=None):
+        super().__init__(config or {})
+        self.optional = "unset"
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class DummyPrompt(PromptPlugin):
+    stages = [PipelineStage.DO]
+    dependencies = ["missing?"]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+def test_missing_optional_dependency_sets_none():
+    container = ResourceContainer()
+    container.register("dependent", DependentRes, {})
+    asyncio.run(container.build_all())
+    dep = container.get("dependent")
+    assert dep.optional is None
+
+
+def test_present_optional_dependency_injected():
+    container = ResourceContainer()
+    container.register("optional", OptionalRes, {})
+    container.register("dependent", DependentRes, {})
+    asyncio.run(container.build_all())
+    opt = container.get("optional")
+    dep = container.get("dependent")
+    assert dep.optional is opt
+
+
+def test_registry_validator_allows_missing_optional(tmp_path):
+    cfg = {
+        "plugins": {
+            "prompts": {
+                "dummy": {"type": "tests.test_optional_dependencies:DummyPrompt"}
+            }
+        }
+    }
+    path = tmp_path / "cfg.yml"
+    path.write_text(yaml.dump(cfg, sort_keys=False))
+    RegistryValidator(str(path)).run()


### PR DESCRIPTION
## Summary
- allow dependency names ending with `?` to be optional
- inject missing optional dependencies as `None`
- explain optional dependencies in the docs
- add tests for optional dependency behaviour

## Testing
- `poetry run black -q tests/test_optional_dependencies.py src/entity/core/resources/container.py src/entity/core/registry_validator.py src/pipeline/initializer.py`
- `PYTHONPATH=src poetry run pytest -q tests/test_optional_dependencies.py`

------
https://chatgpt.com/codex/tasks/task_e_6871072349048322b3cc461e490590a9