### PR TITLE
Document plugin stage override warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Entity lets you craft agent pipelines using a single configuration file. The sam
 - Stateless workers that scale horizontally
 - Unified memory resource for chat, search, and storage
 - In-memory DuckDB backend for quick local testing
+- Overrides of default plugin stages produce log warnings
 
 Check the [hero landing page](https://entity.readthedocs.io/en/latest/) for a visual overview.
 

--- a/docs/source/plugin_guide.md
+++ b/docs/source/plugin_guide.md
@@ -80,9 +80,13 @@ Plugin stages are resolved in a predictable order:
 3. Defaults based on plugin type (``ToolPlugin`` → ``DO``, ``PromptPlugin`` → ``THINK``, ``AdapterPlugin`` → ``PARSE`` + ``DELIVER``).
 4. Stages inferred by ``PluginAutoClassifier``.
 
-Explicit configuration always wins. If a plugin class declares stages that differ from its type defaults the initializer emits a warning. The same warning appears when configuration overrides either the class stages or the defaults so you can double‑check the override is intentional.
+Explicit configuration always wins. If a plugin class declares stages that differ from its type defaults the initializer emits a warning. The same warning appears when configuration overrides either the class stages or the defaults so you can double‑check the override is intentional. Programmatic registration through ``_AgentBuilder`` follows the same rules. ``add_plugin`` checks any provided configuration first, then the class attribute, and finally falls back to the plugin type defaults or auto‑classified stages. Warnings appear whenever a higher‑precedence source overrides a lower one.
 
-Programmatic registration through ``_AgentBuilder`` follows the same rules. ``add_plugin`` checks any provided configuration first, then the class attribute, and finally falls back to the plugin type defaults or auto‑classified stages. Warnings appear whenever a higher‑precedence source overrides a lower one.
+When this occurs you'll see a log line similar to:
+
+```
+WARNING entity.pipeline.initializer: Plugin 'MyPrompt' explicit config stages ['THINK', 'DELIVER'] override type defaults ['THINK']
+```
 
 ## Loading Plugins Automatically
 


### PR DESCRIPTION
## Summary
- mention override warnings in README
- show example log message in plugin guide

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'cli.plugin_tool')*

------
https://chatgpt.com/codex/tasks/task_e_68710734cfc0832290f35403a0be2c72