### PR TITLE
Add INPUT and OUTPUT stages

### DIFF
--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -1,10 +1,10 @@
 """Template for an adapter plugin.
 
 Adapters connect pipeline output to the outside world. Add the generated
-plugin to a workflow so it runs in the ``DELIVER`` stage:
+plugin to a workflow so it runs in the ``OUTPUT`` stage:
 
 ```
-workflow = {PipelineStage.DELIVER: ["MyAdapter"]}
+workflow = {PipelineStage.OUTPUT: ["MyAdapter"]}
 ```
 """
 
@@ -15,7 +15,7 @@ from entity.core.stages import PipelineStage
 class {class_name}(AdapterPlugin):
     """Example adapter plugin."""
 
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
     # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):

--- a/src/cli/templates/workflow_template.py
+++ b/src/cli/templates/workflow_template.py
@@ -3,8 +3,10 @@
 from pipeline import PipelineStage
 
 {workflow_name} = {
+    PipelineStage.INPUT: [],
     PipelineStage.PARSE: [],
     PipelineStage.THINK: [],
     PipelineStage.DO: [],
-    PipelineStage.DELIVER: [],
+    PipelineStage.REVIEW: [],
+    PipelineStage.OUTPUT: [],
 }

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -19,7 +19,6 @@ from entity.core.builder import _AgentBuilder
 from pipeline.config.config_update import update_plugin_configuration
 from entity.utils.logging import get_logger
 from importlib import import_module
-from pathlib import Path
 import sys
 
 try:  # Resolve plugin helpers from installed "cli" package

--- a/src/entity/core/builder.py
+++ b/src/entity/core/builder.py
@@ -197,7 +197,7 @@ class _AgentBuilder:
         if isinstance(plugin, PromptPlugin):
             return [PipelineStage.THINK]
         if isinstance(plugin, AdapterPlugin):
-            return [PipelineStage.PARSE, PipelineStage.DELIVER]
+            return [PipelineStage.INPUT, PipelineStage.OUTPUT]
         return []
 
     def _resolve_plugin_stages(

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -195,10 +195,10 @@ class PluginContext:
         return self._state.failure_info
 
     def set_response(self, value: Any) -> None:
-        if self.current_stage is not PipelineStage.DELIVER:
+        if self.current_stage is not PipelineStage.OUTPUT:
             raise PluginContextError(
                 self.current_stage,
                 self.current_plugin or "unknown",
-                f"set_response may only be called in DELIVER stage, not {self.current_stage}",
+                f"set_response may only be called in OUTPUT stage, not {self.current_stage}",
             )
         self._state.response = value

--- a/src/entity/core/plugin_utils.py
+++ b/src/entity/core/plugin_utils.py
@@ -32,7 +32,7 @@ def default_stages_for_class(plugin_class: Type) -> list[PipelineStage]:
     if issubclass(plugin_class, plugin_base_registry.prompt_plugin):
         return [PipelineStage.THINK]
     if issubclass(plugin_class, plugin_base_registry.adapter_plugin):
-        return [PipelineStage.PARSE, PipelineStage.DELIVER]
+        return [PipelineStage.INPUT, PipelineStage.OUTPUT]
     return []
 
 

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -9,7 +9,7 @@ They offer a small, easy to understand surface for plugin authors.
 
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, List
 
 from entity.utils.logging import get_logger
 
@@ -101,7 +101,7 @@ class PromptPlugin(BasePlugin):
 class AdapterPlugin(BasePlugin):
     """Input or output adapter plugin."""
 
-    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
+    stages = [PipelineStage.INPUT, PipelineStage.OUTPUT]
 
 
 class FailurePlugin(BasePlugin):

--- a/src/entity/core/stages.py
+++ b/src/entity/core/stages.py
@@ -8,11 +8,12 @@ from enum import IntEnum, auto
 class PipelineStage(IntEnum):
     """Ordered pipeline stages."""
 
+    INPUT = auto()
     PARSE = auto()
     THINK = auto()
     DO = auto()
     REVIEW = auto()
-    DELIVER = auto()
+    OUTPUT = auto()
     ERROR = auto()
 
     def __str__(self) -> str:

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -89,7 +89,7 @@ class ClassRegistry:
         if issubclass(cls, PromptPlugin):
             return [PipelineStage.THINK]
         if issubclass(cls, AdapterPlugin):
-            return [PipelineStage.PARSE, PipelineStage.DELIVER]
+            return [PipelineStage.INPUT, PipelineStage.OUTPUT]
         return []
 
     def _resolve_plugin_stages(
@@ -275,7 +275,7 @@ class SystemInitializer:
         if issubclass(cls, PromptPlugin):
             return [PipelineStage.THINK]
         if issubclass(cls, AdapterPlugin):
-            return [PipelineStage.PARSE, PipelineStage.DELIVER]
+            return [PipelineStage.INPUT, PipelineStage.OUTPUT]
         return []
 
     def _resolve_plugin_stages(

--- a/src/pipeline/stages.py
+++ b/src/pipeline/stages.py
@@ -8,11 +8,12 @@ from enum import IntEnum, auto
 class PipelineStage(IntEnum):
     """Ordered pipeline stages."""
 
+    INPUT = auto()
     PARSE = auto()
     THINK = auto()
     DO = auto()
     REVIEW = auto()
-    DELIVER = auto()
+    OUTPUT = auto()
     ERROR = auto()
 
     def __str__(self) -> str:

--- a/src/pipeline/worker.py
+++ b/src/pipeline/worker.py
@@ -12,7 +12,6 @@ from typing import Any
 from entity.core.registries import SystemRegistries
 from entity.core.state import ConversationEntry
 
-from .pipeline import execute_pipeline
 from .state import PipelineState
 
 

--- a/src/plugins/builtin/adapters/cli.py
+++ b/src/plugins/builtin/adapters/cli.py
@@ -9,7 +9,7 @@ from pipeline.stages import PipelineStage
 class CLIAdapter(AdapterPlugin):
     """Placeholder CLI adapter."""
 
-    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
+    stages = [PipelineStage.INPUT, PipelineStage.OUTPUT]
 
     def __init__(self, manager: Any, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/plugins/builtin/adapters/dashboard.py
+++ b/src/plugins/builtin/adapters/dashboard.py
@@ -9,7 +9,7 @@ from pipeline.stages import PipelineStage
 class DashboardAdapter(AdapterPlugin):
     """Placeholder dashboard adapter."""
 
-    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
+    stages = [PipelineStage.INPUT, PipelineStage.OUTPUT]
 
     def __init__(self, manager: Any, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/plugins/builtin/adapters/http_adapter.py
+++ b/src/plugins/builtin/adapters/http_adapter.py
@@ -9,7 +9,7 @@ from pipeline.stages import PipelineStage
 class HTTPAdapter(AdapterPlugin):
     """Placeholder HTTP adapter."""
 
-    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
+    stages = [PipelineStage.INPUT, PipelineStage.OUTPUT]
 
     def __init__(self, manager: Any, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/plugins/builtin/adapters/websocket.py
+++ b/src/plugins/builtin/adapters/websocket.py
@@ -9,7 +9,7 @@ from pipeline.stages import PipelineStage
 class WebSocketAdapter(AdapterPlugin):
     """Placeholder WebSocket adapter."""
 
-    stages = [PipelineStage.PARSE, PipelineStage.DELIVER]
+    stages = [PipelineStage.INPUT, PipelineStage.OUTPUT]
 
     def __init__(self, manager: Any, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/plugins/builtin/resources/echo_llm.py
+++ b/src/plugins/builtin/resources/echo_llm.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Dict
 
 from entity.core.state import LLMResponse
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from threading import Thread
 
 import pytest
-from entity.config.environment import load_env
 
 SRC_PATH = str(Path(__file__).resolve().parents[1] / "src")
 if SRC_PATH not in sys.path:

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -1,5 +1,4 @@
 import subprocess
-import sys
 
 import pytest
 

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -21,7 +21,7 @@ class ThinkPlugin(BasePlugin):
 
 
 class RespondPlugin(BasePlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         context.set_response("ok")

--- a/tests/integration/test_legacy_workflow_compat.py
+++ b/tests/integration/test_legacy_workflow_compat.py
@@ -7,7 +7,7 @@ from entity.core.builder import _AgentBuilder
 
 
 class ReplyPlugin(BasePlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         context.set_response("ok")

--- a/tests/integration/test_pipeline_multi_provider.py
+++ b/tests/integration/test_pipeline_multi_provider.py
@@ -18,7 +18,7 @@ class FailHandler(BaseHTTPRequestHandler):
 
 
 class LLMResponder(BasePlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         response = await context.ask_llm(context.message)

--- a/tests/integration/test_stage_failures.py
+++ b/tests/integration/test_stage_failures.py
@@ -14,7 +14,7 @@ from entity.core.state import ConversationEntry, PipelineState
 
 
 class RespondPlugin(BasePlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         context.set_response({"message": "ok"})
@@ -41,7 +41,7 @@ def make_failing_plugin(stage: PipelineStage):
         PipelineStage.THINK,
         PipelineStage.DO,
         PipelineStage.REVIEW,
-        PipelineStage.DELIVER,
+        PipelineStage.OUTPUT,
     ],
 )
 def test_pipeline_recovers_from_stage_failure(
@@ -50,7 +50,7 @@ def test_pipeline_recovers_from_stage_failure(
     async def run() -> str:
         plugins = PluginRegistry()
         await plugins.register_plugin_for_stage(make_failing_plugin(stage), stage)
-        await plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DELIVER)
+        await plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.OUTPUT)
         capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
         log_file = tmp_path / "state_log.jsonl"
@@ -72,7 +72,7 @@ def test_pipeline_recovers_from_stage_failure(
         logger.close()
         transitions = list(LogReplayer(log_file).transitions())
         stages = [t.stage for t in transitions]
-        assert "deliver" in stages[-1]
+        assert "output" in stages[-1]
 
         return result.get("message", "")
 

--- a/tests/performance/test_full_pipeline_benchmark.py
+++ b/tests/performance/test_full_pipeline_benchmark.py
@@ -13,7 +13,7 @@ from pipeline import (
 
 
 class RespondPlugin:
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def execute(self, context):
         context.set_response("ok")
@@ -23,7 +23,7 @@ class RespondPlugin:
 def test_full_pipeline_benchmark(benchmark):
     plugins = PluginRegistry()
     asyncio.run(
-        plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.DELIVER)
+        plugins.register_plugin_for_stage(RespondPlugin(), PipelineStage.OUTPUT)
     )
     capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 

--- a/tests/performance/test_pipeline_benchmark.py
+++ b/tests/performance/test_pipeline_benchmark.py
@@ -14,7 +14,7 @@ from pipeline import (
 
 
 class NoOpPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         context.set_response("ok")
@@ -22,9 +22,7 @@ class NoOpPlugin(PromptPlugin):
 
 def _make_capabilities():
     plugins = PluginRegistry()
-    asyncio.run(
-        plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.DELIVER)
-    )
+    asyncio.run(plugins.register_plugin_for_stage(NoOpPlugin({}), PipelineStage.OUTPUT))
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -33,9 +33,9 @@ def make_capabilities() -> SystemRegistries:
     plugins = PluginRegistry()
     plugin = PluginAutoClassifier.classify(
         use_tool_plugin,
-        {"stage": PipelineStage.DELIVER, "name": "UseToolPlugin"},
+        {"stage": PipelineStage.OUTPUT, "name": "UseToolPlugin"},
     )
-    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DELIVER))
+    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.OUTPUT))
     return SystemRegistries(resources, tools, plugins)
 
 

--- a/tests/test_builder_stage_resolution.py
+++ b/tests/test_builder_stage_resolution.py
@@ -33,7 +33,7 @@ def test_class_attribute_overrides_type_defaults():
 def test_type_default_overrides_auto_classification():
     builder = _AgentBuilder()
     plugin = InferredPrompt({})
-    plugin.stages = [PipelineStage.DELIVER]
+    plugin.stages = [PipelineStage.OUTPUT]
     plugin._explicit_stages = False
     stages = builder._resolve_plugin_stages(plugin, None)
     assert stages == [PipelineStage.THINK]

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -16,7 +16,7 @@ from user_plugins.failure.error_formatter import ErrorFormatter
 
 
 class UnstablePlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         raise ValueError("boom")
@@ -27,12 +27,12 @@ def make_capabilities():
     asyncio.run(
         plugins.register_plugin_for_stage(
             UnstablePlugin({"failure_threshold": 2, "failure_reset_timeout": 60}),
-            PipelineStage.DELIVER,
+            PipelineStage.OUTPUT,
         )
     )
     asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
     asyncio.run(
-        plugins.register_plugin_for_stage(ErrorFormatter({}), PipelineStage.DELIVER)
+        plugins.register_plugin_for_stage(ErrorFormatter({}), PipelineStage.OUTPUT)
     )
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 

--- a/tests/test_cli/test_cli_adapter.py
+++ b/tests/test_cli/test_cli_adapter.py
@@ -15,7 +15,7 @@ from plugins.builtin.adapters.cli import CLIAdapter
 
 
 class EchoPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -24,9 +24,7 @@ class EchoPlugin(PromptPlugin):
 
 def make_adapter() -> tuple[CLIAdapter, SystemRegistries]:
     plugins = PluginRegistry()
-    asyncio.run(
-        plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DELIVER)
-    )
+    asyncio.run(plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.OUTPUT))
     capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     runtime = _AgentRuntime(capabilities)
     return CLIAdapter(runtime), capabilities

--- a/tests/test_cli/test_cli_validate.py
+++ b/tests/test_cli/test_cli_validate.py
@@ -1,5 +1,4 @@
 import os
-import os
 import subprocess
 import sys
 import yaml

--- a/tests/test_cli/test_cli_websocket.py
+++ b/tests/test_cli/test_cli_websocket.py
@@ -1,6 +1,5 @@
 import sys
 
-import sys
 from pathlib import Path
 
 from plugins.builtin.adapters.websocket import WebSocketAdapter

--- a/tests/test_config/test_workflow_roundtrip.py
+++ b/tests/test_config/test_workflow_roundtrip.py
@@ -8,7 +8,7 @@ from pipeline.workflow import Workflow
 
 
 def test_workflow_roundtrip(tmp_path: Path) -> None:
-    wf_data = {"parse": ["a"], "think": ["b"], "deliver": ["c"]}
+    wf_data = {"parse": ["a"], "think": ["b"], "output": ["c"]}
     wf_yaml = tmp_path / "wf.yaml"
     wf_json = tmp_path / "wf.json"
     wf_yaml.write_text(yaml.dump(wf_data, sort_keys=False))

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -12,7 +12,7 @@ from pipeline import (
 
 
 class ContinuePlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         if context.message == "start":
@@ -20,7 +20,7 @@ class ContinuePlugin(PromptPlugin):
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         if context.message == "next":
@@ -30,10 +30,10 @@ class RespondPlugin(PromptPlugin):
 def make_conversation():
     plugins = PluginRegistry()
     asyncio.run(
-        plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.DELIVER)
+        plugins.register_plugin_for_stage(ContinuePlugin({}), PipelineStage.OUTPUT)
     )
     asyncio.run(
-        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.OUTPUT)
     )
     resources = ResourceContainer()
     asyncio.run(resources.add("memory", Memory()))

--- a/tests/test_core/debug/test_state_logger.py
+++ b/tests/test_core/debug/test_state_logger.py
@@ -45,7 +45,7 @@ def test_logger_and_replay(tmp_path):
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         context.set_response("ok")
@@ -54,7 +54,7 @@ class RespondPlugin(PromptPlugin):
 def test_execute_pipeline_logs_states(tmp_path):
     plugins = PluginRegistry()
     asyncio.run(
-        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.OUTPUT)
     )
     capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
@@ -68,4 +68,4 @@ def test_execute_pipeline_logs_states(tmp_path):
     transitions = list(LogReplayer(log_file).transitions())
     stages = [t.stage for t in transitions]
     assert stages[0] == "parse"
-    assert "deliver" in stages[-1]
+    assert "output" in stages[-1]

--- a/tests/test_core/debug/test_state_manager.py
+++ b/tests/test_core/debug/test_state_manager.py
@@ -31,7 +31,7 @@ class StateManager:
 
 
 class SavePlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     def __init__(self, manager: StateManager) -> None:
         super().__init__({})
@@ -45,7 +45,7 @@ class SavePlugin(PromptPlugin):
 def make_runtime(manager: StateManager) -> _AgentRuntime:
     plugins = PluginRegistry()
     asyncio.run(
-        plugins.register_plugin_for_stage(SavePlugin(manager), PipelineStage.DELIVER)
+        plugins.register_plugin_for_stage(SavePlugin(manager), PipelineStage.OUTPUT)
     )
     capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return _AgentRuntime(capabilities)

--- a/tests/test_core/test_core_plugin_registry_order.py
+++ b/tests/test_core/test_core_plugin_registry_order.py
@@ -7,7 +7,7 @@ from pipeline import PipelineStage, PromptPlugin
 
 
 class First(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -17,7 +17,7 @@ class First(PromptPlugin):
 
 
 class Second(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -26,7 +26,7 @@ class Second(PromptPlugin):
 
 
 class Third(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -71,6 +71,6 @@ def test_agent_initializer_preserves_yaml_order(tmp_path):
     agent = Agent(config_path=str(path))
     asyncio.run(agent._ensure_runtime())
     plugins = agent.runtime.capabilities.plugins.get_plugins_for_stage(
-        PipelineStage.DELIVER
+        PipelineStage.OUTPUT
     )
     assert [p.__class__ for p in plugins] == [Second, First, Third]

--- a/tests/test_core/test_plugin_order.py
+++ b/tests/test_core/test_plugin_order.py
@@ -5,7 +5,7 @@ from entity.core.plugins import PromptPlugin
 
 
 class First(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -15,7 +15,7 @@ class First(PromptPlugin):
 
 
 class Second(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -24,7 +24,7 @@ class Second(PromptPlugin):
 
 
 class Third(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -51,5 +51,5 @@ def test_builder_load_from_yaml_preserves_order(tmp_path):
     path.write_text(yaml.dump(cfg, sort_keys=False))
 
     builder = _AgentBuilder.from_yaml(str(path))
-    plugins = builder.plugin_registry.get_plugins_for_stage(PipelineStage.DELIVER)
+    plugins = builder.plugin_registry.get_plugins_for_stage(PipelineStage.OUTPUT)
     assert [p.__class__ for p in plugins] == [Second, First, Third]

--- a/tests/test_core/test_runtime_plugin_order.py
+++ b/tests/test_core/test_runtime_plugin_order.py
@@ -15,7 +15,7 @@ from pipeline.state import PipelineState
 
 
 class Second(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -24,7 +24,7 @@ class Second(PromptPlugin):
 
 
 class First(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -33,7 +33,7 @@ class First(PromptPlugin):
 
 
 class Final(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -44,9 +44,9 @@ class Final(PromptPlugin):
 
 async def _run_pipeline():
     plugins = PluginRegistry()
-    await plugins.register_plugin_for_stage(Second({}), PipelineStage.DELIVER)
-    await plugins.register_plugin_for_stage(First({}), PipelineStage.DELIVER)
-    await plugins.register_plugin_for_stage(Final({}), PipelineStage.DELIVER)
+    await plugins.register_plugin_for_stage(Second({}), PipelineStage.OUTPUT)
+    await plugins.register_plugin_for_stage(First({}), PipelineStage.OUTPUT)
+    await plugins.register_plugin_for_stage(Final({}), PipelineStage.OUTPUT)
 
     caps = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     state = PipelineState(

--- a/tests/test_dashboard_adapter.py
+++ b/tests/test_dashboard_adapter.py
@@ -17,7 +17,7 @@ from plugins.builtin.adapters import DashboardAdapter
 
 
 class RespPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -26,7 +26,7 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter(tmp_path: Path) -> DashboardAdapter:
     plugins = PluginRegistry()
-    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DELIVER)
+    plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.OUTPUT)
     capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     runtime = _AgentRuntime(capabilities)
     log_path = tmp_path / "state.log"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -40,7 +40,7 @@ class ResourceFailPlugin(PromptPlugin):
 
 
 class FallbackPlugin(FailurePlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         info = context.failure_info
@@ -52,7 +52,7 @@ def make_capabilities(error_plugin, main_plugin=BoomPlugin):
     asyncio.run(plugins.register_plugin_for_stage(main_plugin({}), PipelineStage.DO))
     asyncio.run(plugins.register_plugin_for_stage(BasicLogger({}), PipelineStage.ERROR))
     asyncio.run(
-        plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.DELIVER)
+        plugins.register_plugin_for_stage(error_plugin({}), PipelineStage.OUTPUT)
     )
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 

--- a/tests/test_execute_pending_tools.py
+++ b/tests/test_execute_pending_tools.py
@@ -5,7 +5,6 @@ from entity.core.resources.container import ResourceContainer
 from entity.core.state import (
     ConversationEntry,
     PipelineState,
-    ToolCall,
 )
 from pipeline import PluginRegistry, SystemRegistries, ToolRegistry
 from entity.core.context import PluginContext

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -15,7 +15,7 @@ from plugins.builtin.adapters import HTTPAdapter
 
 
 class RespPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -24,9 +24,7 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter(config=None):
     plugins = PluginRegistry()
-    asyncio.run(
-        plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DELIVER)
-    )
+    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.OUTPUT))
     capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     runtime = _AgentRuntime(capabilities)
     return HTTPAdapter(runtime, config)
@@ -36,7 +34,7 @@ def test_http_adapter_basic():
     adapter = make_adapter()
 
     # ensure the adapter participates in both input and output stages
-    assert HTTPAdapter.stages == [PipelineStage.PARSE, PipelineStage.DELIVER]
+    assert HTTPAdapter.stages == [PipelineStage.PARSE, PipelineStage.OUTPUT]
 
     async def _make_request():
         async with httpx.AsyncClient(

--- a/tests/test_logging_adapter.py
+++ b/tests/test_logging_adapter.py
@@ -14,14 +14,14 @@ from pipeline import (
 
 
 class LoggingAdapter(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         logging.info("adapter", extra={"response": context.state.response})
 
 
 class EchoPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         entry = context.get_conversation_history()[0]
@@ -30,11 +30,9 @@ class EchoPlugin(PromptPlugin):
 
 def make_runtime() -> _AgentRuntime:
     plugins = PluginRegistry()
+    asyncio.run(plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.OUTPUT))
     asyncio.run(
-        plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DELIVER)
-    )
-    asyncio.run(
-        plugins.register_plugin_for_stage(LoggingAdapter({}), PipelineStage.DELIVER)
+        plugins.register_plugin_for_stage(LoggingAdapter({}), PipelineStage.OUTPUT)
     )
     capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     return _AgentRuntime(capabilities)

--- a/tests/test_memory_resource.py
+++ b/tests/test_memory_resource.py
@@ -15,7 +15,7 @@ from pipeline import (
 
 
 class IncrementPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
     dependencies = ["memory"]
 
     async def _execute_impl(self, context):
@@ -28,7 +28,7 @@ class IncrementPlugin(PromptPlugin):
 def make_capabilities():
     plugins = PluginRegistry()
     asyncio.run(
-        plugins.register_plugin_for_stage(IncrementPlugin({}), PipelineStage.DELIVER)
+        plugins.register_plugin_for_stage(IncrementPlugin({}), PipelineStage.OUTPUT)
     )
     resources = ResourceContainer()
     asyncio.run(resources.add("memory", Memory()))

--- a/tests/test_pipeline_looping.py
+++ b/tests/test_pipeline_looping.py
@@ -15,7 +15,7 @@ from pipeline import (
 
 
 class CountingDeliverPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     def __init__(self, config: Optional[dict] = None) -> None:
         super().__init__(config)
@@ -28,7 +28,7 @@ class CountingDeliverPlugin(PromptPlugin):
 
 
 class NoResponseDeliverPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     def __init__(self, config: Optional[dict] = None) -> None:
         super().__init__(config)
@@ -54,7 +54,7 @@ class RecordFailurePlugin(FailurePlugin):
 
 async def make_capabilities(plugin):
     plugins = PluginRegistry()
-    await plugins.register_plugin_for_stage(plugin, PipelineStage.DELIVER)
+    await plugins.register_plugin_for_stage(plugin, PipelineStage.OUTPUT)
     return SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
 
@@ -77,7 +77,7 @@ def test_max_iterations_triggers_error():
 
     async def run() -> PipelineState:
         plugins = PluginRegistry()
-        await plugins.register_plugin_for_stage(plugin, PipelineStage.DELIVER)
+        await plugins.register_plugin_for_stage(plugin, PipelineStage.OUTPUT)
         await plugins.register_plugin_for_stage(
             RecordFailurePlugin(failures), PipelineStage.ERROR
         )

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -4,7 +4,7 @@ from pipeline import ConversationEntry, PipelineStage, PipelineState, PromptPlug
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):  # pragma: no cover - simple
         context.set_response("ok")

--- a/tests/test_plugin_layers.py
+++ b/tests/test_plugin_layers.py
@@ -42,9 +42,9 @@ def make_capabilities() -> SystemRegistries:
     plugins = PluginRegistry()
     plugin = PluginAutoClassifier.classify(
         my_prompt,
-        {"stage": PipelineStage.DELIVER, "name": "MyPrompt"},
+        {"stage": PipelineStage.OUTPUT, "name": "MyPrompt"},
     )
-    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.DELIVER))
+    asyncio.run(plugins.register_plugin_for_stage(plugin, PipelineStage.OUTPUT))
     return SystemRegistries(resources, tools, plugins)
 
 

--- a/tests/test_plugin_registry_order.py
+++ b/tests/test_plugin_registry_order.py
@@ -15,7 +15,7 @@ from entity.core.resources.container import ResourceContainer
 
 
 class First(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -25,7 +25,7 @@ class First(PromptPlugin):
 
 
 class Second(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -34,7 +34,7 @@ class Second(PromptPlugin):
 
 
 class Third(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         order = context.get_metadata("order") or []
@@ -49,9 +49,9 @@ def _set_final_response(context):
 
 def test_plugin_registration_order_matches_execution():
     registry = PluginRegistry()
-    asyncio.run(registry.register_plugin_for_stage(First({}), PipelineStage.DELIVER))
-    asyncio.run(registry.register_plugin_for_stage(Third({}), PipelineStage.DELIVER))
-    asyncio.run(registry.register_plugin_for_stage(Second({}), PipelineStage.DELIVER))
+    asyncio.run(registry.register_plugin_for_stage(First({}), PipelineStage.OUTPUT))
+    asyncio.run(registry.register_plugin_for_stage(Third({}), PipelineStage.OUTPUT))
+    asyncio.run(registry.register_plugin_for_stage(Second({}), PipelineStage.OUTPUT))
     capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), registry)
     result = asyncio.run(execute_pipeline("hi", capabilities))
     assert result == ["first", "third", "second"]
@@ -72,5 +72,5 @@ def test_initializer_preserves_yaml_order(tmp_path):
 
     initializer = SystemInitializer.from_yaml(str(path))
     plugin_reg, _, _, _ = asyncio.run(initializer.initialize())
-    plugins = plugin_reg.get_plugins_for_stage(PipelineStage.DELIVER)
+    plugins = plugin_reg.get_plugins_for_stage(PipelineStage.OUTPUT)
     assert [p.__class__ for p in plugins] == [Second, First, Third]

--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -1,8 +1,6 @@
 import asyncio
 import importlib.util
 import sys
-from pathlib import Path
-from types import ModuleType
 
 import pytest
 from pipeline import PipelineStage

--- a/tests/test_set_response.py
+++ b/tests/test_set_response.py
@@ -16,8 +16,8 @@ def make_context(stage: PipelineStage) -> PluginContext:
     return PluginContext(state, capabilities)
 
 
-def test_set_response_allowed_in_deliver():
-    ctx = make_context(PipelineStage.DELIVER)
+def test_set_response_allowed_in_output():
+    ctx = make_context(PipelineStage.OUTPUT)
     ctx.set_response("ok")
     assert ctx.response == "ok"
 
@@ -26,7 +26,7 @@ def test_set_response_fails_in_other_stage():
     ctx = make_context(PipelineStage.DO)
     with pytest.raises(
         PluginContextError,
-        match="set_response may only be called in DELIVER stage",
+        match="set_response may only be called in OUTPUT stage",
     ):
         ctx.set_response("nope")
 
@@ -38,7 +38,7 @@ class EarlyPlugin(PromptPlugin):
         context.set_response("bad")
 
 
-def test_plugin_cannot_set_response_before_deliver():
+def test_plugin_cannot_set_response_before_output():
     ctx = make_context(PipelineStage.DO)
     plugin = EarlyPlugin({})
     with pytest.raises(PluginContextError):

--- a/tests/test_set_response_validation.py
+++ b/tests/test_set_response_validation.py
@@ -7,7 +7,7 @@ from entity.core.state import PipelineState
 from entity.core.resources.container import ResourceContainer
 
 
-def test_set_response_disallowed_outside_deliver():
+def test_set_response_disallowed_outside_output():
     state = PipelineState(conversation=[], pipeline_id="id")
     ctx = PluginContext(
         state, SystemRegistries(ResourceContainer(), ToolRegistry(), PluginRegistry())
@@ -15,7 +15,7 @@ def test_set_response_disallowed_outside_deliver():
     ctx.set_current_stage(PipelineStage.PARSE)
     with pytest.raises(
         PluginContextError,
-        match="set_response may only be called in DELIVER stage",
+        match="set_response may only be called in OUTPUT stage",
     ):
         ctx.set_response("nope")
     assert state.response is None

--- a/tests/test_state_logging.py
+++ b/tests/test_state_logging.py
@@ -45,7 +45,7 @@ def test_logger_and_replay(tmp_path):
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         context.set_response("ok")
@@ -54,7 +54,7 @@ class RespondPlugin(PromptPlugin):
 def test_execute_pipeline_logs_states(tmp_path):
     plugins = PluginRegistry()
     asyncio.run(
-        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+        plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.OUTPUT)
     )
     capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
 
@@ -68,4 +68,4 @@ def test_execute_pipeline_logs_states(tmp_path):
     transitions = list(LogReplayer(log_file).transitions())
     stages = [t.stage for t in transitions]
     assert stages[0] == "parse"
-    assert "deliver" in stages[-1]
+    assert "output" in stages[-1]

--- a/tests/test_tool_queue_workflow.py
+++ b/tests/test_tool_queue_workflow.py
@@ -25,7 +25,7 @@ class StageOne(PromptPlugin):
 
 
 class StageTwo(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     def __init__(self):
         super().__init__()
@@ -44,7 +44,7 @@ def test_tool_runs_before_next_stage():
     plugins = PluginRegistry()
     asyncio.run(plugins.register_plugin_for_stage(StageOne(), PipelineStage.DO))
     stage_two = StageTwo()
-    asyncio.run(plugins.register_plugin_for_stage(stage_two, PipelineStage.DELIVER))
+    asyncio.run(plugins.register_plugin_for_stage(stage_two, PipelineStage.OUTPUT))
 
     tools = ToolRegistry()
     asyncio.run(tools.add("echo", EchoTool()))

--- a/tests/test_tool_registry_options.py
+++ b/tests/test_tool_registry_options.py
@@ -6,7 +6,6 @@ from entity.core.resources.container import ResourceContainer
 from entity.core.state import (
     ConversationEntry,
     PipelineState,
-    ToolCall,
 )
 from pipeline import PluginRegistry, SystemRegistries, ToolRegistry, PipelineStage
 from entity.core.context import PluginContext

--- a/tests/test_websocket_adapter.py
+++ b/tests/test_websocket_adapter.py
@@ -15,7 +15,7 @@ from plugins.builtin.adapters import WebSocketAdapter
 
 
 class RespPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         first = context.get_conversation_history()[0]
@@ -24,9 +24,7 @@ class RespPlugin(PromptPlugin):
 
 def make_adapter():
     plugins = PluginRegistry()
-    asyncio.run(
-        plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.DELIVER)
-    )
+    asyncio.run(plugins.register_plugin_for_stage(RespPlugin({}), PipelineStage.OUTPUT))
     capabilities = SystemRegistries(ResourceContainer(), ToolRegistry(), plugins)
     runtime = _AgentRuntime(capabilities)
     return WebSocketAdapter(runtime)

--- a/tests/worker/test_pipeline_worker.py
+++ b/tests/worker/test_pipeline_worker.py
@@ -9,7 +9,7 @@ from pipeline.stages import PipelineStage
 
 
 class RespondPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):  # pragma: no cover - trivial
         context.set_response("ok")
@@ -19,7 +19,7 @@ async def build_worker() -> PipelineWorker:
     resources = ResourceContainer()
     await resources.add("memory", Memory())
     plugins = PluginRegistry()
-    await plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.DELIVER)
+    await plugins.register_plugin_for_stage(RespondPlugin({}), PipelineStage.OUTPUT)
     regs = SystemRegistries(resources, ToolRegistry(), plugins)
     return PipelineWorker(regs)
 

--- a/tests/worker/test_stateless_behavior.py
+++ b/tests/worker/test_stateless_behavior.py
@@ -24,7 +24,7 @@ class CountingMemory(Memory):
 
 
 class EchoPlugin(PromptPlugin):
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context):
         context.set_response(context.conversation[-1].content)
@@ -32,7 +32,7 @@ class EchoPlugin(PromptPlugin):
 
 async def make_registries(memory: Memory) -> SystemRegistries:
     plugins = PluginRegistry()
-    await plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.DELIVER)
+    await plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.OUTPUT)
     resources = ResourceContainer()
     await resources.add("memory", memory)
     return SystemRegistries(resources, ToolRegistry(), plugins)


### PR DESCRIPTION
## Summary
- extend PipelineStage enum with INPUT and OUTPUT
- update pipeline execution order to include new stages
- adjust plugins and utilities for INPUT/OUTPUT
- update tests for OUTPUT stage

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: many errors)*
- `poetry run mypy src` *(fails: 160 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing argument)*
- `pytest -q` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6872627b83b08322b573e5fb1a0ca786