### PR TITLE
Add plugin validation hooks

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,2 +1,3 @@
+AGENT NOTE - 2025-07-12: Added config and dependency hooks for plugins
 AGENT NOTE - 2025-07-12: Updated ResourceContainer build sequence and tests
 AGENT NOTE - 2025-07-12: Added canonical resource classes and StandardResources dataclass

--- a/src/entity/core/plugins/__init__.py
+++ b/src/entity/core/plugins/__init__.py
@@ -11,6 +11,7 @@ from .base import (
     FailurePlugin,
     InputAdapterPlugin,
     OutputAdapterPlugin,
+    Plugin,
     PromptPlugin,
     ResourcePlugin,
     ToolExecutionError,

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -47,6 +47,19 @@ class Plugin:
         self.config_version = version
         self._config_history = self._config_history[:version]
 
+    # -----------------------------------------------------
+    @classmethod
+    def validate_config(cls, config: Dict[str, Any]) -> "ValidationResult":
+        """Validate ``config`` and return ``ValidationResult``."""
+
+        return ValidationResult.success_result()
+
+    @classmethod
+    def validate_dependencies(cls, registry: Any) -> "ValidationResult":
+        """Validate dependencies against ``registry``."""
+
+        return ValidationResult.success_result()
+
     async def execute(self, context: Any) -> Any:
         return await self._execute_impl(context)
 
@@ -71,6 +84,12 @@ class Plugin:
             },
         )
         return response
+
+
+class BasePlugin(Plugin):
+    """Backward compatibility alias for :class:`Plugin`."""
+
+    pass
 
 
 class InfrastructurePlugin(Plugin):

--- a/src/plugins/builtin/resources/pg_vector_store.py
+++ b/src/plugins/builtin/resources/pg_vector_store.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from entity.core.plugins import ResourcePlugin
+from entity.core.plugins import ResourcePlugin, ValidationResult
 
 
 class PgVectorStore(ResourcePlugin):
@@ -21,6 +21,14 @@ class PgVectorStore(ResourcePlugin):
 
     async def initialize(self) -> None:
         self._db = self.database
+
+    @classmethod
+    def validate_dependencies(cls, registry: Any) -> "ValidationResult":
+        if not registry.has_plugin("database"):
+            return ValidationResult.error_result(
+                "PgVectorStore requires the PostgresResource to be registered"
+            )
+        return ValidationResult.success_result()
 
     async def add_embedding(self, text: str) -> None:  # pragma: no cover - stub
         return None


### PR DESCRIPTION
## Summary
- add optional validation hooks to Plugin
- check plugin config in registry validator
- expose Plugin from plugins package
- validate PgVectorStore dependencies

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ImportError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ImportError)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option)*
- `pytest tests/test_resources/ -v` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_68727ca19a6c83228b737829ed62b9c1