### PR TITLE
Update canonical resources to use interfaces

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Canonical resources now accept layer-2 interfaces via constructor
 AGENT NOTE - 2025-07-12: Added config and dependency hooks for plugins
 AGENT NOTE - 2025-07-12: Updated ResourceContainer build sequence and tests
 AGENT NOTE - 2025-07-12: Added canonical resource classes and StandardResources dataclass

--- a/src/entity/resources/base.py
+++ b/src/entity/resources/base.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Canonical resource types."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING

--- a/src/entity/resources/interfaces/__init__.py
+++ b/src/entity/resources/interfaces/__init__.py
@@ -1,5 +1,11 @@
 from .database import DatabaseResource
 from .vector_store import VectorStoreResource
 from .llm import LLMResource
+from .storage import StorageResource
 
-__all__ = ["DatabaseResource", "VectorStoreResource", "LLMResource"]
+__all__ = [
+    "DatabaseResource",
+    "VectorStoreResource",
+    "LLMResource",
+    "StorageResource",
+]

--- a/src/entity/resources/interfaces/storage.py
+++ b/src/entity/resources/interfaces/storage.py
@@ -1,0 +1,23 @@
+"""Abstract interface for key/value storage backends."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from entity.core.plugins import ResourcePlugin
+
+
+class StorageResource(ResourcePlugin):
+
+    infrastructure_dependencies = ["storage_backend"]
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+
+    def get(
+        self, key: str, default: Any | None = None
+    ) -> Any:  # pragma: no cover - stub
+        return default
+
+    def set(self, key: str, value: Any) -> None:  # pragma: no cover - stub
+        return None

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Canonical LLM resource."""
+
+from __future__ import annotations
 
 from typing import Any, Dict
 
@@ -14,9 +14,11 @@ class LLM(AgentResource):
     name = "llm"
     dependencies: list[str] = ["llm_provider?"]
 
-    def __init__(self, config: Dict | None = None) -> None:
+    def __init__(
+        self, provider: LLMProvider | None = None, config: Dict | None = None
+    ) -> None:
         super().__init__(config or {})
-        self.provider: LLMProvider | None = None
+        self.provider = provider
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Unified Memory resource."""
+
+from __future__ import annotations
 
 from math import sqrt
 from typing import Any, Dict, Iterable, List
@@ -10,12 +10,9 @@ import inspect
 
 from entity.core.registries import SystemRegistries
 from pipeline.pipeline import execute_pipeline
-from plugins.builtin.resources.database_resource import DatabaseResource
-from plugins.builtin.resources.vector_store_resource import VectorStoreResource
-
 from .base import AgentResource
-from .interfaces.database import DatabaseResource
-from .interfaces.vector_store import VectorStoreResource
+from .interfaces.database import DatabaseResource as DatabaseInterface
+from .interfaces.vector_store import VectorStoreResource as VectorStoreInterface
 from ..core.plugins import ValidationResult
 from ..core.state import ConversationEntry
 
@@ -105,8 +102,8 @@ class Memory(AgentResource):
 
     def __init__(
         self,
-        database: DatabaseResource | None = None,
-        vector_store: VectorStoreResource | None = None,
+        database: DatabaseInterface | None = None,
+        vector_store: VectorStoreInterface | None = None,
         config: Dict | None = None,
     ) -> None:
         super().__init__(config or {})

--- a/src/entity/resources/storage.py
+++ b/src/entity/resources/storage.py
@@ -1,8 +1,10 @@
-from __future__ import annotations
-
 """Canonical storage resource."""
 
+from __future__ import annotations
+
 from typing import Any, Dict
+
+from .interfaces.storage import StorageResource as StorageBackend
 
 from .base import AgentResource
 
@@ -11,17 +13,25 @@ class Storage(AgentResource):
     """Simple key/value storage."""
 
     name = "storage"
-    dependencies: list[str] = []
+    dependencies: list[str] = ["storage_backend?"]
 
-    def __init__(self, config: Dict | None = None) -> None:
+    def __init__(
+        self, backend: StorageBackend | None = None, config: Dict | None = None
+    ) -> None:
         super().__init__(config or {})
         self._data: Dict[str, Any] = {}
+        self.backend = backend
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None
 
     def get(self, key: str, default: Any | None = None) -> Any:
+        if self.backend is not None:
+            return self.backend.get(key, default)
         return self._data.get(key, default)
 
     def set(self, key: str, value: Any) -> None:
+        if self.backend is not None:
+            self.backend.set(key, value)
+            return None
         self._data[key] = value

--- a/tests/test_standard_resources.py
+++ b/tests/test_standard_resources.py
@@ -2,7 +2,11 @@ from entity.resources import LLM, Memory, Storage, StandardResources
 
 
 def test_standard_resources_types() -> None:
-    res = StandardResources(memory=Memory({}), llm=LLM({}), storage=Storage({}))
+    res = StandardResources(
+        memory=Memory(config={}),
+        llm=LLM(config={}),
+        storage=Storage(config={}),
+    )
     assert isinstance(res.memory, Memory)
     assert isinstance(res.llm, LLM)
     assert isinstance(res.storage, Storage)


### PR DESCRIPTION
## Summary
- accept layer-2 interfaces in canonical resource constructors
- add StorageResource interface
- update StandardResources test
- document constructor change

## Testing
- `poetry run ruff check --fix src/entity/resources src/entity/resources/interfaces tests/test_standard_resources.py tests/test_complex_prompt.py`
- `poetry run mypy src` *(fails: ModuleNotFoundError and many type errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src/entity/resources/base.py src/entity/resources/llm.py src/entity/resources/memory.py src/entity/resources/storage.py src/entity/resources/interfaces/__init__.py tests/test_standard_resources.py src/entity/resources/interfaces/storage.py`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option)*
- `pytest tests/test_resources/ -v` *(fails: 'asyncio' not found in markers)*

------
https://chatgpt.com/codex/tasks/task_e_6872843f412c8322a5795fa0a33d5198