### PR TITLE
Ensure canonical resource registration

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Validates canonical resources before initialization
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence
 AGENT NOTE - 2025-07-12: Added config and dependency hooks for plugins
 AGENT NOTE - 2025-07-12: Updated ResourceContainer build sequence and tests

--- a/tests/test_initializer_canonical_resources.py
+++ b/tests/test_initializer_canonical_resources.py
@@ -1,0 +1,39 @@
+import pathlib
+import sys
+import asyncio
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path("src").resolve()))
+
+from pipeline.initializer import SystemInitializer
+
+
+def test_initializer_fails_without_memory():
+    cfg = {
+        "plugins": {
+            "agent_resources": {
+                "llm": {"type": "entity.resources.llm:LLM"},
+                "storage": {"type": "entity.resources.storage:Storage"},
+            }
+        },
+        "workflow": {},
+    }
+    init = SystemInitializer(cfg)
+    with pytest.raises(SystemError, match="memory"):
+        asyncio.run(init.initialize())
+
+
+def test_initializer_accepts_all_canonical_resources():
+    cfg = {
+        "plugins": {
+            "agent_resources": {
+                "memory": {"type": "entity.resources.memory:Memory"},
+                "llm": {"type": "entity.resources.llm:LLM"},
+                "storage": {"type": "entity.resources.storage:Storage"},
+            }
+        },
+        "workflow": {},
+    }
+    init = SystemInitializer(cfg)
+    asyncio.run(init.initialize())


### PR DESCRIPTION
## Summary
- validate that `memory`, `llm`, and `storage` resources are registered
- assign layers when registering resources
- test canonical resource checks
- log update in `agents.log`

## Testing
- `poetry run black src/pipeline/initializer.py tests/test_initializer_canonical_resources.py`
- `poetry run ruff check --fix src/pipeline/initializer.py tests/test_initializer_canonical_resources.py` *(fails: E402)*
- `poetry run mypy src` *(fails: many missing type annotations)*
- `poetry run bandit -r src` *(command not found)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_architecture/ -v` *(no tests ran, error)*
- `pytest tests/test_plugins/ -v` *(no tests ran, error)*
- `pytest tests/test_resources/ -v` *(no tests ran, error)*
- `pytest tests/test_initializer_canonical_resources.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6872887847948322ae35d53b02aa13a8