### PR TITLE
Implement plugin lifecycle hooks

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence
 AGENT NOTE - 2025-07-12: Added config and dependency hooks for plugins
 AGENT NOTE - 2025-07-12: Updated ResourceContainer build sequence and tests

--- a/src/cli/plugin_tool/main.py
+++ b/src/cli/plugin_tool/main.py
@@ -144,6 +144,18 @@ class PluginToolCLI:
         if not isinstance(result, ValidationResult) or not result.success:
             logger.error("Config validation failed: %s", result.error_message)
             return 1
+
+        class _DummyRegistry:
+            def has_plugin(self, _name: str) -> bool:
+                return False
+
+            def list_plugins(self) -> list[str]:
+                return []
+
+        dep_result = plugin_cls.validate_dependencies(_DummyRegistry())
+        if not isinstance(dep_result, ValidationResult) or not dep_result.success:
+            logger.error("Dependency validation failed: %s", dep_result.error_message)
+            return 1
         logger.info("Validation succeeded")
         return 0
 

--- a/src/cli/templates/resource.py
+++ b/src/cli/templates/resource.py
@@ -20,7 +20,7 @@ class {class_name}(ResourcePlugin):
 
     @classmethod
     def validate_config(cls, config: dict) -> ValidationResult:
-        return ValidationResult.success()
+        return ValidationResult.success_result()
 
     async def initialize(self) -> None:
         pass

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -136,6 +136,20 @@ async def initialization_cleanup_context(container: ResourceContainer):
         raise
 
 
+@asynccontextmanager
+async def plugin_cleanup_context(plugins: list[Plugin]):
+    """Shutdown plugins if initialization fails."""
+
+    try:
+        yield
+    except Exception:
+        for plugin in reversed(plugins):
+            shutdown = getattr(plugin, "shutdown", None)
+            if callable(shutdown):
+                await shutdown()
+        raise
+
+
 class SystemInitializer:
     """Initialize and validate all plugins for the pipeline."""
 
@@ -161,6 +175,10 @@ class SystemInitializer:
         self.tool_registry_cls = tool_registry_cls
         self.resource_container_cls = resource_container_cls
         self.workflows: Dict[str, Type] = {}
+        self._plugins: list[Plugin] = []
+        self.plugin_registry: PluginRegistry | None = None
+        self.resource_container: ResourceContainer | None = None
+        self.tool_registry: ToolRegistry | None = None
 
     @classmethod
     def from_yaml(cls, yaml_path: str, env_file: str = ".env") -> "SystemInitializer":
@@ -389,10 +407,14 @@ class SystemInitializer:
 
         # Phase 3: initialize resources via container
         resource_container = self.resource_container_cls()
+        self.resource_container = resource_container
         for name, cls, config in registry.resource_classes():
             resource_container.register(name, cls, config)
 
-        async with initialization_cleanup_context(resource_container):
+        async with (
+            initialization_cleanup_context(resource_container),
+            plugin_cleanup_context(self._plugins),
+        ):
             await resource_container.build_all()
 
             breaker_cfg = self.config.get("runtime_validation_breaker", {})
@@ -428,12 +450,14 @@ class SystemInitializer:
             tool_registry = self.tool_registry_cls(
                 concurrency_limit=tr_cfg.get("concurrency_limit", 5)
             )
+            self.tool_registry = tool_registry
             for name, cls, config in registry.named_tool_classes():
                 instance = cls(config)
                 await tool_registry.add(name, instance)
 
             # Phase 4: instantiate prompt and adapter plugins
             plugin_registry = self.plugin_registry_cls()
+            self.plugin_registry = plugin_registry
             for cls, config in registry.non_resource_non_tool_classes():
                 instance = cls(config)
                 stages, _ = self._resolve_plugin_stages(cls, instance, config)
@@ -441,8 +465,24 @@ class SystemInitializer:
                     await plugin_registry.register_plugin_for_stage(
                         instance, PipelineStage.ensure(stage)
                     )
+                self._plugins.append(instance)
+
+            for plugin in self._plugins:
+                init = getattr(plugin, "initialize", None)
+                if callable(init):
+                    await init()
 
         return plugin_registry, resource_container, tool_registry, workflow
+
+    async def shutdown(self) -> None:
+        """Shutdown resources and plugins."""
+
+        if self.resource_container is not None:
+            await self.resource_container.shutdown_all()
+        for plugin in reversed(self._plugins):
+            shutdown = getattr(plugin, "shutdown", None)
+            if callable(shutdown):
+                await shutdown()
 
     def _validate_dependency_graph(
         self, registry: ClassRegistry, dep_graph: Dict[str, List[str]]


### PR DESCRIPTION
## Summary
- add `has_plugin`, validation, initialization and shutdown support to builder
- extend `SystemInitializer` with plugin lifecycle support
- update CLI resource template for new validation API
- improve plugin validation in CLI tool
- log repository changes

## Testing
- `poetry run black src tests`
- `poetry run ruff check src tests --exclude src/cli/templates`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option)*
- `pytest tests/test_resources/ -v` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_687288819244832284300acd6d257351