### PR TITLE
Add advanced context features

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added advanced context features for plugins
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence
 AGENT NOTE - 2025-07-12: Added config and dependency hooks for plugins

--- a/tests/test_plugin_context_advanced.py
+++ b/tests/test_plugin_context_advanced.py
@@ -1,0 +1,36 @@
+import types
+from datetime import datetime
+
+from entity.core.context import PluginContext
+from entity.core.state import ConversationEntry, PipelineState
+
+
+class DummyRegistries:
+    def __init__(self):
+        self.resources = {}
+        self.tools = types.SimpleNamespace()
+
+
+def make_context(state=None):
+    if state is None:
+        state = PipelineState(conversation=[])
+    return PluginContext(state, DummyRegistries())
+
+
+def test_replace_conversation_history():
+    ctx = make_context()
+    new_history = [
+        ConversationEntry("hi", "user", datetime.now()),
+        ConversationEntry("hello", "assistant", datetime.now()),
+    ]
+    ctx.advanced.replace_conversation_history(new_history)
+
+    assert ctx.get_conversation_history() == new_history
+
+
+def test_update_response():
+    state = PipelineState(conversation=[], response="foo")
+    ctx = make_context(state)
+    ctx.update_response(lambda r: r + "bar")
+
+    assert ctx.response == "foobar"


### PR DESCRIPTION
## Summary
- add `AdvancedContext` inner class for plugins
- expose `advanced` property and response helpers on `PluginContext`
- add tests for the new helpers
- log new note

## Testing
- `poetry run pytest tests/test_plugin_context_advanced.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68728d6677d48322983a899c976cb697