### PR TITLE
Add canonical resource validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Verified canonical resource checks in initializer
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence
 AGENT NOTE - 2025-07-12: Added config and dependency hooks for plugins

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -418,14 +418,15 @@ class SystemInitializer:
         # Phase 3: initialize resources via container
         resource_container = self.resource_container_cls()
         self.resource_container = resource_container
-        for name, cls, config in registry.resource_classes():
-            resource_container.register(name, cls, config)
+        for name, cls, config, layer in registry.resource_classes():
+            resource_container.register(name, cls, config, layer=layer)
 
         async with (
             initialization_cleanup_context(resource_container),
             plugin_cleanup_context(self._plugins),
         ):
             await resource_container.build_all()
+            self._ensure_canonical_resources(resource_container)
 
             breaker_cfg = self.config.get("runtime_validation_breaker", {})
             breaker = CircuitBreaker(

--- a/tests/test_initializer_canonical_resources.py
+++ b/tests/test_initializer_canonical_resources.py
@@ -24,6 +24,36 @@ def test_initializer_fails_without_memory():
         asyncio.run(init.initialize())
 
 
+def test_initializer_fails_without_llm():
+    cfg = {
+        "plugins": {
+            "agent_resources": {
+                "memory": {"type": "entity.resources.memory:Memory"},
+                "storage": {"type": "entity.resources.storage:Storage"},
+            }
+        },
+        "workflow": {},
+    }
+    init = SystemInitializer(cfg)
+    with pytest.raises(SystemError, match="llm"):
+        asyncio.run(init.initialize())
+
+
+def test_initializer_fails_without_storage():
+    cfg = {
+        "plugins": {
+            "agent_resources": {
+                "memory": {"type": "entity.resources.memory:Memory"},
+                "llm": {"type": "entity.resources.llm:LLM"},
+            }
+        },
+        "workflow": {},
+    }
+    init = SystemInitializer(cfg)
+    with pytest.raises(SystemError, match="storage"):
+        asyncio.run(init.initialize())
+
+
 def test_initializer_accepts_all_canonical_resources():
     cfg = {
         "plugins": {


### PR DESCRIPTION
## Summary
- ensure required canonical resources are present
- expand canonical resource coverage tests
- note registry check in `agents.log`

## Testing
- `poetry run ruff check --fix src tests` *(fails: 147 errors)*
- `poetry run mypy src` *(fails: 169 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml`
- `pytest tests/test_initializer_canonical_resources.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68728c7ed890832289942fd877440477