### PR TITLE
Add plugin lifecycle defaults

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added base lifecycle defaults and validation in ResourceContainer
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence
 AGENT NOTE - 2025-07-12: Added config and dependency hooks for plugins

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -60,6 +60,16 @@ class Plugin:
 
         return ValidationResult.success_result()
 
+    async def initialize(self) -> None:
+        """Initialize the plugin instance."""
+
+        return None
+
+    async def shutdown(self) -> None:
+        """Shut down the plugin instance."""
+
+        return None
+
     async def execute(self, context: Any) -> Any:
         return await self._execute_impl(context)
 

--- a/src/plugins/builtin/resources/pg_vector_store.py
+++ b/src/plugins/builtin/resources/pg_vector_store.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from entity.core.plugins import ResourcePlugin, ValidationResult
+from entity.core.plugins import ValidationResult
 
 
 class PgVectorStore(VectorStoreResource):


### PR DESCRIPTION
## Summary
- implement initialize and shutdown hooks in Plugin base class
- call lifecycle validation during resource container build
- expose has_plugin on ResourceContainer
- update pg_vector_store imports
- log agent note

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 147 errors)*
- `poetry run mypy src` *(fails: 171 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed to await coroutine)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed to await coroutine)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: Plugin 'database' does not specify any stages)*
- `pytest tests/test_architecture/ -v` *(no tests ran)*
- `pytest tests/test_plugins/ -v` *(no tests ran)*
- `pytest tests/test_resources/ -v` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68728c75dd3c8322a096d89fa85bcb9c