### PR TITLE
Improve plugin tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated tests for Plugin base and added lifecycle checks
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence
 AGENT NOTE - 2025-07-12: Added config and dependency hooks for plugins

--- a/tests/test_plugin_lifecycle.py
+++ b/tests/test_plugin_lifecycle.py
@@ -1,0 +1,40 @@
+import pytest
+
+from entity.core.builder import _AgentBuilder
+from entity.core.plugins import Plugin
+from entity.core.stages import PipelineStage
+
+
+class LifecyclePlugin(Plugin):
+    stages = [PipelineStage.THINK]
+
+    def __init__(self, config=None):
+        super().__init__(config or {})
+        self.initialized = False
+        self.executed = False
+        self.closed = False
+
+    async def initialize(self) -> None:
+        self.initialized = True
+
+    async def _execute_impl(self, context):
+        self.executed = True
+        return "ok"
+
+    async def shutdown(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_plugin_lifecycle():
+    builder = _AgentBuilder()
+    plugin = LifecyclePlugin({})
+    builder.add_plugin(plugin)
+    builder.build_runtime()
+
+    await plugin.execute(object())
+    assert plugin.initialized
+    assert plugin.executed
+
+    builder.shutdown()
+    assert plugin.closed

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -3,7 +3,7 @@ import yaml
 from entity.core.plugins import (
     AgentResource,
     InfrastructurePlugin,
-    PromptPlugin,
+    Plugin,
     ResourcePlugin,
 )
 from entity.core.stages import PipelineStage
@@ -21,7 +21,7 @@ class A(AgentResource):
         pass
 
 
-class B(PromptPlugin):
+class B(Plugin):
     stages = [PipelineStage.THINK]
     dependencies = ["a"]
 
@@ -33,7 +33,7 @@ class B(PromptPlugin):
         pass
 
 
-class C(PromptPlugin):
+class C(Plugin):
     stages = [PipelineStage.DO]
     dependencies = ["missing"]
 
@@ -46,7 +46,7 @@ class C(PromptPlugin):
         pass
 
 
-class D(PromptPlugin):
+class D(Plugin):
     stages = [PipelineStage.PARSE]
     dependencies = ["e"]
 
@@ -57,7 +57,7 @@ class D(PromptPlugin):
         pass
 
 
-class E(PromptPlugin):
+class E(Plugin):
     stages = [PipelineStage.DO]
     dependencies = ["d"]
 
@@ -98,7 +98,7 @@ class InfraDatabase(InfrastructurePlugin):
         pass
 
 
-class BadPromptInterface(PromptPlugin):
+class BadPromptInterface(Plugin):
     stages = [PipelineStage.THINK]
     dependencies = ["db_interface"]
 
@@ -106,7 +106,7 @@ class BadPromptInterface(PromptPlugin):
         pass
 
 
-class BadPromptInfra(PromptPlugin):
+class BadPromptInfra(Plugin):
     stages = [PipelineStage.THINK]
     dependencies = ["infra_db"]
 
@@ -114,7 +114,7 @@ class BadPromptInfra(PromptPlugin):
         pass
 
 
-class ComplexPrompt(PromptPlugin):
+class ComplexPrompt(Plugin):
     stages = [PipelineStage.THINK]
     dependencies = ["memory"]
 
@@ -252,7 +252,7 @@ def test_plugin_depends_on_infrastructure(tmp_path):
 
 
 def test_stage_override_warning():
-    class OverridePrompt(PromptPlugin):
+    class OverridePrompt(Plugin):
         async def _execute_impl(self, context):
             pass
 

--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -85,3 +85,26 @@ def test_layer_violation():
 
     with pytest.raises(SystemError, match="violates layer rules"):
         asyncio.run(container.build_all())
+
+
+def test_missing_interface_dependencies():
+    class BadInterface(ResourcePlugin):
+        stages: list = []
+
+    container = ResourceContainer()
+    container.register("infra", InfraPlugin, {}, layer=1)
+    container.register("iface", BadInterface, {}, layer=2)
+
+    with pytest.raises(SystemError, match="infrastructure_dependencies"):
+        asyncio.run(container.build_all())
+
+
+def test_missing_infrastructure_type():
+    class BadInfra(InfrastructurePlugin):
+        stages: list = []
+
+    container = ResourceContainer()
+    container.register("bad", BadInfra, {}, layer=1)
+
+    with pytest.raises(SystemError, match="infrastructure_type"):
+        asyncio.run(container.build_all())

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -1,17 +1,17 @@
 from entity.core.builder import _AgentBuilder
-from entity.core.plugins import PromptPlugin
+from entity.core.plugins import Plugin
 from pipeline.initializer import SystemInitializer
 from entity.core.stages import PipelineStage
 
 
-class AttrPrompt(PromptPlugin):
+class AttrPrompt(Plugin):
     stages = [PipelineStage.DO]
 
     async def _execute_impl(self, context):
         pass
 
 
-class InferredPrompt(PromptPlugin):
+class InferredPrompt(Plugin):
     async def _execute_impl(self, context):
         pass
 


### PR DESCRIPTION
## Summary
- update tests to subclass `Plugin`
- add plugin lifecycle test
- validate layer checks for resource container
- log plugin test updates

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402, F821, etc.)*
- `poetry run mypy src` *(fails: found 169 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: Plugin 'database' does not specify any stages)*
- `pytest tests/test_architecture/ -v` *(no tests ran)*
- `pytest tests/test_plugins/ -v` *(no tests ran)*
- `pytest tests/test_resources/ -v` *(no tests ran)*
- `pytest tests -v` *(errors: missing modules and markers)*

------
https://chatgpt.com/codex/tasks/task_e_68728c405c6c8322944b803838543f78