### PR TITLE
Add stage decorators with tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence
 AGENT NOTE - 2025-07-12: Added config and dependency hooks for plugins

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -2,7 +2,22 @@
 
 from __future__ import annotations
 
-__all__ = ["core", "Agent", "AgentBuilder"]
+from .core import decorators as _decorators
+
+
+class _AgentAPI:
+    plugin = staticmethod(_decorators.plugin)
+    input = staticmethod(_decorators.input)
+    parse = staticmethod(_decorators.parse)
+    prompt = staticmethod(_decorators.prompt)
+    tool = staticmethod(_decorators.tool)
+    review = staticmethod(_decorators.review)
+    output = staticmethod(_decorators.output)
+
+
+agent = _AgentAPI()
+
+__all__ = ["core", "Agent", "AgentBuilder", "agent"]
 
 
 def __getattr__(name: str):

--- a/src/entity/core/decorators.py
+++ b/src/entity/core/decorators.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
+from .stages import PipelineStage
+
 from .plugin_utils import PluginAutoClassifier
 
 
@@ -19,3 +21,68 @@ def plugin(func: Optional[Callable] = None, **hints: Any) -> Callable:
         return f
 
     return decorator(func) if func else decorator
+
+
+def input(
+    func: Optional[Callable] = None, **hints: Any
+) -> Callable[[Callable], Callable] | Callable:
+    """Decorator for INPUT stage plugins."""
+
+    hints["stage"] = PipelineStage.INPUT
+    return plugin(func, **hints)
+
+
+def parse(
+    func: Optional[Callable] = None, **hints: Any
+) -> Callable[[Callable], Callable] | Callable:
+    """Decorator for PARSE stage plugins."""
+
+    hints["stage"] = PipelineStage.PARSE
+    return plugin(func, **hints)
+
+
+def prompt(
+    func: Optional[Callable] = None, **hints: Any
+) -> Callable[[Callable], Callable] | Callable:
+    """Decorator for THINK stage plugins."""
+
+    hints["stage"] = PipelineStage.THINK
+    return plugin(func, **hints)
+
+
+def tool(
+    func: Optional[Callable] = None, **hints: Any
+) -> Callable[[Callable], Callable] | Callable:
+    """Decorator for DO stage plugins."""
+
+    hints["stage"] = PipelineStage.DO
+    return plugin(func, **hints)
+
+
+def review(
+    func: Optional[Callable] = None, **hints: Any
+) -> Callable[[Callable], Callable] | Callable:
+    """Decorator for REVIEW stage plugins."""
+
+    hints["stage"] = PipelineStage.REVIEW
+    return plugin(func, **hints)
+
+
+def output(
+    func: Optional[Callable] = None, **hints: Any
+) -> Callable[[Callable], Callable] | Callable:
+    """Decorator for OUTPUT stage plugins."""
+
+    hints["stage"] = PipelineStage.OUTPUT
+    return plugin(func, **hints)
+
+
+__all__ = [
+    "plugin",
+    "input",
+    "parse",
+    "prompt",
+    "tool",
+    "review",
+    "output",
+]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,39 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path("src").resolve()))
+
+from entity import agent
+from entity.core.builder import _AgentBuilder
+from entity.core.stages import PipelineStage
+
+
+_DEFINITIONS = [
+    (agent.input, PipelineStage.INPUT),
+    (agent.parse, PipelineStage.PARSE),
+    (agent.prompt, PipelineStage.THINK),
+    (agent.tool, PipelineStage.DO),
+    (agent.review, PipelineStage.REVIEW),
+    (agent.output, PipelineStage.OUTPUT),
+]
+
+
+def _stage_of(decorator):
+    _ = _AgentBuilder()
+
+    @decorator
+    async def dummy(context):
+        pass
+
+    return dummy.__entity_plugin__.stages
+
+
+for dec, stage in _DEFINITIONS:
+
+    def _make_test(dec=dec, stage=stage):
+        def test_func():
+            assert _stage_of(dec) == [stage]
+
+        return test_func
+
+    globals()[f"test_{dec.__name__}_decorator"] = _make_test()


### PR DESCRIPTION
## Summary
- add stage-specific decorators in `decorators.py`
- expose decorators via an `agent` object
- test that each decorator assigns the correct stage
- note decorator addition in `agents.log`

## Testing
- `poetry run pytest -q tests/test_decorators.py`

------
https://chatgpt.com/codex/tasks/task_e_68728d6806c48322906e54606c8107be