### PR TITLE
Add plugin analyzer

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added plugin analyzer to suggest upgrades
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence
 AGENT NOTE - 2025-07-12: Added config and dependency hooks for plugins

--- a/src/entity/core/decorators.py
+++ b/src/entity/core/decorators.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
+from .logging import get_logger
+from .plugin_analyzer import suggest_upgrade
+
 from .plugin_utils import PluginAutoClassifier
 
 
@@ -13,6 +16,10 @@ def plugin(func: Optional[Callable] = None, **hints: Any) -> Callable:
     def decorator(f: Callable) -> Callable:
         if not (hints.get("plugin_class") or hints.get("stage") or hints.get("stages")):
             raise ValueError("plugin() requires 'plugin_class' or stage hints")
+
+        suggestion = suggest_upgrade(f)
+        if suggestion:
+            get_logger(__name__).warning(suggestion)
 
         plugin_obj = PluginAutoClassifier.classify(f, hints)
         setattr(f, "__entity_plugin__", plugin_obj)

--- a/src/entity/core/plugin_analyzer.py
+++ b/src/entity/core/plugin_analyzer.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Utilities for inspecting plugin functions."""
+
+from typing import Callable
+import ast
+import inspect
+import textwrap
+
+
+def suggest_upgrade(func: Callable) -> str | None:
+    """Return a suggestion to upgrade ``func`` to a class plugin if complex."""
+    try:
+        source = inspect.getsource(func)
+    except OSError:
+        return None
+
+    lines = len(source.splitlines())
+    if lines > 20:
+        return f"Function '{func.__name__}' is {lines} lines long; consider a class-based plugin for clarity."
+
+    try:
+        tree = ast.parse(textwrap.dedent(source))
+    except SyntaxError:
+        return None
+
+    class ComplexityVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.complex = False
+
+        def visit_For(self, node: ast.For) -> None:  # type: ignore[override]
+            self.complex = True
+
+        def visit_AsyncFor(self, node: ast.AsyncFor) -> None:  # type: ignore[override]
+            self.complex = True
+
+        def visit_While(self, node: ast.While) -> None:  # type: ignore[override]
+            self.complex = True
+
+        def visit_If(self, node: ast.If) -> None:  # type: ignore[override]
+            if node.orelse:
+                self.complex = True
+            self.generic_visit(node)
+
+    visitor = ComplexityVisitor()
+    visitor.visit(tree)
+
+    if visitor.complex:
+        return f"Function '{func.__name__}' contains loops or branches; consider upgrading to a class."
+
+    return None

--- a/tests/test_plugin_analyzer.py
+++ b/tests/test_plugin_analyzer.py
@@ -1,0 +1,19 @@
+import logging
+
+
+from pipeline import Plugin  # noqa: F401 - triggers plugin configuration
+
+from entity.core.decorators import plugin
+from entity.core.stages import PipelineStage
+
+
+def test_warning_logged_for_complex_function(caplog):
+    async def complex_func(context):
+        for i in range(5):
+            if i > 2:
+                break
+
+    with caplog.at_level(logging.WARNING):
+        plugin(stage=PipelineStage.THINK)(complex_func)
+
+    assert any("consider" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- create `plugin_analyzer` to inspect plugin functions
- log upgrade suggestions in `plugin` decorator
- test that warnings appear for complex plugins
- log development note

## Testing
- `poetry run pytest tests/test_plugin_analyzer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68728d6b63448322af8d87afa198a2b0