### PR TITLE
Initialize canonical resources before build

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Ensure canonical resources validated before build
 AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -421,12 +421,13 @@ class SystemInitializer:
         for name, cls, config, layer in registry.resource_classes():
             resource_container.register(name, cls, config, layer=layer)
 
+        self._ensure_canonical_resources(resource_container)
+
         async with (
             initialization_cleanup_context(resource_container),
             plugin_cleanup_context(self._plugins),
         ):
             await resource_container.build_all()
-            self._ensure_canonical_resources(resource_container)
 
             breaker_cfg = self.config.get("runtime_validation_breaker", {})
             breaker = CircuitBreaker(


### PR DESCRIPTION
## Summary
- log an agent note
- verify canonical resources before resource container build

## Testing
- `poetry run black src tests`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'tests')*

------
https://chatgpt.com/codex/tasks/task_e_6872909cbb308322b79d613e1be3f2e2