### PR TITLE
Update context memory helper

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: PluginContext memory retrieval uses resource.get
 AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -20,7 +20,8 @@ class PluginContext:
         self._state = state
         self._registries = registries
         self._user_id = user_id or "default"
-        self._memory = getattr(registries.resources, "memory", None)
+        # Use registry helper to fetch memory if registered
+        self._memory = registries.resources.get("memory")
         self._plugin_name: str | None = None
 
     class AdvancedContext:
@@ -204,16 +205,18 @@ class PluginContext:
 
     def remember(self, key: str, value: Any) -> None:
         """Persist ``value`` in the configured memory resource."""
-        if self._memory is not None:
+        memory = self.get_resource("memory")
+        if memory is not None:
             namespaced_key = f"{self._user_id}:{key}"
-            self._memory.remember(namespaced_key, value)
+            memory.remember(namespaced_key, value)
 
     def memory(self, key: str, default: Any | None = None) -> Any:
         """Retrieve a value from persistent memory."""
-        if self._memory is None:
+        memory = self.get_resource("memory")
+        if memory is None:
             return default
         namespaced_key = f"{self._user_id}:{key}"
-        return self._memory.get(namespaced_key, default)
+        return memory.get(namespaced_key, default)
 
     def set_metadata(self, key: str, value: Any) -> None:
         self._state.metadata[key] = value

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -1,0 +1,23 @@
+import types
+
+from entity.core.context import PluginContext
+from entity.core.state import PipelineState
+from entity.resources import Memory
+
+
+class DummyRegistries:
+    def __init__(self) -> None:
+        self.resources = {"memory": Memory(config={})}
+        self.tools = types.SimpleNamespace()
+
+
+def make_context() -> PluginContext:
+    state = PipelineState(conversation=[])
+    return PluginContext(state, DummyRegistries())
+
+
+def test_memory_roundtrip() -> None:
+    ctx = make_context()
+    ctx.remember("foo", "bar")
+
+    assert ctx.memory("foo") == "bar"


### PR DESCRIPTION
## Summary
- fetch memory resource using registry `get`
- fetch memory resource dynamically in `remember` and `memory`
- test memory roundtrip
- log update for project history

## Testing
- `poetry run pytest -q tests/test_plugin_context_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_6872909089648322b4f69d940e2be812