### PR TITLE
Add custom resource access test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added custom resource context test
 AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence

--- a/tests/test_custom_resource_access.py
+++ b/tests/test_custom_resource_access.py
@@ -1,0 +1,29 @@
+import types
+import pytest
+
+from entity.core.resources.container import ResourceContainer
+from entity.core.plugins import AgentResource
+from entity.core.context import PluginContext
+from entity.core.state import PipelineState
+
+
+class DummyResource(AgentResource):
+    stages: list = []
+
+
+@pytest.mark.asyncio
+async def test_custom_resource_access():
+    container = ResourceContainer()
+    container.register("chat_gpt", DummyResource, {}, layer=3)
+
+    await container.build_all()
+    dummy = container.get("chat_gpt")
+
+    registries = types.SimpleNamespace(
+        resources=container, tools=types.SimpleNamespace()
+    )
+    context = PluginContext(PipelineState(conversation=[]), registries)
+
+    assert context.get_resource("chat_gpt") is dummy
+
+    await container.shutdown_all()


### PR DESCRIPTION
## Summary
- add `test_custom_resource_access.py` to validate retrieval of resources via `PluginContext`
- log the addition in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run pytest -q` *(fails: AttributeError: 'coroutine' object has no attribute 'success', NameError: suggest_upgrade not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6872909e33948322a1a6d672f9a54371