### PR TITLE
Add context resource helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Entity lets you craft agent pipelines using a single configuration file. The sam
 - In-memory DuckDB backend for quick local testing
 - Overrides of default plugin stages produce log warnings
 
+### Plugin Context Helpers
+Plugins can access canonical resources with helper methods:
+`context.get_llm()`, `context.get_memory()`, and `context.get_storage()`.
+
 Check the [hero landing page](https://entity.readthedocs.io/en/latest/) for a visual overview.
 
 ## Minimal Example

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs
 AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,3 +11,5 @@ Run any example with:
 ```bash
 poetry run python examples/<name>/main.py
 ```
+
+The `PluginContext` in each example provides `get_llm()`, `get_memory()`, and `get_storage()` helpers for quick resource access.

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -102,6 +102,14 @@ class PluginContext:
         """Return the configured LLM resource."""
         return self._registries.resources.get("llm")
 
+    def get_memory(self) -> Any | None:
+        """Return the configured Memory resource."""
+        return self.get_resource("memory")
+
+    def get_storage(self) -> Any | None:
+        """Return the configured Storage resource."""
+        return self.get_resource("storage")
+
     def say(self, content: str, *, metadata: Dict[str, Any] | None = None) -> None:
         """Append an assistant message to the conversation."""
         self.add_conversation_entry(

--- a/tests/test_context_helpers.py
+++ b/tests/test_context_helpers.py
@@ -1,0 +1,22 @@
+import types
+
+from entity.core.context import PluginContext
+from entity.core.state import PipelineState
+
+
+class DummyRegistries:
+    def __init__(self, resources):
+        self.resources = resources
+        self.tools = types.SimpleNamespace()
+
+
+def make_context():
+    resources = {"memory": object(), "storage": object(), "llm": object()}
+    return PluginContext(PipelineState(conversation=[]), DummyRegistries(resources))
+
+
+def test_get_resource_helpers():
+    ctx = make_context()
+    assert ctx.get_llm() is ctx.get_resource("llm")
+    assert ctx.get_memory() is ctx.get_resource("memory")
+    assert ctx.get_storage() is ctx.get_resource("storage")


### PR DESCRIPTION
## Summary
- expose `get_memory` and `get_storage` in `PluginContext`
- mention helper methods in README and examples
- test new helper methods

## Testing
- `poetry run pytest -q` *(fails: NameError: suggest_upgrade not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6872909391f08322baa257af990be5d9