### PR TITLE
Add AdvancedContext API

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Introduced AdvancedContext API
 AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence

--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -20,4 +20,6 @@ class {class_name}(AdapterPlugin):
 
     async def _execute_impl(self, context):
         if context.has("response"):
-            await context.queue_tool_use("send", {"text": context.load("response")})
+            await context.advanced.queue_tool_use(
+                "send", {"text": context.load("response")}
+            )

--- a/src/cli/templates/resource.py
+++ b/src/cli/templates/resource.py
@@ -26,4 +26,4 @@ class {class_name}(ResourcePlugin):
         pass
 
     async def _execute_impl(self, context) -> None:
-        context.queue_tool_use("refresh", {})
+        context.advanced.queue_tool_use("refresh", {})

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -7,8 +7,68 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
 from entity.core.state import ConversationEntry, PipelineState, ToolCall
+import warnings
 from pipeline.errors import PluginContextError
 from pipeline.stages import PipelineStage
+
+
+class AdvancedContext:
+    """Low-level helpers for advanced plugin features."""
+
+    def __init__(self, parent: "PluginContext") -> None:
+        self._parent = parent
+
+    # ------------------------------------------------------------------
+    # Core helpers
+    # ------------------------------------------------------------------
+    @property
+    def parent(self) -> "PluginContext":
+        return self._parent
+
+    def replace_conversation_history(self, history: list[ConversationEntry]) -> None:
+        self._parent._state.conversation = list(history)
+
+    async def queue_tool_use(
+        self,
+        name: str,
+        *,
+        result_key: str | None = None,
+        **params: Any,
+    ) -> str:
+        if self._parent._registries.tools.get(name) is None:
+            raise ValueError(f"Tool '{name}' not found")
+        if result_key is None:
+            result_key = f"{name}_{len(self._parent._state.pending_tool_calls)}"
+        self._parent._state.pending_tool_calls.append(
+            ToolCall(name=name, params=params, result_key=result_key, source="queued")
+        )
+        return result_key
+
+    def discover_tools(self, **filters: Any) -> list[tuple[str, Any]]:
+        discover = getattr(self._parent._registries.tools, "discover", None)
+        if callable(discover):
+            return discover(**filters)
+        return [
+            (n, t)
+            for n, t in getattr(self._parent._registries.tools, "_tools", {}).items()
+        ]
+
+    def remember(self, key: str, value: Any) -> None:
+        if self._parent._memory is not None:
+            namespaced_key = f"{self._parent._user_id}:{key}"
+            self._parent._memory.remember(namespaced_key, value)
+
+    def memory(self, key: str, default: Any | None = None) -> Any:
+        if self._parent._memory is None:
+            return default
+        namespaced_key = f"{self._parent._user_id}:{key}"
+        return self._parent._memory.get(namespaced_key, default)
+
+    def set_metadata(self, key: str, value: Any) -> None:
+        self._parent._state.metadata[key] = value
+
+    def get_metadata(self, key: str, default: Any | None = None) -> Any:
+        return self._parent._state.metadata.get(key, default)
 
 
 class PluginContext:
@@ -22,21 +82,7 @@ class PluginContext:
         self._user_id = user_id or "default"
         self._memory = getattr(registries.resources, "memory", None)
         self._plugin_name: str | None = None
-
-    class AdvancedContext:
-        """Low-level helpers for advanced plugin features."""
-
-        def __init__(self, parent: "PluginContext") -> None:
-            self._parent = parent
-
-        @property
-        def parent(self) -> "PluginContext":
-            return self._parent
-
-        def replace_conversation_history(
-            self, history: list[ConversationEntry]
-        ) -> None:
-            self._parent._state.conversation = list(history)
+        self._advanced = AdvancedContext(self)
 
     # ------------------------------------------------------------------
     @property
@@ -71,9 +117,9 @@ class PluginContext:
         return self._state.response
 
     @property
-    def advanced(self) -> "PluginContext.AdvancedContext":
+    def advanced(self) -> AdvancedContext:
         """Return helpers for advanced plugins."""
-        return PluginContext.AdvancedContext(self)
+        return self._advanced
 
     def has_response(self) -> bool:
         """Return ``True`` if a response has been set."""
@@ -156,25 +202,20 @@ class PluginContext:
     async def queue_tool_use(
         self, name: str, *, result_key: str | None = None, **params: Any
     ) -> str:
-        """Queue ``name`` for later execution and return its result key."""
-        if self._registries.tools.get(name) is None:
-            raise ValueError(f"Tool '{name}' not found")
-        if result_key is None:
-            result_key = f"{name}_{len(self._state.pending_tool_calls)}"
-        self._state.pending_tool_calls.append(
-            ToolCall(name=name, params=params, result_key=result_key, source="queued")
+        warnings.warn(
+            "PluginContext.queue_tool_use is deprecated; use context.advanced.queue_tool_use",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        return result_key
+        return await self.advanced.queue_tool_use(name, result_key=result_key, **params)
 
     def discover_tools(self, **filters: Any) -> list[tuple[str, Any]]:
-        """Return registered tools matching ``filters``."""
-        discover = getattr(self._registries.tools, "discover", None)
-        if callable(discover):
-            return discover(**filters)
-        # Fallback: return all tools if registry lacks discovery helper
-        return [
-            (n, t) for n, t in getattr(self._registries.tools, "_tools", {}).items()
-        ]
+        warnings.warn(
+            "PluginContext.discover_tools is deprecated; use context.advanced.discover_tools",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.advanced.discover_tools(**filters)
 
     # ------------------------------------------------------------------
     # Stage result helpers
@@ -203,23 +244,36 @@ class PluginContext:
     # ------------------------------------------------------------------
 
     def remember(self, key: str, value: Any) -> None:
-        """Persist ``value`` in the configured memory resource."""
-        if self._memory is not None:
-            namespaced_key = f"{self._user_id}:{key}"
-            self._memory.remember(namespaced_key, value)
+        warnings.warn(
+            "PluginContext.remember is deprecated; use context.advanced.remember",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.advanced.remember(key, value)
 
     def memory(self, key: str, default: Any | None = None) -> Any:
-        """Retrieve a value from persistent memory."""
-        if self._memory is None:
-            return default
-        namespaced_key = f"{self._user_id}:{key}"
-        return self._memory.get(namespaced_key, default)
+        warnings.warn(
+            "PluginContext.memory is deprecated; use context.advanced.memory",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.advanced.memory(key, default)
 
     def set_metadata(self, key: str, value: Any) -> None:
-        self._state.metadata[key] = value
+        warnings.warn(
+            "PluginContext.set_metadata is deprecated; use context.advanced.set_metadata",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.advanced.set_metadata(key, value)
 
     def get_metadata(self, key: str, default: Any | None = None) -> Any:
-        return self._state.metadata.get(key, default)
+        warnings.warn(
+            "PluginContext.get_metadata is deprecated; use context.advanced.get_metadata",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.advanced.get_metadata(key, default)
 
     @property
     def failure_info(self) -> Any:

--- a/tests/test_plugin_context_advanced.py
+++ b/tests/test_plugin_context_advanced.py
@@ -1,14 +1,24 @@
 import types
 from datetime import datetime
+import pytest
 
 from entity.core.context import PluginContext
 from entity.core.state import ConversationEntry, PipelineState
 
 
+class DummyTool:
+    async def execute_function(self, params):
+        return params
+
+
 class DummyRegistries:
     def __init__(self):
         self.resources = {}
-        self.tools = types.SimpleNamespace()
+        tool = DummyTool()
+        self.tools = types.SimpleNamespace(
+            get=lambda name: tool if name == "dummy" else None,
+            discover=lambda **filters: [("dummy", tool)],
+        )
 
 
 def make_context(state=None):
@@ -34,3 +44,16 @@ def test_update_response():
     ctx.update_response(lambda r: r + "bar")
 
     assert ctx.response == "foobar"
+
+
+@pytest.mark.asyncio
+async def test_queue_tool_use_via_property_and_wrapper():
+    state = PipelineState(conversation=[])
+    ctx = make_context(state)
+
+    key1 = await ctx.advanced.queue_tool_use("dummy", x=1)
+    key2 = await ctx.queue_tool_use("dummy", x=2)
+
+    assert key1 == "dummy_0"
+    assert key2 == "dummy_1"
+    assert len(state.pending_tool_calls) == 2


### PR DESCRIPTION
## Summary
- introduce `AdvancedContext` module-level class
- expose advanced context via `PluginContext.advanced`
- update templates and tests to use the new property
- document change in agents log

## Testing
- `poetry run black src/entity/core/context.py tests/test_plugin_context_advanced.py`
- `poetry install --with dev`
- `poetry run pytest -q` *(fails: NameError in suggest_upgrade)*

------
https://chatgpt.com/codex/tasks/task_e_687290ae8118832289c7ee0b90b1da78