### PR TITLE
Warn on long plugin functions

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Warn when plugin functions exceed 20 lines
 AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence

--- a/src/entity/core/plugin_utils.py
+++ b/src/entity/core/plugin_utils.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from importlib import import_module
 from typing import Any, Dict, Optional, Type, cast
 
+from entity.utils.logging import get_logger
+
 from .stages import PipelineStage
 
 
@@ -24,6 +26,8 @@ class PluginBaseRegistry:
 
 
 plugin_base_registry = PluginBaseRegistry()
+
+logger = get_logger(__name__)
 
 
 def default_stages_for_class(plugin_class: Type) -> list[PipelineStage]:
@@ -91,6 +95,19 @@ class PluginAutoClassifier:
             raise TypeError(
                 f"Plugin function '{getattr(plugin_func, '__name__', 'unknown')}' must be async"
             )
+
+        try:
+            source = inspect.getsource(plugin_func)
+        except OSError:
+            lines = 0
+        else:
+            lines = len(source.splitlines())
+            if lines > 20:
+                logger.warning(
+                    "Function '%s' is %d lines long; consider using a class-based plugin",
+                    plugin_func.__name__,
+                    lines,
+                )
 
         hints: Dict[str, Any] = user_hints or {}
 

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -1,0 +1,40 @@
+import logging
+
+from pipeline import Plugin  # noqa: F401 - configure plugins
+
+from entity.core.plugin_utils import PluginAutoClassifier
+from entity.core.stages import PipelineStage
+
+
+async def very_long_function(context):
+    x = 0
+    x += 1
+    x += 2
+    x += 3
+    x += 4
+    x += 5
+    x += 6
+    x += 7
+    x += 8
+    x += 9
+    x += 10
+    x += 11
+    x += 12
+    x += 13
+    x += 14
+    x += 15
+    x += 16
+    x += 17
+    x += 18
+    x += 19
+    x += 20
+    return x
+
+
+def test_warning_for_long_function(caplog):
+    with caplog.at_level(logging.WARNING):
+        PluginAutoClassifier.classify(
+            very_long_function, {"stage": PipelineStage.THINK}
+        )
+
+    assert any("class-based plugin" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- warn when plugin functions grow beyond 20 lines
- test PluginAutoClassifier emits warning for long functions
- log note

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(failed: Command not found)*
- `poetry run unimport --remove-all src tests` *(failed: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(failed: error: the following arguments are required: --config)*
- `poetry run pytest tests/test_plugin_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687290ad876883228c45763453845e81