### PR TITLE
Flatten resource configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,20 @@ Check the [hero landing page](https://entity.readthedocs.io/en/latest/) for a vi
 poetry run entity-cli --config config/dev.yaml
 ```
 
+A typical configuration defines each resource separately:
+
+```yaml
+plugins:
+  resources:
+    database:
+      type: entity.infrastructure.duckdb:DuckDBInfrastructure
+      path: ./agent.duckdb
+    vector_store:
+      type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
+  agent_resources:
+    memory:
+      type: entity.resources.memory:Memory
+      dependencies: [database, vector_store]
+```
+
 See the [Quick Start](docs/source/quick_start.md) for step-by-step setup or browse the [full documentation](https://entity.readthedocs.io/en/latest/).

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Flattened resource configs
 AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -13,6 +13,12 @@ plugins:
     database:
       type: entity.infrastructure.duckdb:DuckDBInfrastructure
       path: ./agent.duckdb
+    # vector_store:
+    #   type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
+    #   table: vector_mem
+    #   embedding_model:
+    #     name: dummy
+    #     dimensions: 3
   # llm:
   #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
   #   provider: ollama
@@ -24,12 +30,6 @@ plugins:
     memory:
       type: entity.resources.memory:Memory
       dependencies: [database]
-  # vector_store:
-  #   type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
-  #   table: vector_mem
-  #   embedding_model:
-  #     name: dummy
-    #     dimensions: 3
     # filesystem:
     #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
     #   bucket: agent-files

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -13,6 +13,12 @@ plugins:
     database:
       type: entity.infrastructure.duckdb:DuckDBInfrastructure
       path: ./agent.duckdb
+    # vector_store:
+    #   type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
+    #   table: vector_mem
+    #   embedding_model:
+    #     name: dummy
+    #     dimensions: 3
     # llm:
     #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
     #   provider: ollama
@@ -25,12 +31,6 @@ plugins:
     memory:
       type: entity.resources.memory:Memory
       dependencies: [database]
-    # vector_store:
-    #   type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
-    #   table: vector_mem
-    #   embedding_model:
-    #     name: dummy
-    #     dimensions: 3
     # filesystem:
     #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
     #   bucket: agent-files

--- a/src/entity/core/registry_validator.py
+++ b/src/entity/core/registry_validator.py
@@ -82,12 +82,6 @@ class RegistryValidator:
                 self.dep_graph[name] = list(getattr(cls, "dependencies", []))
                 self._validate_stage_assignment(name, cls, cfg)
 
-                if name == "memory" and isinstance(cfg, dict):
-                    if cfg.get("vector_store"):
-                        self.has_vector_memory = True
-                        vs_type = cfg["vector_store"].get("type", "")
-                        if vs_type.endswith("PgVectorStore"):
-                            self.uses_pg_vector_store = True
                 if name == "vector_store" or cls.__name__ == "PgVectorStore":
                     self.has_vector_memory = True
                     if cls.__name__ == "PgVectorStore":

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -177,12 +177,10 @@ def test_complex_prompt_requires_vector_store(tmp_path):
 def test_complex_prompt_with_vector_store(tmp_path):
     plugins = {
         "agent_resources": {
-            "memory": {
-                "type": "entity.resources.memory:Memory",
-                "vector_store": {
-                    "type": "tests.test_registry_validator:VectorStoreResource"
-                },
-            }
+            "memory": {"type": "entity.resources.memory:Memory"},
+            "vector_store": {
+                "type": "tests.test_registry_validator:VectorStoreResource"
+            },
         },
         "prompts": {
             "complex_prompt": {"type": "tests.test_registry_validator:ComplexPrompt"}
@@ -195,11 +193,9 @@ def test_complex_prompt_with_vector_store(tmp_path):
 def test_memory_requires_postgres(tmp_path):
     plugins = {
         "agent_resources": {
-            "memory": {
-                "type": "entity.resources.memory:Memory",
-                "vector_store": {
-                    "type": "plugins.builtin.resources.pg_vector_store:PgVectorStore"
-                },
+            "memory": {"type": "entity.resources.memory:Memory"},
+            "vector_store": {
+                "type": "plugins.builtin.resources.pg_vector_store:PgVectorStore"
             },
             "database": {"type": "tests.test_registry_validator:A"},
         }
@@ -212,11 +208,9 @@ def test_memory_requires_postgres(tmp_path):
 def test_memory_with_postgres(tmp_path):
     plugins = {
         "agent_resources": {
-            "memory": {
-                "type": "entity.resources.memory:Memory",
-                "vector_store": {
-                    "type": "plugins.builtin.resources.pg_vector_store:PgVectorStore"
-                },
+            "memory": {"type": "entity.resources.memory:Memory"},
+            "vector_store": {
+                "type": "plugins.builtin.resources.pg_vector_store:PgVectorStore"
             },
             "database": {"type": "tests.test_registry_validator:PostgresResource"},
         },


### PR DESCRIPTION
## Summary
- remove outdated backend-related config models
- simplify PluginsSection validation
- update RegistryValidator to rely on separate vector store config
- adjust registry validator tests
- flatten resource definitions in example configs
- document new layout

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: F821 undefined names)*
- `poetry run mypy src` *(fails: Found 189 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: Plugin 'database' does not specify any stages)*
- `pytest tests/test_architecture/ -v` *(failed: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(failed: Unknown config option)*
- `pytest tests/test_resources/ -v` *(failed: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_68729094ac888322a07e701fb6b9cfc5