### PR TITLE
Add zero-config plugin decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,23 @@ poetry run entity-cli --config config/dev.yaml
 ```
 
 See the [Quick Start](docs/source/quick_start.md) for step-by-step setup or browse the [full documentation](https://entity.readthedocs.io/en/latest/).
+
+### Zero-Config Plugins
+
+Register a tool and prompt without specifying stages:
+
+```python
+from entity import Agent
+
+agent = Agent()
+
+@agent.tool
+async def add(a: int, b: int) -> int:
+    return a + b
+
+
+@agent.prompt
+async def final(ctx):
+    result = await ctx.tool_use("add", a=2, b=2)
+    ctx.set_response(str(result))
+```

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added zero-config decorators for tools and prompts
 AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI
 AGENT NOTE - 2025-07-12: Enforced explicit plugin stages and simplified precedence

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ Each subdirectory contains a small agent showcasing a different feature level.
 - **basic_agent** – echoes the user's message.
 - **intermediate_agent** – runs a chain-of-thought prompt with an echo LLM.
 - **advanced_agent** – demonstrates a ReAct loop with tool usage.
+- **zero_config_agent** – uses `@agent.tool` and `@agent.prompt` decorators.
 
 Run any example with:
 

--- a/examples/zero_config_agent/README.md
+++ b/examples/zero_config_agent/README.md
@@ -1,0 +1,11 @@
+# Zero Config Agent
+
+This example uses the high level `Agent` API and the
+`@agent.tool` and `@agent.prompt` decorators to register plugins
+without specifying stages.
+
+Run it with:
+
+```bash
+poetry run python examples/zero_config_agent/main.py
+```

--- a/examples/zero_config_agent/main.py
+++ b/examples/zero_config_agent/main.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from entity import Agent
+from entity.resources.memory import Memory
+
+agent = Agent()
+
+
+@agent.tool
+async def add(a: int, b: int) -> int:
+    return a + b
+
+
+@agent.prompt
+async def responder(ctx):
+    user = next((e.content for e in ctx.conversation() if e.role == "user"), "")
+    result = await ctx.tool_use("add", a=2, b=2)
+    ctx.set_response(f"{user} -> {result}")
+
+
+async def main() -> None:
+    agent.builder.resource_registry.register("memory", Memory, {})
+    response = await agent.handle("hello")
+    print(response)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -13,6 +13,8 @@ class _AgentAPI:
     tool = staticmethod(_decorators.tool)
     review = staticmethod(_decorators.review)
     output = staticmethod(_decorators.output)
+    prompt_plugin = staticmethod(_decorators.prompt_plugin)
+    tool_plugin = staticmethod(_decorators.tool_plugin)
 
 
 agent = _AgentAPI()

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -9,6 +9,7 @@ from pipeline.exceptions import PipelineError
 from pipeline.workflow import Pipeline
 
 from .builder import _AgentBuilder
+from .plugins import PromptPlugin, ToolPlugin
 from .registries import SystemRegistries
 from .runtime import AgentRuntime
 
@@ -47,6 +48,26 @@ class Agent:
         """Decorator for registering ``func`` as a plugin."""
 
         return self.builder.plugin(func, **hints)
+
+    def tool(
+        self,
+        func: Optional[Callable[..., Any]] = None,
+        **hints: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]] | Callable[..., Any]:
+        """Decorator registering ``func`` as a ``ToolPlugin``."""
+
+        hints["plugin_class"] = ToolPlugin
+        return self.plugin(func, **hints)
+
+    def prompt(
+        self,
+        func: Optional[Callable[..., Any]] = None,
+        **hints: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]] | Callable[..., Any]:
+        """Decorator registering ``func`` as a ``PromptPlugin``."""
+
+        hints["plugin_class"] = PromptPlugin
+        return self.plugin(func, **hints)
 
     def load_plugins_from_directory(
         self, directory: str

--- a/src/entity/core/builder.py
+++ b/src/entity/core/builder.py
@@ -118,6 +118,26 @@ class _AgentBuilder:
 
         return decorator(func) if func else decorator
 
+    def tool(
+        self,
+        func: Optional[Callable[..., Any]] = None,
+        **hints: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]] | Callable[..., Any]:
+        """Decorator registering ``func`` as a ``ToolPlugin``."""
+
+        hints["plugin_class"] = ToolPlugin
+        return self.plugin(func, **hints)
+
+    def prompt(
+        self,
+        func: Optional[Callable[..., Any]] = None,
+        **hints: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]] | Callable[..., Any]:
+        """Decorator registering ``func`` as a ``PromptPlugin``."""
+
+        hints["plugin_class"] = PromptPlugin
+        return self.plugin(func, **hints)
+
     # ---------------------------- discovery helpers ---------------------------
     @classmethod
     def from_directory(cls, directory: str) -> "_AgentBuilder":

--- a/src/entity/core/decorators.py
+++ b/src/entity/core/decorators.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
+from .logging import get_logger
+from .plugin_analyzer import suggest_upgrade
+
 from .stages import PipelineStage
 
 from .plugin_utils import PluginAutoClassifier
+from .plugins import PromptPlugin, ToolPlugin
 
 
 def plugin(func: Optional[Callable] = None, **hints: Any) -> Callable:
@@ -81,6 +85,24 @@ def output(
     return plugin(func, **hints)
 
 
+def prompt_plugin(
+    func: Optional[Callable] = None, **hints: Any
+) -> Callable[[Callable], Callable] | Callable:
+    """Decorator for prompt plugins using default stage."""
+
+    hints["plugin_class"] = PromptPlugin
+    return plugin(func, **hints)
+
+
+def tool_plugin(
+    func: Optional[Callable] = None, **hints: Any
+) -> Callable[[Callable], Callable] | Callable:
+    """Decorator for tool plugins using default stage."""
+
+    hints["plugin_class"] = ToolPlugin
+    return plugin(func, **hints)
+
+
 __all__ = [
     "plugin",
     "input",
@@ -89,4 +111,6 @@ __all__ = [
     "tool",
     "review",
     "output",
+    "prompt_plugin",
+    "tool_plugin",
 ]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(pathlib.Path("src").resolve()))
 from entity import agent
 from entity.core.builder import _AgentBuilder
 from entity.core.stages import PipelineStage
+from entity import Agent
 
 
 _DEFINITIONS = [
@@ -37,3 +38,25 @@ for dec, stage in _DEFINITIONS:
         return test_func
 
     globals()[f"test_{dec.__name__}_decorator"] = _make_test()
+
+
+def test_agent_tool_method_default_stage():
+    ag = Agent()
+
+    @ag.tool
+    async def do_it(ctx):
+        pass
+
+    plugin = ag.builder._added_plugins[-1]
+    assert plugin.stages == [PipelineStage.DO]
+
+
+def test_agent_prompt_method_default_stage():
+    ag = Agent()
+
+    @ag.prompt
+    async def think(ctx):
+        pass
+
+    plugin = ag.builder._added_plugins[-1]
+    assert plugin.stages == [PipelineStage.THINK]


### PR DESCRIPTION
## Summary
- allow `Agent` and `_AgentBuilder` to register prompt and tool plugins without stages
- add matching `prompt_plugin` and `tool_plugin` decorators
- document zero-config usage and provide a new example
- cover new helpers in tests

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'tests')*

------
https://chatgpt.com/codex/tasks/task_e_687290ac5c28832293683436860ae7b1