### PR TITLE
Simplify analyze-plugin messaging

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-12: Simplified plugin analysis output
+
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs
 AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI

--- a/src/cli/plugin_tool/main.py
+++ b/src/cli/plugin_tool/main.py
@@ -254,6 +254,9 @@ class PluginToolCLI:
         from entity.core.plugin_utils import PluginAutoClassifier
 
         found = False
+        # Inspect async callables and classify them as plugins.
+        # The reason indicates whether stages were provided through
+        # configuration hints or fall back to the class defaults.
         for name, obj in module.__dict__.items():
             if name.startswith("_"):
                 continue
@@ -261,15 +264,10 @@ class PluginToolCLI:
                 plugin = PluginAutoClassifier.classify(obj)
                 stages = ", ".join(str(s) for s in plugin.stages)
 
-                reasons: list[str] = []
                 if getattr(plugin, "_explicit_stages", False):
-                    reasons.append("explicit hints")
+                    reason = "configuration hints"
                 else:
-                    if getattr(plugin, "_auto_inferred_stages", False):
-                        reasons.append("source heuristics")
-                    if plugin.stages == getattr(plugin, "_type_default_stages", []):
-                        reasons.append("type defaults")
-                reason = ", ".join(reasons) if reasons else "unknown"
+                    reason = "class defaults"
 
                 logger.info("%s -> %s (%s)", name, stages, reason)
                 found = True


### PR DESCRIPTION
## Summary
- log an agent note
- drop unused analysis checks in the plugin tool
- clarify reason messages when inspecting plugin stages

## Testing
- `poetry run ruff check --fix src tests` *(fails: Found 158 errors)*
- `poetry run mypy src` *(fails: Found 190 errors in 42 files)*
- `poetry run bandit -r src` *(fails: Command not found)*
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option: asyncio_mode)*
- `pytest tests/test_resources/ -v` *(fails: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_68729284107c8322b5149c14bf758988