### PR TITLE
Implement simple stage resolution

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Simplified stage resolution and removed type defaults
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs
 AGENT NOTE - 2025-07-12: Added decorator shortcuts and tests
 AGENT NOTE - 2025-07-12: Added plugin lifecycle hooks and updated CLI

--- a/src/entity/core/builder.py
+++ b/src/entity/core/builder.py
@@ -261,38 +261,15 @@ class _AgentBuilder:
             )
             return None
 
-    def _type_default_stages(self, plugin: Plugin) -> list[PipelineStage]:
-        if isinstance(plugin, ToolPlugin):
-            return [PipelineStage.DO]
-        if isinstance(plugin, PromptPlugin):
-            return [PipelineStage.THINK]
-        if isinstance(plugin, AdapterPlugin):
-            return [PipelineStage.INPUT, PipelineStage.OUTPUT]
-        return []
-
     def _resolve_plugin_stages(
         self, plugin: Plugin, config: Mapping[str, Any] | None
     ) -> list[PipelineStage]:
-        """Resolve final stages for ``plugin`` with sane fallbacks."""
+        """Resolve final stages for ``plugin`` using simple precedence."""
 
-        cfg_val = None
-        if config is not None:
-            cfg_val = config.get("stages") or config.get("stage")
+        from pipeline.utils import get_plugin_stages
 
-        if cfg_val is not None:
-            if not isinstance(cfg_val, list):
-                cfg_val = [cfg_val]
-            return [PipelineStage.ensure(s) for s in cfg_val]
-
-        class_stages = getattr(plugin, "stages", [])
-        if class_stages:
-            return [PipelineStage.ensure(s) for s in class_stages]
-
-        type_default = self._type_default_stages(plugin)
-        if type_default:
-            return [PipelineStage.ensure(s) for s in type_default]
-
-        return [PipelineStage.THINK]
+        cfg = config or plugin.config
+        return get_plugin_stages(plugin.__class__, cfg)
 
     def _register_module_plugins(self, module: ModuleType) -> None:
         import inspect


### PR DESCRIPTION
## Summary
- add `get_plugin_stages` helper and drop `resolve_stages`
- remove type defaults and auto inference logic from builder and initializer
- keep plugin stage precedence clear per Decision #4
- log update

## Testing
- `poetry run pytest tests/test_stage_precedence.py::test_initializer_config_overrides -q`
- `poetry run pytest tests/test_stage_precedence.py tests/test_registry_validator.py -q` *(fails: AttributeError: 'coroutine' object has no attribute 'success')*

------
https://chatgpt.com/codex/tasks/task_e_6872927ffa7083228b9bc3c7951abb46