### PR TITLE
Improve analyze-plugin output

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: clarify analyze-plugin output sources
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/src/cli/plugin_tool/main.py
+++ b/src/cli/plugin_tool/main.py
@@ -83,7 +83,11 @@ class PluginToolCLI:
         doc.add_argument("--out", default="docs/source")
 
         ana = sub.add_parser(
-            "analyze-plugin", help="Suggest pipeline stages for plugin functions"
+            "analyze-plugin",
+            help=(
+                "Show plugin stages and whether they come from config hints"
+                " or class attributes"
+            ),
         )
         ana.add_argument("path", help="Plugin file path")
 
@@ -255,8 +259,8 @@ class PluginToolCLI:
 
         found = False
         # Inspect async callables and classify them as plugins.
-        # The reason indicates whether stages were provided through
-        # configuration hints or fall back to the class defaults.
+        # The reason indicates whether stages come from config hints or
+        # default class attributes.
         for name, obj in module.__dict__.items():
             if name.startswith("_"):
                 continue
@@ -265,9 +269,9 @@ class PluginToolCLI:
                 stages = ", ".join(str(s) for s in plugin.stages)
 
                 if getattr(plugin, "_explicit_stages", False):
-                    reason = "configuration hints"
+                    reason = "config hints"
                 else:
-                    reason = "class defaults"
+                    reason = "class attributes"
 
                 logger.info("%s -> %s (%s)", name, stages, reason)
                 found = True

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -131,7 +131,11 @@ class EntityCLI:
         doc.add_argument("--out", default="docs/source")
 
         ana = plug_sub.add_parser(
-            "analyze-plugin", help="Suggest pipeline stages for plugin functions"
+            "analyze-plugin",
+            help=(
+                "Show plugin stages and whether they come from config hints"
+                " or class attributes"
+            ),
         )
         ana.add_argument("path")
 
@@ -336,7 +340,11 @@ class EntityCLI:
             if inspect.iscoroutinefunction(obj):
                 plugin = PluginAutoClassifier.classify(obj)
                 stages = ", ".join(str(s) for s in plugin.stages)
-                logger.info("%s -> %s", name, stages)
+                if getattr(plugin, "_explicit_stages", False):
+                    reason = "config hints"
+                else:
+                    reason = "class attributes"
+                logger.info("%s -> %s (%s)", name, stages, reason)
                 found = True
         if not found:
             logger.error("No async plugin functions found in %s", path)


### PR DESCRIPTION
## Summary
- update analyze-plugin help to mention stage sources
- log whether stages come from config hints or class attributes
- update CLI to show stage source
- note plugin analysis change in agents.log

## Testing
- `poetry run black src/cli/plugin_tool/main.py src/entity/cli/__init__.py`
- `poetry run ruff check --fix src tests` *(fails: many errors)*
- `poetry run mypy src` *(fails: Found 194 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v`
- `pytest tests/test_plugins/ -v`
- `pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68729522689c83229b35b045747f05ab