### PR TITLE
Rewrite stage precedence tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated stage precedence tests and fixed lifecycle test
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/tests/test_plugin_lifecycle.py
+++ b/tests/test_plugin_lifecycle.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from entity.core.builder import _AgentBuilder
@@ -29,12 +30,13 @@ class LifecyclePlugin(Plugin):
 async def test_plugin_lifecycle():
     builder = _AgentBuilder()
     plugin = LifecyclePlugin({})
-    builder.add_plugin(plugin)
-    builder.build_runtime()
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, builder.add_plugin, plugin)
+    await loop.run_in_executor(None, builder.build_runtime)
 
     await plugin.execute(object())
     assert plugin.initialized
     assert plugin.executed
 
-    builder.shutdown()
+    await loop.run_in_executor(None, builder.shutdown)
     assert plugin.closed

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -1,22 +1,26 @@
 from entity.core.builder import _AgentBuilder
 from entity.core.plugins import Plugin
-from pipeline.initializer import SystemInitializer
 from entity.core.stages import PipelineStage
+from pipeline.initializer import SystemInitializer
 
 
 class AttrPrompt(Plugin):
+    """Prompt with a stage defined as a class attribute."""
+
     stages = [PipelineStage.DO]
 
-    async def _execute_impl(self, context):
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - stub
         pass
 
 
-class InferredPrompt(Plugin):
-    async def _execute_impl(self, context):
+class NoStagePrompt(Plugin):
+    """Prompt without any stage information."""
+
+    async def _execute_impl(self, context) -> None:  # pragma: no cover - stub
         pass
 
 
-def test_builder_config_overrides():
+def test_builder_config_overrides() -> None:
     builder = _AgentBuilder()
     plugin = AttrPrompt({})
 
@@ -25,52 +29,48 @@ def test_builder_config_overrides():
     assert stages == [PipelineStage.REVIEW]
 
 
-def test_builder_class_attribute_overrides():
+def test_builder_class_attribute_when_no_config() -> None:
     builder = _AgentBuilder()
     plugin = AttrPrompt({})
+
     stages = builder._resolve_plugin_stages(plugin, None)
 
     assert stages == [PipelineStage.DO]
 
 
-def test_builder_fallback_stage():
+def test_builder_defaults_to_think() -> None:
     builder = _AgentBuilder()
-    plugin = InferredPrompt({})
+    plugin = NoStagePrompt({})
 
     stages = builder._resolve_plugin_stages(plugin, None)
 
     assert stages == [PipelineStage.THINK]
 
 
-def test_initializer_config_overrides():
+def test_initializer_config_overrides() -> None:
     init = SystemInitializer({})
     plugin = AttrPrompt({})
-    plugin._explicit_stages = True
 
-    stages, explicit = init._resolve_plugin_stages(
+    stages, _ = init._resolve_plugin_stages(
         AttrPrompt, plugin, {"stage": PipelineStage.REVIEW}
     )
 
     assert stages == [PipelineStage.REVIEW]
-    assert explicit is True
 
 
-def test_initializer_class_attribute_overrides():
+def test_initializer_class_attribute_when_no_config() -> None:
     init = SystemInitializer({})
     plugin = AttrPrompt({})
-    plugin._explicit_stages = True
 
-    stages, explicit = init._resolve_plugin_stages(AttrPrompt, plugin, {})
+    stages, _ = init._resolve_plugin_stages(AttrPrompt, plugin, {})
 
     assert stages == [PipelineStage.DO]
-    assert explicit is True
 
 
-def test_initializer_fallback_stage():
+def test_initializer_defaults_to_think() -> None:
     init = SystemInitializer({})
-    plugin = InferredPrompt({})
+    plugin = NoStagePrompt({})
 
-    stages, explicit = init._resolve_plugin_stages(InferredPrompt, plugin, {})
+    stages, _ = init._resolve_plugin_stages(NoStagePrompt, plugin, {})
 
     assert stages == [PipelineStage.THINK]
-    assert explicit is False


### PR DESCRIPTION
## Summary
- update stage precedence tests
- adjust lifecycle test to run blocking calls in an executor
- note update in agents.log

## Testing
- `PYTHONPATH=src poetry run pytest tests/test_stage_precedence.py tests/test_decorators.py tests/test_decorator_plugin.py tests/test_plugin_lifecycle.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687295236be08322b096ee2ad940fc52