### PR TITLE
Simplify stage resolution helpers

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Simplified stage resolution helpers
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/src/entity/core/builder.py
+++ b/src/entity/core/builder.py
@@ -286,10 +286,10 @@ class _AgentBuilder:
     ) -> list[PipelineStage]:
         """Resolve final stages for ``plugin`` using simple precedence."""
 
-        from pipeline.utils import get_plugin_stages
+        from pipeline.utils import resolve_stages
 
         cfg = config or plugin.config
-        return get_plugin_stages(plugin.__class__, cfg)
+        return resolve_stages(plugin.__class__, cfg)
 
     def _register_module_plugins(self, module: ModuleType) -> None:
         import inspect

--- a/src/entity/core/decorators.py
+++ b/src/entity/core/decorators.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
-from .logging import get_logger
-from .plugin_analyzer import suggest_upgrade
 
 from .stages import PipelineStage
 

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -16,7 +16,7 @@ from entity.core.resources.container import ResourceContainer
 from entity.utils.logging import configure_logging, get_logger
 from entity.workflows.discovery import discover_workflows, register_module_workflows
 from pipeline.config import ConfigLoader
-from pipeline.utils import DependencyGraph, get_plugin_stages
+from pipeline.utils import DependencyGraph, resolve_stages
 from pipeline.reliability import CircuitBreaker
 from pipeline.exceptions import CircuitBreakerTripped
 
@@ -87,7 +87,7 @@ class ClassRegistry:
     ) -> tuple[List[PipelineStage], bool]:
         """Determine final stages and whether they were explicit."""
 
-        stages = get_plugin_stages(cls, config)
+        stages = resolve_stages(cls, config)
         explicit = bool(
             (config.get("stage") or config.get("stages"))
             or getattr(cls, "stages", None)
@@ -293,7 +293,7 @@ class SystemInitializer:
     ) -> tuple[List[PipelineStage], bool]:
         """Determine final stages and whether they were explicit."""
 
-        stages = get_plugin_stages(cls, config)
+        stages = resolve_stages(cls, config)
         explicit = bool(
             (config.get("stage") or config.get("stages"))
             or getattr(instance, "_explicit_stages", False)

--- a/src/pipeline/utils/__init__.py
+++ b/src/pipeline/utils/__init__.py
@@ -1,9 +1,7 @@
 """Utility helpers used by the pipeline package."""
 
 from entity.core.resources.container import DependencyGraph
-
 from typing import Any, Iterable, List, Mapping, Type
-
 from pipeline.stages import PipelineStage
 
 
@@ -15,10 +13,10 @@ def _normalize_stages(stages: Any) -> List[PipelineStage]:
     return [PipelineStage.ensure(stages)]
 
 
-def get_plugin_stages(
+def resolve_stages(
     plugin_class: Type, config: Mapping[str, Any]
 ) -> List[PipelineStage]:
-    """Return final stages for ``plugin_class`` following Decision #4."""
+    """Return final stages following Decision #4."""
 
     cfg_value = config.get("stages") or config.get("stage")
     if cfg_value is not None:
@@ -33,4 +31,8 @@ def get_plugin_stages(
     return [PipelineStage.THINK]
 
 
-__all__ = ["DependencyGraph", "get_plugin_stages"]
+# Backward compatible alias
+get_plugin_stages = resolve_stages
+
+
+__all__ = ["DependencyGraph", "resolve_stages", "get_plugin_stages"]


### PR DESCRIPTION
## Summary
- unify helper functions for plugin stage resolution
- update builder and initializer to use new resolve_stages
- clean up decorators imports
- add note on stage helpers to `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: F821 Undefined name `pytest`)*
- `poetry run mypy src` *(fails: Found 194 errors in 43 files)*
- `poetry run bandit -r src`
- `pytest tests/test_architecture/ -v` *(no tests ran)*
- `pytest tests/test_plugins/ -v` *(no tests ran)*
- `pytest tests/test_resources/ -v` *(no tests ran)*
- `poetry run pytest -q tests/test_stage_precedence.py`

------
https://chatgpt.com/codex/tasks/task_e_68729520b48883229e2fe86da92d166f