### PR TITLE
Update README about persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://entity.readthedocs.io/en/latest/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Entity lets you craft agent pipelines using a single configuration file. The same YAML works locally and in production, so iteration stays simple. By default the agent stores conversation data in an in-memory DuckDB database so you can try things instantly.
+Entity lets you craft agent pipelines using a single configuration file. The same YAML works locally and in production, so iteration stays simple. Conversations are persisted externally through the Memory resource, keeping workers stateless. The default DuckDB backend writes this data to disk for immediate durability while still requiring zero setup.
 
 ## Key Features
 - Three-layer plugin system for progressive complexity
 - Hot-reloadable YAML config with validation
 - Stateless workers that scale horizontally
 - Unified memory resource for chat, search, and storage
-- In-memory DuckDB backend for quick local testing
+- DuckDB backend persists to disk for quick local testing
 - Overrides of default plugin stages produce log warnings
 
 ### Plugin Context Helpers

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-13: Updated README to clarify external conversation persistence and disk-backed DuckDB default
+
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs


### PR DESCRIPTION
## Summary
- note how conversation data persists through the Memory resource
- clarify that DuckDB writes to disk by default
- log this change in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 146 errors)*
- `poetry run mypy src` *(fails: found 194 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: syntax errors in templates)*
- `poetry run unimport --diff src tests` *(shows diffs and syntax errors)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: AttributeError)*
- `pytest tests/test_architecture/ -v` *(no tests ran)*
- `pytest tests/test_plugins/ -v` *(no tests ran)*
- `pytest tests/test_resources/ -v` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6872962e82e8832289b3d512d14c8a08