### PR TITLE
Refactor Memory dependency injection

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-12: Memory dependencies updated for resource container injection
+
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -98,21 +98,16 @@ class Memory(AgentResource):
     """Store key/value pairs, conversation history, and vectors."""
 
     name = "memory"
-    dependencies: list[str] = ["database?", "vector_store?"]
+    dependencies: list[str] = ["database", "vector_store"]
 
-    def __init__(
-        self,
-        database: DatabaseInterface | None = None,
-        vector_store: VectorStoreInterface | None = None,
-        config: Dict | None = None,
-    ) -> None:
+    def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
         self._kv: Dict[str, Any] = {}
         self._conversations: Dict[str, List[ConversationEntry]] = {}
         self._vectors: Dict[str, List[float]] = {}
         self._history = ConversationHistory(self._conversations)
-        self.database = database
-        self.vector_store = vector_store
+        self.database: DatabaseInterface | None = None
+        self.vector_store: VectorStoreInterface | None = None
 
     async def _execute_impl(self, context: Any) -> None:  # noqa: D401, ARG002
         return None


### PR DESCRIPTION
## Summary
- update Memory to declare required database/vector_store dependencies
- remove constructor args for database and vector_store
- log new agent note about Memory change

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: AttributeError)*
- `pytest tests/test_architecture/ -v` *(0 tests ran)*
- `pytest tests/test_plugins/ -v` *(0 tests ran)*
- `pytest tests/test_resources/ -v` *(0 tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6872962aa7148322b94fbbdb3b47ff49