### PR TITLE
Add YAML workflow visualization support

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added YAML workflow support to CLI and tests
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -1,0 +1,38 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path("src").resolve()))
+
+from entity.cli import EntityCLI, CLIArgs
+
+
+class DummyCLI(EntityCLI):
+    def _parse_args(self) -> CLIArgs:  # type: ignore[override]
+        return CLIArgs(None, None, command="")
+
+
+def _make_cli() -> DummyCLI:
+    return DummyCLI()
+
+
+def test_load_workflow_yaml(tmp_path):
+    yaml_path = tmp_path / "wf.yaml"
+    yaml_path.write_text(
+        "workflow:\n  INPUT: ['one']\n  OUTPUT: ['two']\n",
+        encoding="utf-8",
+    )
+    cli = _make_cli()
+    workflow = cli._load_workflow(str(yaml_path))
+    assert workflow == {"INPUT": ["one"], "OUTPUT": ["two"]}
+
+
+def test_visualize_workflow_yaml(tmp_path, capsys):
+    yaml_path = tmp_path / "wf.yaml"
+    yaml_path.write_text(
+        "workflow:\n  INPUT: ['one']\n  OUTPUT: ['two']\n",
+        encoding="utf-8",
+    )
+    cli = _make_cli()
+    cli._workflow_visualize(str(yaml_path), fmt="ascii")
+    captured = capsys.readouterr().out.strip()
+    assert "INPUT" in captured and "-> one" in captured


### PR DESCRIPTION
## Summary
- support reading workflow from YAML files in CLI
- update workflow help text
- visualize YAML workflows the same as module files
- test YAML workflow visualization

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError and other errors)*
- `poetry run ruff check --fix src tests` *(fails with multiple lint errors)*
- `poetry run mypy src` *(fails with typing errors)*
- `poetry run bandit -r src` *(reports issues)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6872960f43048322b7383e6423a99369