### PR TITLE
Add breaker settings for runtime checks

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added breaker settings for runtime validation
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -7,6 +7,14 @@ server:
 tool_registry:
   concurrency_limit: 5
 
+breaker_settings:
+  database:
+    failure_threshold: 3
+  external_api:
+    failure_threshold: 5
+  file_system:
+    failure_threshold: 2
+
 plugins:
   infrastructure: {}
   resources:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -7,6 +7,14 @@ server:
 tool_registry:
   concurrency_limit: 10
 
+breaker_settings:
+  database:
+    failure_threshold: 3
+  external_api:
+    failure_threshold: 5
+  file_system:
+    failure_threshold: 2
+
 plugins:
   infrastructure: {}
   resources:

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -4,6 +4,14 @@ server:
   reload: true
   log_level: "info"
 
+breaker_settings:
+  database:
+    failure_threshold: 3
+  external_api:
+    failure_threshold: 5
+  file_system:
+    failure_threshold: 2
+
 plugins:
   infrastructure: {}
   resources:

--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -59,6 +59,20 @@ class CircuitBreakerConfig(BaseModel):
         extra = "allow"
 
 
+class BreakerSettings(BaseModel):
+    """Circuit breaker settings for different resource types."""
+
+    database: CircuitBreakerConfig = Field(
+        default_factory=lambda: CircuitBreakerConfig(failure_threshold=3)
+    )
+    external_api: CircuitBreakerConfig = Field(
+        default_factory=lambda: CircuitBreakerConfig(failure_threshold=5)
+    )
+    file_system: CircuitBreakerConfig = Field(
+        default_factory=lambda: CircuitBreakerConfig(failure_threshold=2)
+    )
+
+
 class EntityConfig(BaseModel):
     server: ServerConfig = Field(
         default_factory=lambda: ServerConfig(host="localhost", port=8000)
@@ -69,6 +83,7 @@ class EntityConfig(BaseModel):
     runtime_validation_breaker: CircuitBreakerConfig = Field(
         default_factory=CircuitBreakerConfig
     )
+    breaker_settings: BreakerSettings = Field(default_factory=BreakerSettings)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "EntityConfig":
@@ -94,6 +109,7 @@ __all__ = [
     "ServerConfig",
     "ToolRegistryConfig",
     "CircuitBreakerConfig",
+    "BreakerSettings",
     "EntityConfig",
     "validate_config",
     "asdict",

--- a/src/pipeline/initializer.py
+++ b/src/pipeline/initializer.py
@@ -391,18 +391,32 @@ class SystemInitializer:
         ):
             await resource_container.build_all()
 
-            breaker_cfg = self.config.get("runtime_validation_breaker", {})
-            breaker = CircuitBreaker(
-                failure_threshold=breaker_cfg.get("failure_threshold", 3),
-                recovery_timeout=breaker_cfg.get("recovery_timeout", 60.0),
-            )
+            model = self._config_model
+            default_cfg = model.runtime_validation_breaker
+            settings = model.breaker_settings
+
             for name, resource in resource_container._resources.items():
                 validate = getattr(resource, "validate_runtime", None)
                 if not callable(validate):
                     continue
 
+                resource_type = getattr(resource, "infrastructure_type", "").lower()
+                if resource_type == "database":
+                    cfg = settings.database
+                elif resource_type in {"external_api", "external-api", "api"}:
+                    cfg = settings.external_api
+                elif resource_type in {"file_system", "filesystem", "file-system"}:
+                    cfg = settings.file_system
+                else:
+                    cfg = default_cfg
+
+                breaker = CircuitBreaker(
+                    failure_threshold=cfg.failure_threshold,
+                    recovery_timeout=cfg.recovery_timeout,
+                )
+
                 async def _run_validation() -> None:
-                    result = await validate()
+                    result = await validate(breaker)
                     if not result.success:
                         raise RuntimeError(result.error_message)
 


### PR DESCRIPTION
## Summary
- define `BreakerSettings` config with defaults
- include `breaker_settings` in `EntityConfig`
- choose circuit breaker thresholds per resource type in initializer
- forward breaker instance to runtime validation
- document defaults in example configuration

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(failed: Command not found)*
- `poetry run unimport --remove-all src tests` *(failed: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `pytest tests/test_architecture/ -v` *(no tests ran)*
- `pytest tests/test_plugins/ -v` *(no tests ran)*
- `pytest tests/test_resources/ -v` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6872960c63cc8322bb062394daf27d66