### PR TITLE
Remove Conversation helper

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Removed Conversation helper in favor of PipelineWorker
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -8,27 +8,11 @@ from datetime import datetime
 import json
 import inspect
 
-from entity.core.registries import SystemRegistries
-from pipeline.pipeline import execute_pipeline
 from .base import AgentResource
 from .interfaces.database import DatabaseResource as DatabaseInterface
 from .interfaces.vector_store import VectorStoreResource as VectorStoreInterface
 from ..core.plugins import ValidationResult
 from ..core.state import ConversationEntry
-
-
-class Conversation:
-    """Simple conversation helper used by tests."""
-
-    def __init__(self, capabilities: SystemRegistries) -> None:
-        self._caps = capabilities
-
-    async def process_request(self, message: str) -> Any:
-        result = await execute_pipeline(message, self._caps)
-        while isinstance(result, dict) and result.get("type") == "continue_processing":
-            next_msg = result.get("message", "")
-            result = await execute_pipeline(next_msg, self._caps)
-        return result
 
 
 def _cosine_similarity(a: Iterable[float], b: Iterable[float]) -> float:
@@ -210,12 +194,6 @@ class Memory(AgentResource):
                 :k
             ]
         ]
-
-    # ------------------------------------------------------------------
-    # Conversation manager
-    # ------------------------------------------------------------------
-    def start_conversation(self, capabilities: SystemRegistries) -> Conversation:
-        return Conversation(capabilities)
 
     @classmethod
     async def validate_config(cls, config: Dict) -> ValidationResult:  # noqa: D401


### PR DESCRIPTION
## Summary
- drop the Conversation helper from `Memory`
- add an agent note documenting the change

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 144 errors)*
- `poetry run mypy src` *(fails: 194 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: AttributeError)*
- `poetry run python -m src.entity.core.registry_validator --config config/prod.yaml` *(failed: AttributeError)*
- `pytest tests/test_architecture/ -v` *(failed: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(failed: Unknown config option)*
- `pytest tests/test_resources/ -v` *(failed: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_6872963e22b08322be744eb2ca615406