### PR TITLE
Add persistence test for PipelineWorker

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added PipelineWorker persistence test
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -1,0 +1,39 @@
+import types
+import pytest
+
+from pipeline import PipelineWorker
+from entity.resources.memory import Memory
+from entity.core.registries import SystemRegistries
+
+
+class DummyRegistries:
+    def __init__(self, memory: Memory) -> None:
+        self.resources = {"memory": memory}
+        self.plugins = types.SimpleNamespace()
+        self.tools = types.SimpleNamespace()
+
+
+@pytest.mark.asyncio
+async def test_conversation_persists_across_workers() -> None:
+    memory = Memory(config={})
+    resources = {"memory": memory}
+    regs = SystemRegistries(
+        resources=resources,
+        tools=types.SimpleNamespace(),
+        plugins=types.SimpleNamespace(),
+    )
+
+    worker1 = PipelineWorker(regs)
+    await worker1.execute_pipeline("chat", "Hello")
+
+    history = await memory.load_conversation("chat")
+    assert len(history) == 1
+    assert history[0].content == "Hello"
+
+    worker2 = PipelineWorker(regs)
+    await worker2.execute_pipeline("chat", "How are you?")
+
+    history = await memory.load_conversation("chat")
+    assert len(history) == 2
+    assert history[0].content == "Hello"
+    assert history[1].content == "How are you?"


### PR DESCRIPTION
## Summary
- ensure PipelineWorker uses Memory between instances
- log update noting new persistence test

## Testing
- `poetry run pytest tests/test_pipeline_worker.py -q`
- `poetry run ruff check --fix src tests` *(fails: 146 errors)*
- `poetry run mypy src` *(fails: 194 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator --config ???` *(failed: missing argument)*
- `pytest tests/test_architecture/ -v` *(no tests found)*
- `pytest tests/test_plugins/ -v` *(no tests found)*
- `pytest tests/test_resources/ -v` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6872964891848322a3aed336f57fe7d4