### PR TITLE
Require explicit storage backend

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Storage now requires a backend; removed in-memory fallback
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/src/entity/resources/storage.py
+++ b/src/entity/resources/storage.py
@@ -13,25 +13,17 @@ class Storage(AgentResource):
     """Simple key/value storage."""
 
     name = "storage"
-    dependencies: list[str] = ["storage_backend?"]
+    dependencies: list[str] = ["storage_backend"]
 
-    def __init__(
-        self, backend: StorageBackend | None = None, config: Dict | None = None
-    ) -> None:
+    def __init__(self, backend: StorageBackend, config: Dict | None = None) -> None:
         super().__init__(config or {})
-        self._data: Dict[str, Any] = {}
         self.backend = backend
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None
 
     def get(self, key: str, default: Any | None = None) -> Any:
-        if self.backend is not None:
-            return self.backend.get(key, default)
-        return self._data.get(key, default)
+        return self.backend.get(key, default)
 
     def set(self, key: str, value: Any) -> None:
-        if self.backend is not None:
-            self.backend.set(key, value)
-            return None
-        self._data[key] = value
+        self.backend.set(key, value)

--- a/tests/test_standard_resources.py
+++ b/tests/test_standard_resources.py
@@ -1,11 +1,24 @@
 from entity.resources import LLM, Memory, Storage, StandardResources
+from entity.resources.interfaces.storage import StorageResource
+
+
+class DummyBackend(StorageResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self._data: dict[str, str] = {}
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._data.get(key, default)
+
+    def set(self, key: str, value: str) -> None:
+        self._data[key] = value
 
 
 def test_standard_resources_types() -> None:
     res = StandardResources(
         memory=Memory(config={}),
         llm=LLM(config={}),
-        storage=Storage(config={}),
+        storage=Storage(backend=DummyBackend(), config={}),
     )
     assert isinstance(res.memory, Memory)
     assert isinstance(res.llm, LLM)


### PR DESCRIPTION
## Summary
- remove in-memory fallback from `Storage` resource
- require a backend and add dummy backend in tests
- log the change

## Testing
- `poetry run ruff check --fix src/entity/resources/storage.py tests/test_standard_resources.py`
- `poetry run mypy src/entity/resources/storage.py tests/test_standard_resources.py` *(fails: Class cannot subclass `StorageResource`)*
- `poetry run bandit -r src/entity/resources/storage.py tests/test_standard_resources.py`
- `poetry run vulture src/entity/resources/storage.py tests/test_standard_resources.py` *(command not found)*
- `poetry run unimport --remove-all src/entity/resources/storage.py tests/test_standard_resources.py` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(usage error)*
- `pytest tests/test_architecture/ -v`
- `pytest tests/test_plugins/ -v`
- `pytest tests/test_resources/ -v`
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68729645c1808322b53379565532a021