### PR TITLE
Add namespaced conversation ID to PipelineWorker

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added user_id namespacing to PipelineWorker conversations
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/src/entity/worker/pipeline_worker.py
+++ b/src/entity/worker/pipeline_worker.py
@@ -20,14 +20,17 @@ class PipelineWorker:
         # user_message is ignored when ``state`` is provided
         return await execute_pipeline("", self.registries, state=state)
 
-    async def execute_pipeline(self, pipeline_id: str, message: str) -> Any:
-        """Process ``message`` using the pipeline identified by ``pipeline_id``."""
+    async def execute_pipeline(
+        self, pipeline_id: str, message: str, *, user_id: str
+    ) -> Any:
+        """Process ``message`` using the pipeline identified by ``pipeline_id`` and ``user_id``."""
+        conversation_id = f"{user_id}_{pipeline_id}"
         memory = self.registries.resources.get("memory")
-        conversation = await memory.load_conversation(pipeline_id)
+        conversation = await memory.load_conversation(conversation_id)
         conversation.append(
             ConversationEntry(content=message, role="user", timestamp=datetime.now())
         )
         state = PipelineState(conversation=conversation, pipeline_id=pipeline_id)
         result = await self.run_stages(state)
-        await memory.save_conversation(pipeline_id, state.conversation)
+        await memory.save_conversation(conversation_id, state.conversation)
         return result

--- a/src/pipeline/worker.py
+++ b/src/pipeline/worker.py
@@ -25,16 +25,19 @@ class PipelineWorker:
         """Return the assistant response for the provided state."""
         return state.conversation[-1].content
 
-    async def execute_pipeline(self, pipeline_id: str, message: str) -> Any:
-        """Process ``message`` for ``pipeline_id``."""
+    async def execute_pipeline(
+        self, pipeline_id: str, message: str, *, user_id: str
+    ) -> Any:
+        """Process ``message`` for ``pipeline_id`` and ``user_id``."""
+        conversation_id = f"{user_id}_{pipeline_id}"
         memory = self.registries.resources.get("memory")
-        history = await memory.load_conversation(pipeline_id)
+        history = await memory.load_conversation(conversation_id)
         history.append(
             ConversationEntry(content=message, role="user", timestamp=datetime.now())
         )
         state = PipelineState(conversation=history, pipeline_id=pipeline_id)
         result = await self.run_stages(state)
-        await memory.save_conversation(pipeline_id, state.conversation)
+        await memory.save_conversation(conversation_id, state.conversation)
         return result
 
 

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -1,0 +1,37 @@
+import types
+import pytest
+
+from pipeline.worker import PipelineWorker
+
+
+class DummyMemory:
+    def __init__(self) -> None:
+        self.loaded_id = None
+        self.saved_id = None
+        self.history = []
+
+    async def load_conversation(self, conversation_id: str):
+        self.loaded_id = conversation_id
+        return list(self.history)
+
+    async def save_conversation(self, conversation_id: str, history):
+        self.saved_id = conversation_id
+        self.history = list(history)
+
+
+class DummyRegistries:
+    def __init__(self) -> None:
+        self.resources = {"memory": DummyMemory()}
+        self.tools = types.SimpleNamespace()
+
+
+@pytest.mark.asyncio
+async def test_conversation_id_generation():
+    regs = DummyRegistries()
+    worker = PipelineWorker(regs)
+    result = await worker.execute_pipeline("pipe1", "hello", user_id="u123")
+
+    assert result == "hello"
+    mem = regs.resources["memory"]
+    assert mem.loaded_id == "u123_pipe1"
+    assert mem.saved_id == "u123_pipe1"


### PR DESCRIPTION
## Summary
- namespace pipeline conversations by user_id
- adjust entity pipeline worker accordingly
- add regression test
- document change in agents.log

## Testing
- `poetry run pytest tests/test_pipeline_worker.py -q`
- `poetry run pytest -q` *(fails: coroutine object has no attribute 'success', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68729626f774832290fd4f52a221b240