### PR TITLE
Remove ConversationHistory helper

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
+
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs


### PR DESCRIPTION
## Summary
- drop `ConversationHistory` class and `_history` property from Memory
- use local dictionary directly for conversation history when no DB is configured
- update notes

## Testing
- `poetry run black src tests user_plugins`
- `poetry run ruff check --fix src tests` *(fails: 144 errors)*
- `poetry run mypy src` *(fails: found 195 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: requires --config)*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option)*
- `pytest tests/test_resources/ -v` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_6872964222948322aa84e414658ac118