### PR TITLE
Update memory tests with database persistence

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated Memory tests with database backend
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterable, List
 from datetime import datetime
 import json
 import inspect
+import asyncio
 
 from entity.core.registries import SystemRegistries
 from pipeline.pipeline import execute_pipeline
@@ -122,16 +123,65 @@ class Memory(AgentResource):
     # ------------------------------------------------------------------
     def get(self, key: str, default: Any | None = None) -> Any:
         """Return ``key`` from memory or ``default`` when missing."""
+        if self.database is not None:
+            table = self.database.config.get("kv_table", "kv_store")
+
+            async def _get() -> Any:
+                async with self.database.connection() as conn:
+                    rows = await _fetchall(
+                        conn,
+                        f"SELECT value FROM {table} WHERE key = ?",
+                        key,
+                    )
+                if not rows:
+                    return default
+                value = (
+                    rows[0][0] if not isinstance(rows[0], dict) else rows[0]["value"]
+                )
+                try:
+                    return json.loads(value)
+                except Exception:
+                    return value
+
+            return asyncio.get_event_loop().run_until_complete(_get())
         return self._kv.get(key, default)
 
     def set(self, key: str, value: Any) -> None:
         """Persist ``value`` for later retrieval."""
+        if self.database is not None:
+            table = self.database.config.get("kv_table", "kv_store")
+
+            async def _set() -> None:
+                async with self.database.connection() as conn:
+                    await _exec(
+                        conn,
+                        f"DELETE FROM {table} WHERE key = ?",
+                        key,
+                    )
+                    await _exec(
+                        conn,
+                        f"INSERT INTO {table} VALUES (?, ?)",
+                        key,
+                        json.dumps(value),
+                    )
+
+            asyncio.get_event_loop().run_until_complete(_set())
+            return None
         self._kv[key] = value
 
     # Backwards compatibility
     remember = set
 
     def clear(self) -> None:
+        if self.database is not None:
+            table = self.database.config.get("kv_table", "kv_store")
+
+            async def _clear() -> None:
+                async with self.database.connection() as conn:
+                    await _exec(conn, f"DELETE FROM {table}")
+
+            asyncio.get_event_loop().run_until_complete(_clear())
+            return None
         self._kv.clear()
 
     # ------------------------------------------------------------------

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -1,13 +1,68 @@
 import types
+from datetime import datetime
+import asyncio
+import json
+
+from contextlib import asynccontextmanager
 
 from entity.core.context import PluginContext
-from entity.core.state import PipelineState
+from entity.core.state import ConversationEntry, PipelineState
 from entity.resources import Memory
+from entity.resources.interfaces.database import DatabaseResource
+
+
+class DummyConnection:
+    def __init__(self, store: dict) -> None:
+        self.store = store
+
+    async def execute(self, query: str, params: tuple) -> None:
+        if query.startswith("DELETE FROM conversation_history"):
+            cid = params
+            self.store["history"].pop(cid, None)
+        elif query.startswith("INSERT INTO conversation_history"):
+            cid, role, content, metadata, ts = params
+            self.store.setdefault("history", {}).setdefault(cid, []).append(
+                (role, content, json.loads(metadata), ts)
+            )
+        elif query.startswith("DELETE FROM kv_store"):
+            key = params
+            self.store.setdefault("kv", {}).pop(key, None)
+        elif query.startswith("INSERT INTO kv_store"):
+            key, value = params
+            self.store.setdefault("kv", {})[key] = json.loads(value)
+
+    async def fetch(self, query: str, params: tuple) -> list:
+        if query.startswith(
+            "SELECT role, content, metadata, timestamp FROM conversation_history"
+        ):
+            cid = params
+            return [
+                (role, content, metadata, ts)
+                for role, content, metadata, ts in self.store.get("history", {}).get(
+                    cid, []
+                )
+            ]
+        if query.startswith("SELECT value FROM kv_store"):
+            key = params
+            if key in self.store.get("kv", {}):
+                return [(json.dumps(self.store["kv"][key]),)]
+        return []
+
+
+class DummyDatabase(DatabaseResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.data: dict = {"history": {}, "kv": {}}
+
+    @asynccontextmanager
+    async def connection(self):
+        yield DummyConnection(self.data)
 
 
 class DummyRegistries:
     def __init__(self) -> None:
-        self.resources = {"memory": Memory(config={})}
+        db = DummyDatabase()
+        self.resources = {"memory": Memory(database=db, config={})}
         self.tools = types.SimpleNamespace()
 
 
@@ -21,3 +76,16 @@ def test_memory_roundtrip() -> None:
     ctx.remember("foo", "bar")
 
     assert ctx.memory("foo") == "bar"
+
+
+def test_memory_persists_between_instances() -> None:
+    db = DummyDatabase()
+    mem1 = Memory(database=db, config={})
+    mem1.set("foo", "bar")
+    entry = ConversationEntry("hi", "user", datetime.now())
+    asyncio.run(mem1.save_conversation("cid", [entry]))
+
+    mem2 = Memory(database=db, config={})
+    assert mem2.get("foo") == "bar"
+    history = asyncio.run(mem2.load_conversation("cid"))
+    assert history == [entry]


### PR DESCRIPTION
## Summary
- extend Memory resource with simple DB-backed key-value helpers
- create dummy database for tests
- verify persistence across Memory instances

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(no tests ran)*
- `pytest tests/test_plugins/ -v` *(no tests ran)*
- `pytest tests/test_resources/ -v` *(no tests ran)*
- `pytest tests/test_plugin_context_memory.py::test_memory_persists_between_instances -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68729638fc7083229de32b57f3a37601