### PR TITLE
Update examples for refactored memory resource

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated examples for Memory injection and prefixed PipelineWorker IDs
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -13,12 +13,12 @@ plugins:
     database:
       type: entity.infrastructure.duckdb:DuckDBInfrastructure
       path: ./agent.duckdb
-    # vector_store:
-    #   type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
-    #   table: vector_mem
-    #   embedding_model:
-    #     name: dummy
-    #     dimensions: 3
+    vector_store:
+      type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
+      table: vector_mem
+      embedding_model:
+        name: dummy
+        dimensions: 3
   # llm:
   #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
   #   provider: ollama
@@ -29,7 +29,7 @@ plugins:
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
-      dependencies: [database]
+      dependencies: [database, vector_store]
     # filesystem:
     #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
     #   bucket: agent-files

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -13,12 +13,12 @@ plugins:
     database:
       type: entity.infrastructure.duckdb:DuckDBInfrastructure
       path: ./agent.duckdb
-    # vector_store:
-    #   type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
-    #   table: vector_mem
-    #   embedding_model:
-    #     name: dummy
-    #     dimensions: 3
+    vector_store:
+      type: plugins.builtin.resources.duckdb_vector_store:DuckDBVectorStore
+      table: vector_mem
+      embedding_model:
+        name: dummy
+        dimensions: 3
     # llm:
     #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
     #   provider: ollama
@@ -30,7 +30,7 @@ plugins:
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
-      dependencies: [database]
+      dependencies: [database, vector_store]
     # filesystem:
     #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
     #   bucket: agent-files

--- a/examples/advanced_agent/main.py
+++ b/examples/advanced_agent/main.py
@@ -53,12 +53,15 @@ class FinalResponder(PromptPlugin):
 
 async def main() -> None:
     resources = ResourceContainer()
-    db = DuckDBInfrastructure({"path": "./agent.duckdb"})
-    memory = Memory(database=db)
-    await db.initialize()
-    await resources.add("database", db)
-    await resources.add("memory", memory)
-    await resources.add("llm", EchoLLMResource({}))
+    resources.register(
+        "database",
+        DuckDBInfrastructure,
+        {"path": "./agent.duckdb"},
+        layer=1,
+    )
+    resources.register("memory", Memory, {}, layer=3)
+    resources.register("llm", EchoLLMResource, {}, layer=3)
+    await resources.build_all()
 
     tools = ToolRegistry()
     await tools.add("calc", CalculatorTool())

--- a/examples/basic_agent/main.py
+++ b/examples/basic_agent/main.py
@@ -39,11 +39,14 @@ async def main() -> None:
     await plugins.register_plugin_for_stage(EchoPrompt(), PipelineStage.DELIVER, "echo")
 
     resources = ResourceContainer()
-    db = DuckDBInfrastructure({"path": "./agent.duckdb"})
-    memory = Memory(database=db)
-    await db.initialize()
-    await resources.add("database", db)
-    await resources.add("memory", memory)
+    resources.register(
+        "database",
+        DuckDBInfrastructure,
+        {"path": "./agent.duckdb"},
+        layer=1,
+    )
+    resources.register("memory", Memory, {}, layer=3)
+    await resources.build_all()
 
     caps = SystemRegistries(resources=resources, tools=ToolRegistry(), plugins=plugins)
 

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -51,12 +51,15 @@ class FinalResponder(PromptPlugin):
 
 async def main() -> None:
     resources = ResourceContainer()
-    db = DuckDBInfrastructure({"path": "./agent.duckdb"})
-    memory = Memory(database=db)
-    await db.initialize()
-    await resources.add("database", db)
-    await resources.add("memory", memory)
-    await resources.add("llm", EchoLLMResource({}))
+    resources.register(
+        "database",
+        DuckDBInfrastructure,
+        {"path": "./agent.duckdb"},
+        layer=1,
+    )
+    resources.register("memory", Memory, {}, layer=3)
+    resources.register("llm", EchoLLMResource, {}, layer=3)
+    await resources.build_all()
 
     plugins = PluginRegistry()
     await plugins.register_plugin_for_stage(

--- a/src/entity/worker/pipeline_worker.py
+++ b/src/entity/worker/pipeline_worker.py
@@ -20,14 +20,17 @@ class PipelineWorker:
         # user_message is ignored when ``state`` is provided
         return await execute_pipeline("", self.registries, state=state)
 
-    async def execute_pipeline(self, pipeline_id: str, message: str) -> Any:
-        """Process ``message`` using the pipeline identified by ``pipeline_id``."""
+    async def execute_pipeline(
+        self, pipeline_id: str, message: str, user_id: str
+    ) -> Any:
+        """Process ``message`` using the pipeline identified by ``pipeline_id`` and ``user_id``."""
         memory = self.registries.resources.get("memory")
-        conversation = await memory.load_conversation(pipeline_id)
+        conversation_id = f"{user_id}_{pipeline_id}"
+        conversation = await memory.load_conversation(conversation_id)
         conversation.append(
             ConversationEntry(content=message, role="user", timestamp=datetime.now())
         )
-        state = PipelineState(conversation=conversation, pipeline_id=pipeline_id)
+        state = PipelineState(conversation=conversation, pipeline_id=conversation_id)
         result = await self.run_stages(state)
-        await memory.save_conversation(pipeline_id, state.conversation)
+        await memory.save_conversation(conversation_id, state.conversation)
         return result

--- a/src/pipeline/worker.py
+++ b/src/pipeline/worker.py
@@ -25,16 +25,19 @@ class PipelineWorker:
         """Return the assistant response for the provided state."""
         return state.conversation[-1].content
 
-    async def execute_pipeline(self, pipeline_id: str, message: str) -> Any:
-        """Process ``message`` for ``pipeline_id``."""
+    async def execute_pipeline(
+        self, pipeline_id: str, message: str, user_id: str
+    ) -> Any:
+        """Process ``message`` for ``pipeline_id`` and ``user_id``."""
         memory = self.registries.resources.get("memory")
-        history = await memory.load_conversation(pipeline_id)
+        conversation_id = f"{user_id}_{pipeline_id}"
+        history = await memory.load_conversation(conversation_id)
         history.append(
             ConversationEntry(content=message, role="user", timestamp=datetime.now())
         )
-        state = PipelineState(conversation=history, pipeline_id=pipeline_id)
+        state = PipelineState(conversation=history, pipeline_id=conversation_id)
         result = await self.run_stages(state)
-        await memory.save_conversation(pipeline_id, state.conversation)
+        await memory.save_conversation(conversation_id, state.conversation)
         return result
 
 


### PR DESCRIPTION
## Summary
- instantiate `Memory` via the container in example agents
- prefix conversation IDs with `user_id` in `PipelineWorker`
- declare vector store in example config files
- log note about the updated examples

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 146 errors)*
- `poetry run mypy src` *(fails: 194 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(failed: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(failed: Unknown config option)*
- `pytest tests/test_resources/ -v` *(failed: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_68729633fc308322896e3ce349f1b2e4