### PR TITLE
Implement runtime validation on reload

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added runtime validation check on reload and tests
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -17,6 +17,8 @@ from entity.core.agent import Agent
 from entity.core.plugins import Plugin, ValidationResult
 from entity.core.builder import _AgentBuilder
 from pipeline.config.config_update import update_plugin_configuration
+from pipeline.exceptions import CircuitBreakerTripped
+from pipeline.reliability import CircuitBreaker
 from entity.utils.logging import get_logger
 from importlib import import_module
 import sys
@@ -482,6 +484,12 @@ class EntityCLI:
             registry = agent.runtime.capabilities.plugins
             pipeline_manager = getattr(agent.runtime, "manager", None)
 
+            breaker_cfg = new_cfg.get("runtime_validation_breaker", {})
+            breaker = CircuitBreaker(
+                failure_threshold=breaker_cfg.get("failure_threshold", 3),
+                recovery_timeout=breaker_cfg.get("recovery_timeout", 60.0),
+            )
+
             plugins = new_cfg.get("plugins", {})
             for section in plugins.values():
                 if not isinstance(section, dict):
@@ -496,6 +504,37 @@ class EntityCLI:
                     if not result.success:
                         logger.error(result.error_message)
                         return 2 if result.requires_restart else 1
+
+                    plugin = registry.get_plugin(name)
+                    if plugin is None:
+                        continue
+                    validate = getattr(plugin, "validate_runtime", None)
+                    if not callable(validate):
+                        continue
+
+                    async def _run_validation() -> None:
+                        v_result = await validate()
+                        if not v_result.success:
+                            raise RuntimeError(v_result.message)
+
+                    try:
+                        await breaker.call(_run_validation)
+                    except CircuitBreakerTripped as exc:
+                        logger.error(
+                            "Runtime validation failure threshold exceeded: %s",
+                            exc,
+                        )
+                        await plugin.rollback_config(plugin.config_version - 1)
+                        return 1
+                    except Exception as exc:
+                        logger.error("Runtime validation failed for %s: %s", name, exc)
+                        await plugin.rollback_config(plugin.config_version - 1)
+                        if breaker._failure_count >= breaker.failure_threshold:
+                            logger.error(
+                                "Runtime validation failure threshold exceeded"
+                            )
+                            return 1
+                        return 1
             logger.info("Configuration updated successfully")
             return 0
 

--- a/tests/test_reload_runtime_validation.py
+++ b/tests/test_reload_runtime_validation.py
@@ -1,0 +1,56 @@
+import asyncio
+from pathlib import Path
+import yaml
+
+from entity.core.agent import Agent
+from entity.core.builder import _AgentBuilder
+from entity.core.plugins import Plugin, ValidationResult
+from entity.core.stages import PipelineStage
+from entity.cli import EntityCLI
+
+
+class RuntimeCheckPlugin(Plugin):
+    name = "checker"
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        return "ok"
+
+    async def validate_runtime(self) -> ValidationResult:
+        if not self.config.get("valid", True):
+            return ValidationResult(False, "runtime failed")
+        return ValidationResult(True, "")
+
+    pass
+
+
+async def run_reload(cli: EntityCLI, agent: Agent, cfg_path: Path) -> int:
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, cli._reload_config, agent, str(cfg_path))
+
+
+def test_reload_aborts_on_failed_runtime_validation(tmp_path):
+    builder = _AgentBuilder()
+    plugin = RuntimeCheckPlugin({"valid": True})
+    builder.add_plugin(plugin)
+    runtime = builder.build_runtime()
+
+    agent = Agent()
+    agent._builder = builder
+    agent._runtime = runtime
+
+    # Ensure config updates do not call async validator
+    RuntimeCheckPlugin.validate_config = classmethod(
+        lambda cls, cfg: ValidationResult(True, "")
+    )
+
+    cli = EntityCLI.__new__(EntityCLI)
+    cfg = {
+        "plugins": {"prompts": {"checker": {"valid": False}}},
+        "runtime_validation_breaker": {"failure_threshold": 1},
+    }
+    cfg_file = tmp_path / "reload.yaml"
+    cfg_file.write_text(yaml.safe_dump(cfg))
+
+    result = cli._reload_config(agent, str(cfg_file))
+    assert result == 1


### PR DESCRIPTION
## Summary
- invoke plugin runtime validation after config reload with circuit breaker
- abort reload when validation fails
- test reload failure on invalid runtime

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 148 errors)*
- `poetry run mypy src` *(fails: 194 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli -c config/dev.yaml validate` *(fails: validation errors)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: AttributeError)*
- `pytest tests/test_reload_runtime_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872960055bc8322af792ebd2b848d54