### PR TITLE
Add PipelineWorker memory persistence test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test
 AGENT NOTE - 2025-07-12: Updated Memory tests with database backend
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -1,6 +1,11 @@
+import json
 import types
+from contextlib import asynccontextmanager
+
 import pytest
 
+from entity.resources import Memory
+from entity.resources.interfaces.database import DatabaseResource
 from pipeline.worker import PipelineWorker
 
 
@@ -19,9 +24,64 @@ class DummyMemory:
         self.history = list(history)
 
 
+class DummyConnection:
+    def __init__(self, store: dict) -> None:
+        self.store = store
+
+    async def execute(self, query: str, params: tuple) -> None:
+        if query.startswith("DELETE FROM conversation_history"):
+            cid = params
+            self.store["history"].pop(cid, None)
+        elif query.startswith("INSERT INTO conversation_history"):
+            cid, role, content, metadata, ts = params
+            self.store.setdefault("history", {}).setdefault(cid, []).append(
+                (role, content, json.loads(metadata), ts)
+            )
+        elif query.startswith("DELETE FROM kv_store"):
+            key = params
+            self.store.setdefault("kv", {}).pop(key, None)
+        elif query.startswith("INSERT INTO kv_store"):
+            key, value = params
+            self.store.setdefault("kv", {})[key] = json.loads(value)
+
+    async def fetch(self, query: str, params: tuple) -> list:
+        if query.startswith(
+            "SELECT role, content, metadata, timestamp FROM conversation_history"
+        ):
+            cid = params
+            return [
+                (role, content, metadata, ts)
+                for role, content, metadata, ts in self.store.get("history", {}).get(
+                    cid, []
+                )
+            ]
+        if query.startswith("SELECT value FROM kv_store"):
+            key = params
+            if key in self.store.get("kv", {}):
+                return [(json.dumps(self.store["kv"][key]),)]
+        return []
+
+
+class DummyDatabase(DatabaseResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.data: dict = {"history": {}, "kv": {}}
+
+    @asynccontextmanager
+    async def connection(self):
+        yield DummyConnection(self.data)
+
+
 class DummyRegistries:
     def __init__(self) -> None:
         self.resources = {"memory": DummyMemory()}
+        self.tools = types.SimpleNamespace()
+
+
+class DBRegistries:
+    def __init__(self) -> None:
+        db = DummyDatabase()
+        self.resources = {"memory": Memory(database=db, config={})}
         self.tools = types.SimpleNamespace()
 
 
@@ -35,3 +95,16 @@ async def test_conversation_id_generation():
     mem = regs.resources["memory"]
     assert mem.loaded_id == "u123_pipe1"
     assert mem.saved_id == "u123_pipe1"
+
+
+@pytest.mark.asyncio
+async def test_workers_share_database_memory():
+    regs = DBRegistries()
+    worker1 = PipelineWorker(regs)
+    await worker1.execute_pipeline("pipe1", "first", user_id="u1")
+
+    worker2 = PipelineWorker(regs)
+    await worker2.execute_pipeline("pipe1", "second", user_id="u1")
+
+    history = await regs.resources["memory"].load_conversation("u1_pipe1")
+    assert [e.content for e in history] == ["first", "second"]


### PR DESCRIPTION
## Summary
- add test ensuring PipelineWorker instances share database-backed Memory
- log test addition in agents.log

## Testing
- `poetry run ruff check --fix tests/test_pipeline_worker.py`
- `poetry run mypy src` *(fails: 204 errors)*
- `poetry run bandit -r src`
- `vulture src tests` *(errors due to templates)*
- `unimport -r src tests` *(errors due to invalid templates)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed to import StageResolver)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed to import StageResolver)*
- `poetry run python -m src.entity.core.registry_validator --config <missing>` *(error: missing --config)
- `pytest tests/test_architecture/ -v` *(error: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(no tests ran)*
- `pytest tests/test_resources/ -v` *(error: Unknown config option)*
- `pytest` *(multiple import errors)*


------
https://chatgpt.com/codex/tasks/task_e_687298b428208322ae7591bdbb2c4a20