### PR TITLE
Refactor memory resource

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Refactored Memory to use database and vector store only
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -53,16 +53,16 @@ class AdvancedContext:
             for n, t in getattr(self._parent._registries.tools, "_tools", {}).items()
         ]
 
-    def remember(self, key: str, value: Any) -> None:
+    async def remember(self, key: str, value: Any) -> None:
         if self._parent._memory is not None:
             namespaced_key = f"{self._parent._user_id}:{key}"
-            self._parent._memory.remember(namespaced_key, value)
+            await self._parent._memory.set(namespaced_key, value)
 
-    def memory(self, key: str, default: Any | None = None) -> Any:
+    async def memory(self, key: str, default: Any | None = None) -> Any:
         if self._parent._memory is None:
             return default
         namespaced_key = f"{self._parent._user_id}:{key}"
-        return self._parent._memory.get(namespaced_key, default)
+        return await self._parent._memory.get(namespaced_key, default)
 
     def set_metadata(self, key: str, value: Any) -> None:
         self._parent._state.metadata[key] = value
@@ -252,21 +252,21 @@ class PluginContext:
     # Persistent memory helpers
     # ------------------------------------------------------------------
 
-    def remember(self, key: str, value: Any) -> None:
+    async def remember(self, key: str, value: Any) -> None:
         warnings.warn(
             "PluginContext.remember is deprecated; use context.advanced.remember",
             DeprecationWarning,
             stacklevel=2,
         )
-        self.advanced.remember(key, value)
+        await self.advanced.remember(key, value)
 
-    def memory(self, key: str, default: Any | None = None) -> Any:
+    async def memory(self, key: str, default: Any | None = None) -> Any:
         warnings.warn(
             "PluginContext.memory is deprecated; use context.advanced.memory",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.advanced.memory(key, default)
+        return await self.advanced.memory(key, default)
 
     def set_metadata(self, key: str, value: Any) -> None:
         warnings.warn(

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from math import sqrt
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, List
 from datetime import datetime
 import json
 import inspect
@@ -29,30 +28,6 @@ class Conversation:
             next_msg = result.get("message", "")
             result = await execute_pipeline(next_msg, self._caps)
         return result
-
-
-def _cosine_similarity(a: Iterable[float], b: Iterable[float]) -> float:
-    num = sum(x * y for x, y in zip(a, b))
-    denom_a = sqrt(sum(x * x for x in a))
-    denom_b = sqrt(sum(y * y for y in b))
-    if denom_a == 0 or denom_b == 0:
-        return 0.0
-    return num / (denom_a * denom_b)
-
-
-class ConversationHistory:
-    """Helper managing conversation histories."""
-
-    def __init__(self, store: Dict[str, List[ConversationEntry]]) -> None:
-        self._store = store
-
-    async def save(
-        self, conversation_id: str, history: List[ConversationEntry]
-    ) -> None:
-        self._store[conversation_id] = list(history)
-
-    async def load(self, conversation_id: str) -> List[ConversationEntry]:
-        return list(self._store.get(conversation_id, []))
 
 
 def _normalize_args(args: tuple[Any, ...]) -> Any:
@@ -98,7 +73,7 @@ class Memory(AgentResource):
     """Store key/value pairs, conversation history, and vectors."""
 
     name = "memory"
-    dependencies: list[str] = ["database?", "vector_store?"]
+    dependencies: list[str] = ["database", "vector_store"]
 
     def __init__(
         self,
@@ -107,10 +82,6 @@ class Memory(AgentResource):
         config: Dict | None = None,
     ) -> None:
         super().__init__(config or {})
-        self._kv: Dict[str, Any] = {}
-        self._conversations: Dict[str, List[ConversationEntry]] = {}
-        self._vectors: Dict[str, List[float]] = {}
-        self._history = ConversationHistory(self._conversations)
         self.database = database
         self.vector_store = vector_store
 
@@ -120,19 +91,38 @@ class Memory(AgentResource):
     # ------------------------------------------------------------------
     # Key-value helpers
     # ------------------------------------------------------------------
-    def get(self, key: str, default: Any | None = None) -> Any:
-        """Return ``key`` from memory or ``default`` when missing."""
-        return self._kv.get(key, default)
+    async def get(self, key: str, default: Any | None = None) -> Any:
+        """Return ``key`` from persistent storage or ``default`` when missing."""
+        table = self.database.config.get("kv_table", "memory_kv")
+        async with self.database.connection() as conn:
+            rows = await _fetchall(
+                conn,
+                f"SELECT value FROM {table} WHERE key = ?",
+                key,
+            )
+        if not rows:
+            return default
+        value = rows[0][0] if not isinstance(rows[0], dict) else rows[0].get("value")
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
 
-    def set(self, key: str, value: Any) -> None:
+    async def set(self, key: str, value: Any) -> None:
         """Persist ``value`` for later retrieval."""
-        self._kv[key] = value
+        table = self.database.config.get("kv_table", "memory_kv")
+        payload = json.dumps(value)
+        async with self.database.connection() as conn:
+            await _exec(conn, f"DELETE FROM {table} WHERE key = ?", key)
+            await _exec(conn, f"INSERT INTO {table} VALUES (?, ?)", key, payload)
 
     # Backwards compatibility
     remember = set
 
-    def clear(self) -> None:
-        self._kv.clear()
+    async def clear(self) -> None:
+        table = self.database.config.get("kv_table", "memory_kv")
+        async with self.database.connection() as conn:
+            await _exec(conn, f"DELETE FROM {table}")
 
     # ------------------------------------------------------------------
     # Conversation helpers
@@ -140,76 +130,58 @@ class Memory(AgentResource):
     async def save_conversation(
         self, conversation_id: str, history: List[ConversationEntry]
     ) -> None:
-        if self.database is not None:
-            table = self.database.config.get("history_table", "conversation_history")
-            async with self.database.connection() as conn:
+        table = self.database.config.get("history_table", "conversation_history")
+        async with self.database.connection() as conn:
+            await _exec(
+                conn,
+                f"DELETE FROM {table} WHERE conversation_id = ?",
+                conversation_id,
+            )
+            for entry in history:
                 await _exec(
                     conn,
-                    f"DELETE FROM {table} WHERE conversation_id = ?",
+                    f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?)",
                     conversation_id,
+                    entry.role,
+                    entry.content,
+                    json.dumps(entry.metadata),
+                    entry.timestamp.isoformat(),
                 )
-                for entry in history:
-                    await _exec(
-                        conn,
-                        f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?)",
-                        conversation_id,
-                        entry.role,
-                        entry.content,
-                        json.dumps(entry.metadata),
-                        entry.timestamp.isoformat(),
-                    )
-            return None
-        await self._history.save(conversation_id, history)
 
     async def load_conversation(self, conversation_id: str) -> List[ConversationEntry]:
-        if self.database is not None:
-            table = self.database.config.get("history_table", "conversation_history")
-            async with self.database.connection() as conn:
-                rows = await _fetchall(
-                    conn,
-                    f"SELECT role, content, metadata, timestamp FROM {table} WHERE conversation_id = ? ORDER BY timestamp",
-                    conversation_id,
+        table = self.database.config.get("history_table", "conversation_history")
+        async with self.database.connection() as conn:
+            rows = await _fetchall(
+                conn,
+                f"SELECT role, content, metadata, timestamp FROM {table} WHERE conversation_id = ? ORDER BY timestamp",
+                conversation_id,
+            )
+        result: List[ConversationEntry] = []
+        for row in rows:
+            role = row[0] if not isinstance(row, dict) else row["role"]
+            content = row[1] if not isinstance(row, dict) else row["content"]
+            metadata = row[2] if not isinstance(row, dict) else row.get("metadata", {})
+            timestamp = row[3] if not isinstance(row, dict) else row["timestamp"]
+            if isinstance(timestamp, str):
+                timestamp = datetime.fromisoformat(timestamp)
+            result.append(
+                ConversationEntry(
+                    content=content,
+                    role=role,
+                    timestamp=timestamp,
+                    metadata=metadata,
                 )
-            result: List[ConversationEntry] = []
-            for row in rows:
-                role = row[0] if not isinstance(row, dict) else row["role"]
-                content = row[1] if not isinstance(row, dict) else row["content"]
-                metadata = (
-                    row[2] if not isinstance(row, dict) else row.get("metadata", {})
-                )
-                timestamp = row[3] if not isinstance(row, dict) else row["timestamp"]
-                if isinstance(timestamp, str):
-                    timestamp = datetime.fromisoformat(timestamp)
-                result.append(
-                    ConversationEntry(
-                        content=content,
-                        role=role,
-                        timestamp=timestamp,
-                        metadata=metadata,
-                    )
-                )
-            return result
-        return await self._history.load(conversation_id)
-
-    @property
-    def conversation_history(self) -> ConversationHistory:
-        """Return the conversation history manager."""
-        return self._history
+            )
+        return result
 
     # ------------------------------------------------------------------
     # Vector helpers
     # ------------------------------------------------------------------
-    async def add_embedding(self, key: str, vector: List[float]) -> None:
-        self._vectors[key] = vector
+    async def add_embedding(self, text: str) -> None:
+        await self.vector_store.add_embedding(text)
 
-    async def search_similar(self, vector: List[float], k: int = 5) -> List[str]:
-        scores = {k_: _cosine_similarity(vector, v) for k_, v in self._vectors.items()}
-        return [
-            k
-            for k, _ in sorted(scores.items(), key=lambda item: item[1], reverse=True)[
-                :k
-            ]
-        ]
+    async def search_similar(self, query: str, k: int = 5) -> List[str]:
+        return await self.vector_store.query_similar(query, k)
 
     # ------------------------------------------------------------------
     # Conversation manager

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -173,9 +173,12 @@ def test_complex_prompt_requires_vector_store(tmp_path):
         "prompts": {
             "complex_prompt": {"type": "tests.test_registry_validator:ComplexPrompt"}
         },
+        "agent_resources": {
+            "database": {"type": "tests.test_registry_validator:DBInterface"}
+        },
     }
     path = _write_config(tmp_path, plugins)
-    with pytest.raises(SystemError, match="layer-3 or layer-4"):
+    with pytest.raises(SystemError, match="vector store"):
         RegistryValidator(str(path)).run()
 
 
@@ -186,14 +189,14 @@ def test_complex_prompt_with_vector_store(tmp_path):
             "vector_store": {
                 "type": "tests.test_registry_validator:VectorStoreResource"
             },
+            "database": {"type": "tests.test_registry_validator:DBInterface"},
         },
         "prompts": {
             "complex_prompt": {"type": "tests.test_registry_validator:ComplexPrompt"}
         },
     }
     path = _write_config(tmp_path, plugins)
-    with pytest.raises(SystemError, match="layer-3 or layer-4"):
-        RegistryValidator(str(path)).run()
+    RegistryValidator(str(path)).run()
 
 
 def test_memory_requires_postgres(tmp_path):

--- a/tests/test_standard_resources.py
+++ b/tests/test_standard_resources.py
@@ -1,9 +1,34 @@
+from contextlib import asynccontextmanager
 from entity.resources import LLM, Memory, Storage, StandardResources
+from entity.resources.interfaces.database import DatabaseResource
+from entity.resources.interfaces.vector_store import VectorStoreResource
+
+
+class _DBConn:
+    async def execute(self, *args):
+        return None
+
+    async def fetch(self, *args):
+        return []
+
+
+class DummyDB(DatabaseResource):
+    @asynccontextmanager
+    async def connection(self):
+        yield _DBConn()
+
+
+class DummyVector(VectorStoreResource):
+    async def add_embedding(self, text: str) -> None:
+        return None
+
+    async def query_similar(self, query: str, k: int = 5) -> list[str]:
+        return []
 
 
 def test_standard_resources_types() -> None:
     res = StandardResources(
-        memory=Memory(config={}),
+        memory=Memory(database=DummyDB(), vector_store=DummyVector(), config={}),
         llm=LLM(config={}),
         storage=Storage(config={}),
     )


### PR DESCRIPTION
## Summary
- drop in-memory fallback data structures for Memory
- mandate database and vector store dependencies
- persist key/value pairs and conversations to the database
- route embedding operations through the vector store
- adapt PluginContext helpers to the new async API
- update tests for the new Memory interface

## Testing
- `poetry run black src/entity/resources/memory.py src/entity/core/context.py tests/test_plugin_context_memory.py tests/test_standard_resources.py tests/test_registry_validator.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687296222dac83228ccc65b84f729aa6