### PR TITLE
Add DuckDB-backed memory fixtures

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added temporary DuckDB-based Memory fixture in tests
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -74,8 +74,8 @@ class Memory(AgentResource):
         self._kv: Dict[str, Any] = {}
         self._conversations: Dict[str, List[ConversationEntry]] = {}
         self._vectors: Dict[str, List[float]] = {}
-        self.database = database
-        self.vector_store = vector_store
+        self.database = None
+        self.vector_store = None
 
     async def _execute_impl(self, context: Any) -> None:  # noqa: D401, ARG002
         return None
@@ -151,6 +151,7 @@ class Memory(AgentResource):
                         metadata=metadata,
                     )
                 )
+            return result
 
     # ------------------------------------------------------------------
     # Vector helpers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from entity.infrastructure import DuckDBInfrastructure
+from entity.resources import Memory
+
+
+@pytest.fixture()
+async def memory_db(tmp_path: Path) -> Memory:
+    db_path = tmp_path / "memory.duckdb"
+    db = DuckDBInfrastructure({"path": str(db_path)})
+    await db.initialize()
+    async with db.connection() as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
+        )
+    mem = Memory(config={})
+    mem.database = db
+    try:
+        yield mem
+    finally:
+        await db.shutdown()

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -35,3 +35,18 @@ async def test_conversation_id_generation():
     mem = regs.resources["memory"]
     assert mem.loaded_id == "u123_pipe1"
     assert mem.saved_id == "u123_pipe1"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_persists_conversation(memory_db):
+    regs = types.SimpleNamespace(
+        resources={"memory": memory_db}, tools=types.SimpleNamespace()
+    )
+    worker = PipelineWorker(regs)
+
+    await worker.execute_pipeline("pipe1", "hello", user_id="u1")
+    await worker.execute_pipeline("pipe1", "world", user_id="u1")
+
+    mem = regs.resources["memory"]
+    history = await mem.load_conversation("u1_pipe1")
+    assert [h.content for h in history] == ["hello", "world"]

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -1,23 +1,26 @@
 import types
+import pytest
 
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
-from entity.resources import Memory
 
 
 class DummyRegistries:
-    def __init__(self) -> None:
-        self.resources = {"memory": Memory(config={})}
+    def __init__(self, memory) -> None:
+        self.resources = {"memory": memory}
         self.tools = types.SimpleNamespace()
 
 
-def make_context() -> PluginContext:
+def make_context(memory) -> PluginContext:
     state = PipelineState(conversation=[])
-    return PluginContext(state, DummyRegistries())
+    return PluginContext(state, DummyRegistries(memory))
 
 
-def test_memory_roundtrip() -> None:
-    ctx = make_context()
+@pytest.mark.asyncio
+async def test_memory_roundtrip(memory_db) -> None:
+    ctx = make_context(memory_db)
     ctx.remember("foo", "bar")
 
     assert ctx.memory("foo") == "bar"
+    ctx2 = make_context(memory_db)
+    assert ctx2.memory("foo") == "bar"


### PR DESCRIPTION
## Summary
- fix `Memory` initialization and conversation loading
- provide a reusable `memory_db` fixture using DuckDB
- test plugin context and pipeline worker with persistent memory
- note fixture addition in agents log

## Testing
- `poetry run pytest tests/test_plugin_context_memory.py tests/test_pipeline_worker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687298b193bc8322b76263b1f0c49198