### PR TITLE
Refactor Memory persistence

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output

--- a/src/entity/infrastructure/duckdb.py
+++ b/src/entity/infrastructure/duckdb.py
@@ -45,6 +45,12 @@ class DuckDBInfrastructure(InfrastructurePlugin):
         finally:
             pass
 
+    def get_connection_pool(self) -> duckdb.DuckDBPyConnection:
+        """Return the shared DuckDB connection."""
+        if self._conn is None:
+            self._conn = duckdb.connect(self.path)
+        return self._conn
+
     async def shutdown(self) -> None:
         if self._conn is not None:
             self._conn.close()

--- a/src/entity/infrastructure/postgres.py
+++ b/src/entity/infrastructure/postgres.py
@@ -24,6 +24,9 @@ class _DummyPool:
     async def close(self) -> None:  # pragma: no cover - placeholder
         return None
 
+    def get_pool(self) -> "_DummyPool":
+        return self
+
 
 class PostgresInfrastructure(InfrastructurePlugin):
     """Minimal Postgres infrastructure stub used in tests."""
@@ -54,6 +57,10 @@ class PostgresInfrastructure(InfrastructurePlugin):
             yield conn
         finally:
             await self._pool.release(conn)
+
+    def get_connection_pool(self) -> Any:
+        """Return the underlying connection pool."""
+        return self._pool
 
     async def validate_runtime(self) -> ValidationResult:
         """Check connectivity using a simple query."""

--- a/src/entity/resources/interfaces/database.py
+++ b/src/entity/resources/interfaces/database.py
@@ -17,3 +17,7 @@ class DatabaseResource(ResourcePlugin):
     @asynccontextmanager
     async def connection(self) -> Iterator[Any]:  # pragma: no cover - stub
         yield None
+
+    def get_connection_pool(self) -> Any:  # pragma: no cover - stub
+        """Return the underlying connection or pool."""
+        return None

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -1,23 +1,50 @@
 import types
+import duckdb
+from contextlib import asynccontextmanager
 
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
 from entity.resources import Memory
+from entity.resources.interfaces.database import DatabaseResource
+
+
+class DuckDBResource(DatabaseResource):
+    def __init__(self, path: str) -> None:
+        super().__init__({})
+        self.conn = duckdb.connect(path)
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
+        )
+
+    @asynccontextmanager
+    async def connection(self):
+        yield self.conn
+
+    def get_connection_pool(self):
+        return self.conn
 
 
 class DummyRegistries:
-    def __init__(self) -> None:
-        self.resources = {"memory": Memory(config={})}
+    def __init__(self, path: str) -> None:
+        db = DuckDBResource(path)
+        mem = Memory(config={})
+        mem.database = db
+        mem.vector_store = None
+        self.resources = {"memory": mem}
         self.tools = types.SimpleNamespace()
 
 
-def make_context() -> PluginContext:
+def make_context(tmp_path) -> PluginContext:
     state = PipelineState(conversation=[])
-    return PluginContext(state, DummyRegistries())
+    regs = DummyRegistries(str(tmp_path / "mem.duckdb"))
+    return PluginContext(state, regs)
 
 
-def test_memory_roundtrip() -> None:
-    ctx = make_context()
+def test_memory_roundtrip(tmp_path) -> None:
+    ctx = make_context(tmp_path)
     ctx.remember("foo", "bar")
 
     assert ctx.memory("foo") == "bar"


### PR DESCRIPTION
## Summary
- remove in-memory fields from `Memory`
- persist kv pairs and chat history via the database connection pool
- delegate vector operations to the VectorStore resource
- add test helper using DuckDB to validate `PluginContext` memory helpers
- expose `get_connection_pool` on database interfaces and implementations

## Testing
- `poetry run ruff check --fix src tests` *(fails: 159 errors)*
- `poetry run mypy src` *(fails: ModuleNotFoundError)*
- `poetry run bandit -r src` *(fails: Command not found)*
- `poetry run vulture src tests` *(fails: invalid syntax in templates)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option)*
- `pytest tests/test_resources/ -v` *(fails: Unknown config option)*
- `pytest tests/test_pipeline_worker.py tests/test_plugin_context_memory.py -v` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_687298ad0e448322b4bd559e22018d2f