### PR TITLE
Refactor Memory resource persistence

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated Memory resource to use database persistence only
 AGENT NOTE - 2025-07-12: Replaced SystemError with InitializationError messages
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 


### PR DESCRIPTION
## Summary
- ensure Memory depends on database and vector_store
- drop local caches for kv, conversation and vector data
- verify dependencies during initialize
- always use the injected database connection for persistence
- document change in `agents.log`

## Testing
- `poetry run black src/entity/resources/memory.py`
- `poetry run ruff check --fix src/entity/resources/memory.py`
- `python -m py_compile src/entity/resources/memory.py`
- `poetry run mypy src/entity/resources/memory.py`
- `poetry run bandit -r src/entity/resources/memory.py`
- `poetry run vulture src/entity/resources/memory.py` *(fails: Command not found)*
- `poetry run unimport --remove-all src/entity/resources/memory.py` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ImportError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ImportError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ImportError)*
- `pytest tests/test_architecture/ -v` *(no tests ran)*
- `pytest tests/test_plugins/ -v` *(no tests ran)*
- `pytest tests/test_resources/ -v` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68729a9256b083228aca21ebc332e49d