### PR TITLE
Add connection pool support

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-13: Added connection pool support for database infrastructure and updated Memory resource.
 AGENT NOTE - 2025-07-12: Replaced SystemError with InitializationError messages
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 

--- a/src/entity/infrastructure/postgres.py
+++ b/src/entity/infrastructure/postgres.py
@@ -7,22 +7,18 @@ from pipeline.exceptions import CircuitBreakerTripped
 from pipeline.reliability import CircuitBreaker
 
 from entity.core.plugins import InfrastructurePlugin, ValidationResult
+from entity.core.resources.container import PoolConfig, ResourcePool
 
 
 class _DummyConn:
-    async def execute(self, *args: Any, **kwargs: Any) -> None:
+    async def execute(
+        self, *args: Any, **kwargs: Any
+    ) -> None:  # pragma: no cover - stub
         return None
 
 
-class _DummyPool:
-    async def acquire(self) -> _DummyConn:
-        return _DummyConn()
-
-    async def release(self, _conn: _DummyConn) -> None:
-        return None
-
-    async def close(self) -> None:  # pragma: no cover - placeholder
-        return None
+async def _create_conn() -> _DummyConn:
+    return _DummyConn()
 
 
 class PostgresInfrastructure(InfrastructurePlugin):
@@ -35,7 +31,8 @@ class PostgresInfrastructure(InfrastructurePlugin):
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
-        self._pool = _DummyPool()
+        pool_cfg = PoolConfig(**self.config.get("pool", {}))
+        self._pool = ResourcePool(_create_conn, pool_cfg)
         self._breaker = CircuitBreaker(
             failure_threshold=self.config.get("failure_threshold", 3),
             recovery_timeout=self.config.get("recovery_timeout", 60.0),
@@ -45,15 +42,15 @@ class PostgresInfrastructure(InfrastructurePlugin):
         return None
 
     async def initialize(self) -> None:
-        return None
+        await self._pool.initialize()
 
     @asynccontextmanager
     async def connection(self) -> Any:
-        conn = await self._pool.acquire()
-        try:
+        async with self._pool as conn:
             yield conn
-        finally:
-            await self._pool.release(conn)
+
+    def get_connection_pool(self) -> ResourcePool:
+        return self._pool
 
     async def validate_runtime(self) -> ValidationResult:
         """Check connectivity using a simple query."""

--- a/src/entity/resources/interfaces/database.py
+++ b/src/entity/resources/interfaces/database.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from typing import Any, Dict, Iterator
 
+from entity.core.resources.container import PoolConfig, ResourcePool
+
 from entity.core.plugins import ResourcePlugin
 
 
@@ -14,6 +16,15 @@ class DatabaseResource(ResourcePlugin):
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
 
+    def get_connection_pool(self) -> ResourcePool:  # pragma: no cover - stub
+        """Return the shared connection pool from the infrastructure."""
+        infra = getattr(self, "database", None)
+        if infra is not None:
+            return infra.get_connection_pool()
+        return ResourcePool(lambda: None, PoolConfig())
+
     @asynccontextmanager
     async def connection(self) -> Iterator[Any]:  # pragma: no cover - stub
-        yield None
+        pool = self.get_connection_pool()
+        async with pool as conn:
+            yield conn


### PR DESCRIPTION
## Summary
- expose `get_connection_pool()` on database interfaces
- manage pools in Postgres and DuckDB infrastructure
- update Memory resource to use the new pool
- adjust dummy database for tests
- log the change

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 160 errors)*
- `poetry run mypy src` *(fails: found 213 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed to import StageResolver)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed to import StageResolver)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: circular import)*
- `pytest tests/test_architecture/ -v` *(failed: unknown config option)*
- `pytest tests/test_plugins/ -v` *(failed: unknown config option)*
- `pytest tests/test_resources/ -v` *(failed: unknown config option)*


------
https://chatgpt.com/codex/tasks/task_e_68729a94329c8322bb1cf6c575395c8b