### PR TITLE
Consolidate pipeline worker

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Consolidated PipelineWorker to single implementation
 AGENT NOTE - 2025-07-12: Replaced SystemError with InitializationError messages
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 

--- a/src/entity/worker/pipeline_worker.py
+++ b/src/entity/worker/pipeline_worker.py
@@ -34,3 +34,6 @@ class PipelineWorker:
         result = await self.run_stages(state)
         await memory.save_conversation(conversation_id, state.conversation)
         return result
+
+
+__all__ = ["PipelineWorker"]

--- a/src/pipeline/worker.py
+++ b/src/pipeline/worker.py
@@ -1,44 +1,7 @@
 from __future__ import annotations
 
-"""Stateless pipeline worker.
+"""Re-export the canonical :class:`PipelineWorker`."""
 
-Loads conversation context from memory for each request and
-persists updates after execution.
-"""
-
-from datetime import datetime
-from typing import Any
-
-from entity.core.registries import SystemRegistries
-from entity.core.state import ConversationEntry
-
-from .state import PipelineState
-
-
-class PipelineWorker:
-    """Execute pipelines without retaining local state."""
-
-    def __init__(self, registries: SystemRegistries) -> None:
-        self.registries = registries
-
-    async def run_stages(self, state: PipelineState) -> Any:
-        """Return the assistant response for the provided state."""
-        return state.conversation[-1].content
-
-    async def execute_pipeline(
-        self, pipeline_id: str, message: str, *, user_id: str
-    ) -> Any:
-        """Process ``message`` for ``pipeline_id`` and ``user_id``."""
-        conversation_id = f"{user_id}_{pipeline_id}"
-        memory = self.registries.resources.get("memory")
-        history = await memory.load_conversation(conversation_id)
-        history.append(
-            ConversationEntry(content=message, role="user", timestamp=datetime.now())
-        )
-        state = PipelineState(conversation=history, pipeline_id=pipeline_id)
-        result = await self.run_stages(state)
-        await memory.save_conversation(conversation_id, state.conversation)
-        return result
-
+from entity.worker.pipeline_worker import PipelineWorker
 
 __all__ = ["PipelineWorker"]


### PR DESCRIPTION
## Summary
- centralize pipeline worker implementation
- re-export worker from `pipeline.worker`
- note change in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: many existing issues)*
- `poetry run mypy src` *(fails: 202 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: unrecognized arguments)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ImportError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ImportError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ImportError)*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option)*
- `pytest tests/test_resources/ -v` *(fails: Unknown config option)*
- `pytest tests/test_pipeline_worker.py -v` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_68729a95856483228290422369e30356