### PR TITLE
Ensure memory tests use database

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated tests to require database for Memory and verified persistence via connection pool
 AGENT NOTE - 2025-07-12: Replaced SystemError with InitializationError messages
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -10,8 +10,6 @@ import inspect
 import asyncio
 
 from .base import AgentResource
-from .interfaces.database import DatabaseResource as DatabaseInterface
-from .interfaces.vector_store import VectorStoreResource as VectorStoreInterface
 from ..core.plugins import ValidationResult
 from ..core.state import ConversationEntry
 
@@ -201,6 +199,7 @@ class Memory(AgentResource):
                         metadata=metadata,
                     )
                 )
+            return result
 
     # ------------------------------------------------------------------
     # Vector helpers

--- a/tests/test_standard_resources.py
+++ b/tests/test_standard_resources.py
@@ -1,5 +1,28 @@
+from contextlib import asynccontextmanager
+
 from entity.resources import LLM, Memory, Storage, StandardResources
+from entity.resources import memory as memory_module
+from entity.resources.interfaces.database import DatabaseResource
 from entity.resources.interfaces.storage import StorageResource
+
+
+class DummyConnection:
+    async def execute(
+        self, query: str, params: tuple
+    ) -> None:  # pragma: no cover - stub
+        pass
+
+    async def fetch(self, query: str, params: tuple) -> list:  # pragma: no cover - stub
+        return []
+
+
+class DummyDatabase(DatabaseResource):
+    def __init__(self) -> None:
+        super().__init__({})
+
+    @asynccontextmanager
+    async def connection(self):
+        yield DummyConnection()
 
 
 class DummyBackend(StorageResource):
@@ -15,8 +38,13 @@ class DummyBackend(StorageResource):
 
 
 def test_standard_resources_types() -> None:
+    db = DummyDatabase()
+    memory_module.database = db
+    memory_module.vector_store = None
+    memory = Memory(config={})
+
     res = StandardResources(
-        memory=Memory(config={}),
+        memory=memory,
         llm=LLM(config={}),
         storage=Storage(backend=DummyBackend(), config={}),
     )


### PR DESCRIPTION
## Summary
- add agent note
- create dummy DB resources in tests
- ensure Memory persists via connection pool
- fix load_conversation return in memory

## Testing
- `poetry run black src/entity/resources/memory.py tests/test_plugin_context_memory.py tests/test_standard_resources.py`
- `PYTHONPATH=src pytest tests/test_standard_resources.py::test_standard_resources_types tests/test_plugin_context_memory.py::test_memory_roundtrip tests/test_plugin_context_memory.py::test_memory_persists_between_instances tests/test_plugin_context_memory.py::test_memory_persists_with_connection_pool -q`
- `poetry run ruff check --fix src tests` *(fails: many lint errors)*
- `poetry run mypy src` *(fails: many type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68729a96b3c88322814535337ca2d28b