### PR TITLE
Add worker statelessness tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-12: Added stateless worker tests
+
 AGENT NOTE - 2025-07-12: Replaced SystemError with InitializationError messages
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 

--- a/tests/test_stateless_worker.py
+++ b/tests/test_stateless_worker.py
@@ -1,0 +1,82 @@
+import json
+import types
+from contextlib import asynccontextmanager
+
+import pytest
+
+from entity.resources import Memory
+from entity.resources.interfaces.database import DatabaseResource
+from pipeline.worker import PipelineWorker
+
+
+class DummyConnection:
+    def __init__(self, store: dict) -> None:
+        self.store = store
+
+    async def execute(self, query: str, params: tuple) -> None:
+        if query.startswith("DELETE FROM conversation_history"):
+            cid = params
+            self.store["history"].pop(cid, None)
+        elif query.startswith("INSERT INTO conversation_history"):
+            cid, role, content, metadata, ts = params
+            self.store.setdefault("history", {}).setdefault(cid, []).append(
+                (role, content, json.loads(metadata), ts)
+            )
+
+    async def fetch(self, query: str, params: tuple) -> list:
+        if query.startswith(
+            "SELECT role, content, metadata, timestamp FROM conversation_history"
+        ):
+            cid = params
+            return [
+                (role, content, metadata, ts)
+                for role, content, metadata, ts in self.store.get("history", {}).get(
+                    cid, []
+                )
+            ]
+        return []
+
+
+class DummyDatabase(DatabaseResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.data: dict = {"history": {}}
+
+    @asynccontextmanager
+    async def connection(self):
+        yield DummyConnection(self.data)
+
+
+class DummyRegistries:
+    def __init__(self, db: DummyDatabase) -> None:
+        self.resources = {"memory": Memory(database=db, config={})}
+        self.tools = types.SimpleNamespace()
+
+
+@pytest.mark.asyncio
+async def test_workers_share_state_across_instances() -> None:
+    db = DummyDatabase()
+
+    regs1 = DummyRegistries(db)
+    worker1 = PipelineWorker(regs1)
+    await worker1.execute_pipeline("pipe", "hello", user_id="u1")
+
+    regs2 = DummyRegistries(db)
+    worker2 = PipelineWorker(regs2)
+    await worker2.execute_pipeline("pipe", "there", user_id="u1")
+
+    history = await regs2.resources["memory"].load_conversation("u1_pipe")
+    assert [e.content for e in history] == ["hello", "there"]
+
+
+@pytest.mark.asyncio
+async def test_worker_does_not_cache_state() -> None:
+    db = DummyDatabase()
+    regs = DummyRegistries(db)
+    worker = PipelineWorker(regs)
+
+    await worker.execute_pipeline("pipe", "first", user_id="u1")
+    await worker.execute_pipeline("pipe", "second", user_id="u1")
+
+    history = await regs.resources["memory"].load_conversation("u1_pipe")
+    assert [e.content for e in history] == ["first", "second"]


### PR DESCRIPTION
## Summary
- add a unit test validating that PipelineWorker remains stateless
- log note about new tests

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: many errors)*
- `poetry run mypy src` *(fails: 202 errors)*
- `poetry run bandit -r src` *(fails: command not found)*
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option)*
- `pytest tests/test_resources/ -v` *(fails: Unknown config option)*
- `pytest` *(fails: multiple ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68729a97caa08322836556a469a6e795