### PR TITLE
Update README with Decision 6 summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ plugins:
 
 See the [Quick Start](docs/source/quick_start.md) for step-by-step setup or browse the [full documentation](https://entity.readthedocs.io/en/latest/).
 
+### Stateless Workers (Decision 6)
+
+Workers hold no conversation state between requests. Instead, the `Memory` resource persists data to an external store. Each worker loads the conversation from `Memory` at the start of a request and saves updates when finished. This allows any worker process to handle any user without coordination.
+
+The default configuration persists `Memory` through DuckDB:
+
+```yaml
+agent_resources:
+  memory:
+    type: entity.resources.memory:Memory
+    dependencies: [database]
+```
+
+See [`config/dev.yaml`](config/dev.yaml) for the complete example.
+
 ### Zero-Config Plugins
 
 Register a tool and prompt without specifying stages:

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Summarized Decision 6 and stateless workers in README
 AGENT NOTE - 2025-07-12: Replaced SystemError with InitializationError messages
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 


### PR DESCRIPTION
## Summary
- document stateless worker architecture
- add dev note in agents log

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: F841 unused variable errors)*
- `poetry run mypy src` *(fails: found 202 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed to import StageResolver)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed to import StageResolver)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: circular import)*
- `pytest tests/test_architecture/ -v` *(failed: unknown config option)*
- `pytest tests/test_plugins/ -v` *(failed: unknown config option)*
- `pytest tests/test_resources/ -v` *(failed: unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_68729a98ed4c832286d003f1e4100e8a