### PR TITLE
Add default runtime validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added default validate_runtime method for Plugin base class
 AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test
 AGENT NOTE - 2025-07-12: Updated Memory tests with database backend
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -71,6 +71,11 @@ class Plugin:
 
         return ValidationResult.success_result()
 
+    async def validate_runtime(self) -> "ValidationResult":
+        """Validate the runtime environment for the plugin."""
+
+        return ValidationResult.success_result()
+
     async def initialize(self) -> None:
         """Initialize the plugin instance."""
 


### PR DESCRIPTION
## Summary
- add default `validate_runtime` method to `Plugin` base class

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: found 165 errors)*
- `poetry run mypy src` *(fails: Found 206 errors in 43 files)*
- `poetry run bandit -r src` *(fails: Command not found)*
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ImportError: cannot import name 'InitializationError')*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option)*
- `pytest tests/test_resources/ -v` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_68729ad3ad0c8322944acde3789786df