### PR TITLE
Add error handling docs

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added error handling docs and index
 AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test
 AGENT NOTE - 2025-07-12: Updated Memory tests with database backend
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+sphinx==8.1.3
+myst-parser==4.0.1
+sphinx-autobuild==2024.10.3
+furo==2024.8.6
+sphinx-autoapi==3.5.0
+sphinx-autodoc2==0.5.0
+sphinxcontrib-mermaid==1.0.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,38 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "entity"
+author = "C. Thomas Brittain"
+release = "0.0.29"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autosectionlabel",
+    "autodoc2",
+    "sphinxcontrib.mermaid",
+]
+
+templates_path = ["_templates"]
+exclude_patterns: list[str] = []
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "furo"
+html_static_path = ["_static"]
+
+# https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html
+autodoc2_packages = ["../../src/entity"]

--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -1,0 +1,44 @@
+# Error Handling and Validation
+
+Entity performs validation in three distinct phases to surface issues early:
+
+1. **Phase 1 – Syntax Validation**
+   - Runs in under 100&nbsp;ms.
+   - Checks configuration syntax, plugin structure, and obvious conflicts.
+2. **Phase 2 – Dependency Validation**
+   - Completes in less than one second.
+   - Ensures resources exist, detects circular dependencies, and verifies versions.
+3. **Phase 3 – Runtime Validation**
+   - Occurs in the background after startup.
+   - Confirms database connections and external API reachability.
+
+Circuit breakers prevent cascading failures. The framework uses these defaults:
+
+| Resource Type    | Failures to Open | Reset Timeout (s) |
+|------------------|-----------------|------------------|
+| Databases        | 3               | 30               |
+| External APIs    | 5               | 60               |
+| File Systems     | 2               | 15               |
+
+Use the CLI to run validations at any time:
+
+```bash
+poetry run entity-cli validate --config config/dev.yaml
+```
+
+This command executes Phases&nbsp;1 and&nbsp;2 and reports any problems before the pipeline starts.
+
+## Tuning Circuit Breaker Thresholds
+
+You can override defaults in your configuration:
+
+```yaml
+plugins:
+  - db:
+      type: Postgres
+      failure_threshold: 5
+      failure_reset_timeout: 120
+      init_failure_threshold: 2
+```
+
+Lower thresholds provide rapid feedback during development. Production deployments typically use higher limits.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,11 @@
+# Entity Documentation
+
+Welcome to the Entity pipeline framework documentation.
+
+```{toctree}
+:maxdepth: 2
+:hidden:
+error_handling
+```
+
+The following pages cover core concepts and usage patterns.

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -6,11 +6,8 @@ from typing import Any, Dict, List
 from datetime import datetime
 import json
 import inspect
-import asyncio
 
 from .base import AgentResource
-from .interfaces.database import DatabaseResource as DatabaseInterface
-from .interfaces.vector_store import VectorStoreResource as VectorStoreInterface
 from ..core.plugins import ValidationResult
 from ..core.state import ConversationEntry
 

--- a/tests/test_infrastructure_validate_runtime.py
+++ b/tests/test_infrastructure_validate_runtime.py
@@ -1,7 +1,6 @@
 import pytest
 
 from entity.infrastructure import DuckDBInfrastructure, PostgresInfrastructure
-from pipeline.exceptions import CircuitBreakerTripped
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -3,7 +3,7 @@ import pytest
 
 from contextlib import asynccontextmanager
 from entity.core.context import PluginContext
-from entity.core.state import ConversationEntry, PipelineState
+from entity.core.state import PipelineState
 from entity.resources import Memory
 from entity.resources.interfaces.database import DatabaseResource
 from entity.resources.interfaces.vector_store import VectorStoreResource


### PR DESCRIPTION
## Summary
- restore minimal Sphinx configuration
- document validation phases and circuit breaker tuning
- expose docs via Sphinx index
- update automated notes

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(failed: Found 165 errors)*
- `poetry run mypy src` *(failed: Found 206 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(failed: command not found)*
- `poetry run unimport --remove-all src tests` *(failed: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: ImportError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: ImportError)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ImportError)*
- `pytest tests/test_architecture/ -v` *(failed: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(failed: Unknown config option)*
- `pytest tests/test_resources/ -v` *(failed: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_68729ad9d8a483229b7592ce375f0a60