### PR TITLE
Add CLI YAML workflow loading

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added workflow YAML support with CLI test
 AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test
 AGENT NOTE - 2025-07-12: Updated Memory tests with database backend
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -100,12 +100,12 @@ class EntityCLI:
         create.add_argument("workflow_name")
         create.add_argument("--out", default="src/workflows")
         validate = wf_sub.add_parser(
-            "validate", help="Validate a workflow module or YAML config"
+            "validate", help="Validate a workflow module or YAML file"
         )
         validate.add_argument("file", help="Workflow .py or .yaml file")
         visualize = wf_sub.add_parser(
             "visualize",
-            help="Visualize workflow from module or YAML config",
+            help="Visualize workflow from module or YAML file",
         )
         visualize.add_argument("file", help="Workflow .py or .yaml file")
         visualize.add_argument(
@@ -407,15 +407,17 @@ class EntityCLI:
 
     def _load_workflow(self, path: str) -> Optional[dict]:
         p = Path(path)
-        if p.suffix in {".yaml", ".yml"}:
+        if p.suffix.lower() in {".yaml", ".yml"}:
             try:
                 data = yaml.safe_load(p.read_text()) or {}
             except Exception as exc:  # noqa: BLE001
                 logger.error("Cannot parse %s: %s", path, exc)
                 return None
+
             workflow = data.get("workflow")
             if isinstance(workflow, dict):
                 return workflow
+
             logger.error("No workflow mapping found in %s", path)
             return None
 

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -36,3 +36,31 @@ def test_visualize_workflow_yaml(tmp_path, capsys):
     cli._workflow_visualize(str(yaml_path), fmt="ascii")
     captured = capsys.readouterr().out.strip()
     assert "INPUT" in captured and "-> one" in captured
+
+
+class VisualCLI(EntityCLI):
+    def __init__(self, file_path: str) -> None:
+        self._file_path = file_path
+        super().__init__()
+
+    def _parse_args(self) -> CLIArgs:  # type: ignore[override]
+        return CLIArgs(
+            None,
+            None,
+            command="workflow",
+            workflow_cmd="visualize",
+            file=self._file_path,
+            fmt="ascii",
+        )
+
+
+def test_cli_visualize_command(tmp_path, capsys):
+    yaml_path = tmp_path / "wf.yaml"
+    yaml_path.write_text(
+        "workflow:\n  INPUT: ['one']\n  OUTPUT: ['two']\n",
+        encoding="utf-8",
+    )
+    cli = VisualCLI(str(yaml_path))
+    cli.run()
+    captured = capsys.readouterr().out.strip()
+    assert "INPUT" in captured and "-> one" in captured


### PR DESCRIPTION
## Summary
- update help text for workflow commands
- load workflow mapping from YAML files
- add CLI test demonstrating `workflow visualize`
- add agent note

## Testing
- `poetry run ruff check --fix src tests` *(fails: 165 errors)*
- `poetry run mypy src` *(fails: 206 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found: vulture)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found: unimport)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ImportError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ImportError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ImportError)*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option)*
- `pytest tests/test_resources/ -v` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_68729adb35448322bf75d9cd8901d8b0