### PR TITLE
Implement response termination control

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,5 @@ async def add(a: int, b: int) -> int:
 @agent.prompt
 async def final(ctx):
     result = await ctx.tool_use("add", a=2, b=2)
-    ctx.set_response(str(result))
+    ctx.say(str(result))
 ```

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Adopted Response Termination Control using say() for final output
 AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test
 AGENT NOTE - 2025-07-12: Updated Memory tests with database backend
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output

--- a/examples/advanced_agent/main.py
+++ b/examples/advanced_agent/main.py
@@ -48,7 +48,7 @@ class FinalResponder(PromptPlugin):
 
     async def _execute_impl(self, context: PluginContext) -> None:
         assistant = [e.content for e in context.conversation() if e.role == "assistant"]
-        context.set_response(assistant[-1] if assistant else "")
+        context.say(assistant[-1] if assistant else "")
 
 
 async def main() -> None:

--- a/examples/basic_agent/main.py
+++ b/examples/basic_agent/main.py
@@ -31,7 +31,7 @@ class EchoPrompt(PromptPlugin):
             if entry.role == "user":
                 last_message = entry.content
                 break
-        context.set_response(f"You said: {last_message}")
+        context.say(f"You said: {last_message}")
 
 
 async def main() -> None:

--- a/examples/duckdb_memory_agent/main.py
+++ b/examples/duckdb_memory_agent/main.py
@@ -98,7 +98,7 @@ class IncrementPrompt(PromptPlugin):
         memory: DuckDBMemory = context.get_resource("memory")  # type: ignore[assignment]
         count = memory.get("count", 0) + 1
         memory.remember("count", count)
-        context.set_response(f"Count: {count}")
+        context.say(f"Count: {count}")
 
 
 async def main() -> None:

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -46,7 +46,7 @@ class FinalResponder(PromptPlugin):
         assistant_messages = [
             e.content for e in context.conversation() if e.role == "assistant"
         ]
-        context.set_response(assistant_messages[-1] if assistant_messages else "")
+        context.say(assistant_messages[-1] if assistant_messages else "")
 
 
 async def main() -> None:

--- a/examples/zero_config_agent/main.py
+++ b/examples/zero_config_agent/main.py
@@ -15,7 +15,7 @@ async def add(a: int, b: int) -> int:
 async def responder(ctx):
     user = next((e.content for e in ctx.conversation() if e.role == "user"), "")
     result = await ctx.tool_use("add", a=2, b=2)
-    ctx.set_response(f"{user} -> {result}")
+    ctx.say(f"{user} -> {result}")
 
 
 async def main() -> None:

--- a/src/entity/plugins/prompts/chain_of_thought.py
+++ b/src/entity/plugins/prompts/chain_of_thought.py
@@ -20,10 +20,7 @@ class ChainOfThoughtPrompt(PromptPlugin):
         breakdown = await self.call_llm(
             context, breakdown_prompt, purpose="problem_breakdown"
         )
-        context.say(
-            f"Problem breakdown: {breakdown.content}",
-            metadata={"reasoning_step": "breakdown"},
-        )
+        context.think("problem_breakdown", breakdown.content)
 
         steps: List[str] = []
         for step in range(int(self.config.get("max_steps", 5))):
@@ -34,10 +31,7 @@ class ChainOfThoughtPrompt(PromptPlugin):
                 context, reasoning_prompt, purpose=f"reasoning_step_{step + 1}"
             )
             steps.append(reasoning.content)
-            context.say(
-                f"Reasoning step {step + 1}: {reasoning.content}",
-                metadata={"reasoning_step": step + 1},
-            )
+            context.think(f"reasoning_step_{step + 1}", reasoning.content)
 
             if self._needs_tools(reasoning.content):
                 await context.tool_use(

--- a/src/entity/plugins/prompts/react.py
+++ b/src/entity/plugins/prompts/react.py
@@ -31,10 +31,7 @@ class ReActPrompt(PromptPlugin):
             thought = await self.call_llm(
                 context, thought_prompt, purpose=f"react_thought_step_{step}"
             )
-            context.say(
-                f"Thought: {thought.content}",
-                metadata={"react_step": step, "type": "thought"},
-            )
+            context.think(f"thought_{step}", thought.content)
             step_record: Dict[str, str] = {"thought": thought.content}
 
             action_prompt = (
@@ -50,7 +47,7 @@ class ReActPrompt(PromptPlugin):
 
             if decision.content.startswith("Final Answer:"):
                 answer = decision.content.replace("Final Answer:", "").strip()
-                context.set_response(answer)
+                context.think("final_answer", answer)
                 steps.append(step_record)
                 context.store("react_steps", steps)
                 return
@@ -59,16 +56,14 @@ class ReActPrompt(PromptPlugin):
                 action_text = decision.content.replace("Action:", "").strip()
                 action_name, params = self._parse_action(action_text)
                 step_record["action"] = action_text
-                context.say(
-                    f"Action: {action_text}",
-                    metadata={"react_step": step, "type": "action"},
-                )
+                context.think(f"action_{step}", action_text)
                 await context.tool_use(action_name, **params)
 
             steps.append(step_record)
 
-        context.set_response(
-            "I've reached my reasoning limit without finding a definitive answer."
+        context.think(
+            "final_answer",
+            "I've reached my reasoning limit without finding a definitive answer.",
         )
         context.store("react_steps", steps)
 

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -286,14 +286,11 @@ async def execute_pipeline(
                                 "iteration": state.iteration,
                             },
                         )
-                    if state.failure_info:
+                    if state.failure_info or state.response is not None:
                         break
                     state.last_completed_stage = stage
 
-                if (
-                    state.response is not None
-                    and state.last_completed_stage == PipelineStage.OUTPUT
-                ):
+                if state.response is not None:
                     break
 
                 if state.failure_info is not None or state.iteration >= max_iterations:
@@ -306,7 +303,9 @@ async def execute_pipeline(
                             stage="iteration_guard",
                             plugin_name="pipeline",
                             error_type="max_iterations",
-                            error_message=f"Reached {max_iterations} iterations",
+                            error_message=(
+                                f"No OUTPUT plugin responded after {max_iterations} iterations"
+                            ),
                             original_exception=RuntimeError(
                                 "max iteration limit reached"
                             ),

--- a/tests/test_response_control.py
+++ b/tests/test_response_control.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path("src").resolve()))
+import pytest
+
+from entity.core.context import PluginContext
+from entity.core.plugins import PromptPlugin
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.state import ConversationEntry, PipelineState
+from pipeline.stages import PipelineStage
+from pipeline.pipeline import execute_pipeline
+from pipeline.errors import PluginContextError
+
+
+class DummyRegs:
+    def __init__(self) -> None:
+        self.resources = {}
+        self.tools = ToolRegistry()
+
+
+def make_context(stage: PipelineStage) -> PluginContext:
+    state = PipelineState(conversation=[])
+    ctx = PluginContext(state, DummyRegs())
+    ctx.set_current_stage(stage)
+    ctx.set_current_plugin("test")
+    return ctx
+
+
+def test_say_only_output_stage() -> None:
+    ctx = make_context(PipelineStage.THINK)
+    with pytest.raises(PluginContextError):
+        ctx.say("hi")
+
+
+class Thinker(PromptPlugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        context.think("data", "x")
+
+
+class Responder(PromptPlugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        val = context.reflect("data")
+        context.say(f"final:{val}")
+
+
+class SilentOutput(PromptPlugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_pipeline_terminates_after_say() -> None:
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(Thinker({}), PipelineStage.THINK, "t")
+    await plugins.register_plugin_for_stage(Responder({}), PipelineStage.OUTPUT, "r")
+    regs = SystemRegistries(resources={}, tools=ToolRegistry(), plugins=plugins)
+    state = PipelineState(
+        conversation=[ConversationEntry("hi", "user", datetime.now())],
+        pipeline_id="test",
+    )
+    result = await execute_pipeline("hi", regs, state=state)
+    assert result == "final:x"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_max_iteration_error() -> None:
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(Thinker({}), PipelineStage.THINK, "t")
+    await plugins.register_plugin_for_stage(SilentOutput({}), PipelineStage.OUTPUT, "o")
+    regs = SystemRegistries(resources={}, tools=ToolRegistry(), plugins=plugins)
+    state = PipelineState(
+        conversation=[ConversationEntry("hi", "user", datetime.now())],
+        pipeline_id="pid",
+    )
+    await execute_pipeline("hi", regs, state=state, max_iterations=2)
+    assert state.failure_info and state.failure_info.error_type == "max_iterations"


### PR DESCRIPTION
## Summary
- enforce OUTPUT-only `say()` for final response
- add `think()` and `reflect()` helpers
- update reasoning plugins for new helpers
- revise example responders to call `say()`
- include regression tests for response control
- log adoption of new termination model

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: too many errors)*
- `poetry run mypy src` *(fails: 206 errors)*
- `poetry run bandit -r src` *(command not found)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: ModuleNotFoundError: No module named 'entity')*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: ModuleNotFoundError: No module named 'entity')*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/test_architecture/ -v` *(no tests found)*
- `pytest tests/test_plugins/ -v` *(no tests found)*
- `pytest tests/test_resources/ -v` *(no tests found)*
- `pytest tests/test_response_control.py -v` *(failed: ModuleNotFoundError: No module named 'entity')*


------
https://chatgpt.com/codex/tasks/task_e_68729b40e1088322ace857d13aebf46d