### PR TITLE
Implement async think/reflect in plugins

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Replaced store/load with async think/reflect and updated templates
 AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test
 AGENT NOTE - 2025-07-12: Updated Memory tests with database backend
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output

--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -19,7 +19,6 @@ class {class_name}(AdapterPlugin):
     # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
-        if context.has("response"):
-            await context.advanced.queue_tool_use(
-                "send", {"text": context.load("response")}
-            )
+        response = await context.reflect("response")
+        if response is not None:
+            await context.advanced.queue_tool_use("send", {"text": response})

--- a/src/cli/templates/prompt.py
+++ b/src/cli/templates/prompt.py
@@ -19,10 +19,11 @@ class {class_name}(PromptPlugin):
     # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
-        if context.has("answer"):
-            context.say(context.load("answer"))
+        existing = await context.reflect("answer")
+        if existing is not None:
+            context.say(existing)
             return
 
         result = await context.tool_use("some_tool", query=context.message)
-        context.store("answer", result)
+        await context.think("answer", result)
         context.say(result)

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -240,9 +240,17 @@ class PluginContext:
             del self._state.stage_results[oldest]
         self._state.stage_results[key] = value
 
+    async def think(self, key: str, value: Any) -> None:
+        """Async wrapper around :meth:`store`."""
+        self.store(key, value)
+
     def load(self, key: str, default: Any | None = None) -> Any:
         """Retrieve a stored value."""
         return self._state.stage_results.get(key, default)
+
+    async def reflect(self, key: str, default: Any | None = None) -> Any:
+        """Async wrapper around :meth:`load`."""
+        return self.load(key, default)
 
     def has(self, key: str) -> bool:
         """Return ``True`` if ``key`` exists in stage results."""

--- a/src/entity/plugins/prompts/chain_of_thought.py
+++ b/src/entity/plugins/prompts/chain_of_thought.py
@@ -49,8 +49,8 @@ class ChainOfThoughtPrompt(PromptPlugin):
             if "final answer" in reasoning.content.lower():
                 break
 
-        context.store("reasoning_complete", True)
-        context.store("reasoning_steps", steps)
+        await context.think("reasoning_complete", True)
+        await context.think("reasoning_steps", steps)
 
     def _needs_tools(self, reasoning_text: str) -> bool:
         indicators = ["need to calculate", "should look up", "requires analysis"]

--- a/src/entity/plugins/prompts/react.py
+++ b/src/entity/plugins/prompts/react.py
@@ -52,7 +52,7 @@ class ReActPrompt(PromptPlugin):
                 answer = decision.content.replace("Final Answer:", "").strip()
                 context.set_response(answer)
                 steps.append(step_record)
-                context.store("react_steps", steps)
+                await context.think("react_steps", steps)
                 return
 
             if decision.content.startswith("Action:"):
@@ -70,7 +70,7 @@ class ReActPrompt(PromptPlugin):
         context.set_response(
             "I've reached my reasoning limit without finding a definitive answer."
         )
-        context.store("react_steps", steps)
+        await context.think("react_steps", steps)
 
     def _build_step_context(
         self, conversation: List[ConversationEntry], question: str

--- a/src/pipeline/tools/execution.py
+++ b/src/pipeline/tools/execution.py
@@ -28,7 +28,7 @@ async def execute_pending_tools(
         async with sem:
             result = await tool.execute_function(call.params)
         results[call.result_key] = result
-        context.store(call.result_key, result)
+        await context.think(call.result_key, result)
 
     await asyncio.gather(*(run_call(c) for c in list(state.pending_tool_calls)))
     return results


### PR DESCRIPTION
## Summary
- add `think` and `reflect` async helpers to `PluginContext`
- adapt prompt plugins to use `await context.think`
- update pipeline tool execution logic
- refresh CLI templates to demonstrate new helpers
- record agent note

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 160 remaining errors)*
- `poetry run mypy src` *(fails: Found 206 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ImportError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ImportError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ImportError)*
- `pytest tests/test_architecture/ -v` *(fails: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(fails: Unknown config option)*
- `pytest tests/test_resources/ -v` *(fails: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_68729b4763c08322b3abe39dc170831b