### PR TITLE
Update README with mise setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,11 @@ async def final(ctx):
     result = await ctx.tool_use("add", a=2, b=2)
     ctx.set_response(str(result))
 ```
+## Development Environment Setup
+
+This project uses `mise` for Python version management. The `.python-version` file specifies the required interpreter. The `.mise.toml` config explicitly enables this file so future `mise` releases won't warn about idiomatic version files. After installing `mise`, run:
+
+```bash
+mise install
+```
+

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Documented mise setup in README
 AGENT NOTE - 2025-07-12: Added temporary DuckDB-based Memory fixture in tests
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 


### PR DESCRIPTION
## Summary
- document mise usage under Development Environment Setup
- log new development note in agents.log

## Testing
- `poetry run black README.md` *(fails: cannot parse)*
- `poetry run black src tests` *(fails: 1 file failed to reformat)*
- `poetry run ruff check --fix src tests` *(fails with 156 errors)*
- `poetry run mypy src` *(fails: syntax error in memory.py)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ImportError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ImportError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ImportError)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68729b68f0488322acfa913fd23d91eb