### PR TITLE
Update Memory initialization

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1048,14 +1048,14 @@ Pipeline Execution 2:
 - `Memory` class provides advanced technical interface for complex operations
 - Serves as backend for PluginContext anthropomorphic methods (`remember()`, `recall()`, `think()`, `say()`)
 - Core conversation methods `save_conversation()` and `load_conversation()` handle external conversation persistence
-- Required database and vector_store backends for durable persistence and similarity search
+- Requires a database backend for persistence; optionally uses a vector_store for similarity search
 - Replaces SimpleMemoryResource, MemoryResource, ConversationManager, and Memory interface
 - **External persistence guarantee**: All data persisted to database/storage, never held in Memory resource instance variables
 
 **External Persistence Architecture with Post-Construction Dependency Injection**:
 ```python
 class Memory(ResourcePlugin):
-    dependencies = ["database", "vector_store"]
+    dependencies = ["database", "vector_store?"]
     
     def __init__(self, config: Dict | None = None):
         super().__init__(config or {})
@@ -1069,8 +1069,6 @@ class Memory(ResourcePlugin):
         # Validation that required dependencies were injected
         if self.database is None:
             raise ResourceInitializationError("Database dependency not injected")
-        if self.vector_store is None:
-            raise ResourceInitializationError("VectorStore dependency not injected")
     
     # Advanced technical interface for complex operations
     async def query(self, sql: str, params: list = None) -> List[Dict]:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ plugins:
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
-      dependencies: [database, vector_store]
+      dependencies: [database, vector_store?]
 ```
 
 See the [Quick Start](docs/source/quick_start.md) for step-by-step setup or browse the [full documentation](https://entity.readthedocs.io/en/latest/).

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Memory depends on database; vector_store optional
 AGENT NOTE - 2025-07-12: Updated Memory tests with database backend
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -37,7 +37,7 @@ plugins:
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
-      dependencies: [database]
+      dependencies: [database, vector_store?]
     # filesystem:
     #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
     #   bucket: agent-files

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -38,7 +38,7 @@ plugins:
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
-      dependencies: [database]
+      dependencies: [database, vector_store?]
     # filesystem:
     #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
     #   bucket: agent-files

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -25,7 +25,7 @@ plugins:
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
-      dependencies: [database]
+      dependencies: [database, vector_store?]
     # storage:
     #   type: plugins.builtin.resources.storage_resource:StorageResource
   custom_resources: {}

--- a/src/pipeline/errors.py
+++ b/src/pipeline/errors.py
@@ -39,6 +39,10 @@ class ResourceError(PipelineError):
     pass
 
 
+class ResourceInitializationError(ResourceError):
+    """Raised when a resource is missing required dependencies."""
+
+
 class ToolExecutionError(PipelineError):
     pass
 
@@ -108,6 +112,7 @@ __all__ = [
     "PluginContextError",
     "PluginExecutionError",
     "ResourceError",
+    "ResourceInitializationError",
     "StageExecutionError",
     "ToolExecutionError",
     "ErrorResponse",


### PR DESCRIPTION
## Summary
- make vector store optional for Memory
- validate database injection on Memory initialization
- document the new requirement
- update configs to include optional vector_store dependency

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(failed: Command not found)*
- `poetry run unimport --remove-all src tests` *(failed: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed to run)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed to run)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `pytest tests/test_architecture/ -v` *(failed: Unknown config option)*
- `pytest tests/test_plugins/ -v` *(failed: Unknown config option)*
- `pytest tests/test_resources/ -v` *(failed: Unknown config option)*

------
https://chatgpt.com/codex/tasks/task_e_687298b2e6f08322afd499c2cd673cd7