### PR TITLE
Add context think/reflect helpers

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-12: Removed deprecated store/load helpers
+AGENT NOTE - 2025-07-12: Introduced think()/reflect() helpers
 AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test
 AGENT NOTE - 2025-07-12: Updated Memory tests with database backend
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output

--- a/src/cli/templates/adapter.py
+++ b/src/cli/templates/adapter.py
@@ -19,7 +19,7 @@ class {class_name}(AdapterPlugin):
     # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
-        if context.has("response"):
+        if await context.reflect("response") is not None:
             await context.advanced.queue_tool_use(
-                "send", {"text": context.load("response")}
+                "send", {"text": await context.reflect("response")}
             )

--- a/src/cli/templates/failure.py
+++ b/src/cli/templates/failure.py
@@ -19,4 +19,4 @@ class {class_name}(FailurePlugin):
     # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
-        context.store("failure_info", context.failure_info)
+        await context.think("failure_info", context.failure_info)

--- a/src/cli/templates/prompt.py
+++ b/src/cli/templates/prompt.py
@@ -19,10 +19,10 @@ class {class_name}(PromptPlugin):
     # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
-        if context.has("answer"):
-            context.say(context.load("answer"))
+        if await context.reflect("answer") is not None:
+            context.say(await context.reflect("answer"))
             return
 
         result = await context.tool_use("some_tool", query=context.message)
-        context.store("answer", result)
+        await context.think("answer", result)
         context.say(result)

--- a/src/entity/plugins/prompts/chain_of_thought.py
+++ b/src/entity/plugins/prompts/chain_of_thought.py
@@ -49,8 +49,8 @@ class ChainOfThoughtPrompt(PromptPlugin):
             if "final answer" in reasoning.content.lower():
                 break
 
-        context.store("reasoning_complete", True)
-        context.store("reasoning_steps", steps)
+        await context.think("reasoning_complete", True)
+        await context.think("reasoning_steps", steps)
 
     def _needs_tools(self, reasoning_text: str) -> bool:
         indicators = ["need to calculate", "should look up", "requires analysis"]

--- a/src/entity/plugins/prompts/react.py
+++ b/src/entity/plugins/prompts/react.py
@@ -52,7 +52,7 @@ class ReActPrompt(PromptPlugin):
                 answer = decision.content.replace("Final Answer:", "").strip()
                 context.set_response(answer)
                 steps.append(step_record)
-                context.store("react_steps", steps)
+                await context.think("react_steps", steps)
                 return
 
             if decision.content.startswith("Action:"):
@@ -70,7 +70,7 @@ class ReActPrompt(PromptPlugin):
         context.set_response(
             "I've reached my reasoning limit without finding a definitive answer."
         )
-        context.store("react_steps", steps)
+        await context.think("react_steps", steps)
 
     def _build_step_context(
         self, conversation: List[ConversationEntry], question: str

--- a/src/pipeline/tools/execution.py
+++ b/src/pipeline/tools/execution.py
@@ -28,7 +28,7 @@ async def execute_pending_tools(
         async with sem:
             result = await tool.execute_function(call.params)
         results[call.result_key] = result
-        context.store(call.result_key, result)
+        await context.think(call.result_key, result)
 
     await asyncio.gather(*(run_call(c) for c in list(state.pending_tool_calls)))
     return results

--- a/user_plugins/prompts/chain_of_thought.py
+++ b/user_plugins/prompts/chain_of_thought.py
@@ -54,8 +54,8 @@ class ChainOfThoughtPrompt(PromptPlugin):
             if "final answer" in reasoning.content.lower():
                 break
 
-        context.store("reasoning_complete", True)
-        context.store("reasoning_steps", reasoning_steps)
+        await context.think("reasoning_complete", True)
+        await context.think("reasoning_steps", reasoning_steps)
 
     def _needs_tools(self, reasoning_text: str) -> bool:
         """Return True if ``reasoning_text`` suggests tool usage."""

--- a/user_plugins/prompts/intent_classifier.py
+++ b/user_plugins/prompts/intent_classifier.py
@@ -35,4 +35,4 @@ class IntentClassifierPrompt(PromptPlugin):
         last_message = context.conversation()[-1].content
         prompt = "Classify the user's intent in one word.\n" f"Message: {last_message}"
         response = await self.call_llm(context, prompt, purpose="intent_classification")
-        context.store("intent", response.content)
+        await context.think("intent", response.content)


### PR DESCRIPTION
## Summary
- add async `think`, `reflect` and `clear_thoughts` helpers
- deprecate `store` and `load`
- update templates and plugins to use new helpers
- record helper introduction in agents log

## Testing
- `poetry run black src tests user_plugins`
- `poetry run ruff check --fix src/entity/core/context.py src/entity/plugins/prompts/chain_of_thought.py src/entity/plugins/prompts/react.py src/pipeline/tools/execution.py user_plugins/prompts/intent_classifier.py user_plugins/prompts/chain_of_thought.py`
- `poetry run mypy src/entity/core/context.py src/entity/plugins/prompts/chain_of_thought.py src/entity/plugins/prompts/react.py src/pipeline/tools/execution.py user_plugins/prompts/intent_classifier.py user_plugins/prompts/chain_of_thought.py`
- `pytest -q` *(fails: Unknown config option: asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_68729b461bdc8322bfe697e3f79bf4b7