### PR TITLE
Document optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ plugins:
       dependencies: [database, vector_store]
 ```
 
+To make a dependency optional, append `?` to its name, e.g. `vector_store?`. Optional dependencies aren't validated during initialization and will be `None` if not configured.
+
 See the [Quick Start](docs/source/quick_start.md) for step-by-step setup or browse the [full documentation](https://entity.readthedocs.io/en/latest/).
 
 ### Stateless Workers (Decision 6)

--- a/agents.log
+++ b/agents.log
@@ -1,6 +1,8 @@
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 
+AGENT NOTE - 2025-07-12: Documented optional dependencies marked with `?`
+
 AGENT NOTE - 2025-07-12: Simplified plugin analysis output
 
 AGENT NOTE - 2025-07-12: Added get_memory/get_storage helpers and updated docs

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -13,7 +13,6 @@ from .interfaces.vector_store import (
 )
 from ..core.plugins import ValidationResult
 from ..core.state import ConversationEntry
-from pipeline.errors import InitializationError
 
 
 class Memory(AgentResource):

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
 
-from contextlib import asynccontextmanager
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
 from entity.resources import Memory


### PR DESCRIPTION
## Summary
- document optional dependency syntax with `?`
- note that optional dependencies aren't validated on init

## Testing
- `poetry run black . --check`
- `poetry run ruff check --fix src tests` *(fails: 190 errors)*
- `poetry run mypy src` *(fails: 213 errors)*
- `poetry run bandit -r src` *(fails: command not found)*
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872a0d3c4808322ad3b1ef9daf5f85c