### PR TITLE
Refactor Memory resource injection

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated Memory resource for DI and adjusted examples/tests
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 

--- a/examples/advanced_agent/main.py
+++ b/examples/advanced_agent/main.py
@@ -54,7 +54,8 @@ class FinalResponder(PromptPlugin):
 async def main() -> None:
     resources = ResourceContainer()
     db = DuckDBInfrastructure({"path": "./agent.duckdb"})
-    memory = Memory(database=db)
+    memory = Memory(config={})
+    memory.database = db
     await db.initialize()
     await resources.add("database", db)
     await resources.add("memory", memory)

--- a/examples/basic_agent/main.py
+++ b/examples/basic_agent/main.py
@@ -40,7 +40,8 @@ async def main() -> None:
 
     resources = ResourceContainer()
     db = DuckDBInfrastructure({"path": "./agent.duckdb"})
-    memory = Memory(database=db)
+    memory = Memory(config={})
+    memory.database = db
     await db.initialize()
     await resources.add("database", db)
     await resources.add("memory", memory)

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -52,7 +52,8 @@ class FinalResponder(PromptPlugin):
 async def main() -> None:
     resources = ResourceContainer()
     db = DuckDBInfrastructure({"path": "./agent.duckdb"})
-    memory = Memory(database=db)
+    memory = Memory(config={})
+    memory.database = db
     await db.initialize()
     await resources.add("database", db)
     await resources.add("memory", memory)

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -111,7 +111,9 @@ class DBRegistries:
             async def __aexit__(self, exc_type, exc, tb):
                 return False
 
-        self.resources = _Resources(memory=Memory(database=db, config={}))
+        mem = Memory(config={})
+        mem.database = db
+        self.resources = _Resources(memory=mem)
         self.tools = types.SimpleNamespace()
         self.validators = None
 

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
 
-from contextlib import asynccontextmanager
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
 from entity.resources import Memory

--- a/tests/test_stateless_worker.py
+++ b/tests/test_stateless_worker.py
@@ -49,7 +49,9 @@ class DummyDatabase(DatabaseResource):
 
 class DummyRegistries:
     def __init__(self, db: DummyDatabase) -> None:
-        self.resources = {"memory": Memory(database=db, config={})}
+        mem = Memory(config={})
+        mem.database = db
+        self.resources = {"memory": mem}
         self.tools = types.SimpleNamespace()
 
 


### PR DESCRIPTION
## Summary
- refactor `Memory` so dependencies are injected later
- update tests and examples to set `database` manually
- log update in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src` *(fails: Argument 2 to "register_plugin_for_stage" has incompatible type "PipelineStage"; expected "str" etc.)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: syntax errors in templates)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(runtime warning)*
- `poetry run entity-cli --config config/prod.yaml verify` *(runtime warning)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ImportError due to circular import)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872a1760754832282032d74bf931cf7