### PR TITLE
Add advanced memory operations

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Added advanced memory methods with database and vector store calls
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List
 import json
 
@@ -53,21 +53,11 @@ class Memory(AgentResource):
     # ------------------------------------------------------------------
     # Key-value helpers
     # ------------------------------------------------------------------
-    def get(self, key: str, default: Any | None = None) -> Any:
-        if self._pool is None:
-            return default
-        row = self._pool.execute(
-            f"SELECT value FROM {self._kv_table} WHERE key = ?", (key,)
-        ).fetchone()
-        return json.loads(row[0]) if row else default
+    async def get(self, key: str, default: Any | None = None) -> Any:
+        return await self.fetch_persistent(key, default)
 
-    def set(self, key: str, value: Any) -> None:
-        if self._pool is None:
-            return
-        self._pool.execute(
-            f"INSERT OR REPLACE INTO {self._kv_table} VALUES (?, ?)",
-            (key, json.dumps(value)),
-        )
+    async def set(self, key: str, value: Any) -> None:
+        await self.store_persistent(key, value)
 
     remember = set
 
@@ -128,12 +118,146 @@ class Memory(AgentResource):
             await self.vector_store.add_embedding(text)
 
     async def search_similar(self, text: str, k: int = 5) -> List[str]:
-        if self.vector_store is None:
-            return []
-        return await self.vector_store.query_similar(text, k)
+        return await self.vector_search(text, k)
 
     @classmethod
     async def validate_config(
         cls, config: Dict[str, Any]
     ) -> ValidationResult:  # noqa: D401
         return ValidationResult.success_result()
+
+    # ------------------------------------------------------------------
+    # Advanced operations
+    # ------------------------------------------------------------------
+
+    async def query(self, sql: str, params: List | None = None) -> List[Dict[str, Any]]:
+        """Execute ``sql`` using the injected database."""
+        if self._pool is None:
+            raise InitializationError("Database dependency not injected")
+
+        cursor = self._pool.execute(sql, params or [])
+        columns = [d[0] for d in cursor.description]
+        return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+    async def vector_search(self, query: str, k: int = 5) -> List[str]:
+        """Delegate semantic search to the vector store."""
+        if self.vector_store is None:
+            return []
+        return await self.vector_store.query_similar(query, k)
+
+    async def batch_store(self, key_value_pairs: Dict[str, Any]) -> None:
+        """Store multiple key/value pairs efficiently."""
+        if self._pool is None:
+            return
+        rows = [(key, json.dumps(value)) for key, value in key_value_pairs.items()]
+        self._pool.executemany(
+            f"INSERT OR REPLACE INTO {self._kv_table} VALUES (?, ?)", rows
+        )
+
+    async def store_persistent(self, key: str, value: Any) -> None:
+        """Persist ``value`` under ``key``."""
+        if self._pool is None:
+            return
+        self._pool.execute(
+            f"INSERT OR REPLACE INTO {self._kv_table} VALUES (?, ?)",
+            (key, json.dumps(value)),
+        )
+
+    async def fetch_persistent(self, key: str, default: Any = None) -> Any:
+        """Retrieve a persisted value."""
+        if self._pool is None:
+            return default
+        row = self._pool.execute(
+            f"SELECT value FROM {self._kv_table} WHERE key = ?",
+            (key,),
+        ).fetchone()
+        return json.loads(row[0]) if row else default
+
+    async def delete_persistent(self, key: str) -> None:
+        """Remove ``key`` from persistent storage."""
+        if self._pool is None:
+            return
+        self._pool.execute(
+            f"DELETE FROM {self._kv_table} WHERE key = ?",
+            (key,),
+        )
+
+    async def add_conversation_entry(
+        self, conversation_id: str, entry: ConversationEntry
+    ) -> None:
+        """Append a single entry to ``conversation_id``."""
+        if self._pool is None:
+            return
+        self._pool.execute(
+            f"INSERT INTO {self._history_table} VALUES (?, ?, ?, ?, ?)",
+            (
+                conversation_id,
+                entry.role,
+                entry.content,
+                json.dumps(entry.metadata),
+                entry.timestamp.isoformat(),
+            ),
+        )
+
+    async def conversation_search(
+        self, query: str, user_id: str | None = None, days: int | None = None
+    ) -> List[Dict[str, Any]]:
+        """Search conversation history using simple text matching."""
+        if self._pool is None:
+            return []
+
+        sql = (
+            f"SELECT conversation_id, role, content, metadata, timestamp "
+            f"FROM {self._history_table}"
+        )
+        clauses = []
+        params: List[Any] = []
+        if user_id:
+            clauses.append("conversation_id LIKE ?")
+            params.append(f"{user_id}%")
+        if days is not None:
+            since = (datetime.now() - timedelta(days=days)).isoformat()
+            clauses.append("timestamp >= ?")
+            params.append(since)
+        if query:
+            clauses.append("content LIKE ?")
+            params.append(f"%{query}%")
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY timestamp DESC"
+
+        rows = self._pool.execute(sql, params).fetchall()
+        return [
+            {
+                "conversation_id": row[0],
+                "role": row[1],
+                "content": row[2],
+                "metadata": json.loads(row[3]) if row[3] else {},
+                "timestamp": row[4],
+            }
+            for row in rows
+        ]
+
+    async def conversation_statistics(self, user_id: str) -> Dict[str, Any]:
+        """Return simple statistics for a user's conversations."""
+        if self._pool is None:
+            return {}
+        conv_rows = self._pool.execute(
+            f"SELECT DISTINCT conversation_id FROM {self._history_table} "
+            "WHERE conversation_id LIKE ?",
+            (f"{user_id}%",),
+        ).fetchall()
+        total_messages = self._pool.execute(
+            f"SELECT COUNT(*) FROM {self._history_table} WHERE conversation_id LIKE ?",
+            (f"{user_id}%",),
+        ).fetchone()[0]
+        return {
+            "conversations": len(conv_rows),
+            "messages": total_messages,
+        }
+
+    # ------------------------------------------------------------------
+    # Backwards compatibility
+    # ------------------------------------------------------------------
+
+    remember = store_persistent


### PR DESCRIPTION
## Summary
- update Memory resource with advanced database/vector store helpers
- add conversation search & statistics helpers
- note update in agents log

## Testing
- `poetry run black src/entity/resources/memory.py`
- `poetry run ruff check --fix src/entity/resources/memory.py`
- `poetry run mypy src` *(fails: ModuleNotFoundError)*
- `poetry run bandit -r src` *(command not found)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(not run due to previous failure)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872a176a4c08322906434a6da32c272