### PR TITLE
Switch to persistent memory API

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-12: Updated persistent memory helpers to new API
+
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
 
-from contextlib import asynccontextmanager
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
 from entity.resources import Memory


### PR DESCRIPTION
## Summary
- add persistent memory helpers to `Memory`
- route `AdvancedContext` memory helpers to new API
- update deprecated helpers in `PluginContext`
- clean up test import
- log helper note

## Testing
- `poetry run ruff check --fix src tests` *(fails: 192 errors)*
- `poetry run mypy src` *(fails: 213 errors)*
- `poetry run bandit -r src` *(command not found)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed to run)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed to run)*
- `poetry run python -m src.entity.core.registry_validator` *(failed to run)*
- `pytest tests/test_architecture/ -v` *(failed to run)*
- `pytest tests/test_plugins/ -v` *(failed to run)*
- `pytest tests/test_resources/ -v` *(failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_6872a1782e908322a1261600519e06be