### PR TITLE
Add tests for Memory.initialize dependency checks

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-12: Added Memory initialization error tests
+
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -13,7 +13,7 @@ from .interfaces.vector_store import (
 )
 from ..core.plugins import ValidationResult
 from ..core.state import ConversationEntry
-from pipeline.errors import InitializationError
+from pipeline.errors import ResourceInitializationError
 
 
 class Memory(AgentResource):
@@ -36,16 +36,19 @@ class Memory(AgentResource):
         self._history_table = self.config.get("history_table", "conversation_history")
 
     async def initialize(self) -> None:
-        if self.database is not None:
-            self._pool = self.database.get_connection_pool()
-            async with self.database.connection() as conn:
-                conn.execute(
-                    f"CREATE TABLE IF NOT EXISTS {self._kv_table} (key TEXT PRIMARY KEY, value TEXT)"
-                )
-                conn.execute(
-                    f"CREATE TABLE IF NOT EXISTS {self._history_table} ("
-                    "conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
-                )
+        if self.database is None:
+            raise ResourceInitializationError("Database dependency not injected")
+        if self.vector_store is None:
+            raise ResourceInitializationError("VectorStore dependency not injected")
+        self._pool = self.database.get_connection_pool()
+        async with self.database.connection() as conn:
+            conn.execute(
+                f"CREATE TABLE IF NOT EXISTS {self._kv_table} (key TEXT PRIMARY KEY, value TEXT)"
+            )
+            conn.execute(
+                f"CREATE TABLE IF NOT EXISTS {self._history_table} ("
+                "conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
+            )
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None

--- a/src/pipeline/errors.py
+++ b/src/pipeline/errors.py
@@ -39,6 +39,12 @@ class ResourceError(PipelineError):
     pass
 
 
+class ResourceInitializationError(ResourceError):
+    """Raised when a resource fails to initialize."""
+
+    pass
+
+
 class InitializationError(PipelineError):
     """Raised when a plugin or resource fails to initialize."""
 
@@ -122,6 +128,7 @@ __all__ = [
     "PluginContextError",
     "PluginExecutionError",
     "ResourceError",
+    "ResourceInitializationError",
     "InitializationError",
     "StageExecutionError",
     "ToolExecutionError",

--- a/tests/test_resources/test_memory_init.py
+++ b/tests/test_resources/test_memory_init.py
@@ -1,0 +1,45 @@
+import pytest
+from entity.resources import Memory
+from entity.resources.interfaces.vector_store import VectorStoreResource
+from entity.resources.interfaces.database import DatabaseResource
+from pipeline.errors import ResourceInitializationError
+from contextlib import asynccontextmanager
+
+
+class DummyDB(DatabaseResource):
+    def get_connection_pool(self):
+        class _Pool:
+            def execute(self, *args, **kwargs):
+                pass
+
+        return _Pool()
+
+    @asynccontextmanager
+    async def connection(self):
+        yield self.get_connection_pool()
+
+
+class DummyVector(VectorStoreResource):
+    async def add_embedding(self, text: str) -> None:
+        return None
+
+    async def query_similar(self, query: str, k: int = 5):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_initialize_without_database_raises():
+    mem = Memory(config={})
+    mem.vector_store = DummyVector()
+
+    with pytest.raises(ResourceInitializationError, match="Database dependency"):
+        await mem.initialize()
+
+
+@pytest.mark.asyncio
+async def test_initialize_without_vector_store_raises():
+    mem = Memory(config={})
+    mem.database = DummyDB()
+
+    with pytest.raises(ResourceInitializationError, match="VectorStore dependency"):
+        await mem.initialize()


### PR DESCRIPTION
## Summary
- create ResourceInitializationError for missing dependencies
- validate Memory.initialize() for injected database and vector store
- add unit tests ensuring Memory.initialize() fails without dependencies
- log update in agents.log

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: Found 192 errors)*
- `poetry run mypy src` *(fails: Found 213 errors in 43 files)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(failed: ImportError)*
- `poetry run pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6872a17ef7f48322a71187a0b31511d2