### PR TITLE
Export resource interfaces

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Exported resource interfaces at package root
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -2,5 +2,15 @@ from .base import AgentResource, StandardResources
 from .llm import LLM
 from .memory import Memory
 from .storage import Storage
+from .interfaces import DatabaseResource, LLMResource, VectorStoreResource
 
-__all__ = ["AgentResource", "Memory", "LLM", "Storage", "StandardResources"]
+__all__ = [
+    "AgentResource",
+    "Memory",
+    "LLM",
+    "Storage",
+    "StandardResources",
+    "DatabaseResource",
+    "VectorStoreResource",
+    "LLMResource",
+]

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -13,7 +13,6 @@ from .interfaces.vector_store import (
 )
 from ..core.plugins import ValidationResult
 from ..core.state import ConversationEntry
-from pipeline.errors import InitializationError
 
 
 class Memory(AgentResource):

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
 
-from contextlib import asynccontextmanager
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
 from entity.resources import Memory


### PR DESCRIPTION
## Summary
- expose interface classes in resources package
- clean up unused imports after running ruff
- update agent log

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 190 errors remain)*
- `poetry run mypy src` *(fails: Found 213 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed to await coroutine)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed to await coroutine)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ImportError)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872a190c1748322acb00578a0491ec8