### PR TITLE
Refactor resource injection

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated Memory, LLM and Storage injection patterns
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -7,18 +7,15 @@ from typing import Any, Dict
 from ..core.plugins import ValidationResult
 
 from .base import AgentResource
-from .interfaces.llm import LLMResource as LLMProvider
+from .interfaces.llm import LLMResource
 
 
 class LLM(AgentResource):
     """Simple LLM wrapper."""
 
     name = "llm"
-    dependencies: list[str] = ["llm_provider?"]
 
-    def __init__(
-        self, provider: LLMProvider | None = None, config: Dict | None = None
-    ) -> None:
+    def __init__(self, provider: LLMResource, config: Dict | None = None) -> None:
         super().__init__(config or {})
         self.provider = provider
 

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -13,14 +13,12 @@ from .interfaces.vector_store import (
 )
 from ..core.plugins import ValidationResult
 from ..core.state import ConversationEntry
-from pipeline.errors import InitializationError
 
 
 class Memory(AgentResource):
     """Persist conversations, key/value pairs and vectors."""
 
     name = "memory"
-    dependencies: list[str] = ["database", "vector_store"]
 
     def __init__(
         self,
@@ -29,8 +27,8 @@ class Memory(AgentResource):
         config: Dict[str, Any] | None = None,
     ) -> None:
         super().__init__(config or {})
-        self.database: DatabaseInterface | None = None
-        self.vector_store: VectorStoreInterface | None = None
+        self.database = database
+        self.vector_store = vector_store
         self._pool: Any | None = None
         self._kv_table = self.config.get("kv_table", "memory_kv")
         self._history_table = self.config.get("history_table", "conversation_history")

--- a/src/entity/resources/storage.py
+++ b/src/entity/resources/storage.py
@@ -6,7 +6,6 @@ from typing import Any, Dict
 
 from ..core.plugins import ValidationResult
 
-from .interfaces.storage import StorageResource as StorageBackend
 
 from .base import AgentResource
 
@@ -15,25 +14,20 @@ class Storage(AgentResource):
     """Simple key/value storage."""
 
     name = "storage"
-    dependencies: list[str] = ["storage_backend"]
 
-    def __init__(self, backend: StorageBackend, config: Dict | None = None) -> None:
+    def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
-        self.backend = backend
+        self._data: Dict[str, Any] = {}
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None
 
     def get(self, key: str, default: Any | None = None) -> Any:
-        return self.backend.get(key, default)
+        return self._data.get(key, default)
 
     def set(self, key: str, value: Any) -> None:
-        self.backend.set(key, value)
+        self._data[key] = value
 
     async def validate_runtime(self) -> ValidationResult:
         """Check backend availability."""
-        if hasattr(self.backend, "validate_runtime"):
-            result = await self.backend.validate_runtime()
-            if not result.success:
-                return ValidationResult.error_result(f"backend: {result.message}")
         return ValidationResult.success_result()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,7 @@ async def memory_db(tmp_path: Path) -> Memory:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
         )
-    mem = Memory(config={})
-    mem.database = db
+    mem = Memory(database=db, vector_store=None, config={})
     try:
         yield mem
     finally:

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
 
-from contextlib import asynccontextmanager
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
 from entity.resources import Memory
@@ -34,9 +33,7 @@ class DuckDBResource(DatabaseResource):
 class DummyRegistries:
     def __init__(self, path: str) -> None:
         db = DuckDBResource(path)
-        mem = Memory(config={})
-        mem.database = db
-        mem.vector_store = None
+        mem = Memory(database=db, vector_store=None, config={})
         self.resources = {"memory": mem}
         self.tools = types.SimpleNamespace()
 
@@ -58,14 +55,12 @@ def test_memory_persists_between_instances() -> None:
     asyncio.set_event_loop(asyncio.new_event_loop())
     loop = asyncio.get_event_loop()
     db = DummyDatabase()
-    memory_module.database = db
-    memory_module.vector_store = None
-    mem1 = Memory(config={})
+    mem1 = Memory(database=db, vector_store=None, config={})
     mem1.set("foo", "bar")
     entry = ConversationEntry("hi", "user", datetime.now())
     loop.run_until_complete(mem1.save_conversation("cid", [entry]))
 
-    mem2 = Memory(config={})
+    mem2 = Memory(database=db, vector_store=None, config={})
     assert mem2.get("foo") == "bar"
     history = loop.run_until_complete(mem2.load_conversation("cid"))
     assert history == [entry]
@@ -75,14 +70,12 @@ def test_memory_persists_with_connection_pool() -> None:
     asyncio.set_event_loop(asyncio.new_event_loop())
     loop = asyncio.get_event_loop()
     pool = DummyPool()
-    memory_module.database = pool
-    memory_module.vector_store = None
-    mem1 = Memory(config={})
+    mem1 = Memory(database=pool, vector_store=None, config={})
     mem1.set("foo", "bar")
     entry = ConversationEntry("hi", "user", datetime.now())
     loop.run_until_complete(mem1.save_conversation("cid", [entry]))
 
-    mem2 = Memory(config={})
+    mem2 = Memory(database=pool, vector_store=None, config={})
     assert mem2.get("foo") == "bar"
     history = loop.run_until_complete(mem2.load_conversation("cid"))
     assert history == [entry]

--- a/tests/test_standard_resources.py
+++ b/tests/test_standard_resources.py
@@ -1,8 +1,9 @@
 from contextlib import asynccontextmanager
 
 from entity.resources import LLM, Memory, Storage, StandardResources
-from entity.resources import memory as memory_module
 from entity.resources.interfaces.database import DatabaseResource
+from entity.resources.interfaces.llm import LLMResource
+from entity.core.state import LLMResponse
 from entity.resources.interfaces.storage import StorageResource
 
 
@@ -48,16 +49,19 @@ class DummyVector(VectorStoreResource):
         return []
 
 
+class DummyLLMProvider(LLMResource):
+    async def generate(self, prompt: str) -> LLMResponse:
+        return LLMResponse(content=prompt)
+
+
 def test_standard_resources_types() -> None:
     db = DummyDatabase()
-    memory_module.database = db
-    memory_module.vector_store = None
-    memory = Memory(config={})
+    memory = Memory(database=db, vector_store=None, config={})
 
     res = StandardResources(
         memory=memory,
-        llm=LLM(config={}),
-        storage=Storage(backend=DummyBackend(), config={}),
+        llm=LLM(provider=DummyLLMProvider({}), config={}),
+        storage=Storage(config={}),
     )
     assert isinstance(res.memory, Memory)
     assert isinstance(res.llm, LLM)


### PR DESCRIPTION
## Summary
- inject dependencies through constructors
- adjust storage to be standalone
- update tests for new constructors
- note the changes

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `pytest tests/test_architecture/ -v`
- `pytest tests/test_plugins/ -v`
- `pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6872a191d8188322a5079d85db7cd8ad