### PR TITLE
Fix memory tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ async def memory_db(tmp_path: Path) -> Memory:
         )
     mem = Memory(config={})
     mem.database = db
+    mem.vector_store = None
+    await mem.initialize()
     try:
         yield mem
     finally:

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -1,4 +1,7 @@
 import types
+import asyncio
+import json
+from datetime import datetime
 import duckdb
 from contextlib import asynccontextmanager
 
@@ -7,8 +10,9 @@ asyncio.set_event_loop(loop)
 
 from contextlib import asynccontextmanager
 from entity.core.context import PluginContext
-from entity.core.state import PipelineState
+from entity.core.state import PipelineState, ConversationEntry
 from entity.resources import Memory
+from entity.resources import memory as memory_module
 from entity.resources.interfaces.database import DatabaseResource
 
 
@@ -31,12 +35,65 @@ class DuckDBResource(DatabaseResource):
         return self.conn
 
 
+class DummyConnection:
+    def __init__(self, store: dict) -> None:
+        self.store = store
+
+    async def execute(self, query: str, params: tuple) -> None:
+        if query.startswith("DELETE FROM conversation_history"):
+            cid = params[0] if isinstance(params, tuple) else params
+            self.store.setdefault("history", {}).pop(cid, None)
+        elif query.startswith("INSERT INTO conversation_history"):
+            cid, role, content, metadata, ts = params
+            self.store.setdefault("history", {}).setdefault(cid, []).append(
+                (role, content, json.loads(metadata), ts)
+            )
+        elif query.startswith("DELETE FROM kv_store"):
+            key = params[0] if isinstance(params, tuple) else params
+            self.store.setdefault("kv", {}).pop(key, None)
+        elif query.startswith("INSERT INTO kv_store"):
+            key, value = params
+            self.store.setdefault("kv", {})[key] = json.loads(value)
+
+    async def fetch(self, query: str, params: tuple) -> list:
+        if query.startswith(
+            "SELECT role, content, metadata, timestamp FROM conversation_history"
+        ):
+            cid = params[0] if isinstance(params, tuple) else params
+            return [
+                (role, content, metadata, ts)
+                for role, content, metadata, ts in self.store.get("history", {}).get(
+                    cid, []
+                )
+            ]
+        if query.startswith("SELECT value FROM kv_store"):
+            key = params[0] if isinstance(params, tuple) else params
+            if key in self.store.get("kv", {}):
+                return [(json.dumps(self.store["kv"][key]),)]
+        return []
+
+
+class DummyDatabase(DatabaseResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.data: dict = {"history": {}, "kv": {}}
+
+    @asynccontextmanager
+    async def connection(self):
+        yield DummyConnection(self.data)
+
+
+class DummyPool(DummyDatabase):
+    pass
+
+
 class DummyRegistries:
     def __init__(self, path: str) -> None:
         db = DuckDBResource(path)
         mem = Memory(config={})
         mem.database = db
         mem.vector_store = None
+        asyncio.get_event_loop().run_until_complete(mem.initialize())
         self.resources = {"memory": mem}
         self.tools = types.SimpleNamespace()
 
@@ -49,9 +106,9 @@ def make_context(tmp_path) -> PluginContext:
 
 def test_memory_roundtrip(tmp_path) -> None:
     ctx = make_context(tmp_path)
-    ctx.remember("foo", "bar")
-
-    assert ctx.memory("foo") == "bar"
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(ctx.remember("foo", "bar"))
+    assert loop.run_until_complete(ctx.memory("foo")) == "bar"
 
 
 def test_memory_persists_between_instances() -> None:
@@ -61,11 +118,13 @@ def test_memory_persists_between_instances() -> None:
     memory_module.database = db
     memory_module.vector_store = None
     mem1 = Memory(config={})
+    asyncio.get_event_loop().run_until_complete(mem1.initialize())
     mem1.set("foo", "bar")
     entry = ConversationEntry("hi", "user", datetime.now())
     loop.run_until_complete(mem1.save_conversation("cid", [entry]))
 
     mem2 = Memory(config={})
+    asyncio.get_event_loop().run_until_complete(mem2.initialize())
     assert mem2.get("foo") == "bar"
     history = loop.run_until_complete(mem2.load_conversation("cid"))
     assert history == [entry]
@@ -78,11 +137,13 @@ def test_memory_persists_with_connection_pool() -> None:
     memory_module.database = pool
     memory_module.vector_store = None
     mem1 = Memory(config={})
+    asyncio.get_event_loop().run_until_complete(mem1.initialize())
     mem1.set("foo", "bar")
     entry = ConversationEntry("hi", "user", datetime.now())
     loop.run_until_complete(mem1.save_conversation("cid", [entry]))
 
     mem2 = Memory(config={})
+    asyncio.get_event_loop().run_until_complete(mem2.initialize())
     assert mem2.get("foo") == "bar"
     history = loop.run_until_complete(mem2.load_conversation("cid"))
     assert history == [entry]

--- a/tests/test_standard_resources.py
+++ b/tests/test_standard_resources.py
@@ -1,9 +1,11 @@
 from contextlib import asynccontextmanager
+import asyncio
 
 from entity.resources import LLM, Memory, Storage, StandardResources
 from entity.resources import memory as memory_module
 from entity.resources.interfaces.database import DatabaseResource
 from entity.resources.interfaces.storage import StorageResource
+from entity.resources.interfaces.vector_store import VectorStoreResource
 
 
 class DummyConnection:
@@ -53,6 +55,7 @@ def test_standard_resources_types() -> None:
     memory_module.database = db
     memory_module.vector_store = None
     memory = Memory(config={})
+    asyncio.get_event_loop().run_until_complete(memory.initialize())
 
     res = StandardResources(
         memory=memory,


### PR DESCRIPTION
## Summary
- update tests for memory initialization
- wire dummy DBs through initialization

## Testing
- `PYTHONPATH=src poetry run pytest tests/test_plugin_context_memory.py tests/test_pipeline_worker.py tests/test_standard_resources.py` *(fails: ImportError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6872a17a6888832288b22594a7b3c66d