### PR TITLE
Fix duplicate get_connection_pool

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Merge duplicate get_connection_pool functions
 AGENT NOTE - 2025-07-12: Removed deprecated store/load helpers
 AGENT NOTE - 2025-07-12: Introduced think()/reflect() helpers
 AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test

--- a/src/entity/resources/interfaces/database.py
+++ b/src/entity/resources/interfaces/database.py
@@ -17,16 +17,12 @@ class DatabaseResource(ResourcePlugin):
         super().__init__(config or {})
 
     def get_connection_pool(self) -> ResourcePool:  # pragma: no cover - stub
-        """Return the shared connection pool from the infrastructure."""
+        """Return the connection pool provided by the database infrastructure."""
         infra = getattr(self, "database", None)
-        if infra is not None:
-            return infra.get_connection_pool()
-        return ResourcePool(lambda: None, PoolConfig())
+        if infra is None:
+            return ResourcePool(lambda: None, PoolConfig())
+        return infra.get_connection_pool()
 
     @asynccontextmanager
     async def connection(self) -> Iterator[Any]:  # pragma: no cover - stub
         yield None
-
-    def get_connection_pool(self) -> Any:  # pragma: no cover - stub
-        """Return the underlying connection or pool."""
-        return None


### PR DESCRIPTION
## Summary
- add agent note on database connection pool changes
- merge the duplicate `get_connection_pool` methods in `DatabaseResource`

## Testing
- `poetry run black src/entity/resources/interfaces/database.py`
- `poetry run ruff check --fix src/entity/resources/interfaces/database.py`
- `poetry run mypy src/entity/resources/interfaces/database.py` *(fails: Class cannot subclass "ResourcePlugin")*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: cannot import name 'InitializationError')*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872aeed7a1083229ae9ac7c1c4ca814