### PR TITLE
Fix DuckDB pool usage

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated DuckDB connection pool usage
 AGENT NOTE - 2025-07-12: Removed deprecated store/load helpers
 AGENT NOTE - 2025-07-12: Introduced think()/reflect() helpers
 AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test


### PR DESCRIPTION
## Summary
- define `_conn` as `None` in `DuckDBInfrastructure.__init__`
- remove unused connection accessor and rely on `ResourcePool`
- log the work in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402, F821, etc.)*
- `poetry run mypy src` *(fails: found 218 errors)*
- `poetry run bandit -r src` *(fails: Command not found)*
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError: No module named 'pipeline')*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872aee91ce08322bc54c7b03cc163fe