### PR TITLE
Update pipeline stage enumeration

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Removed DELIVER alias and assigned sequential stage values
 AGENT NOTE - 2025-07-12: Removed deprecated store/load helpers
 AGENT NOTE - 2025-07-12: Introduced think()/reflect() helpers
 AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test

--- a/examples/advanced_agent/main.py
+++ b/examples/advanced_agent/main.py
@@ -44,7 +44,7 @@ class ReActPrompt(PromptPlugin):
 class FinalResponder(PromptPlugin):
     """Return the last assistant message."""
 
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         assistant = [e.content for e in context.conversation() if e.role == "assistant"]
@@ -69,7 +69,7 @@ async def main() -> None:
         ReActPrompt({"max_steps": 2}), PipelineStage.THINK, "react"
     )
     await plugins.register_plugin_for_stage(
-        FinalResponder(), PipelineStage.DELIVER, "final"
+        FinalResponder(), PipelineStage.OUTPUT, "final"
     )
 
     caps = SystemRegistries(resources=resources, tools=tools, plugins=plugins)

--- a/examples/basic_agent/main.py
+++ b/examples/basic_agent/main.py
@@ -23,7 +23,7 @@ from pipeline.state import ConversationEntry, PipelineState
 class EchoPrompt(PromptPlugin):
     """Return the last user message."""
 
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         last_message = ""
@@ -36,7 +36,7 @@ class EchoPrompt(PromptPlugin):
 
 async def main() -> None:
     plugins = PluginRegistry()
-    await plugins.register_plugin_for_stage(EchoPrompt(), PipelineStage.DELIVER, "echo")
+    await plugins.register_plugin_for_stage(EchoPrompt(), PipelineStage.OUTPUT, "echo")
 
     resources = ResourceContainer()
     db = DuckDBInfrastructure({"path": "./agent.duckdb"})

--- a/examples/duckdb_memory_agent/main.py
+++ b/examples/duckdb_memory_agent/main.py
@@ -91,7 +91,7 @@ class DuckDBMemory(ResourcePlugin):
 class IncrementPrompt(PromptPlugin):
     """Increment a counter stored in memory."""
 
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
     dependencies = ["memory"]
 
     async def _execute_impl(self, context: PluginContext) -> None:
@@ -108,7 +108,7 @@ async def main() -> None:
 
     plugins = PluginRegistry()
     await plugins.register_plugin_for_stage(
-        IncrementPrompt({}), PipelineStage.DELIVER, "increment"
+        IncrementPrompt({}), PipelineStage.OUTPUT, "increment"
     )
 
     caps = SystemRegistries(resources=resources, tools=ToolRegistry(), plugins=plugins)

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -40,7 +40,7 @@ class ChainOfThoughtPrompt(PromptPlugin):
 class FinalResponder(PromptPlugin):
     """Send the last assistant message as the response."""
 
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         assistant_messages = [
@@ -64,7 +64,7 @@ async def main() -> None:
         ChainOfThoughtPrompt({"max_steps": 1}), PipelineStage.THINK, "cot"
     )
     await plugins.register_plugin_for_stage(
-        FinalResponder(), PipelineStage.DELIVER, "final"
+        FinalResponder(), PipelineStage.OUTPUT, "final"
     )
 
     caps = SystemRegistries(resources=resources, tools=ToolRegistry(), plugins=plugins)

--- a/src/entity/core/stages.py
+++ b/src/entity/core/stages.py
@@ -9,12 +9,11 @@ class PipelineStage(IntEnum):
     """Ordered pipeline stages."""
 
     INPUT = auto()
-    PARSE = INPUT
+    PARSE = auto()
     THINK = auto()
     DO = auto()
     REVIEW = auto()
     OUTPUT = auto()
-    DELIVER = OUTPUT
     ERROR = auto()
 
     def __str__(self) -> str:

--- a/src/pipeline/stages.py
+++ b/src/pipeline/stages.py
@@ -9,12 +9,11 @@ class PipelineStage(IntEnum):
     """Ordered pipeline stages."""
 
     INPUT = auto()
-    PARSE = INPUT
+    PARSE = auto()
     THINK = auto()
     DO = auto()
     REVIEW = auto()
     OUTPUT = auto()
-    DELIVER = OUTPUT
     ERROR = auto()
 
     def __str__(self) -> str:

--- a/user_plugins/failure/error_formatter.py
+++ b/user_plugins/failure/error_formatter.py
@@ -12,7 +12,7 @@ from pipeline.stages import PipelineStage
 class ErrorFormatter(FailurePlugin):
     """Generate a simple user message from captured failure information."""
 
-    stages = [PipelineStage.DELIVER]
+    stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context: PluginContext) -> None:
         info = context.failure_info


### PR DESCRIPTION
## Summary
- use sequential auto values for each PipelineStage
- drop DELIVER alias
- adjust examples and plugins to use OUTPUT
- document the change in `agents.log`

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src` *(fails: cannot find module 'entity')*
- `poetry run bandit -r src`
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872aee713548322959f70a751c81855