### PR TITLE
Update LLM resource dependencies

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated LLM dependencies and init signature
 AGENT NOTE - 2025-07-12: Removed deprecated store/load helpers
 AGENT NOTE - 2025-07-12: Introduced think()/reflect() helpers
 AGENT NOTE - 2025-07-12: Added PipelineWorker memory persistence test

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -14,10 +14,11 @@ class LLM(AgentResource):
     """Simple LLM wrapper."""
 
     name = "llm"
+    dependencies = ["llm_provider"]
 
-    def __init__(self, provider: LLMResource, config: Dict | None = None) -> None:
+    def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
-        self.provider = provider
+        self.provider: LLMResource | None = None
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None

--- a/tests/test_standard_resources.py
+++ b/tests/test_standard_resources.py
@@ -61,7 +61,7 @@ def test_standard_resources_types() -> None:
 
     res = StandardResources(
         memory=memory,
-        llm=LLM(provider=DummyLLMProvider({}), config={}),
+        llm=LLM(config={}),
         storage=Storage(config={}),
     )
     assert isinstance(res.memory, Memory)


### PR DESCRIPTION
## Summary
- inject provider into `LLM` via container
- adjust unit test to new constructor
- note change in agents log

## Testing
- `poetry run black src/entity/resources/llm.py tests/test_standard_resources.py`
- `poetry run ruff check --fix src tests` *(fails: 184 errors)*
- `poetry run mypy src` *(fails: 220 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: ImportError)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: entity)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: entity)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: entity)*

------
https://chatgpt.com/codex/tasks/task_e_6872aee597008322859f1b5c222821a0