### PR TITLE
Refactor context stage result helpers

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Consolidated think, reflect, and clear_thoughts to use temporary stage results
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -9,7 +9,7 @@ import inspect
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Optional, Type
+from typing import Any, Awaitable, Callable, Optional
 
 import yaml
 

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -239,41 +239,19 @@ class PluginContext:
         return self.advanced.discover_tools(**filters)
 
     # ------------------------------------------------------------------
-    # Stage result helpers ("think"/"reflect")
+    # Temporary stage result helpers ("think"/"reflect")
     # ------------------------------------------------------------------
 
     async def think(self, key: str, value: Any) -> None:
-        """Persist ``value`` for later pipeline stages."""
-        if (
-            self._state.max_stage_results is not None
-            and len(self._state.stage_results) >= self._state.max_stage_results
-        ):
-            oldest = next(iter(self._state.stage_results))
-            del self._state.stage_results[oldest]
-        self._state.stage_results[key] = value
-
-    async def reflect(self, key: str, default: Any | None = None) -> Any:
-        """Retrieve a stored value."""
-        return self._state.stage_results.get(key, default)
-
-    async def clear_thoughts(self) -> None:
-        """Remove all stored stage results."""
-        self._state.stage_results.clear()
-
-    # ------------------------------------------------------------------
-    # Anthropomorphic temporary storage helpers
-    # ------------------------------------------------------------------
-
-    async def think(self, key: str, value: Any) -> None:
-        """Store a temporary value for later reflection."""
+        """Store a temporary stage result for later reflection."""
         self._temporary_thoughts[key] = value
 
     async def reflect(self, key: str, default: Any | None = None) -> Any:
-        """Retrieve a previously stored thought."""
+        """Retrieve a previously stored temporary stage result."""
         return self._temporary_thoughts.get(key, default)
 
     async def clear_thoughts(self) -> None:
-        """Remove all stored thoughts."""
+        """Remove all stored temporary stage results."""
         self._temporary_thoughts.clear()
 
     # ------------------------------------------------------------------

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -11,7 +11,6 @@ asyncio.set_event_loop(loop)
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState, ConversationEntry
 from entity.resources import Memory
-from entity.resources import memory as memory_module
 from entity.resources.interfaces.database import DatabaseResource
 from pipeline.errors import ResourceInitializationError
 import pytest


### PR DESCRIPTION
## Summary
- consolidate `think`, `reflect`, and `clear_thoughts` methods
- use temporary storage for stage results
- update unused imports via unimport
- log maintenance note

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src` *(fails: 211 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ImportError: cannot import name 'InitializationError')*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872bc5e43a48322ad8dddd311b74ba5