### PR TITLE
Fix DatabaseResource get_connection_pool

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Consolidated database interface pool access
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class

--- a/src/entity/resources/interfaces/database.py
+++ b/src/entity/resources/interfaces/database.py
@@ -17,11 +17,11 @@ class DatabaseResource(ResourcePlugin):
         super().__init__(config or {})
 
     def get_connection_pool(self) -> ResourcePool:  # pragma: no cover - stub
-        """Return the connection pool provided by the database infrastructure."""
-        infra = getattr(self, "database", None)
-        if infra is None:
-            return ResourcePool(lambda: None, PoolConfig())
-        return infra.get_connection_pool()
+        """Return the connection pool from the injected infrastructure."""
+        infrastructure = getattr(self, "database", None)
+        if infrastructure:
+            return infrastructure.get_connection_pool()
+        return ResourcePool(lambda: None, PoolConfig())
 
     @asynccontextmanager
     async def connection(self) -> Iterator[Any]:  # pragma: no cover - stub


### PR DESCRIPTION
## Summary
- consolidate duplicate `get_connection_pool` logic
- log new agent note

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 175 errors)*
- `poetry run mypy src` *(fails: 214 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ImportError)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872bc60a18c83228e4a6572d97a2bda