### PR TITLE
Verify DuckDB connection handling

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Verified DuckDBInfrastructure _conn initialization and ResourcePool usage
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -11,7 +11,6 @@ asyncio.set_event_loop(loop)
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState, ConversationEntry
 from entity.resources import Memory
-from entity.resources import memory as memory_module
 from entity.resources.interfaces.database import DatabaseResource
 from pipeline.errors import ResourceInitializationError
 import pytest


### PR DESCRIPTION
## Summary
- add agent note about verifying DuckDBInfra connection
- ruff cleaned an unused import

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402, F841, etc.)*
- `poetry run mypy src` *(fails: found 214 errors)*
- `poetry run bandit -r src` *(fails: B101, B608 issues)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(errors: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(errors: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ImportError)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872bc5fa54483229933310de4d9de8b