### PR TITLE
Set explicit stage enum values

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Assigned explicit pipeline stage values
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class

--- a/src/entity/core/stages.py
+++ b/src/entity/core/stages.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-from enum import IntEnum, auto
+from enum import IntEnum
 
 
 class PipelineStage(IntEnum):
     """Ordered pipeline stages."""
 
-    INPUT = auto()
-    PARSE = auto()
-    THINK = auto()
-    DO = auto()
-    REVIEW = auto()
-    OUTPUT = auto()
-    ERROR = auto()
+    INPUT = 1
+    PARSE = 2
+    THINK = 3
+    DO = 4
+    REVIEW = 5
+    OUTPUT = 6
+    ERROR = 7
 
     def __str__(self) -> str:
         return self.name.lower()

--- a/src/pipeline/stages.py
+++ b/src/pipeline/stages.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 """Enumeration of pipeline execution stages."""
 
-from enum import IntEnum, auto
+from enum import IntEnum
 
 
 class PipelineStage(IntEnum):
     """Ordered pipeline stages."""
 
-    INPUT = auto()
-    PARSE = auto()
-    THINK = auto()
-    DO = auto()
-    REVIEW = auto()
-    OUTPUT = auto()
-    ERROR = auto()
+    INPUT = 1
+    PARSE = 2
+    THINK = 3
+    DO = 4
+    REVIEW = 5
+    OUTPUT = 6
+    ERROR = 7
 
     def __str__(self) -> str:
         return self.name.lower()


### PR DESCRIPTION
## Summary
- assign unique sequential values for each pipeline stage
- log note about the change

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run pytest tests/test_architecture/ -v`
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6872bc5dc13083228654f7dcb7b36150