### PR TITLE
Refactor Memory tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Memory now initialized via injected dependencies
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -11,7 +11,6 @@ asyncio.set_event_loop(loop)
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState, ConversationEntry
 from entity.resources import Memory
-from entity.resources import memory as memory_module
 from entity.resources.interfaces.database import DatabaseResource
 from pipeline.errors import ResourceInitializationError
 import pytest
@@ -117,12 +116,16 @@ def test_memory_persists_between_instances() -> None:
     loop = asyncio.get_event_loop()
     db = DummyDatabase()
     mem1 = Memory(config={})
+    mem1.database = db
+    mem1.vector_store = None
     asyncio.get_event_loop().run_until_complete(mem1.initialize())
     mem1.set("foo", "bar")
     entry = ConversationEntry("hi", "user", datetime.now())
     loop.run_until_complete(mem1.save_conversation("cid", [entry]))
 
     mem2 = Memory(config={})
+    mem2.database = db
+    mem2.vector_store = None
     asyncio.get_event_loop().run_until_complete(mem2.initialize())
     assert mem2.get("foo") == "bar"
     history = loop.run_until_complete(mem2.load_conversation("cid"))
@@ -134,12 +137,16 @@ def test_memory_persists_with_connection_pool() -> None:
     loop = asyncio.get_event_loop()
     pool = DummyPool()
     mem1 = Memory(config={})
+    mem1.database = pool
+    mem1.vector_store = None
     asyncio.get_event_loop().run_until_complete(mem1.initialize())
     mem1.set("foo", "bar")
     entry = ConversationEntry("hi", "user", datetime.now())
     loop.run_until_complete(mem1.save_conversation("cid", [entry]))
 
     mem2 = Memory(config={})
+    mem2.database = pool
+    mem2.vector_store = None
     asyncio.get_event_loop().run_until_complete(mem2.initialize())
     assert mem2.get("foo") == "bar"
     history = loop.run_until_complete(mem2.load_conversation("cid"))

--- a/tests/test_standard_resources.py
+++ b/tests/test_standard_resources.py
@@ -59,6 +59,8 @@ class DummyLLMProvider(LLMResource):
 def test_standard_resources_types() -> None:
     db = DummyDatabase()
     memory = Memory(config={})
+    memory.database = db
+    memory.vector_store = None
     asyncio.get_event_loop().run_until_complete(memory.initialize())
 
     res = StandardResources(


### PR DESCRIPTION
## Summary
- adjust Memory tests to inject dependencies when initializing
- document new Memory initialization in agents log

## Testing
- `poetry run black tests/test_plugin_context_memory.py tests/test_standard_resources.py`
- `poetry run ruff check --fix src tests` *(fails: E402 and F821 in various files)*
- `poetry run mypy src` *(fails: Found 214 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ImportError due to circular import)*
- `poetry run pytest tests/test_resources/ -v`
- `poetry run pytest -k "" -v` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6872bc5c6e64832294d932fca898653f