### PR TITLE
Handle unknown plugins on reload

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store
 AGENT NOTE - 2025-07-12: Removed ConversationHistory helper class

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -526,7 +526,8 @@ class EntityCLI:
                 for name, config in section.items():
                     plugin = registry.get_plugin(name)
                     if plugin is None:
-                        continue
+                        logger.error("Plugin %s not registered", name)
+                        return 2
 
                     cfg_result = await plugin.__class__.validate_config(config)
                     if not cfg_result.success:

--- a/tests/test_reload_unknown_plugin.py
+++ b/tests/test_reload_unknown_plugin.py
@@ -1,0 +1,39 @@
+import yaml
+from pathlib import Path
+
+from entity.core.agent import Agent
+from entity.core.builder import _AgentBuilder
+from entity.core.plugins import Plugin, ValidationResult
+from entity.core.stages import PipelineStage
+from entity.cli import EntityCLI
+
+
+class SimplePlugin(Plugin):
+    name = "simple"
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        return "ok"
+
+    @classmethod
+    async def validate_config(cls, config):
+        return ValidationResult(True, "")
+
+
+def test_reload_requires_restart_when_plugin_missing(tmp_path: Path) -> None:
+    builder = _AgentBuilder()
+    plugin = SimplePlugin({})
+    builder.add_plugin(plugin)
+    runtime = builder.build_runtime()
+
+    agent = Agent()
+    agent._builder = builder
+    agent._runtime = runtime
+
+    cli = EntityCLI.__new__(EntityCLI)
+    cfg = {"plugins": {"prompts": {"unknown": {}}}}
+    cfg_file = tmp_path / "reload.yaml"
+    cfg_file.write_text(yaml.safe_dump(cfg))
+
+    result = cli._reload_config(agent, str(cfg_file))
+    assert result == 2


### PR DESCRIPTION
## Summary
- raise an error when hot-reload finds an unregistered plugin
- cover restart-required status in a unit test

## Testing
- `poetry run pytest tests/test_reload_unknown_plugin.py::test_reload_requires_restart_when_plugin_missing -q`

------
https://chatgpt.com/codex/tasks/task_e_6872be4106048322a2989b1ece27d52b