### PR TITLE
Refactor context stage result helpers

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Unified context.think/reflect with stage_results and added advanced temporary helpers
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store

--- a/tests/test_context_helpers.py
+++ b/tests/test_context_helpers.py
@@ -21,8 +21,19 @@ async def test_think_reflect_and_clear():
     ctx = make_context()
     await ctx.think("x", 1)
     assert await ctx.reflect("x") == 1
+    assert ctx._state.stage_results["x"] == 1
     await ctx.clear_thoughts()
     assert await ctx.reflect("x") is None
+    assert ctx._state.stage_results == {}
+
+
+@pytest.mark.asyncio
+async def test_advanced_temp_helpers():
+    ctx = make_context()
+    await ctx.advanced.think_temp("y", 2)
+    assert await ctx.advanced.reflect_temp("y") == 2
+    await ctx.advanced.clear_temp()
+    assert await ctx.advanced.reflect_temp("y") is None
 
 
 def test_get_resource_helpers():


### PR DESCRIPTION
## Summary
- use `PipelineState.stage_results` for cognitive operations in `PluginContext`
- add temp thought helpers to `AdvancedContext`
- update context helper tests
- log note about stage result API update

## Testing
- `poetry run ruff check --fix src/entity/core/context.py tests/test_context_helpers.py`
- `poetry run mypy src` *(fails: 211 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ImportError)*
- `poetry run pytest tests/test_context_helpers.py::test_think_reflect_and_clear -q`
- `poetry run pytest tests/test_response_control.py::test_pipeline_terminates_after_say -q` *(failed: TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_6872c1b9f5588322a12b2a5c209f6a66