### PR TITLE
Fix Memory stubs and add persistence tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Fixed memory persistence stubs and added basic tests.
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -55,21 +55,7 @@ class Memory(AgentResource):
     async def set(self, key: str, value: Any) -> None:
         await self.store_persistent(key, value)
 
-    remember = set
-
-    async def store_persistent(self, key: str, value: Any) -> None:
-        self.set(key, value)
-
-    async def fetch_persistent(self, key: str, default: Any | None = None) -> Any:
-        return self.get(key, default)
-
-    async def delete_persistent(self, key: str) -> None:
-        if self._pool is None:
-            return
-        self._pool.execute(
-            f"DELETE FROM {self._kv_table} WHERE key = ?",
-            (key,),
-        )
+    # ``store_persistent`` and ``fetch_persistent`` are implemented below.
 
     def clear(self) -> None:
         if self._pool is not None:

--- a/tests/test_memory_basic.py
+++ b/tests/test_memory_basic.py
@@ -1,0 +1,47 @@
+import sqlite3
+from contextlib import asynccontextmanager
+
+import pytest
+from entity.resources import Memory
+from entity.resources.interfaces.database import DatabaseResource
+
+
+class SqliteDB(DatabaseResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
+        )
+
+    @asynccontextmanager
+    async def connection(self):
+        yield self.conn
+
+    def get_connection_pool(self):
+        return self.conn
+
+
+@pytest.fixture()
+async def simple_memory() -> Memory:
+    mem = Memory(config={})
+    mem.database = SqliteDB()
+    mem.vector_store = None
+    await mem.initialize()
+    yield mem
+
+
+@pytest.mark.asyncio
+async def test_set_get(simple_memory: Memory) -> None:
+    await simple_memory.set("foo", "bar")
+    assert await simple_memory.get("foo") == "bar"
+
+
+@pytest.mark.asyncio
+async def test_remember_alias(simple_memory: Memory) -> None:
+    assert Memory.remember is Memory.store_persistent
+    await simple_memory.remember("alpha", 123)
+    assert await simple_memory.get("alpha") == 123


### PR DESCRIPTION
## Summary
- clean up Memory resource stubs to avoid recursion
- define `remember` once after the persistence methods
- test `set`, `get`, and `remember`
- log the update in `agents.log`

## Testing
- `poetry run pytest tests/test_memory_basic.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6872c1b881648322b34e183724efbcf5