### PR TITLE
Add PlanAndExecute prompt plugin

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Added PlanAndExecute prompt plugin with docs and tests
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Memory now persists to DuckDB and vector store

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -9,3 +9,11 @@ error_handling
 ```
 
 The following pages cover core concepts and usage patterns.
+
+## Built-in Reasoning Patterns
+
+Entity ships with several prompt plugins for common reasoning flows:
+
+- `ChainOfThoughtPrompt` – incremental step-by-step reasoning.
+- `ReActPrompt` – reason and act in a loop.
+- `PlanAndExecutePrompt` – decompose a goal and track execution.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ Each subdirectory contains a small agent showcasing a different feature level.
 - **basic_agent** – echoes the user's message.
 - **intermediate_agent** – runs a chain-of-thought prompt with an echo LLM.
 - **advanced_agent** – demonstrates a ReAct loop with tool usage.
+- **planner_agent** – uses the PlanAndExecute prompt for goal tracking.
 - **zero_config_agent** – uses `@agent.tool` and `@agent.prompt` decorators.
 
 Run any example with:

--- a/examples/planner_agent/README.md
+++ b/examples/planner_agent/README.md
@@ -1,0 +1,7 @@
+# Planner Agent
+
+Demonstrates the built-in PlanAndExecutePrompt for goal decomposition.
+
+```bash
+poetry run python examples/planner_agent/main.py
+```

--- a/examples/planner_agent/main.py
+++ b/examples/planner_agent/main.py
@@ -1,0 +1,74 @@
+import asyncio
+from typing import Any
+from pathlib import Path
+import sys
+
+from entity.core.plugins import PromptPlugin, ResourcePlugin
+from entity.core.context import PluginContext
+from pipeline.stages import PipelineStage
+from datetime import datetime
+
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.resources.container import ResourceContainer
+from entity.infrastructure.duckdb import DuckDBInfrastructure
+from entity.resources.memory import Memory
+from pipeline.pipeline import execute_pipeline, generate_pipeline_id
+from pipeline.state import ConversationEntry, PipelineState
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from entity.plugins.prompts.plan_and_execute import PlanAndExecutePrompt
+
+
+class EchoLLMResource(ResourcePlugin):
+    async def generate(self, prompt: str) -> Any:
+        if "Break the goal" in prompt:
+            return {"content": "Step one\nStep two"}
+        if "Execute step" in prompt:
+            step = prompt.split(":", 1)[1].strip()
+            return {"content": f"Executed {step}"}
+        return {"content": prompt}
+
+
+class FinalResponder(PromptPlugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        assistant = [e.content for e in context.conversation() if e.role == "assistant"]
+        context.say(assistant[-1] if assistant else "")
+
+
+async def main() -> None:
+    resources = ResourceContainer()
+    db = DuckDBInfrastructure({"path": "./agent.duckdb"})
+    memory = Memory(config={})
+    memory.database = db
+    await db.initialize()
+    await resources.add("database", db)
+    await resources.add("memory", memory)
+    await resources.add("llm", EchoLLMResource({}))
+
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(
+        PlanAndExecutePrompt({}), PipelineStage.THINK, "planner"
+    )
+    await plugins.register_plugin_for_stage(
+        FinalResponder(), PipelineStage.OUTPUT, "final"
+    )
+
+    caps = SystemRegistries(resources=resources, tools=ToolRegistry(), plugins=plugins)
+
+    state = PipelineState(
+        conversation=[
+            ConversationEntry(
+                content="Build a shed", role="user", timestamp=datetime.now()
+            )
+        ],
+        pipeline_id=generate_pipeline_id(),
+    )
+    result: dict[str, Any] = await execute_pipeline("Build a shed", caps, state=state)
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/entity/plugins/prompts/__init__.py
+++ b/src/entity/plugins/prompts/__init__.py
@@ -2,5 +2,6 @@
 
 from .chain_of_thought import ChainOfThoughtPrompt
 from .react import ReActPrompt
+from .plan_and_execute import PlanAndExecutePrompt
 
-__all__ = ["ChainOfThoughtPrompt", "ReActPrompt"]
+__all__ = ["ChainOfThoughtPrompt", "ReActPrompt", "PlanAndExecutePrompt"]

--- a/src/entity/plugins/prompts/chain_of_thought.py
+++ b/src/entity/plugins/prompts/chain_of_thought.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import List
 
-from ..core.context import ConversationEntry, PluginContext
-from ..core.plugins import PromptPlugin
-from ..core.stages import PipelineStage
+from ...core.context import ConversationEntry, PluginContext
+from ...core.plugins import PromptPlugin
+from ...core.stages import PipelineStage
 
 
 class ChainOfThoughtPrompt(PromptPlugin):

--- a/src/entity/plugins/prompts/plan_and_execute.py
+++ b/src/entity/plugins/prompts/plan_and_execute.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import List
+
+from ...core.context import ConversationEntry, PluginContext
+from ...core.plugins import PromptPlugin
+from ...core.stages import PipelineStage
+
+
+class PlanAndExecutePrompt(PromptPlugin):
+    """Plan tasks for a goal and mark them completed."""
+
+    dependencies = ["llm"]
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        goal = self._latest_user_message(context.conversation())
+        planning_prompt = f"Break the goal into steps: {goal}"
+        plan = await self.call_llm(context, planning_prompt, purpose="plan")
+        steps = self._parse_steps(plan.content)
+        await context.think("plan", steps)
+
+        results: List[str] = []
+        for index, step in enumerate(steps, 1):
+            exec_prompt = f"Execute step {index}: {step}"
+            result = await self.call_llm(
+                context, exec_prompt, purpose=f"execute_{index}"
+            )
+            results.append(result.content)
+            await context.think(f"step_{index}", result.content)
+
+        await context.think("results", results)
+        await context.think("completed", True)
+
+    def _latest_user_message(self, conversation: List[ConversationEntry]) -> str:
+        user_entries = [e.content for e in conversation if e.role == "user"]
+        return user_entries[-1] if user_entries else ""
+
+    def _parse_steps(self, text: str) -> List[str]:
+        steps = [line.strip(" .") for line in text.splitlines() if line.strip()]
+        return steps

--- a/src/entity/plugins/prompts/react.py
+++ b/src/entity/plugins/prompts/react.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple
 
-from ..core.context import ConversationEntry, PluginContext
-from ..core.plugins import PromptPlugin
-from ..core.stages import PipelineStage
+from ...core.context import ConversationEntry, PluginContext
+from ...core.plugins import PromptPlugin
+from ...core.stages import PipelineStage
 
 
 class ReActPrompt(PromptPlugin):

--- a/tests/test_plan_and_execute_prompt.py
+++ b/tests/test_plan_and_execute_prompt.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+import pytest
+
+from entity.plugins.prompts.plan_and_execute import PlanAndExecutePrompt
+from entity.core.context import PluginContext
+from entity.core.registries import (
+    SystemRegistries,
+    PluginRegistry,
+    ToolRegistry,
+)
+from entity.core.resources.container import ResourceContainer
+from entity.core.state import ConversationEntry, LLMResponse
+from pipeline.state import PipelineState
+from entity.resources.interfaces.llm import LLMResource
+from pipeline.stages import PipelineStage
+
+
+class DummyLLMProvider(LLMResource):
+    async def generate(self, prompt: str) -> LLMResponse:
+        if "Break the goal" in prompt:
+            return LLMResponse(content="Step one\nStep two")
+        return LLMResponse(content=f"Executed {prompt.split(':', 1)[1].strip()}")
+
+
+@pytest.mark.asyncio
+async def test_plan_and_execute_prompt() -> None:
+    llm = DummyLLMProvider({})
+    container = ResourceContainer()
+    await container.add("llm", llm)
+
+    plugins = PluginRegistry()
+    regs = SystemRegistries(resources=container, tools=ToolRegistry(), plugins=plugins)
+
+    state = PipelineState(
+        conversation=[ConversationEntry("Do something", "user", datetime.now())],
+        pipeline_id="pid",
+    )
+    ctx = PluginContext(state, regs)
+    ctx.set_current_stage(PipelineStage.THINK)
+    plugin = PlanAndExecutePrompt({})
+    await plugin.execute(ctx)
+    assert await ctx.reflect("plan") == ["Step one", "Step two"]
+    assert await ctx.reflect("completed") is True


### PR DESCRIPTION
## Summary
- implement `PlanAndExecutePrompt` for goal decomposition and execution tracking
- register new prompt plugin
- document available reasoning patterns
- add planner agent example using the new plugin
- provide unit test for PlanAndExecutePrompt

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402 and other errors)*
- `poetry run mypy src` *(fails: many errors)*
- `poetry run bandit -r src` *(reports several issues)*
- `poetry run vulture src tests` *(fails: syntax errors in templates)*
- `poetry run unimport --remove-all src tests` *(command not recognized)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: import error)*
- `poetry run pytest tests/test_plan_and_execute_prompt.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c1bad2dc8322ac5bd292b1fa3ac9