### PR TITLE
Document LoggingResource and metrics collector

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Documented LoggingResource and MetricsCollector usage in docs; updated YAML templates.
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -27,6 +27,8 @@ plugins:
     #   embedding_model:
     #     name: dummy
     #     dimensions: 3
+    # metrics_collector:
+    #   type: entity.resources.metrics_collector:MetricsCollectorResource
   # llm:
   #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
   #   provider: ollama
@@ -84,7 +86,7 @@ plugins:
     #   type: plugins.builtin.adapters.cli:CLIAdapter
     #   stages: [deliver]
     # logging:
-    #   type: plugins.builtin.adapters.logging:LoggingAdapter
+    #   type: entity.resources.logging:LoggingResource
     #   stages: [deliver]
   prompts:
     chain_of_thought:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -27,6 +27,8 @@ plugins:
     #   embedding_model:
     #     name: dummy
     #     dimensions: 3
+    # metrics_collector:
+    #   type: entity.resources.metrics_collector:MetricsCollectorResource
     # llm:
     #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
     #   provider: ollama
@@ -87,7 +89,7 @@ plugins:
     #   type: plugins.builtin.adapters.cli:CLIAdapter
     #   stages: [deliver]
     # logging:
-    #   type: plugins.builtin.adapters.logging:LoggingAdapter
+    #   type: entity.resources.logging:LoggingResource
     #   stages: [deliver]
   prompts:
     chain_of_thought:

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -18,6 +18,8 @@ plugins:
     database:
       type: entity.infrastructure.duckdb:DuckDBInfrastructure
       path: ./agent.duckdb
+    # metrics_collector:
+    #   type: entity.resources.metrics_collector:MetricsCollectorResource
     # llm:
     #   provider: ollama
     #   base_url: "${OLLAMA_BASE_URL}"
@@ -48,7 +50,7 @@ plugins:
     # cli:
     #   type: plugins.builtin.adapters.cli:CLIAdapter
     # logging:
-    #   type: plugins.builtin.adapters.logging:LoggingAdapter
+    #   type: entity.resources.logging:LoggingResource
   prompts:
     chain_of_thought:
       type: entity.plugins.prompts.chain_of_thought:ChainOfThoughtPrompt

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -11,3 +11,33 @@ error_handling
 ```
 
 The following pages cover core concepts and usage patterns.
+
+## LoggingResource
+
+The `LoggingResource` provides structured logging across all pipeline components. It supports multiple outputs like console, JSON files, and real-time streams.
+
+```yaml
+plugins:
+  resources:
+    logging:
+      type: entity.resources.logging:LoggingResource
+      outputs:
+        - type: console
+          level: info
+        - type: structured_file
+          level: debug
+          path: logs/entity.jsonl
+```
+
+## MetricsCollectorResource
+
+`MetricsCollectorResource` collects performance and custom metrics from every plugin. The resource is automatically added if not specified.
+
+```yaml
+plugins:
+  resources:
+    metrics_collector:
+      type: entity.resources.metrics_collector:MetricsCollectorResource
+      retention_days: 90
+      buffer_size: 1000
+```


### PR DESCRIPTION
## Summary
- document the new `LoggingResource` and `MetricsCollectorResource`
- update YAML templates to show how to enable logging and metrics resources
- prepend an agent note in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: found 163 errors)*
- `poetry run mypy src` *(fails: found 209 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails due to syntax error in templates)*
- `poetry run unimport --remove-all src tests` *(fails: unrecognized arguments --remove-all)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: ModuleNotFoundError: No module named 'entity')*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: ModuleNotFoundError: No module named 'entity')*
- `poetry run python -m src.entity.core.registry_validator` *(failed: required --config argument)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872cc177d708322ad17aecf74465b09