### PR TITLE
Fix examples to use output stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ See [`config/dev.yaml`](config/dev.yaml) for the complete example.
 
 ### Zero-Config Plugins
 
-Register a tool and prompt without specifying stages:
+Register a tool and prompt. The prompt plugin runs in the OUTPUT stage
+so any call to `ctx.say()` occurs at the correct point in the pipeline:
 
 ```python
 from entity import Agent
@@ -76,7 +77,9 @@ async def add(a: int, b: int) -> int:
     return a + b
 
 
-@agent.prompt
+from pipeline.stages import PipelineStage
+
+@agent.prompt(stage=PipelineStage.OUTPUT)
 async def final(ctx):
     result = await ctx.tool_use("add", a=2, b=2)
     ctx.say(str(result))

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Updated examples to enforce OUTPUT stage for ctx.say and demonstrate think/reflect usage
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization

--- a/examples/advanced_agent/README.md
+++ b/examples/advanced_agent/README.md
@@ -1,6 +1,8 @@
 # Advanced Agent
 
 This example demonstrates a ReAct-style loop with the built-in calculator tool.
+The THINK stage stores analysis with `ctx.think()` and the OUTPUT stage
+returns it using `ctx.reflect()`.
 
 ```bash
 poetry run python examples/advanced_agent/main.py

--- a/examples/advanced_agent/main.py
+++ b/examples/advanced_agent/main.py
@@ -38,7 +38,9 @@ class ReActPrompt(PromptPlugin):
             (e.content for e in context.conversation() if e.role == "user"), ""
         )
         tool_result = await context.tool_use("calc", expression="2+2")
-        context.say(f"Thinking about {question} using tool result {tool_result}")
+        await context.think(
+            "analysis", f"Thinking about {question} using tool result {tool_result}"
+        )
 
 
 class FinalResponder(PromptPlugin):
@@ -47,8 +49,8 @@ class FinalResponder(PromptPlugin):
     stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        assistant = [e.content for e in context.conversation() if e.role == "assistant"]
-        context.say(assistant[-1] if assistant else "")
+        analysis = await context.reflect("analysis")
+        context.say(analysis or "")
 
 
 async def main() -> None:

--- a/examples/intermediate_agent/README.md
+++ b/examples/intermediate_agent/README.md
@@ -1,6 +1,8 @@
 # Intermediate Agent
 
-This example uses a simple chain-of-thought prompt and an echo LLM resource.
+This example splits reasoning across stages. The THINK stage stores a
+`thought` with `ctx.think()` and the OUTPUT stage retrieves it using
+`ctx.reflect()`.
 
 ```bash
 poetry run python examples/intermediate_agent/main.py

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -34,7 +34,7 @@ class ChainOfThoughtPrompt(PromptPlugin):
 
     async def _execute_impl(self, context: PluginContext) -> None:
         user = next((e.content for e in context.conversation() if e.role == "user"), "")
-        context.say(f"Thought about: {user}")
+        await context.think("thought", f"Thought about: {user}")
 
 
 class FinalResponder(PromptPlugin):
@@ -43,10 +43,8 @@ class FinalResponder(PromptPlugin):
     stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        assistant_messages = [
-            e.content for e in context.conversation() if e.role == "assistant"
-        ]
-        context.say(assistant_messages[-1] if assistant_messages else "")
+        thought = await context.reflect("thought")
+        context.say(thought or "")
 
 
 async def main() -> None:

--- a/examples/zero_config_agent/README.md
+++ b/examples/zero_config_agent/README.md
@@ -1,8 +1,9 @@
 # Zero Config Agent
 
 This example uses the high level `Agent` API and the
-`@agent.tool` and `@agent.prompt` decorators to register plugins
-without specifying stages.
+`@agent.tool` and `@agent.prompt` decorators to register plugins. The
+prompt is assigned to the `OUTPUT` stage so responses are emitted from
+the correct point in the pipeline.
 
 Run it with:
 

--- a/examples/zero_config_agent/main.py
+++ b/examples/zero_config_agent/main.py
@@ -2,6 +2,7 @@ import asyncio
 
 from entity import Agent
 from entity.resources.memory import Memory
+from pipeline.stages import PipelineStage
 
 agent = Agent()
 
@@ -11,7 +12,7 @@ async def add(a: int, b: int) -> int:
     return a + b
 
 
-@agent.prompt
+@agent.prompt(stage=PipelineStage.OUTPUT)
 async def responder(ctx):
     user = next((e.content for e in ctx.conversation() if e.role == "user"), "")
     result = await ctx.tool_use("add", a=2, b=2)


### PR DESCRIPTION
## Summary
- update examples to keep ctx.say in OUTPUT stage
- show storing intermediate results with ctx.think() and ctx.reflect()
- update README snippets and docs accordingly

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 163 errors)*
- `poetry run mypy src` *(fails: found 209 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: invalid syntax at templates)*
- `poetry run unimport --remove src tests` *(fails: invalid syntax at templates)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: AttributeError)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872cc0a903c832295bcef67a9d2ff47