### PR TITLE
Add Docker and OpenTofu infrastructure plugins

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added Docker and OpenTofu infrastructure plugins with basic deploy tests
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization

--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -1,4 +1,12 @@
 from .postgres import PostgresInfrastructure
 from .duckdb import DuckDBInfrastructure
+from .docker import DockerInfrastructure
+from .opentofu import OpenTofuInfrastructure, AWSStandardInfrastructure
 
-__all__ = ["PostgresInfrastructure", "DuckDBInfrastructure"]
+__all__ = [
+    "PostgresInfrastructure",
+    "DuckDBInfrastructure",
+    "DockerInfrastructure",
+    "OpenTofuInfrastructure",
+    "AWSStandardInfrastructure",
+]

--- a/src/entity/infrastructure/docker.py
+++ b/src/entity/infrastructure/docker.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from entity.core.plugins import InfrastructurePlugin
+
+
+class DockerInfrastructure(InfrastructurePlugin):
+    """Simple Docker-based infrastructure for local development."""
+
+    name = "docker"
+    infrastructure_type = "container"
+    resource_category = "infrastructure"
+    stages: list = []
+    dependencies: list[str] = []
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.path = Path(self.config.get("path", ".")).resolve()
+        self.deployed = False
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def deploy(self) -> None:
+        """Write Docker configuration files."""
+        self.path.mkdir(parents=True, exist_ok=True)
+        (self.path / "Dockerfile").write_text("FROM python:3.11-slim\n")
+        (self.path / "docker-compose.yml").write_text(
+            "version: '3'\nservices:\n  agent:\n    build: .\n"
+        )
+        self.deployed = True
+
+    async def destroy(self) -> None:
+        """Remove generated Docker configuration."""
+        for name in ["Dockerfile", "docker-compose.yml"]:
+            try:
+                (self.path / name).unlink()
+            except FileNotFoundError:  # pragma: no cover - best effort cleanup
+                pass
+        self.deployed = False

--- a/src/entity/infrastructure/opentofu.py
+++ b/src/entity/infrastructure/opentofu.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from entity.core.plugins import InfrastructurePlugin
+
+
+class OpenTofuInfrastructure(InfrastructurePlugin):
+    """Base class for OpenTofu-based cloud deployments."""
+
+    infrastructure_type = "cloud"
+    resource_category = "infrastructure"
+    stages: list = []
+    dependencies: list[str] = []
+
+    def __init__(
+        self,
+        provider: str,
+        template: str,
+        region: str = "us-east-1",
+        config: Dict | None = None,
+    ) -> None:
+        super().__init__(config or {})
+        self.provider = provider
+        self.template = template
+        self.region = region
+        self.path = Path(self.config.get("path", ".")).resolve()
+        self.deployed = False
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def deploy(self) -> None:
+        """Write minimal OpenTofu configuration."""
+        self.path.mkdir(parents=True, exist_ok=True)
+        (self.path / "main.tf").write_text(f"# {self.provider} {self.template}\n")
+        self.deployed = True
+
+    async def destroy(self) -> None:
+        """Remove generated OpenTofu configuration."""
+        try:
+            (self.path / "main.tf").unlink()
+        except FileNotFoundError:  # pragma: no cover - best effort cleanup
+            pass
+        self.deployed = False
+
+
+class AWSStandardInfrastructure(OpenTofuInfrastructure):
+    """Example AWS deployment using the standard template."""
+
+    name = "aws-standard"
+    provider = "aws"
+
+    def __init__(self, region: str = "us-east-1", config: Dict | None = None) -> None:
+        super().__init__("aws", "standard", region, config)

--- a/tests/test_infrastructure_deploy.py
+++ b/tests/test_infrastructure_deploy.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import pytest
+
+from entity.infrastructure import DockerInfrastructure, AWSStandardInfrastructure
+
+
+@pytest.mark.asyncio
+async def test_docker_deploy_creates_files(tmp_path):
+    infra = DockerInfrastructure({"path": str(tmp_path)})
+    await infra.deploy()
+    assert (tmp_path / "Dockerfile").exists()
+    assert (tmp_path / "docker-compose.yml").exists()
+    assert infra.deployed
+
+    await infra.destroy()
+    assert not (tmp_path / "Dockerfile").exists()
+    assert not (tmp_path / "docker-compose.yml").exists()
+    assert not infra.deployed
+
+
+@pytest.mark.asyncio
+async def test_opentofu_deploy_creates_main(tmp_path):
+    infra = AWSStandardInfrastructure(
+        region="us-east-1", config={"path": str(tmp_path)}
+    )
+    await infra.deploy()
+    assert (tmp_path / "main.tf").exists()
+    assert infra.deployed
+
+    await infra.destroy()
+    assert not (tmp_path / "main.tf").exists()
+    assert not infra.deployed


### PR DESCRIPTION
## Summary
- implement `DockerInfrastructure` with simple deploy/destroy logic
- implement `OpenTofuInfrastructure` base and `AWSStandardInfrastructure`
- register new infrastructure plugins
- test configuration file generation for Docker and OpenTofu
- add agent note about new infrastructure plugins

## Testing
- `poetry run pytest tests/test_infrastructure_deploy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872cc37857883228929d24421a6ee93