### PR TITLE
Add LoggingResource with multi-output logging

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Added LoggingResource and updated docs/tests
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,6 +8,7 @@ The pipeline implementation now lives under the ``entity.pipeline`` package. Imp
 :maxdepth: 2
 :hidden:
 error_handling
+logging
 ```
 
 The following pages cover core concepts and usage patterns.

--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -1,0 +1,27 @@
+# Logging Resource
+
+Entity provides a built in `LoggingResource` offering a single async `log()`
+interface. It can write to multiple destinations at the same time. The default
+configuration prints to the console.
+
+## Usage
+
+Plugins and resources obtain the logger via the context:
+
+```python
+logger = context.get_resource("logging")
+await logger.log("info", "step starting", component="plugin", pipeline_id=context.pipeline_id)
+```
+
+## Configuration Example
+
+```yaml
+plugins:
+  agent_resources:
+    logging:
+      type: entity.resources.logging:LoggingResource
+      outputs:
+        - type: console
+        - type: structured_file
+          path: ./logs/agent.jsonl
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,4 +13,5 @@ Run any example with:
 poetry run python examples/<name>/main.py
 ```
 
-The `PluginContext` in each example provides `get_llm()`, `get_memory()`, and `get_storage()` helpers for quick resource access.
+The `PluginContext` in each example provides `get_llm()`, `get_memory()`,
+`get_storage()`, and `get_resource("logging")` for unified logging access.

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -192,6 +192,11 @@ class ResourceContainer:
 
     async def build_all(self) -> None:
         """Instantiate and initialize resources in layer order."""
+        if "logging" not in self._classes and "logging" not in self._resources:
+            from entity.resources.logging import LoggingResource
+
+            self.register("logging", LoggingResource, {}, layer=3)
+
         self._validate_layers()
         self._order = self._resolve_order()
         self._init_order = []

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -552,7 +552,7 @@ class SystemInitializer:
     def _ensure_canonical_resources(self, container: ResourceContainer) -> None:
         """Verify required canonical resources are registered."""
 
-        required = {"memory", "llm", "storage"}
+        required = {"memory", "llm", "storage", "logging"}
         registered = set(container._classes)
         missing = required - registered
         if missing:

--- a/src/entity/resources/logging.py
+++ b/src/entity/resources/logging.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+"""Unified logging resource with multiple outputs."""
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .base import AgentResource
+
+
+def _level(name: str) -> int:
+    """Return numeric logging level for ``name``."""
+    return logging._nameToLevel.get(name.upper(), logging.INFO)
+
+
+@dataclass
+class LogEntry:
+    timestamp: str
+    level: str
+    message: str
+    component: str
+    user_id: Optional[str]
+    pipeline_id: Optional[str]
+    stage: Optional[str]
+    plugin_name: Optional[str]
+    resource_name: Optional[str]
+    extra: Dict[str, Any]
+
+
+class LogOutput:
+    """Base class for log outputs."""
+
+    def __init__(self, level: int) -> None:
+        self.level = level
+
+    async def write(
+        self, entry: Dict[str, Any]
+    ) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class ConsoleLogOutput(LogOutput):
+    """Write logs to standard output."""
+
+    async def write(self, entry: Dict[str, Any]) -> None:
+        msg = (
+            f"[{entry['timestamp']}] {entry['level'].upper()} "
+            f"{entry['component']}: {entry['message']}"
+        )
+        print(msg)
+
+
+class StructuredFileOutput(LogOutput):
+    """Append structured logs to a JSON Lines file."""
+
+    def __init__(self, path: str, level: int) -> None:
+        super().__init__(level)
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self.path.open("a", encoding="utf-8")
+        self._lock = asyncio.Lock()
+
+    async def write(self, entry: Dict[str, Any]) -> None:
+        async with self._lock:
+            self._handle.write(json.dumps(entry) + "\n")
+            self._handle.flush()
+
+    def close(self) -> None:
+        self._handle.close()
+
+
+class StreamLogOutput(LogOutput):
+    """Broadcast log entries over a WebSocket."""
+
+    def __init__(self, host: str, port: int, level: int) -> None:
+        super().__init__(level)
+        self.host = host
+        self.port = port
+        self.server: Any | None = None
+        self.clients: set[Any] = set()
+
+    async def start(self) -> None:
+        import websockets
+
+        self.server = await websockets.serve(self._handler, self.host, self.port)
+        # Capture actual port when 0 was provided
+        self.port = self.server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        if self.server is None:
+            return
+        self.server.close()
+        await self.server.wait_closed()
+
+    async def _handler(self, websocket: Any, _path: str) -> None:
+        self.clients.add(websocket)
+        try:
+            await websocket.wait_closed()
+        finally:
+            self.clients.discard(websocket)
+
+    async def write(self, entry: Dict[str, Any]) -> None:
+        if self.server is None:
+            return
+        message = json.dumps(entry)
+        for ws in list(self.clients):
+            try:
+                await ws.send(message)
+            except Exception:  # pragma: no cover - best effort
+                self.clients.discard(ws)
+
+
+class LoggingResource(AgentResource):
+    """Canonical logging resource with async ``log`` API."""
+
+    name = "logging"
+    dependencies: List[str] = []
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        super().__init__(config or {})
+        self._outputs: List[LogOutput] = []
+        self._stream_outputs: List[StreamLogOutput] = []
+
+    async def initialize(self) -> None:
+        outputs_cfg = self.config.get("outputs", [{"type": "console"}])
+        for out in outputs_cfg:
+            otype = out.get("type", "console")
+            level = _level(out.get("level", "INFO"))
+            if otype == "console":
+                self._outputs.append(ConsoleLogOutput(level))
+            elif otype in {"structured_file", "file"}:
+                path = out.get("path", "agent.log")
+                self._outputs.append(StructuredFileOutput(path, level))
+            elif otype in {"real_time_stream", "stream"}:
+                host = out.get("host", "127.0.0.1")
+                port = int(out.get("port", 0))
+                stream = StreamLogOutput(host, port, level)
+                await stream.start()
+                self._outputs.append(stream)
+                self._stream_outputs.append(stream)
+
+    async def shutdown(self) -> None:
+        for out in self._outputs:
+            close = getattr(out, "close", None)
+            if callable(close):
+                close()
+        for stream in self._stream_outputs:
+            await stream.stop()
+
+    async def log(
+        self,
+        level: str,
+        message: str,
+        *,
+        component: str,
+        user_id: str | None = None,
+        pipeline_id: str | None = None,
+        stage: Any | None = None,
+        plugin_name: str | None = None,
+        resource_name: str | None = None,
+        **extra: Any,
+    ) -> None:
+        entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "level": level.lower(),
+            "message": message,
+            "component": component,
+            "user_id": user_id,
+            "pipeline_id": pipeline_id,
+            "stage": str(stage) if stage is not None else None,
+            "plugin_name": plugin_name,
+            "resource_name": resource_name,
+        }
+        if extra:
+            entry.update(extra)
+
+        level_no = _level(level)
+        for output in self._outputs:
+            if level_no >= output.level:
+                await output.write(entry)
+
+
+__all__ = ["LoggingResource"]

--- a/tests/test_initializer_canonical_resources.py
+++ b/tests/test_initializer_canonical_resources.py
@@ -57,6 +57,22 @@ def test_initializer_fails_without_storage():
         asyncio.run(init.initialize())
 
 
+def test_initializer_fails_without_logging():
+    cfg = {
+        "plugins": {
+            "agent_resources": {
+                "memory": {"type": "entity.resources.memory:Memory"},
+                "llm": {"type": "entity.resources.llm:LLM"},
+                "storage": {"type": "entity.resources.storage:Storage"},
+            }
+        },
+        "workflow": {},
+    }
+    init = SystemInitializer(cfg)
+    with pytest.raises(InitializationError, match="logging"):
+        asyncio.run(init.initialize())
+
+
 def test_initializer_accepts_all_canonical_resources():
     cfg = {
         "plugins": {
@@ -64,6 +80,7 @@ def test_initializer_accepts_all_canonical_resources():
                 "memory": {"type": "entity.resources.memory:Memory"},
                 "llm": {"type": "entity.resources.llm:LLM"},
                 "storage": {"type": "entity.resources.storage:Storage"},
+                "logging": {"type": "entity.resources.logging:LoggingResource"},
             }
         },
         "workflow": {},

--- a/tests/test_logging_resource.py
+++ b/tests/test_logging_resource.py
@@ -1,0 +1,51 @@
+import asyncio
+import json
+
+import pytest
+import websockets
+
+from entity.core.resources.container import ResourceContainer
+from entity.resources.logging import LoggingResource
+
+
+@pytest.mark.asyncio
+async def test_logging_file_and_console(tmp_path, capsys):
+    log_file = tmp_path / "log.jsonl"
+    container = ResourceContainer()
+    container.register(
+        "logging",
+        LoggingResource,
+        {"outputs": [{"type": "structured_file", "path": str(log_file)}]},
+        layer=3,
+    )
+    await container.build_all()
+    logger: LoggingResource = container.get("logging")  # type: ignore[assignment]
+    await logger.log("info", "hello", component="plugin", pipeline_id="1")
+    await container.shutdown_all()
+
+    captured = capsys.readouterr().out
+    with open(log_file, "r", encoding="utf-8") as handle:
+        data = json.loads(handle.readline())
+    assert data["message"] == "hello"
+    assert "hello" in captured
+
+
+@pytest.mark.asyncio
+async def test_logging_stream_output(tmp_path):
+    container = ResourceContainer()
+    container.register(
+        "logging",
+        LoggingResource,
+        {"outputs": [{"type": "real_time_stream", "port": 0}]},
+        layer=3,
+    )
+    await container.build_all()
+    logger: LoggingResource = container.get("logging")  # type: ignore[assignment]
+    stream = next(o for o in logger._stream_outputs)
+    uri = f"ws://{stream.host}:{stream.port}"
+    async with websockets.connect(uri) as ws:
+        await logger.log("info", "hi", component="resource")
+        msg = await asyncio.wait_for(ws.recv(), timeout=2)
+    await container.shutdown_all()
+    data = json.loads(msg)
+    assert data["message"] == "hi"


### PR DESCRIPTION
## Summary
- implement `LoggingResource` with console, file and WebSocket outputs
- auto-register it during resource build and mark as required canonical resource
- document usage and update example
- add tests covering new logging functionality

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402 etc.)*
- `poetry run mypy src` *(fails: 210 errors)*
- `poetry run bandit -r src` *(reports issues)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: AttributeError)*
- `PYTHONPATH=src pytest tests/test_architecture/ -v` *(failed: config option asyncio_mode)*
- `PYTHONPATH=src pytest tests/test_plugins/ -v` *(failed: config option asyncio_mode)*
- `PYTHONPATH=src pytest tests/test_resources/ -v` *(failed: config option asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_6872cc06dbd08322a0684c30c80218c4