### PR TITLE
Fix PluginContext memory helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ All pipeline utilities are now provided under the ``entity.pipeline`` namespace.
 ### Plugin Context Helpers
 Plugins can access canonical resources with helper methods:
 `context.get_llm()`, `context.get_memory()`, and `context.get_storage()`.
+Use `context.remember()`, `context.recall()`, and `context.forget()` to persist
+small values across requests.
 
 Check the [hero landing page](https://entity.readthedocs.io/en/latest/) for a visual overview.
 

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Removed deprecation warnings from PluginContext memory helpers
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization

--- a/examples/duckdb_memory_agent/main.py
+++ b/examples/duckdb_memory_agent/main.py
@@ -95,9 +95,8 @@ class IncrementPrompt(PromptPlugin):
     dependencies = ["memory"]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        memory: DuckDBMemory = context.get_resource("memory")  # type: ignore[assignment]
-        count = memory.get("count", 0) + 1
-        memory.remember("count", count)
+        count = await context.recall("count", 0) + 1
+        await context.remember("count", count)
         context.say(f"Count: {count}")
 
 

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -279,29 +279,21 @@ class PluginContext:
     # ------------------------------------------------------------------
 
     async def remember(self, key: str, value: Any) -> None:
-        warnings.warn(
-            "PluginContext.remember is deprecated; use context.advanced.remember",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        await self._memory.store_persistent(f"{self._user_id}:{key}", value)
+        """Persist ``value`` under ``key`` for the current user."""
+        if self._memory is not None:
+            await self._memory.store_persistent(f"{self._user_id}:{key}", value)
 
-    async def memory(self, key: str, default: Any | None = None) -> Any:
-        warnings.warn(
-            "PluginContext.memory is deprecated; use context.advanced.memory",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    async def recall(self, key: str, default: Any | None = None) -> Any:
+        """Retrieve a persisted value for ``key``."""
         if self._memory is None:
             return default
         return await self._memory.fetch_persistent(f"{self._user_id}:{key}", default)
 
+    # alias for backward compatibility
+    memory = recall
+
     async def forget(self, key: str) -> None:
-        warnings.warn(
-            "PluginContext.forget is deprecated; use context.advanced.forget",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        """Remove ``key`` from persistent storage."""
         if self._memory is not None:
             await self._memory.delete_persistent(f"{self._user_id}:{key}")
 

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -257,3 +257,5 @@ class Memory(AgentResource):
     # ------------------------------------------------------------------
 
     remember = store_persistent
+    recall = fetch_persistent
+    forget = delete_persistent

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -8,12 +8,12 @@ from contextlib import asynccontextmanager
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
 
-from entity.core.context import PluginContext
-from entity.core.state import PipelineState, ConversationEntry
-from entity.resources import Memory
-from entity.resources.interfaces.database import DatabaseResource
-from entity.pipeline.errors import ResourceInitializationError
-import pytest
+from entity.core.context import PluginContext  # noqa: E402
+from entity.core.state import PipelineState, ConversationEntry  # noqa: E402
+from entity.resources import Memory  # noqa: E402
+from entity.resources.interfaces.database import DatabaseResource  # noqa: E402
+from entity.pipeline.errors import ResourceInitializationError  # noqa: E402
+import pytest  # noqa: E402
 
 
 class DuckDBResource(DatabaseResource):
@@ -108,7 +108,7 @@ def test_memory_roundtrip(tmp_path) -> None:
     ctx = make_context(tmp_path)
     loop = asyncio.get_event_loop()
     loop.run_until_complete(ctx.remember("foo", "bar"))
-    assert loop.run_until_complete(ctx.memory("foo")) == "bar"
+    assert loop.run_until_complete(ctx.recall("foo")) == "bar"
 
 
 def test_memory_persists_between_instances() -> None:


### PR DESCRIPTION
## Summary
- drop deprecation warnings from context memory helpers
- delegate remember/recall/forget directly to Memory
- document simple helpers in README
- use new helpers in duckdb example and tests

## Testing
- `poetry run black src/entity/core/context.py src/entity/resources/memory.py examples/duckdb_memory_agent/main.py tests/test_plugin_context_memory.py`
- `poetry run ruff check --fix src/entity/core/context.py src/entity/resources/memory.py examples/duckdb_memory_agent/main.py tests/test_plugin_context_memory.py`
- `poetry run mypy src` *(fails: 209 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests --exclude src/cli/templates`
- `poetry run unimport --exclude src/cli/templates src tests`
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*


------
https://chatgpt.com/codex/tasks/task_e_6872cc2b03b88322a641e2ba49239bc6