### PR TITLE
Add default agent setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ To make a dependency optional, append `?` to its name, e.g. `vector_store?`. Opt
 
 See the [Quick Start](docs/source/quick_start.md) for step-by-step setup or browse the [full documentation](https://entity.readthedocs.io/en/latest/).
 
+### Quick Start
+
+The package exposes a default agent instance for quick experiments. It uses
+Ollama for LLM calls, persists memory in `./agent_memory.duckdb`, and stores
+files under `./agent_files`.
+
+```python
+from entity import agent
+
+@agent.tool
+async def add(a: int, b: int) -> int:
+    return a + b
+
+
+@agent.prompt
+async def respond(ctx):
+    result = await ctx.tool_use("add", a=2, b=2)
+    ctx.say(str(result))
+
+import asyncio
+asyncio.run(agent.handle("calc"))
+```
+
+Ensure [Ollama](https://ollama.ai) is installed and run `ollama pull llama3` before testing.
+
 ### Stateless Workers (Decision 6)
 
 Workers hold no conversation state between requests. Instead, the `Memory` resource persists data to an external store. Each worker loads the conversation from `Memory` at the start of a request and saves updates when finished. This allows any worker process to handle any user without coordination.

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Default agent auto-config and tests
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -1,25 +1,104 @@
-"""Core utilities for the Entity framework."""
+"""Convenient access to the Entity agent and utilities."""
 
 from __future__ import annotations
 
-from .core import decorators as _decorators
+from .core.agent import Agent
+from .infrastructure import DuckDBInfrastructure
+from .resources import LLM, Memory, Storage
+from plugins.builtin.resources.ollama_llm import OllamaLLMResource
+from plugins.builtin.resources.duckdb_resource import DuckDBResource
+from .core.stages import PipelineStage
+from .core.plugins import PromptPlugin, ToolPlugin
+from .utils.setup_manager import Layer0SetupManager
+from entity.core.registries import SystemRegistries
+from entity.core.runtime import AgentRuntime
+from entity.core.resources.container import ResourceContainer
 
 
-class _AgentAPI:
-    plugin = staticmethod(_decorators.plugin)
-    input = staticmethod(_decorators.input)
-    parse = staticmethod(_decorators.parse)
-    prompt = staticmethod(_decorators.prompt)
-    tool = staticmethod(_decorators.tool)
-    review = staticmethod(_decorators.review)
-    output = staticmethod(_decorators.output)
-    prompt_plugin = staticmethod(_decorators.prompt_plugin)
-    tool_plugin = staticmethod(_decorators.tool_plugin)
+def _create_default_agent() -> Agent:
+    setup = Layer0SetupManager()
+    try:
+        setup.setup_resources()
+    except Exception:  # noqa: BLE001 - best effort setup
+        pass
+    agent = Agent()
+    builder = agent.builder
+
+    db = DuckDBInfrastructure({"path": str(setup.db_path)})
+    llm_provider = OllamaLLMResource({})
+    llm = LLM({})
+    memory = Memory({})
+    storage = Storage({})
+
+    llm.provider = llm_provider
+    memory.database = db
+
+    resources = ResourceContainer()
+    import asyncio
+
+    asyncio.run(db.initialize())
+    asyncio.run(memory.initialize())
+    asyncio.run(resources.add("database", db))
+    asyncio.run(resources.add("llm_provider", llm_provider))
+    asyncio.run(resources.add("llm", llm))
+    asyncio.run(resources.add("memory", memory))
+    asyncio.run(resources.add("storage", storage))
+
+    caps = SystemRegistries(
+        resources=resources,
+        tools=builder.tool_registry,
+        plugins=builder.plugin_registry,
+    )
+    agent._runtime = AgentRuntime(caps)
+    return agent
 
 
-agent = _AgentAPI()
+agent = _create_default_agent()
 
-__all__ = ["core", "Agent", "AgentBuilder", "agent"]
+# Expose decorator helpers bound to the default agent
+plugin = agent.plugin
+
+
+def input(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.INPUT, **hints)
+
+
+def parse(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.PARSE, **hints)
+
+
+def prompt(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.THINK, **hints)
+
+
+def tool(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.DO, **hints)
+
+
+def review(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.REVIEW, **hints)
+
+
+def output(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.OUTPUT, **hints)
+
+
+def prompt_plugin(func=None, **hints):
+    hints["plugin_class"] = PromptPlugin
+    return agent.plugin(func, **hints)
+
+
+def tool_plugin(func=None, **hints):
+    hints["plugin_class"] = ToolPlugin
+    return agent.plugin(func, **hints)
+
+
+__all__ = [
+    "core",
+    "Agent",
+    "AgentBuilder",
+    "agent",
+]
 
 
 def __getattr__(name: str):
@@ -27,10 +106,6 @@ def __getattr__(name: str):
         from . import core as _core
 
         return _core
-    if name == "Agent":
-        from .core.agent import Agent as _Agent
-
-        return _Agent
     if name == "AgentBuilder":
         from .core.builder import _AgentBuilder
 

--- a/src/entity/utils/setup_manager.py
+++ b/src/entity/utils/setup_manager.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+import duckdb
+import httpx
+
+
+class Layer0SetupManager:
+    """Handle zero-config environment checks."""
+
+    def __init__(
+        self,
+        *,
+        db_path: str = "./agent_memory.duckdb",
+        files_dir: str = "./agent_files",
+        model: str = "llama3",
+        base_url: str = "http://localhost:11434",
+    ) -> None:
+        self.db_path = Path(db_path)
+        self.files_dir = Path(files_dir)
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+
+    async def ensure_ollama(self) -> None:
+        """Verify local Ollama installation and model."""
+        url = f"{self.base_url}/api/tags"
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(url)
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                "Ollama not reachable at http://localhost:11434. "
+                "Install from https://ollama.com and start the service."
+            ) from exc
+        tags = resp.json().get("models", [])
+        if not tags:
+            raise RuntimeError(
+                f"No Ollama models installed. Run 'ollama pull {self.model}'."
+            )
+
+    def setup_resources(self) -> None:
+        """Create local resources if they do not exist."""
+        if not self.db_path.exists():
+            conn = duckdb.connect(str(self.db_path))
+            conn.close()
+        self.files_dir.mkdir(parents=True, exist_ok=True)

--- a/src/plugins/builtin/resources/__init__.py
+++ b/src/plugins/builtin/resources/__init__.py
@@ -1,11 +1,15 @@
 """Resource implementations shipped with the framework."""
 
 from .echo_llm import EchoLLMResource
+from .ollama_llm import OllamaLLMResource
+from .duckdb_resource import DuckDBResource
 from .llm_base import LLM
 from .pg_vector_store import PgVectorStore
 
 __all__ = [
     "LLM",
     "EchoLLMResource",
+    "OllamaLLMResource",
+    "DuckDBResource",
     "PgVectorStore",
 ]

--- a/src/plugins/builtin/resources/duckdb_resource.py
+++ b/src/plugins/builtin/resources/duckdb_resource.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from entity.resources.interfaces.database import DatabaseResource
+from entity.core.plugins import ValidationResult
+
+
+class DuckDBResource(DatabaseResource):
+    """Database interface wired to DuckDB infrastructure."""
+
+    dependencies = ["database_infra"]
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+
+    @classmethod
+    def validate_config(cls, config: Dict) -> ValidationResult:
+        return ValidationResult.success_result()
+
+    @classmethod
+    def validate_dependencies(cls, registry: Any) -> ValidationResult:
+        return ValidationResult.success_result()

--- a/src/plugins/builtin/resources/echo_llm.py
+++ b/src/plugins/builtin/resources/echo_llm.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from entity.core.state import LLMResponse
 
-from .llm_resource import LLMResource
+from entity.resources.interfaces.llm import LLMResource
 
 
 class EchoLLMResource(LLMResource):

--- a/src/plugins/builtin/resources/ollama_llm.py
+++ b/src/plugins/builtin/resources/ollama_llm.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import httpx
+
+from entity.core.state import LLMResponse
+from entity.resources.interfaces.llm import LLMResource
+
+
+class OllamaLLMResource(LLMResource):
+    """LLM provider using a local Ollama server."""
+
+    dependencies: list[str] = []
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.model = self.config.get("model", "llama3")
+        self.base_url = self.config.get("base_url", "http://localhost:11434")
+
+    async def generate(self, prompt: str) -> LLMResponse:
+        data = {"model": self.model, "prompt": prompt}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(f"{self.base_url}/api/generate", json=data)
+        return LLMResponse(content=resp.json().get("response", ""))

--- a/src/plugins/builtin/resources/pg_vector_store.py
+++ b/src/plugins/builtin/resources/pg_vector_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from entity.core.plugins import ValidationResult
+from entity.resources.interfaces.vector_store import VectorStoreResource
 
 
 class PgVectorStore(VectorStoreResource):

--- a/tests/test_default_agent.py
+++ b/tests/test_default_agent.py
@@ -1,0 +1,29 @@
+import asyncio
+
+from entity import agent
+from plugins.builtin.resources.ollama_llm import OllamaLLMResource
+
+
+@agent.tool
+async def add(a: int, b: int) -> int:
+    return a + b
+
+
+@agent.prompt
+async def final(ctx):
+    result = await ctx.tool_use("add", a=1, b=1)
+    ctx.say(str(result))
+
+
+def test_agent_handle(monkeypatch):
+    async def fake_generate(self, prompt: str):
+        return "ok"
+
+    monkeypatch.setattr(OllamaLLMResource, "generate", fake_generate, False)
+    result = asyncio.run(agent.handle("hi"))
+    assert result["message"] == "hi"
+
+
+def test_plugins_registered():
+    assert agent.builder.has_plugin("add")
+    assert agent.builder.has_plugin("final")


### PR DESCRIPTION
## Summary
- create Layer0SetupManager for minimal local setup
- add Ollama and DuckDB resources with a default agent on import
- register decorator helpers on the default instance
- document the quick start workflow
- test default agent behaviour

## Testing
- `PYTHONPATH=src poetry run pytest tests/test_default_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6872cc3353f883229207da3936fb26cd