### PR TITLE
Implement metrics collector resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ All pipeline utilities are now provided under the ``entity.pipeline`` namespace.
 - Stateless workers that scale horizontally
 - Unified memory resource for chat, search, and storage
 - DuckDB backend persists to disk for quick local testing
+- Automatic metrics collection via a shared MetricsCollector resource
 - Overrides of default plugin stages produce log warnings
 
 ### Plugin Context Helpers

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Implemented MetricsCollector resource and injection
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload
 AGENT NOTE - 2025-07-13: Updated tests for Memory initialization

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -2,6 +2,7 @@ from .base import AgentResource, StandardResources
 from .llm import LLM
 from .memory import Memory
 from .storage import Storage
+from .metrics_collector import MetricsCollectorResource
 from .interfaces import DatabaseResource, LLMResource, VectorStoreResource
 
 __all__ = [
@@ -9,6 +10,7 @@ __all__ = [
     "Memory",
     "LLM",
     "Storage",
+    "MetricsCollectorResource",
     "StandardResources",
     "DatabaseResource",
     "VectorStoreResource",

--- a/src/entity/resources/metrics_collector.py
+++ b/src/entity/resources/metrics_collector.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Any, Dict, List
+
+from .base import AgentResource
+from ..pipeline.stages import PipelineStage
+from ..core.plugins import ValidationResult
+
+
+class MetricsCollectorResource(AgentResource):  # type: ignore[misc]
+    """In-memory metrics collector available to all plugins."""
+
+    name = "metrics_collector"
+    dependencies: List[str] = []
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        super().__init__(config or {})
+        self.plugin_metrics: List[Dict[str, Any]] = []
+        self.resource_metrics: List[Dict[str, Any]] = []
+        self.custom_metrics: List[Dict[str, Any]] = []
+        self.counters: Dict[str, int] = defaultdict(int)
+
+    # ------------------------------------------------------------------
+    # Core collection methods used by framework
+    # ------------------------------------------------------------------
+    async def record_plugin_execution(
+        self,
+        *,
+        pipeline_id: str,
+        stage: PipelineStage,
+        plugin_name: str,
+        duration_ms: float,
+        success: bool,
+        error_type: str | None = None,
+    ) -> None:
+        self.plugin_metrics.append(
+            {
+                "pipeline_id": pipeline_id,
+                "stage": stage,
+                "plugin_name": plugin_name,
+                "duration_ms": duration_ms,
+                "success": success,
+                "error_type": error_type,
+                "timestamp": time.time(),
+            }
+        )
+
+    async def record_resource_operation(
+        self,
+        *,
+        pipeline_id: str,
+        resource_name: str,
+        operation: str,
+        duration_ms: float,
+        success: bool,
+        metadata: Dict[str, Any] | None = None,
+    ) -> None:
+        self.resource_metrics.append(
+            {
+                "pipeline_id": pipeline_id,
+                "resource_name": resource_name,
+                "operation": operation,
+                "duration_ms": duration_ms,
+                "success": success,
+                "metadata": metadata or {},
+                "timestamp": time.time(),
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Plugin-facing methods for custom metrics
+    # ------------------------------------------------------------------
+    async def record_custom_metric(
+        self,
+        *,
+        pipeline_id: str,
+        metric_name: str,
+        value: float,
+        metadata: Dict[str, Any] | None = None,
+    ) -> None:
+        self.custom_metrics.append(
+            {
+                "pipeline_id": pipeline_id,
+                "metric_name": metric_name,
+                "value": value,
+                "metadata": metadata or {},
+                "timestamp": time.time(),
+            }
+        )
+
+    async def increment_counter(
+        self,
+        *,
+        pipeline_id: str,
+        counter_name: str,
+        increment: int = 1,
+        metadata: Dict[str, Any] | None = None,
+    ) -> None:
+        self.counters[counter_name] += increment
+        self.custom_metrics.append(
+            {
+                "pipeline_id": pipeline_id,
+                "metric_name": counter_name,
+                "value": self.counters[counter_name],
+                "metadata": metadata or {},
+                "timestamp": time.time(),
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Analytics and querying
+    # ------------------------------------------------------------------
+    async def get_unified_agent_log(
+        self,
+        *,
+        pipeline_id: str | None = None,
+        user_id: str | None = None,
+        time_range: tuple[float, float] | None = None,
+    ) -> List[Dict[str, Any]]:
+        entries = self.plugin_metrics + self.resource_metrics + self.custom_metrics
+        if pipeline_id is not None:
+            entries = [e for e in entries if e.get("pipeline_id") == pipeline_id]
+        if time_range is not None:
+            start, end = time_range
+            entries = [e for e in entries if start <= e.get("timestamp", 0) <= end]
+        if user_id is not None:
+            entries = [e for e in entries if e.get("user_id") == user_id]
+        return list(entries)
+
+    async def get_performance_summary(
+        self, agent_name: str, hours: int = 24
+    ) -> Dict[str, Any]:
+        cutoff = time.time() - hours * 3600
+        plugin_calls = [m for m in self.plugin_metrics if m["timestamp"] >= cutoff]
+        resource_ops = [m for m in self.resource_metrics if m["timestamp"] >= cutoff]
+        return {
+            "agent": agent_name,
+            "plugin_executions": len(plugin_calls),
+            "resource_operations": len(resource_ops),
+        }
+
+    @classmethod
+    async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        return ValidationResult.success_result()

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -1,0 +1,43 @@
+import pytest
+
+from entity.core.context import PluginContext
+from entity.core.plugins import Plugin, ResourcePlugin
+from entity.core.registries import SystemRegistries
+from entity.core.state import PipelineState
+from entity.pipeline.stages import PipelineStage
+from entity.resources.metrics_collector import MetricsCollectorResource
+
+
+class DummyPlugin(Plugin):  # type: ignore[misc]
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        await context.think("dummy", True)
+
+
+class DummyResource(ResourcePlugin):  # type: ignore[misc]
+    async def do_work(self, context: PluginContext) -> int:
+        result: int = await self._track_operation("do_work", lambda: 1, context=context)
+        return result
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_metrics_collection() -> None:
+    metrics = MetricsCollectorResource()
+    plugin = DummyPlugin()
+    resource = DummyResource()
+    plugin.metrics_collector = metrics
+    resource.metrics_collector = metrics
+
+    state = PipelineState(conversation=[], pipeline_id="pid")
+    regs = SystemRegistries(resources={}, tools=None, plugins=None, validators=None)
+    ctx = PluginContext(state, regs)
+    ctx.set_current_stage(PipelineStage.THINK)
+
+    await plugin.execute(ctx)
+    await resource.do_work(ctx)
+
+    assert metrics.plugin_metrics
+    assert metrics.resource_metrics
+    log = await metrics.get_unified_agent_log(pipeline_id="pid")
+    assert len(log) >= 2


### PR DESCRIPTION
## Summary
- add in-memory `MetricsCollectorResource` with query helpers
- inject `metrics_collector` dependency into all plugins during initialization
- wrap plugin execution and resource operations for metrics collection
- expose new resource from package
- document metrics collector
- add tests to verify metrics recording

## Testing
- `poetry run ruff check --fix src/entity/resources/metrics_collector.py src/entity/core/plugins/base.py src/entity/pipeline/initializer.py src/entity/resources/__init__.py tests/test_metrics_collector.py`
- `poetry run mypy src/entity/resources/metrics_collector.py tests/test_metrics_collector.py`
- `poetry run bandit -r src/entity/resources/metrics_collector.py`
- `poetry run vulture src/entity/resources/metrics_collector.py tests/test_metrics_collector.py` *(fails: Command not found)*
- `poetry run unimport --remove-all src/entity/resources/metrics_collector.py tests/test_metrics_collector.py` *(fails: Command not found)*
- `poetry run pytest tests/test_metrics_collector.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872cc08d044832289d11ec6b9b54d34