### PR TITLE
Implement LoggingResource defaults

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Implemented LoggingResource with config models and initializer defaults
 AGENT NOTE - 2025-07-12: Removed deprecation warnings from PluginContext memory helpers
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -76,6 +76,22 @@ class BreakerSettings(BaseModel):
     )
 
 
+class LogOutputConfig(BaseModel):
+    """Configuration for a single logging output."""
+
+    type: str = "console"
+    level: str = "info"
+    path: str | None = None
+    host: str | None = None
+    port: int | None = None
+
+
+class LoggingConfig(BaseModel):
+    """Settings controlling the :class:`LoggingResource`."""
+
+    outputs: list[LogOutputConfig] = Field(default_factory=lambda: [LogOutputConfig()])
+
+
 class EntityConfig(BaseModel):
     server: ServerConfig = Field(
         default_factory=lambda: ServerConfig(host="localhost", port=8000)
@@ -113,6 +129,8 @@ __all__ = [
     "ToolRegistryConfig",
     "CircuitBreakerConfig",
     "BreakerSettings",
+    "LogOutputConfig",
+    "LoggingConfig",
     "EntityConfig",
     "validate_config",
     "asdict",

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -552,7 +552,7 @@ class SystemInitializer:
     def _ensure_canonical_resources(self, container: ResourceContainer) -> None:
         """Verify required canonical resources are registered."""
 
-        required = {"memory", "llm", "storage", "logging"}
+        required = {"memory", "llm", "storage"}
         registered = set(container._classes)
         missing = required - registered
         if missing:
@@ -563,3 +563,8 @@ class SystemInitializer:
                 f"Missing canonical resources: {missing_list}. Add them to your configuration.",
                 kind="Resource",
             )
+
+        if "logging" not in registered:
+            from entity.resources.logging import LoggingResource
+
+            container.register("logging", LoggingResource, {}, layer=3)

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -1,5 +1,6 @@
 from .base import AgentResource, StandardResources
 from .llm import LLM
+from .logging import LoggingResource
 from .memory import Memory
 from .storage import Storage
 from .interfaces import DatabaseResource, LLMResource, VectorStoreResource
@@ -9,6 +10,7 @@ __all__ = [
     "Memory",
     "LLM",
     "Storage",
+    "LoggingResource",
     "StandardResources",
     "DatabaseResource",
     "VectorStoreResource",

--- a/tests/test_initializer_canonical_resources.py
+++ b/tests/test_initializer_canonical_resources.py
@@ -69,8 +69,9 @@ def test_initializer_fails_without_logging():
         "workflow": {},
     }
     init = SystemInitializer(cfg)
-    with pytest.raises(InitializationError, match="logging"):
-        asyncio.run(init.initialize())
+    asyncio.run(init.initialize())
+    assert init.resource_container is not None
+    assert init.resource_container.get("logging") is not None
 
 
 def test_initializer_accepts_all_canonical_resources():

--- a/tests/test_logging_resource.py
+++ b/tests/test_logging_resource.py
@@ -49,3 +49,12 @@ async def test_logging_stream_output(tmp_path):
     await container.shutdown_all()
     data = json.loads(msg)
     assert data["message"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_logging_auto_registration():
+    container = ResourceContainer()
+    await container.build_all()
+    logger = container.get("logging")
+    assert isinstance(logger, LoggingResource)
+    await container.shutdown_all()


### PR DESCRIPTION
## Summary
- add LogOutputConfig and LoggingConfig models
- include LoggingResource in resources package exports
- ensure initializer registers a default LoggingResource
- adjust canonical resource tests
- test automatic logging registration

## Testing
- `poetry run pytest tests/test_logging_resource.py tests/test_initializer_canonical_resources.py -q` *(fails: AttributeError 'coroutine' object has no attribute 'success')*

------
https://chatgpt.com/codex/tasks/task_e_6872cf58845c83228011bfb7b483261e