### PR TITLE
Fix async results in registry validator

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Registry validator runs async validations
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/src/entity/core/registry_validator.py
+++ b/src/entity/core/registry_validator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import pathlib
 import sys
 from typing import Dict, List
@@ -134,6 +135,8 @@ class RegistryValidator:
                 result = ValidationResult.success_result()
             else:
                 result = validate(self.registry)
+                if asyncio.iscoroutine(result):
+                    result = asyncio.run(result)
             if not result.success:
                 raise SystemError(
                     f"Dependency validation failed for {cls.__name__}: {result.message}"
@@ -186,6 +189,8 @@ class RegistryValidator:
                 result = ValidationResult.success_result()
             else:
                 result = validate(cfg)
+                if asyncio.iscoroutine(result):
+                    result = asyncio.run(result)
             if not result.success:
                 raise SystemError(
                     f"Config validation failed for {cls.__name__}: {result.message}"


### PR DESCRIPTION
## Summary
- handle coroutine results in RegistryValidator dependency and config checks
- add changelog note

## Testing
- `poetry run black src/entity/core/registry_validator.py`
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402 Module level import not at top of file)*
- `poetry run mypy src` *(fails: Found 216 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: AttributeError)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872d216fd048322bb892c3398876fd7