### PR TITLE
Fix plugin analysis selections

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added selections list initialization in analyze-plugin
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/src/cli/plugin_tool/main.py
+++ b/src/cli/plugin_tool/main.py
@@ -275,6 +275,7 @@ class PluginToolCLI:
                 ResourcePlugin,
             )
 
+        selections: list[tuple[str, Type[Plugin], list[PipelineStage]]] = []
         found = False
         # Inspect async callables and classify them as plugins.
         # The reason indicates whether stages come from config hints or


### PR DESCRIPTION
## Summary
- ensure stage overrides populate the `selections` list during `analyze-plugin`
- note work in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402 and other errors)*
- `poetry run mypy src` *(fails: 214 errors in 53 files)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: template syntax errors)*
- `poetry run unimport src tests` *(reports refactoring/invalid syntax)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: AttributeError)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872d213ca3c832289dcf08ec3fe2e74