### PR TITLE
Fix CircuitBreaker parameter in Postgres runtime validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Fixed validate_runtime parameter for CircuitBreaker
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/src/entity/infrastructure/postgres.py
+++ b/src/entity/infrastructure/postgres.py
@@ -57,7 +57,9 @@ class PostgresInfrastructure(InfrastructurePlugin):
         """Return the underlying connection pool."""
         return self._pool
 
-    async def validate_runtime(self) -> ValidationResult:
+    async def validate_runtime(
+        self, breaker: CircuitBreaker | None = None
+    ) -> ValidationResult:
         """Check connectivity using a simple query."""
 
         if not hasattr(self._pool, "acquire"):


### PR DESCRIPTION
## Summary
- allow passing a CircuitBreaker instance to `validate_runtime`
- note the change in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402 Module level import not at top of file)*
- `poetry run mypy src` *(fails: Found 215 errors in 53 files)*
- `poetry run bandit -r src` *(reports several low/medium issues)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: required argument --config missing)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872d202bbc48322b0d6e0781020ed95