### PR TITLE
Update layer validation for AgentResource

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated layer validation for AgentResource types
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload


### PR DESCRIPTION
## Summary
- support core.plugins.AgentResource subclasses in `_validate_layers`
- clarify error message when agent resource layer mismatch

## Testing
- `poetry run black src/entity/core/resources/container.py`
- `poetry run ruff check --fix src/entity/core/resources/container.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `pytest tests/test_architecture/ -v`
- `pytest tests/test_plugins/ -v`
- `pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6872d1fd8c608322a8e2fce76c9d620b