### PR TITLE
Update async validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated ResourceContainer async validation
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -210,6 +210,8 @@ class ResourceContainer:
                         cls = self._classes[name]
                         cfg = self._configs[name]
                         result = cls.validate_config(cfg)
+                        if asyncio.iscoroutine(result):
+                            result = await result
                         if not result.success:
                             raise InitializationError(
                                 name,
@@ -217,7 +219,10 @@ class ResourceContainer:
                                 f"{result.message}. Fix the resource configuration.",
                                 kind="Resource",
                             )
+
                         dep_result = cls.validate_dependencies(self)
+                        if asyncio.iscoroutine(dep_result):
+                            dep_result = await dep_result
                         if not dep_result.success:
                             raise InitializationError(
                                 name,


### PR DESCRIPTION
## Summary
- handle coroutine returns from resource validation
- log update

## Testing
- `poetry run black src/entity/core/resources/container.py`
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 160 errors)*
- `poetry run mypy src` *(fails: Found 216 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing arguments)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872d1f88ab48322a2a122894a92d81b