### PR TITLE
Improve DuckDB connection reuse

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated duckdb connection context to use existing connection if available
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/src/entity/infrastructure/duckdb.py
+++ b/src/entity/infrastructure/duckdb.py
@@ -45,9 +45,12 @@ class DuckDBInfrastructure(InfrastructurePlugin):
 
     @asynccontextmanager
     async def connection(self) -> Iterator[duckdb.DuckDBPyConnection]:
-        """Yield a connection from the pool."""
-        async with self._pool as conn:
-            yield conn
+        """Yield an existing connection or acquire one from the pool."""
+        if self._conn is not None:
+            yield self._conn
+        else:
+            async with self._pool as conn:
+                yield conn
 
     async def shutdown(self) -> None:
         while not self._pool._pool.empty():


### PR DESCRIPTION
## Summary
- reuse existing connection in DuckDB infrastructure
- log agent note about connection reuse

## Testing
- `poetry run black src/entity/infrastructure/duckdb.py`
- `poetry run ruff check --fix src/entity/infrastructure/duckdb.py`
- `poetry run mypy src` *(fails: 216 errors)*
- `poetry run bandit -r src`
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872d200c9d8832291b9899bab89ffdf