### PR TITLE
Adjust canonical resource check order

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Moved canonical resources check earlier in initializer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -398,6 +398,15 @@ class SystemInitializer:
                     f"{result.message}. Fix plugin dependencies.",
                 )
 
+        # Register resources early so we can verify canonical ones exist
+        resource_container = self.resource_container_cls()
+        self.resource_container = resource_container
+        for name, cls, config, _layer in registry.resource_classes():
+            resource_container.register(name, cls, config)
+
+        # Ensure required canonical resources before dependency validation
+        self._ensure_canonical_resources(resource_container)
+
         # Phase 2: dependency validation
         self._validate_dependency_graph(registry, dep_graph)
         for plugin_class, config in registry.all_plugin_classes():
@@ -409,16 +418,10 @@ class SystemInitializer:
                     f"{result.message}. Update the plugin configuration.",
                 )
 
-        # Phase 3: initialize resources via container
-        resource_container = self.resource_container_cls()
-        self.resource_container = resource_container
-        for name, cls, config, _layer in registry.resource_classes():
-            resource_container.register(name, cls, config)
-
-        self._ensure_canonical_resources(resource_container)
-
         # Fail fast if any canonical resources are missing before initialization
         self._ensure_canonical_resources(resource_container)
+
+        # Phase 3: initialize resources via container
 
         async with (
             initialization_cleanup_context(resource_container),


### PR DESCRIPTION
## Summary
- call `_ensure_canonical_resources` before validating the dependency graph
- keep a second check before resources build
- add agent note about this init change

## Testing
- `poetry run black src/entity/pipeline/initializer.py tests/test_infrastructure_deploy.py`
- `poetry run ruff check --fix src tests` *(fails: 160 errors)*
- `poetry run mypy src` *(fails: Found 216 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config ???` *(error: missing argument)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872d20407f083228027d66bb09b0a5f