### PR TITLE
Add pipeline compatibility wrapper

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Added compatibility pipeline.pipeline module
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -1,0 +1,16 @@
+import warnings
+from importlib import import_module
+
+warnings.warn(
+    "The 'pipeline.pipeline' module is deprecated. Use 'entity.pipeline.pipeline' instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+_module = import_module("entity.pipeline.pipeline")
+
+__all__ = getattr(_module, "__all__", [])
+
+
+def __getattr__(name: str):
+    return getattr(_module, name)


### PR DESCRIPTION
## Summary
- expose `pipeline.pipeline` module under the old namespace
- log this change for future agents

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402 module level import not at top of file)*
- `poetry run mypy src` *(fails: found 217 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: syntax errors in template files)*
- `poetry run unimport --remove-all src tests` *(fails: unrecognized arguments)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: the following arguments are required: --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872d21943e8832282c37c0f76cdda63