### PR TITLE
Fix plugin import fallback path

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated import_plugin_class to retry after adding src path
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/src/entity/core/plugin_utils.py
+++ b/src/entity/core/plugin_utils.py
@@ -68,9 +68,8 @@ def import_plugin_class(path: str) -> Type:
         module = import_module(module_path)
     except ModuleNotFoundError:
         sys.path.insert(0, str(Path.cwd()))
-        module = sys.modules.get(module_path)
-        if module is None:
-            module = import_module(module_path)
+        sys.path.append(str(Path.cwd() / "src"))
+        module = import_module(module_path)
     return getattr(module, class_name)
 
 


### PR DESCRIPTION
## Summary
- append `Path.cwd() / "src"` to `sys.path` in `import_plugin_class`
- log note about plugin import change

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402 errors)*
- `poetry run mypy src` *(fails: found 215 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests` *(shows syntax errors)*
- `poetry run entity-cli --config config/dev.yaml verify` *(warns coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(warns coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*


------
https://chatgpt.com/codex/tasks/task_e_6872d218007c8322b5b4d3fec9edaf7d