### PR TITLE
Inject infrastructure deps

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -67,6 +67,7 @@ async def test_container_lifecycle_and_order():
 
     assert infra.initialized
     assert iface.initialized
+    assert iface.infra is infra
     assert canon.initialized
     assert canon.iface is iface
 


### PR DESCRIPTION
## Summary
- automatically inject `infrastructure_dependencies` when registering resource plugins
- validate that all dependencies are registered
- test that resource interfaces receive their infrastructure dependency
- log implementation note

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: Found 160 errors)*
- `poetry run mypy src` *(fails: Found 216 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found: vulture)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found: unimport)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: error: the following arguments are required: --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872d1fc5888832296ec0dede7d956ff