### PR TITLE
Convert builder methods to async

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Converted builder methods to async and updated usages
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline
 AGENT NOTE - 2025-07-12: Added restart check for unknown plugins in CLI reload

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -33,7 +33,96 @@ def _create_default_agent() -> Agent:
     llm.provider = llm_provider
     memory.database = db
 
-__all__ = ["core", "Agent", "agent"]
+    resources = ResourceContainer()
+    import asyncio
+
+    asyncio.run(db.initialize())
+    asyncio.run(memory.initialize())
+    asyncio.run(resources.add("database", db))
+    asyncio.run(resources.add("llm_provider", llm_provider))
+    asyncio.run(resources.add("llm", llm))
+    asyncio.run(resources.add("memory", memory))
+    asyncio.run(resources.add("storage", storage))
+
+    caps = SystemRegistries(
+        resources=resources,
+        tools=builder.tool_registry,
+        plugins=builder.plugin_registry,
+    )
+    agent._runtime = AgentRuntime(caps)
+    return agent
+
+
+agent = _create_default_agent()
+
+# Expose decorator helpers bound to the default agent
+plugin = agent.plugin
+
+
+def input(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.INPUT, **hints)
+
+
+agent.input = input
+
+
+def parse(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.PARSE, **hints)
+
+
+agent.parse = parse
+
+
+def prompt(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.THINK, **hints)
+
+
+agent.prompt = prompt
+
+
+def tool(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.DO, **hints)
+
+
+agent.tool = tool
+
+
+def review(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.REVIEW, **hints)
+
+
+agent.review = review
+
+
+def output(func=None, **hints):
+    return agent.plugin(func, stage=PipelineStage.OUTPUT, **hints)
+
+
+agent.output = output
+
+
+def prompt_plugin(func=None, **hints):
+    hints["plugin_class"] = PromptPlugin
+    return agent.plugin(func, **hints)
+
+
+agent.prompt_plugin = prompt_plugin
+
+
+def tool_plugin(func=None, **hints):
+    hints["plugin_class"] = ToolPlugin
+    return agent.plugin(func, **hints)
+
+
+agent.tool_plugin = tool_plugin
+
+
+__all__ = [
+    "core",
+    "Agent",
+    "AgentBuilder",
+    "agent",
+]
 
 
 def __getattr__(name: str):
@@ -41,8 +130,8 @@ def __getattr__(name: str):
         from . import core as _core
 
         return _core
-    if name == "Agent":
-        from .core.agent import Agent as _Agent
+    if name == "AgentBuilder":
+        from .core.builder import _AgentBuilder
 
-        return _Agent
+        return _AgentBuilder
     raise AttributeError(name)

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -464,6 +464,11 @@ class EntityCLI:
     # -----------------------------------------------------
     async def _verify_plugins(self, config_path: str) -> int:
         async def _run() -> int:
+            if agent._runtime is None:
+                agent._runtime = await agent.builder.build_runtime()
+
+            if agent._runtime is None:
+                agent._runtime = await agent.builder.build_runtime()
             try:
                 agent = Agent(config_path)
                 await agent._ensure_runtime()
@@ -501,10 +506,10 @@ class EntityCLI:
                 tmp = Agent.from_config(agent.config_path)
                 agent._builder = tmp._builder
                 agent._runtime = tmp._runtime
-            else:
-                agent._runtime = agent.builder.build_runtime()
 
         async def _run() -> int:
+            if agent._runtime is None:
+                agent._runtime = await agent.builder.build_runtime()
 
             with open(file_path, "r", encoding="utf-8") as handle:
                 new_cfg = yaml.safe_load(handle) or {}

--- a/src/entity/pipeline/workflow.py
+++ b/src/entity/pipeline/workflow.py
@@ -27,7 +27,7 @@ class Pipeline:
     builder: _AgentBuilder = field(default_factory=_AgentBuilder)
     workflow: Optional[WorkflowMapping] = None
 
-    def build_runtime(self) -> AgentRuntime:
+    async def build_runtime(self) -> AgentRuntime:
         """Build an AgentRuntime using the stored builder and workflow."""
 
-        return self.builder.build_runtime(workflow=self.workflow)
+        return await self.builder.build_runtime(workflow=self.workflow)

--- a/tests/test_plugin_lifecycle.py
+++ b/tests/test_plugin_lifecycle.py
@@ -29,8 +29,8 @@ class LifecyclePlugin(Plugin):
 async def test_plugin_lifecycle():
     ag = Agent()
     plugin = LifecyclePlugin({})
-    ag.builder.add_plugin(plugin)
-    ag.builder.build_runtime()
+    await ag.builder.add_plugin(plugin)
+    await ag.builder.build_runtime()
 
     await plugin.execute(object())
     assert plugin.initialized

--- a/tests/test_reload_runtime_validation.py
+++ b/tests/test_reload_runtime_validation.py
@@ -1,6 +1,7 @@
 import asyncio
 from pathlib import Path
 import yaml
+import pytest
 
 from entity.core.agent import Agent
 from entity.core.plugins import Plugin, ValidationResult
@@ -28,11 +29,12 @@ async def run_reload(cli: EntityCLI, agent: Agent, cfg_path: Path) -> int:
     return await loop.run_in_executor(None, cli._reload_config, agent, str(cfg_path))
 
 
-def test_reload_aborts_on_failed_runtime_validation(tmp_path):
+@pytest.mark.asyncio
+async def test_reload_aborts_on_failed_runtime_validation(tmp_path):
     agent = Agent()
     plugin = RuntimeCheckPlugin({"valid": True})
-    agent.builder.add_plugin(plugin)
-    agent._runtime = agent.builder.build_runtime()
+    await agent.builder.add_plugin(plugin)
+    agent._runtime = await agent.builder.build_runtime()
 
     # Ensure config updates do not call async validator
     RuntimeCheckPlugin.validate_config = classmethod(

--- a/tests/test_reload_unknown_plugin.py
+++ b/tests/test_reload_unknown_plugin.py
@@ -1,4 +1,6 @@
+import asyncio
 import yaml
+import pytest
 from pathlib import Path
 
 from entity.core.agent import Agent
@@ -19,11 +21,12 @@ class SimplePlugin(Plugin):
         return ValidationResult(True, "")
 
 
-def test_reload_requires_restart_when_plugin_missing(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_reload_requires_restart_when_plugin_missing(tmp_path: Path) -> None:
     agent = Agent()
     plugin = SimplePlugin({})
-    agent.builder.add_plugin(plugin)
-    agent._runtime = agent.builder.build_runtime()
+    await agent.builder.add_plugin(plugin)
+    agent._runtime = await agent.builder.build_runtime()
 
     cli = EntityCLI.__new__(EntityCLI)
     cfg = {"plugins": {"prompts": {"unknown": {}}}}


### PR DESCRIPTION
## Summary
- allow async plugin registration
- make runtime creation awaitable
- hook decorator utilities onto default agent
- update tests for new async APIs

## Testing
- `poetry run pytest -q` *(fails: RuntimeWarning: coroutine 'Plugin.validate_dependencies' was never awaited)*

------
https://chatgpt.com/codex/tasks/task_e_6872d2103ba483228e4f2e003d60f3e9