### PR TITLE
Fix runtime validation test monkeypatch

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated runtime validation tests to use monkeypatch
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/tests/test_infrastructure_validate_runtime.py
+++ b/tests/test_infrastructure_validate_runtime.py
@@ -1,4 +1,5 @@
 import pytest
+from contextlib import asynccontextmanager
 
 from entity.infrastructure import DuckDBInfrastructure, PostgresInfrastructure
 
@@ -14,7 +15,11 @@ async def test_duckdb_runtime_breaker_opens(monkeypatch):
         def close(self):
             pass
 
-    db._conn = BadConn()
+    @asynccontextmanager
+    async def bad_connection(self):
+        yield BadConn()
+
+    monkeypatch.setattr(DuckDBInfrastructure, "connection", bad_connection)
 
     res1 = await db.validate_runtime()
     assert not res1.success


### PR DESCRIPTION
## Summary
- patch DuckDBInfrastructure.connection instead of assigning `_conn`
- document the change in agents log

## Testing
- `poetry run ruff check --fix tests/test_infrastructure_validate_runtime.py`
- `poetry run black tests/test_infrastructure_validate_runtime.py`
- `poetry run mypy src` *(fails: 248 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `poetry run pytest tests/test_infrastructure_validate_runtime.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6872d672d9088322898471d54f002ca0