### PR TITLE
Fix resource initializer test isolation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Patched build_all in initializer test using monkeypatch
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/tests/test_initializer_canonical_resources.py
+++ b/tests/test_initializer_canonical_resources.py
@@ -74,7 +74,7 @@ def test_initializer_fails_without_logging():
     assert init.resource_container.get("logging") is not None
 
 
-def test_initializer_accepts_all_canonical_resources():
+def test_initializer_accepts_all_canonical_resources(monkeypatch):
     cfg = {
         "plugins": {
             "agent_resources": {
@@ -92,5 +92,5 @@ def test_initializer_accepts_all_canonical_resources():
         return None
 
     # Skip resource initialization complexity
-    ResourceContainer.build_all = types.MethodType(_noop, ResourceContainer)
+    monkeypatch.setattr(ResourceContainer, "build_all", _noop)
     asyncio.run(init.initialize())


### PR DESCRIPTION
## Summary
- use pytest's monkeypatch to stub `ResourceContainer.build_all`
- log the update

## Testing
- `poetry run pytest tests/test_initializer_canonical_resources.py::test_initializer_accepts_all_canonical_resources -q` *(fails: InitializationError missing dependency 'database')*

------
https://chatgpt.com/codex/tasks/task_e_6872d67df2548322a05fd8e821c04f5a