### PR TITLE
Fix synchronous validation handling

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Hot-reload validation supports sync and async methods
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -534,12 +534,20 @@ class EntityCLI:
                         logger.error("Plugin %s not registered", name)
                         return 2
 
-                    cfg_result = await plugin.__class__.validate_config(config)
+                    config_validator = plugin.__class__.validate_config
+                    if inspect.iscoroutinefunction(config_validator):
+                        cfg_result = await config_validator(config)
+                    else:
+                        cfg_result = config_validator(config)
                     if not cfg_result.success:
                         logger.error("%s config invalid: %s", name, cfg_result.message)
                         return 1
 
-                    dep_result = await plugin.__class__.validate_dependencies(registry)
+                    dep_validator = plugin.__class__.validate_dependencies
+                    if inspect.iscoroutinefunction(dep_validator):
+                        dep_result = await dep_validator(registry)
+                    else:
+                        dep_result = dep_validator(registry)
                     if not dep_result.success:
                         logger.error(
                             "%s dependency check failed: %s",

--- a/tests/test_infrastructure_deploy.py
+++ b/tests/test_infrastructure_deploy.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from entity.infrastructure import DockerInfrastructure, AWSStandardInfrastructure


### PR DESCRIPTION
## Summary
- allow hot-reload to call sync validation functions
- update tests formatting
- log note about sync/async reload handling

## Testing
- `poetry run black src/entity/cli/__init__.py tests/test_infrastructure_deploy.py`
- `poetry run ruff check --fix src tests` *(fails: 151 errors)*
- `poetry run mypy src` *(fails: found 248 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872d67d97708322b3337407f2477c56