### PR TITLE
Fix plugin tool selections typing

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Implemented stage aliasing and updated PluginTool analyze selections
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/src/cli/plugin_tool/main.py
+++ b/src/cli/plugin_tool/main.py
@@ -275,7 +275,7 @@ class PluginToolCLI:
                 ResourcePlugin,
             )
 
-        selections: list[tuple[str, Type[Plugin], list[PipelineStage]]] = []
+        selections: list[tuple[str, type, list]] = []
         found = False
         # Inspect async callables and classify them as plugins.
         # The reason indicates whether stages come from config hints or

--- a/src/entity/core/stages.py
+++ b/src/entity/core/stages.py
@@ -30,6 +30,12 @@ class PipelineStage(IntEnum):
     def ensure(cls, value: "PipelineStage | str") -> "PipelineStage":
         if isinstance(value, cls):
             return value
+        alias_map = {
+            "parse": "input",
+            "deliver": "output",
+        }
+        if isinstance(value, str):
+            value = alias_map.get(value.lower(), value)
         return cls.from_str(str(value))
 
 

--- a/src/entity/pipeline/stages.py
+++ b/src/entity/pipeline/stages.py
@@ -30,4 +30,10 @@ class PipelineStage(IntEnum):
     def ensure(cls, value: "PipelineStage | str") -> "PipelineStage":
         if isinstance(value, cls):
             return value
+        alias_map = {
+            "parse": "input",
+            "deliver": "output",
+        }
+        if isinstance(value, str):
+            value = alias_map.get(value.lower(), value)
         return cls.from_str(str(value))


### PR DESCRIPTION
## Summary
- handle stage aliases `parse` and `deliver`
- make the plugin tool selection list generic
- log dev note

## Testing
- `poetry run pytest tests/test_plugin_tool_analyze.py tests/test_resources/test_memory_init.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d67c59d08322a59c3e202a25d8de