### PR TITLE
Fix async tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Replaced run_until_complete with asyncio.run in tests; updated DummyConnection params
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -43,7 +43,7 @@ class DummyConnection:
     def __init__(self, store: dict) -> None:
         self.store = store
 
-    def execute(self, query: str, params: tuple):
+    def execute(self, query: str, params: tuple | None = None):
         if query.startswith("DELETE FROM conversation_history"):
             cid = params
             self.store["history"].pop(cid, None)
@@ -119,7 +119,7 @@ class DBRegistries:
         mem = Memory(config={})
         mem.database = db
         mem.vector_store = None
-        asyncio.get_event_loop().run_until_complete(mem.initialize())
+        asyncio.run(mem.initialize())
         self.resources = _Resources(memory=mem)
         self.tools = types.SimpleNamespace()
         self.validators = None

--- a/tests/test_standard_resources.py
+++ b/tests/test_standard_resources.py
@@ -55,7 +55,7 @@ def test_standard_resources_types() -> None:
     memory = Memory(config={})
     memory.database = db
     memory.vector_store = None
-    asyncio.get_event_loop().run_until_complete(memory.initialize())
+    asyncio.run(memory.initialize())
 
     llm = LLM(config={})
     llm.provider = DummyLLMProvider({})

--- a/tests/test_stateless_worker.py
+++ b/tests/test_stateless_worker.py
@@ -13,7 +13,7 @@ class DummyConnection:
     def __init__(self, store: dict) -> None:
         self.store = store
 
-    async def execute(self, query: str, params: tuple) -> None:
+    async def execute(self, query: str, params: tuple | None = None) -> None:
         if query.startswith("DELETE FROM conversation_history"):
             cid = params
             self.store["history"].pop(cid, None)


### PR DESCRIPTION
## Summary
- replace `run_until_complete` with `asyncio.run`
- make DummyConnection.execute params optional
- update memory initialization
- note test updates in `agents.log`

## Testing
- `poetry run ruff check --fix src tests` *(fails: Found 157 errors)*
- `poetry run mypy src` *(fails: Found 248 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: AttributeError)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872d67a692c83228f072674b24220f1