### PR TITLE
Add missing plugin packages and async validator handling

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Registry validator handles async results and package init files added
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/src/entity/core/registry_validator.py
+++ b/src/entity/core/registry_validator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 import pathlib
 import sys
 from typing import Dict, List
@@ -135,7 +136,7 @@ class RegistryValidator:
                 result = ValidationResult.success_result()
             else:
                 result = validate(self.registry)
-                if asyncio.iscoroutine(result):
+                if inspect.isawaitable(result):
                     result = asyncio.run(result)
             if not result.success:
                 raise SystemError(
@@ -189,7 +190,7 @@ class RegistryValidator:
                 result = ValidationResult.success_result()
             else:
                 result = validate(cfg)
-                if asyncio.iscoroutine(result):
+                if inspect.isawaitable(result):
                     result = asyncio.run(result)
             if not result.success:
                 raise SystemError(

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Entry point for plugin modules."""

--- a/src/plugins/builtin/__init__.py
+++ b/src/plugins/builtin/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in plugins distributed with Entity."""


### PR DESCRIPTION
## Summary
- expose plugin directories as packages
- ensure registry validator awaits any coroutine results
- note the change in agents.log

## Testing
- `poetry run pytest tests/test_registry_validator.py -v`
- `poetry run bandit -r src`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_6872d67c958c8322a0b0830db9aaf278