### PR TITLE
Update plugin lifecycle test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Replaced async test with asyncio.run for plugin lifecycle
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/tests/test_infrastructure_deploy.py
+++ b/tests/test_infrastructure_deploy.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from entity.infrastructure import DockerInfrastructure, AWSStandardInfrastructure

--- a/tests/test_plugin_lifecycle.py
+++ b/tests/test_plugin_lifecycle.py
@@ -1,4 +1,4 @@
-import pytest
+import asyncio
 
 from entity.core.agent import Agent
 from entity.core.plugins import Plugin
@@ -25,14 +25,13 @@ class LifecyclePlugin(Plugin):
         self.closed = True
 
 
-@pytest.mark.asyncio
-async def test_plugin_lifecycle():
+def test_plugin_lifecycle():
     ag = Agent()
     plugin = LifecyclePlugin({})
-    await ag.builder.add_plugin(plugin)
-    await ag.builder.build_runtime()
+    asyncio.run(ag.builder.add_plugin(plugin))
+    asyncio.run(ag.builder.build_runtime())
 
-    await plugin.execute(object())
+    asyncio.run(plugin.execute(object()))
     assert plugin.initialized
     assert plugin.executed
 


### PR DESCRIPTION
## Summary
- remove pytest.mark.asyncio from plugin lifecycle test
- run plugin lifecycle synchronously via asyncio.run
- record change in agents.log

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: Found 151 errors)*
- `poetry run mypy src` *(fails: Found 248 errors in 54 files)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: invalid syntax in templates)*
- `poetry run unimport --remove src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: AttributeError: 'NoneType' object has no attribute 'items')*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872d67b02bc8322a64c2e921cce23e7