### PR TITLE
Extend complex_func to trigger PluginAutoClassifier

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Extended complex_func in tests to exceed 20 lines for PluginAutoClassifier warning
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/tests/test_plugin_analyzer.py
+++ b/tests/test_plugin_analyzer.py
@@ -9,9 +9,30 @@ from entity.core.stages import PipelineStage
 
 def test_warning_logged_for_complex_function(caplog):
     async def complex_func(context):
+        total = 0
         for i in range(5):
             if i > 2:
                 break
+            total += i
+        for j in range(3):
+            total += j
+        for k in range(3):
+            total += k
+        for l in range(3):
+            total += l
+        for m in range(3):
+            total += m
+        for n in range(3):
+            total += n
+        for o in range(3):
+            total += o
+        for p in range(3):
+            total += p
+        for q in range(3):
+            total += q
+        for r in range(3):
+            total += r
+        return total
 
     with caplog.at_level(logging.WARNING):
         plugin(stage=PipelineStage.THINK)(complex_func)


### PR DESCRIPTION
## Summary
- extend `complex_func` in `test_plugin_analyzer` so it spans more than 20 lines
- add an agent note about extending the test

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src` *(fails: many errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872d6795f648322bff6a58942051bf0