### PR TITLE
Remove AgentBuilder from public exports

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Removed AgentBuilder from exports and migrated tests
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/examples/zero_config_agent/main.py
+++ b/examples/zero_config_agent/main.py
@@ -20,7 +20,7 @@ async def responder(ctx):
 
 
 async def main() -> None:
-    agent.builder.resource_registry.register("memory", Memory, {})
+    agent.register_resource("memory", Memory, {})
     response = await agent.handle("hello")
     print(response)
 

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -120,7 +120,6 @@ agent.tool_plugin = tool_plugin
 __all__ = [
     "core",
     "Agent",
-    "AgentBuilder",
     "agent",
 ]
 

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -13,6 +13,7 @@ from .plugin_utils import PluginAutoClassifier
 from entity.pipeline.exceptions import PipelineError
 from entity.pipeline.utils import StageResolver
 from entity.pipeline.workflow import Pipeline
+from entity.pipeline.stages import PipelineStage
 
 from .plugins import (
     AdapterPlugin,
@@ -384,6 +385,37 @@ class Agent:
         """Import a package and register any plugins it contains."""
 
         self.builder.load_plugins_from_package(package_name)
+
+    def register_resource(
+        self,
+        name: str,
+        cls: type,
+        config: Mapping[str, Any] | None = None,
+        *,
+        layer: int | None = None,
+    ) -> None:
+        """Register a resource with the underlying builder."""
+
+        self.builder.resource_registry.register(name, cls, config or {}, layer=layer)
+
+    def has_plugin(self, name: str) -> bool:
+        """Return True if a plugin, resource or tool named ``name`` exists."""
+
+        return self.builder.has_plugin(name)
+
+    async def build_runtime(
+        self,
+        workflow: Mapping[PipelineStage | str, Iterable[str]] | None = None,
+    ) -> AgentRuntime:
+        """Build and assign a runtime using the internal builder."""
+
+        self._runtime = await self.builder.build_runtime(workflow)
+        return self._runtime
+
+    def shutdown(self) -> None:
+        """Shut down plugins and resources."""
+
+        self.builder.shutdown()
 
     # ------------------------------------------------------------------
     # Workflow helpers

--- a/tests/test_default_agent.py
+++ b/tests/test_default_agent.py
@@ -25,5 +25,5 @@ def test_agent_handle(monkeypatch):
 
 
 def test_plugins_registered():
-    assert agent.builder.has_plugin("add")
-    assert agent.builder.has_plugin("final")
+    assert agent.has_plugin("add")
+    assert agent.has_plugin("final")

--- a/tests/test_plugin_lifecycle.py
+++ b/tests/test_plugin_lifecycle.py
@@ -29,12 +29,12 @@ class LifecyclePlugin(Plugin):
 async def test_plugin_lifecycle():
     ag = Agent()
     plugin = LifecyclePlugin({})
-    await ag.builder.add_plugin(plugin)
-    await ag.builder.build_runtime()
+    await ag.add_plugin(plugin)
+    await ag.build_runtime()
 
     await plugin.execute(object())
     assert plugin.initialized
     assert plugin.executed
 
-    ag.builder.shutdown()
+    ag.shutdown()
     assert plugin.closed

--- a/tests/test_reload_runtime_validation.py
+++ b/tests/test_reload_runtime_validation.py
@@ -33,8 +33,8 @@ async def run_reload(cli: EntityCLI, agent: Agent, cfg_path: Path) -> int:
 async def test_reload_aborts_on_failed_runtime_validation(tmp_path):
     agent = Agent()
     plugin = RuntimeCheckPlugin({"valid": True})
-    await agent.builder.add_plugin(plugin)
-    agent._runtime = await agent.builder.build_runtime()
+    await agent.add_plugin(plugin)
+    await agent.build_runtime()
 
     # Ensure config updates do not call async validator
     RuntimeCheckPlugin.validate_config = classmethod(

--- a/tests/test_reload_unknown_plugin.py
+++ b/tests/test_reload_unknown_plugin.py
@@ -1,4 +1,3 @@
-import asyncio
 import yaml
 import pytest
 from pathlib import Path
@@ -25,8 +24,8 @@ class SimplePlugin(Plugin):
 async def test_reload_requires_restart_when_plugin_missing(tmp_path: Path) -> None:
     agent = Agent()
     plugin = SimplePlugin({})
-    await agent.builder.add_plugin(plugin)
-    agent._runtime = await agent.builder.build_runtime()
+    await agent.add_plugin(plugin)
+    await agent.build_runtime()
 
     cli = EntityCLI.__new__(EntityCLI)
     cfg = {"plugins": {"prompts": {"unknown": {}}}}


### PR DESCRIPTION
## Summary
- drop `AgentBuilder` from package exports
- expose builder helpers on `Agent`
- refactor examples to register resources through `Agent`
- update tests to use `Agent` API

## Testing
- `poetry run black src tests examples`
- `poetry run ruff check --fix src tests` *(fails: 151 remaining)*
- `poetry run mypy src` *(fails: found 248 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing `--config`)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*
- `poetry run pytest tests/test_default_agent.py::test_plugins_registered -v`

------
https://chatgpt.com/codex/tasks/task_e_6872d6666a2083228d6ef010c4ac6317