### PR TITLE
Add automatic logging to plugins and resources

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added automatic logging to plugins and resources
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/docs/source/logging.md
+++ b/docs/source/logging.md
@@ -25,3 +25,11 @@ plugins:
         - type: structured_file
           path: ./logs/agent.jsonl
 ```
+
+## Automatic Logging
+
+All plugins based on :class:`~entity.core.plugins.BasePlugin` automatically log
+the start, success, and failure of their ``execute`` method. Resource classes
+derived from :class:`~entity.core.plugins.ResourcePlugin` log each operation
+tracked via ``_track_operation``. No additional code is required other than
+having a ``LoggingResource`` registered in the system.

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -367,6 +367,8 @@ class SystemInitializer:
                 deps = list(getattr(cls, "dependencies", []))
                 if "metrics_collector" not in deps:
                     deps.append("metrics_collector")
+                if "logging" not in deps:
+                    deps.append("logging")
                 cls.dependencies = deps
                 registry.register_class(cls, config, name, layer)
                 dep_graph[name] = deps
@@ -382,6 +384,8 @@ class SystemInitializer:
                 deps = list(getattr(cls, "dependencies", []))
                 if "metrics_collector" not in deps:
                     deps.append("metrics_collector")
+                if "logging" not in deps:
+                    deps.append("logging")
                 cls.dependencies = deps
                 registry.register_class(cls, config, name, 4)
                 dep_graph[name] = deps
@@ -522,6 +526,12 @@ class SystemInitializer:
             self.tool_registry = tool_registry
             for name, cls, config in registry.named_tool_classes():
                 instance = cls(config)
+                metrics = resource_container.get("metrics_collector")
+                if metrics is not None:
+                    setattr(instance, "metrics_collector", metrics)
+                log_res = resource_container.get("logging")
+                if log_res is not None:
+                    setattr(instance, "logging", log_res)
                 await tool_registry.add(name, instance)
 
             # Phase 4: instantiate prompt and adapter plugins
@@ -532,6 +542,9 @@ class SystemInitializer:
                 metrics = resource_container.get("metrics_collector")
                 if metrics is not None:
                     setattr(instance, "metrics_collector", metrics)
+                log_res = resource_container.get("logging")
+                if log_res is not None:
+                    setattr(instance, "logging", log_res)
                 stages, _ = StageResolver._resolve_plugin_stages(
                     cls, config, instance, logger=logger
                 )

--- a/tests/test_logging_integration.py
+++ b/tests/test_logging_integration.py
@@ -1,0 +1,78 @@
+import asyncio
+import json
+import types
+
+import pytest
+
+from entity.core.context import PluginContext
+from entity.core.state import PipelineState
+from entity.core.plugins import Plugin, ResourcePlugin
+from entity.core.stages import PipelineStage
+from entity.resources.logging import LoggingResource
+
+
+class DummyPlugin(Plugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> str:
+        return "ok"
+
+
+class DummyResource(ResourcePlugin):
+    infrastructure_dependencies: list[str] = []
+    resource_category = "test"
+
+    async def do(self) -> str:
+        async def _inner() -> str:
+            return "done"
+
+        return await self._track_operation(operation="do", func=_inner)
+
+
+@pytest.mark.asyncio
+async def test_plugin_logging(tmp_path):
+    log_file = tmp_path / "plugin.jsonl"
+    logger = LoggingResource(
+        {"outputs": [{"type": "structured_file", "path": str(log_file)}]}
+    )
+    await logger.initialize()
+    plugin = DummyPlugin({})
+    plugin.logging = logger
+    registries = types.SimpleNamespace(
+        resources=types.SimpleNamespace(get=lambda _n: None),
+        tools=types.SimpleNamespace(),
+        plugins=None,
+        validators=None,
+    )
+    state = PipelineState(conversation=[], pipeline_id="123")
+    context = PluginContext(state, registries)
+    context.set_current_stage(PipelineStage.THINK)
+
+    await plugin.execute(context)
+    await logger.shutdown()
+    with open(log_file, "r", encoding="utf-8") as handle:
+        entries = [json.loads(line) for line in handle]
+
+    messages = [e["message"] for e in entries]
+    assert "Plugin execution started" in messages
+    assert "Plugin execution succeeded" in messages
+
+
+@pytest.mark.asyncio
+async def test_resource_logging(tmp_path):
+    log_file = tmp_path / "resource.jsonl"
+    logger = LoggingResource(
+        {"outputs": [{"type": "structured_file", "path": str(log_file)}]}
+    )
+    await logger.initialize()
+    resource = DummyResource({})
+    resource.logging = logger
+
+    await resource.do()
+    await logger.shutdown()
+    with open(log_file, "r", encoding="utf-8") as handle:
+        entries = [json.loads(line) for line in handle]
+
+    messages = [e["message"] for e in entries]
+    assert "do started" in messages
+    assert "do succeeded" in messages


### PR DESCRIPTION
## Summary
- inject logging into all plugins and resources
- add logging to execution tracking
- update `SystemInitializer` for logging dependency
- document automatic logging behavior
- add regression tests for logging
- log note in `agents.log`

## Testing
- `poetry run pytest tests/test_logging_integration.py -q`
- `poetry run pytest tests/test_metrics_collector.py::test_plugin_dependencies_include_metrics -q`


------
https://chatgpt.com/codex/tasks/task_e_6872d65f45b08322b295409e6e010116