### PR TITLE
Fix await for context helpers

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Awaited asynchronous context helpers in prompt plugins to remove coroutine warnings
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/src/entity/plugins/prompts/chain_of_thought.py
+++ b/src/entity/plugins/prompts/chain_of_thought.py
@@ -20,7 +20,7 @@ class ChainOfThoughtPrompt(PromptPlugin):
         breakdown = await self.call_llm(
             context, breakdown_prompt, purpose="problem_breakdown"
         )
-        context.think("problem_breakdown", breakdown.content)
+        await context.think("problem_breakdown", breakdown.content)
 
         steps: List[str] = []
         for step in range(int(self.config.get("max_steps", 5))):
@@ -31,7 +31,7 @@ class ChainOfThoughtPrompt(PromptPlugin):
                 context, reasoning_prompt, purpose=f"reasoning_step_{step + 1}"
             )
             steps.append(reasoning.content)
-            context.think(f"reasoning_step_{step + 1}", reasoning.content)
+            await context.think(f"reasoning_step_{step + 1}", reasoning.content)
 
             if self._needs_tools(reasoning.content):
                 await context.tool_use(

--- a/src/entity/plugins/prompts/react.py
+++ b/src/entity/plugins/prompts/react.py
@@ -31,7 +31,7 @@ class ReActPrompt(PromptPlugin):
             thought = await self.call_llm(
                 context, thought_prompt, purpose=f"react_thought_step_{step}"
             )
-            context.think(f"thought_{step}", thought.content)
+            await context.think(f"thought_{step}", thought.content)
             step_record: Dict[str, str] = {"thought": thought.content}
 
             action_prompt = (
@@ -47,7 +47,7 @@ class ReActPrompt(PromptPlugin):
 
             if decision.content.startswith("Final Answer:"):
                 answer = decision.content.replace("Final Answer:", "").strip()
-                context.think("final_answer", answer)
+                await context.think("final_answer", answer)
                 steps.append(step_record)
                 await context.think("react_steps", steps)
                 return
@@ -56,12 +56,12 @@ class ReActPrompt(PromptPlugin):
                 action_text = decision.content.replace("Action:", "").strip()
                 action_name, params = self._parse_action(action_text)
                 step_record["action"] = action_text
-                context.think(f"action_{step}", action_text)
+                await context.think(f"action_{step}", action_text)
                 await context.tool_use(action_name, **params)
 
             steps.append(step_record)
 
-        context.think(
+        await context.think(
             "final_answer",
             "I've reached my reasoning limit without finding a definitive answer.",
         )

--- a/tests/test_response_control.py
+++ b/tests/test_response_control.py
@@ -38,14 +38,14 @@ class Thinker(PromptPlugin):
     stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        context.think("data", "x")
+        await context.think("data", "x")
 
 
 class Responder(PromptPlugin):
     stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        val = context.reflect("data")
+        val = await context.reflect("data")
         context.say(f"final:{val}")
 
 


### PR DESCRIPTION
## Summary
- await ChainOfThoughtPrompt context.think calls
- await ReActPrompt context helper calls
- fix tests referencing async context helpers
- note the fix in `agents.log`

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml`
- `pytest tests/test_architecture/ -v`
- `pytest tests/test_plugins/ -v`
- `pytest tests/test_resources/ -v`
- `pytest -q`
- `pytest tests/test_response_control.py::test_pipeline_terminates_after_say -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d65f08fc832287b83caf46d317a1