### PR TITLE
Enable runtime workflow execution

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Implemented runtime pipeline execution and added tests.
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -34,19 +34,27 @@ class _AgentRuntime:
     """Minimal runtime executor for an Agent."""
 
     capabilities: SystemRegistries
+    workflow: Workflow | None = None
     manager: Any = field(init=False)
 
-    def __init__(self, capabilities: SystemRegistries) -> None:
+    def __init__(
+        self, capabilities: SystemRegistries, *, workflow: Workflow | None = None
+    ) -> None:
         self.capabilities = capabilities
+        self.workflow = workflow
         self.__post_init__()
 
     def __post_init__(self) -> None:
         self.manager = None
 
-    async def run_pipeline(
-        self, message: str, *, user_id: str | None = None
-    ) -> Dict[str, Any]:
-        return {"message": message, "user_id": user_id or "default"}
+    async def run_pipeline(self, message: str, *, user_id: str | None = None) -> Any:
+        from entity.pipeline.pipeline import Pipeline as ExecPipeline, execute_pipeline
+
+        if self.workflow is None:
+            return await execute_pipeline(message, self.capabilities, user_id=user_id)
+
+        pipeline = ExecPipeline(self.workflow)
+        return await pipeline.run_message(message, self.capabilities, user_id=user_id)
 
     async def handle(
         self, message: str, *, user_id: str | None = None
@@ -266,7 +274,14 @@ class _AgentBuilder:
             tools=self.tool_registry,
             plugins=self.plugin_registry,
         )
-        return _AgentRuntime(capabilities)
+        wf_obj = None
+        if workflow is not None:
+            wf_obj = (
+                workflow
+                if isinstance(workflow, Workflow)
+                else Workflow.from_dict(workflow)
+            )
+        return _AgentRuntime(capabilities, workflow=wf_obj)
 
     def shutdown(self) -> None:
         """Shut down plugins and resources."""
@@ -454,13 +469,13 @@ class Agent:
                 initializer = SystemInitializer.from_yaml(path, env_file)
 
         async def _build() -> tuple[AgentRuntime, dict[str, type]]:
-            plugins, resources, tools, _ = await initializer.initialize()
+            plugins, resources, tools, wf = await initializer.initialize()
             caps = SystemRegistries(
                 resources=resources,
                 tools=tools,
                 plugins=plugins,
             )
-            return AgentRuntime(caps), initializer.workflows
+            return AgentRuntime(caps, workflow=wf), initializer.workflows
 
         runtime, workflows = asyncio.run(_build())
         agent = cls(config_path=path)
@@ -471,7 +486,8 @@ class Agent:
     # ------------------------------------------------------------------
     async def _ensure_runtime(self) -> None:
         if self._runtime is None:
-            self._runtime = await self.builder.build_runtime()
+            workflow = self.pipeline.workflow if self.pipeline else None
+            self._runtime = await self.builder.build_runtime(workflow=workflow)
 
     @property
     def runtime(self) -> AgentRuntime:

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -1,0 +1,47 @@
+import pytest
+
+from entity.core.agent import Agent, _AgentBuilder
+from entity.core.plugins import Plugin
+from entity.pipeline.stages import PipelineStage
+from entity.workflows.base import Workflow
+
+
+class ThoughtPlugin(Plugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        last = context.conversation()[-1].content
+        await context.think("msg", last)
+
+
+class EchoPlugin(Plugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context):
+        msg = await context.reflect("msg")
+        context.say(f"{msg}!")
+
+
+@pytest.mark.asyncio
+async def test_builder_runtime_executes_workflow():
+    builder = _AgentBuilder()
+    await builder.add_plugin(ThoughtPlugin({}))
+    await builder.add_plugin(EchoPlugin({}))
+    wf = Workflow(
+        {PipelineStage.THINK: ["ThoughtPlugin"], PipelineStage.OUTPUT: ["EchoPlugin"]}
+    )
+    runtime = await builder.build_runtime(workflow=wf)
+    result = await runtime.handle("hello")
+    assert result == "hello!"
+
+
+@pytest.mark.asyncio
+async def test_agent_handle_runs_workflow():
+    agent = Agent()
+    await agent.add_plugin(ThoughtPlugin({}))
+    await agent.add_plugin(EchoPlugin({}))
+    agent.pipeline = Workflow(
+        {PipelineStage.THINK: ["ThoughtPlugin"], PipelineStage.OUTPUT: ["EchoPlugin"]}
+    )
+    result = await agent.handle("bye")
+    assert result == "bye!"

--- a/tests/test_default_agent.py
+++ b/tests/test_default_agent.py
@@ -9,7 +9,7 @@ async def add(a: int, b: int) -> int:
     return a + b
 
 
-@agent.prompt
+@agent.output
 async def final(ctx):
     result = await ctx.tool_use("add", a=1, b=1)
     ctx.say(str(result))
@@ -21,7 +21,7 @@ def test_agent_handle(monkeypatch):
 
     monkeypatch.setattr(OllamaLLMResource, "generate", fake_generate, False)
     result = asyncio.run(agent.handle("hi"))
-    assert result["message"] == "hi"
+    assert result == "2"
 
 
 def test_plugins_registered():


### PR DESCRIPTION
## Summary
- implement pipeline execution in `_AgentRuntime.run_pipeline`
- pass workflow information when creating runtimes
- allow `Agent.handle` to execute configured workflows
- fix default agent test and add tests verifying runtime plugin execution
- add dev note

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src/entity/core/agent.py tests/test_default_agent.py tests/test_agent_runtime.py` *(fails: E402 Module level import not at top of file)*
- `poetry run mypy src` *(fails: Found 249 errors in 54 files)*
- `poetry run bandit -r src` *(reports 35 low, 10 medium issues)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(raised RuntimeWarning)*
- `poetry run entity-cli --config config/prod.yaml verify` *(raised RuntimeWarning)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing `--config` argument)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872d6643ebc8322a76a209ef0dc1325