### PR TITLE
Fix canonical resource test isolation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Fixed logging tests to use monkeypatch and avoid global state
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/tests/test_logging_resource.py
+++ b/tests/test_logging_resource.py
@@ -9,9 +9,10 @@ from entity.resources.logging import LoggingResource
 
 
 @pytest.mark.asyncio
-async def test_logging_file_and_console(tmp_path, capsys):
+async def test_logging_file_and_console(tmp_path, capsys, monkeypatch):
     log_file = tmp_path / "log.jsonl"
     container = ResourceContainer()
+    monkeypatch.setattr(LoggingResource, "dependencies", [])
     container.register(
         "logging",
         LoggingResource,
@@ -31,8 +32,9 @@ async def test_logging_file_and_console(tmp_path, capsys):
 
 
 @pytest.mark.asyncio
-async def test_logging_stream_output(tmp_path):
+async def test_logging_stream_output(tmp_path, monkeypatch):
     container = ResourceContainer()
+    monkeypatch.setattr(LoggingResource, "dependencies", [])
     container.register(
         "logging",
         LoggingResource,
@@ -52,8 +54,9 @@ async def test_logging_stream_output(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_logging_auto_registration():
+async def test_logging_auto_registration(monkeypatch):
     container = ResourceContainer()
+    monkeypatch.setattr(LoggingResource, "dependencies", [])
     await container.build_all()
     logger = container.get("logging")
     assert isinstance(logger, LoggingResource)


### PR DESCRIPTION
## Summary
- isolate initializer test with monkeypatch
- ensure logging tests patch dependencies
- record testing note

## Testing
- `poetry run pytest tests/test_logging_resource.py::test_logging_auto_registration -vv`

------
https://chatgpt.com/codex/tasks/task_e_6872d675c1b08322b5cb88fd1506deab