### PR TITLE
Update initializer tests for canonical resources

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated initializer tests for new dependencies
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline


### PR DESCRIPTION
## Summary
- ensure initializer tests include database and llm provider
- patch resource initialization using monkeypatch
- expect missing canonical resource errors
- log update in agents.log

## Testing
- `poetry run pytest tests/test_initializer_canonical_resources.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d6750a388322818fd928156e3789