### PR TITLE
Use pooled DB connections in memory resource

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated Memory resource to use pooled connections and adjusted tests
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -11,6 +11,7 @@ from .interfaces.database import DatabaseResource as DatabaseInterface
 from .interfaces.vector_store import (
     VectorStoreResource as VectorStoreInterface,
 )
+from ..core.resources.container import ResourcePool
 from ..core.plugins import ValidationResult
 from ..core.state import ConversationEntry
 from entity.pipeline.errors import InitializationError, ResourceInitializationError
@@ -26,7 +27,7 @@ class Memory(AgentResource):
         super().__init__(config or {})
         self.database: DatabaseInterface | None = None
         self.vector_store: VectorStoreInterface | None = None
-        self._pool: Any | None = None
+        self._pool: ResourcePool | None = None
         self._kv_table = self.config.get("kv_table", "memory_kv")
         self._history_table = self.config.get("history_table", "conversation_history")
 


### PR DESCRIPTION
## Summary
- keep database connection pool on `Memory`
- fetch connections from `DatabaseResource` context manager
- expand dummy connection in tests to mimic DB cursor
- adjust plugin memory tests for async API
- document the change

## Testing
- `poetry run pytest tests/test_plugin_context_memory.py -v`
- `poetry run pytest tests/test_memory_basic.py -v`
- `poetry run pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6872d67886b483229062a65d65e2d635