### PR TITLE
Add config models and validation for core resources

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-13: Consolidated pipeline under entity.pipeline

--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -76,6 +76,34 @@ class BreakerSettings(BaseModel):
     )
 
 
+class MemoryConfig(BaseModel):
+    """Configuration model for the :class:`~entity.resources.memory.Memory`."""
+
+    kv_table: str = "memory_kv"
+    history_table: str = "conversation_history"
+
+    class Config:
+        extra = "forbid"
+
+
+class LLMConfig(BaseModel):
+    """Configuration model for the :class:`~entity.resources.llm.LLM`."""
+
+    provider: str = "default"
+
+    class Config:
+        extra = "forbid"
+
+
+class StorageConfig(BaseModel):
+    """Configuration model for the :class:`~entity.resources.storage.Storage`."""
+
+    namespace: str = "default"
+
+    class Config:
+        extra = "forbid"
+
+
 class LogOutputConfig(BaseModel):
     """Configuration for a single logging output."""
 
@@ -129,6 +157,9 @@ __all__ = [
     "ToolRegistryConfig",
     "CircuitBreakerConfig",
     "BreakerSettings",
+    "MemoryConfig",
+    "LLMConfig",
+    "StorageConfig",
     "LogOutputConfig",
     "LoggingConfig",
     "EntityConfig",

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from ..core.plugins import ValidationResult
+from entity.config.models import LLMConfig
+from pydantic import ValidationError
 
 from .base import AgentResource
 from .interfaces.llm import LLMResource
@@ -19,6 +21,14 @@ class LLM(AgentResource):
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
         self.provider: LLMResource | None = None
+
+    @classmethod
+    async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        try:
+            LLMConfig.parse_obj(config)
+        except ValidationError as exc:
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None

--- a/src/entity/resources/logging.py
+++ b/src/entity/resources/logging.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .base import AgentResource
+from entity.config.models import LoggingConfig
+from pydantic import ValidationError
+from entity.core.plugins import ValidationResult
 
 
 def _level(name: str) -> int:
@@ -125,6 +128,14 @@ class LoggingResource(AgentResource):
         super().__init__(config or {})
         self._outputs: List[LogOutput] = []
         self._stream_outputs: List[StreamLogOutput] = []
+
+    @classmethod
+    async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        try:
+            LoggingConfig.parse_obj(config)
+        except ValidationError as exc:
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()
 
     async def initialize(self) -> None:
         outputs_cfg = self.config.get("outputs", [{"type": "console"}])

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -12,6 +12,8 @@ from .interfaces.vector_store import (
     VectorStoreResource as VectorStoreInterface,
 )
 from ..core.plugins import ValidationResult
+from entity.config.models import MemoryConfig
+from pydantic import ValidationError
 from ..core.state import ConversationEntry
 from entity.pipeline.errors import InitializationError, ResourceInitializationError
 
@@ -124,6 +126,10 @@ class Memory(AgentResource):
     async def validate_config(
         cls, config: Dict[str, Any]
     ) -> ValidationResult:  # noqa: D401
+        try:
+            MemoryConfig.parse_obj(config)
+        except ValidationError as exc:
+            return ValidationResult.error_result(str(exc))
         return ValidationResult.success_result()
 
     # ------------------------------------------------------------------

--- a/src/entity/resources/storage.py
+++ b/src/entity/resources/storage.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from ..core.plugins import ValidationResult
+from entity.config.models import StorageConfig
+from pydantic import ValidationError
 
 
 from .base import AgentResource
@@ -18,6 +20,14 @@ class Storage(AgentResource):
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
         self._data: Dict[str, Any] = {}
+
+    @classmethod
+    async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        try:
+            StorageConfig.parse_obj(config)
+        except ValidationError as exc:
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None

--- a/tests/test_builtin_resource_configs.py
+++ b/tests/test_builtin_resource_configs.py
@@ -1,0 +1,31 @@
+import pytest
+
+from entity.resources.memory import Memory
+from entity.resources.logging import LoggingResource
+from entity.resources.llm import LLM
+from entity.resources.storage import Storage
+from entity.core.plugins import ValidationResult
+
+
+@pytest.mark.asyncio
+async def test_memory_config_invalid():
+    result = await Memory.validate_config({"kv_table": 123})
+    assert not result.success
+
+
+@pytest.mark.asyncio
+async def test_logging_config_invalid():
+    result = await LoggingResource.validate_config({"outputs": ""})
+    assert not result.success
+
+
+@pytest.mark.asyncio
+async def test_llm_config_invalid():
+    result = await LLM.validate_config({"provider": 123})
+    assert not result.success
+
+
+@pytest.mark.asyncio
+async def test_storage_config_invalid():
+    result = await Storage.validate_config({"namespace": 1})
+    assert not result.success


### PR DESCRIPTION
## Summary
- create `MemoryConfig`, `LLMConfig`, and `StorageConfig`
- use BaseModel validation in logging, memory, llm and storage resources
- add unit tests for built in resource configuration
- document the changes in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 154 remaining errors)*
- `poetry run mypy src` *(fails: found 251 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: AttributeError)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `PYTHONPATH=src pytest tests/test_builtin_resource_configs.py -q` *(failed: ModuleNotFoundError: No module named 'duckdb')*


------
https://chatgpt.com/codex/tasks/task_e_6872d664f5b08322ad87550af3e47941