### PR TITLE
Remove parse/deliver stage aliases

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-16: Removed parse/deliver stage aliases from PipelineStage
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent

--- a/src/entity/core/stages.py
+++ b/src/entity/core/stages.py
@@ -30,12 +30,6 @@ class PipelineStage(IntEnum):
     def ensure(cls, value: "PipelineStage | str") -> "PipelineStage":
         if isinstance(value, cls):
             return value
-        alias_map = {
-            "parse": "input",
-            "deliver": "output",
-        }
-        if isinstance(value, str):
-            value = alias_map.get(value.lower(), value)
         return cls.from_str(str(value))
 
 

--- a/src/entity/pipeline/stages.py
+++ b/src/entity/pipeline/stages.py
@@ -30,10 +30,4 @@ class PipelineStage(IntEnum):
     def ensure(cls, value: "PipelineStage | str") -> "PipelineStage":
         if isinstance(value, cls):
             return value
-        alias_map = {
-            "parse": "input",
-            "deliver": "output",
-        }
-        if isinstance(value, str):
-            value = alias_map.get(value.lower(), value)
         return cls.from_str(str(value))

--- a/tests/test_plugin_tool_analyze.py
+++ b/tests/test_plugin_tool_analyze.py
@@ -37,8 +37,8 @@ def test_analyze_plugin_override(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr("builtins.input", lambda *_: "parse,deliver")
 
     with caplog.at_level(logging.INFO):
-        cli._analyze_plugin()
+        result = cli._analyze_plugin()
 
     log = "\n".join(r.message for r in caplog.records)
-    assert "input" in log
-    assert "output" in log
+    assert result == 1
+    assert "Invalid stage" in log


### PR DESCRIPTION
## Summary
- drop alias rewriting from `PipelineStage.ensure`
- adjust plugin tool tests
- record update in `agents.log`

## Testing
- `poetry run pytest -q` *(fails: NameError: name 'start' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6872de50d69c832295c76dc3ea5bbfbc