### PR TITLE
Add forbidden pipeline import test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added test for forbidden imports in user plugins
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent

--- a/tests/test_user_plugin_imports.py
+++ b/tests/test_user_plugin_imports.py
@@ -1,0 +1,14 @@
+import re
+from pathlib import Path
+
+
+def test_user_plugins_do_not_import_pipeline():
+    base = Path("user_plugins")
+    pattern = re.compile(r"^(?:from|import)\s+(entity\.pipeline|pipeline)")
+    offending = []
+    for py_file in base.rglob("*.py"):
+        with py_file.open() as f:
+            for lineno, line in enumerate(f, 1):
+                if pattern.search(line):
+                    offending.append(f"{py_file}:{lineno}:{line.strip()}")
+    assert not offending, "Forbidden pipeline imports found:\n" + "\n".join(offending)


### PR DESCRIPTION
## Summary
- add test scanning user plugins for `entity.pipeline` or `pipeline`
- log note about new test

## Testing
- `poetry run black src tests`
- `poetry run pytest -q` *(fails: RuntimeError: Event loop is closed, ModuleNotFoundError: 'entity', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6872dea578548322a305cff35307a3b5