### PR TITLE
Maintain test references

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Verified tests only use default_setup and kitchen_sink; no example references found
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent


### PR DESCRIPTION
## Summary
- confirm no remaining paths to old examples
- log findings in `agents.log`

## Testing
- `poetry run black tests`
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: found 159 errors)*
- `poetry run mypy src` *(fails: found 255 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: AttributeError 'NoneType' object has no attribute 'items')*
- `poetry run pytest -k example -q`
- `poetry run pytest -k "" -q` *(fails: 37 failed, 56 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6872def14da08322bcbe2c389b66683e