### PR TITLE
Add basic example tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-17: Added tests for zero_config example and kitchen_sink placeholder
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent

--- a/examples/zero_config_agent/main.py
+++ b/examples/zero_config_agent/main.py
@@ -2,7 +2,7 @@ import asyncio
 
 from entity import Agent
 from entity.resources.memory import Memory
-from pipeline.stages import PipelineStage
+from entity.pipeline.stages import PipelineStage
 
 agent = Agent()
 

--- a/tests/test_examples_run.py
+++ b/tests/test_examples_run.py
@@ -1,0 +1,34 @@
+import asyncio
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_zero_config_example_runs(monkeypatch):
+    """examples/zero_config_agent should run without network calls."""
+    from httpx import AsyncClient
+
+    async def fake_post(self, url, json):
+        class R:
+            def json(self):
+                return {"response": "ok"}
+
+        return R()
+
+    monkeypatch.patch.object(AsyncClient, "post", fake_post)
+
+    mod = import_module("examples.zero_config_agent.main")
+    assert hasattr(mod, "main")
+    await mod.main()
+
+
+@pytest.mark.asyncio
+async def test_kitchen_sink_example(monkeypatch):
+    path = Path("examples/kitchen_sink/main.py")
+    if not path.exists():
+        pytest.skip("kitchen_sink example not present")
+    mod = import_module("examples.kitchen_sink.main")
+    assert hasattr(mod, "main")
+    await mod.main()


### PR DESCRIPTION
## Summary
- verify zero config example runs and patch network calls
- add placeholder test for kitchen sink example
- fix import path in zero_config_agent example
- update agents log

## Testing
- `poetry run pytest -q` *(fails: DummyRegistries object has no attribute 'plugins')*

------
https://chatgpt.com/codex/tasks/task_e_6872dea0ac8c8322834b5dcec4200597