### PR TITLE
Add test for resource dependency violations

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added test for cross-layer dependency violation in ResourceContainer
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer
 AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent

--- a/tests/test_resource_dependencies.py
+++ b/tests/test_resource_dependencies.py
@@ -1,0 +1,34 @@
+import asyncio
+import pytest
+
+from entity.core.resources.container import ResourceContainer
+from entity.core.plugins import InfrastructurePlugin, ResourcePlugin, AgentResource
+from entity.pipeline.errors import InitializationError
+
+
+class DummyInfra(InfrastructurePlugin):
+    infrastructure_type = "infra"
+    stages: list = []
+
+
+class HigherResource(AgentResource):
+    stages: list = []
+
+
+class LowerInterface(ResourcePlugin):
+    infrastructure_dependencies = ["infra"]
+    dependencies = ["higher"]
+    stages: list = []
+
+
+def test_dependency_on_higher_layer_raises(monkeypatch) -> None:
+    monkeypatch.setattr(DummyInfra, "dependencies", [])
+    monkeypatch.setattr(HigherResource, "dependencies", [])
+    monkeypatch.setattr(LowerInterface, "dependencies", ["higher"])
+    container = ResourceContainer()
+    container.register("infra", DummyInfra, {}, layer=1)
+    container.register("higher", HigherResource, {}, layer=3)
+    container.register("lower", LowerInterface, {}, layer=2)
+
+    with pytest.raises(InitializationError, match="layer rules"):
+        asyncio.run(container.build_all())


### PR DESCRIPTION
## Summary
- add regression test for detecting invalid cross-layer dependencies
- patch resource container tests to remove default metric deps
- log note about the new test

## Testing
- `poetry run pytest tests/test_resource_container.py tests/test_resource_dependencies.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6872def377488322b9db13f162367869