### PR TITLE
Replace deprecated pipeline imports in examples and plugins

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Updated plugins and examples to use entity.core.stages and removed pipeline.errors calls
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests
 AGENT NOTE - 2025-07-12: Added infrastructure deps injection in ResourceContainer

--- a/examples/basic_agent/main.py
+++ b/examples/basic_agent/main.py
@@ -8,10 +8,11 @@ import sys
 base = Path(__file__).resolve().parents[2]
 sys.path.append(str(base / "src"))
 sys.path.append(str(base))
+# ruff: noqa: E402
 
 from entity.core.plugins import PromptPlugin
 from entity.core.context import PluginContext
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 from datetime import datetime
 
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry

--- a/examples/default_setup/main.py
+++ b/examples/default_setup/main.py
@@ -1,8 +1,7 @@
 import asyncio
 
 from entity import Agent
-from entity.resources.memory import Memory
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 agent = Agent()
 

--- a/examples/duckdb_memory_agent/main.py
+++ b/examples/duckdb_memory_agent/main.py
@@ -10,13 +10,14 @@ import sys
 base = Path(__file__).resolve().parents[2]
 sys.path.append(str(base / "src"))
 sys.path.append(str(base))
+# ruff: noqa: E402
 
 import duckdb
 
 from entity.core.plugins import PromptPlugin, ResourcePlugin
 from entity.core.context import PluginContext
 from entity.core.state import ConversationEntry
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
 from entity.core.resources.container import ResourceContainer
 from entity.pipeline.pipeline import execute_pipeline, generate_pipeline_id

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -8,11 +8,12 @@ import sys
 base = Path(__file__).resolve().parents[2]
 sys.path.append(str(base / "src"))
 sys.path.append(str(base))
+# ruff: noqa: E402
 
 from user_plugins.responders import ComplexPromptResponder
 from entity.core.plugins import PromptPlugin, ResourcePlugin
 from entity.core.context import PluginContext
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 from datetime import datetime
 
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry

--- a/examples/kitchen_sink/main.py
+++ b/examples/kitchen_sink/main.py
@@ -8,12 +8,13 @@ import sys
 base = Path(__file__).resolve().parents[2]
 sys.path.append(str(base / "src"))
 sys.path.append(str(base))
+# ruff: noqa: E402
 
 from user_plugins.tools.calculator_tool import CalculatorTool
 from user_plugins.responders import ReactResponder
 from entity.core.plugins import PromptPlugin, ResourcePlugin
 from entity.core.context import PluginContext
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 from datetime import datetime
 
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry

--- a/user_plugins/failure/basic_logger.py
+++ b/user_plugins/failure/basic_logger.py
@@ -8,7 +8,7 @@ from entity.core.plugins import FailurePlugin
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from entity.core.context import PluginContext
 
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 
 class BasicLogger(FailurePlugin):

--- a/user_plugins/failure/default_responder.py
+++ b/user_plugins/failure/default_responder.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from entity.core.context import PluginContext
-from pipeline.errors import create_error_response, create_static_error_response
-from pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 
 class DefaultResponder(FailurePlugin):
@@ -19,10 +18,22 @@ class DefaultResponder(FailurePlugin):
         if info is None:
             await context.think(
                 "failure_response",
-                create_static_error_response(context.pipeline_id).to_dict(),
+                {
+                    "error": "System error occurred",
+                    "message": "An unexpected error prevented processing your request.",
+                    "error_id": context.pipeline_id,
+                    "type": "static_fallback",
+                },
             )
         else:
             await context.think(
                 "failure_response",
-                create_error_response(context.pipeline_id, info).to_dict(),
+                {
+                    "error": info.error_message,
+                    "message": "Unable to process request",
+                    "error_id": context.pipeline_id,
+                    "plugin": info.plugin_name,
+                    "stage": info.stage,
+                    "type": "plugin_error",
+                },
             )

--- a/user_plugins/failure/error_formatter.py
+++ b/user_plugins/failure/error_formatter.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from entity.core.context import PluginContext
-from pipeline.errors import create_static_error_response
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 
 class ErrorFormatter(FailurePlugin):
@@ -17,7 +16,12 @@ class ErrorFormatter(FailurePlugin):
     async def _execute_impl(self, context: PluginContext) -> None:
         failure_msg = await context.reflect("failure_response")
         if failure_msg is None:
-            failure_msg = create_static_error_response(context.pipeline_id).to_dict()
+            failure_msg = {
+                "error": "System error occurred",
+                "message": "An unexpected error prevented processing your request.",
+                "error_id": context.pipeline_id,
+                "type": "static_fallback",
+            }
         elif hasattr(failure_msg, "to_dict"):
             failure_msg = failure_msg.to_dict()
         await context.say(failure_msg)

--- a/user_plugins/prompts/chain_of_thought.py
+++ b/user_plugins/prompts/chain_of_thought.py
@@ -5,7 +5,7 @@ from typing import List
 from entity.core.plugins import PromptPlugin
 from entity.core.state import ConversationEntry
 from entity.core.context import PluginContext
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 
 class ChainOfThoughtPrompt(PromptPlugin):

--- a/user_plugins/prompts/complex_prompt.py
+++ b/user_plugins/prompts/complex_prompt.py
@@ -6,7 +6,7 @@ from entity.core.plugins import PromptPlugin
 from entity.core.state import ConversationEntry
 from entity.core.context import PluginContext
 from entity.resources.memory import Memory
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 
 class ComplexPrompt(PromptPlugin):

--- a/user_plugins/prompts/intent_classifier.py
+++ b/user_plugins/prompts/intent_classifier.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from entity.core.plugins import PromptPlugin, ValidationResult
 from entity.core.context import PluginContext
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 
 class IntentClassifierPrompt(PromptPlugin):

--- a/user_plugins/prompts/pii_scrubber.py
+++ b/user_plugins/prompts/pii_scrubber.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from entity.core.plugins import PromptPlugin
 from entity.core.context import PluginContext
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 from entity.core.state import ConversationEntry
 
 

--- a/user_plugins/prompts/react_prompt.py
+++ b/user_plugins/prompts/react_prompt.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Tuple
 from entity.core.plugins import PromptPlugin
 from entity.core.state import ConversationEntry
 from entity.core.context import PluginContext
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 
 class ReActPrompt(PromptPlugin):

--- a/user_plugins/responders/complex_prompt_responder.py
+++ b/user_plugins/responders/complex_prompt_responder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from entity.core.context import PluginContext
 from entity.core.plugins import PromptPlugin
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 
 class ComplexPromptResponder(PromptPlugin):

--- a/user_plugins/responders/react_responder.py
+++ b/user_plugins/responders/react_responder.py
@@ -4,7 +4,7 @@ from typing import List
 
 from entity.core.context import PluginContext
 from entity.core.plugins import PromptPlugin
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 
 
 class ReactResponder(PromptPlugin):

--- a/user_plugins/tools/calculator_tool.py
+++ b/user_plugins/tools/calculator_tool.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from pydantic import BaseModel
 
 from entity.core.plugins import ToolPlugin
-from entity.pipeline.stages import PipelineStage
+from entity.core.stages import PipelineStage
 from entity.core.validation.input import validate_params
 
 


### PR DESCRIPTION
## Summary
- switch to `entity.core.stages` in user plugins and examples
- drop `pipeline.errors` helpers in failure plugins
- add lint ignore hints for examples
- log refactor note

## Testing
- `poetry run ruff check --fix examples user_plugins`
- `poetry run mypy src examples user_plugins` *(fails: ModuleNotFoundError)*
- `poetry run bandit -r src`
- `poetry run vulture src` *(fails: Command not found)*
- `poetry run unimport --remove-all src examples user_plugins` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872e288060c83229d86fff89a9374b5