### PR TITLE
Remove leftover sandbox references

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -6,9 +6,6 @@ from .core.agent import Agent
 from .infrastructure import DuckDBInfrastructure
 from .resources import LLM, Memory, Storage
 from plugins.builtin.resources.ollama_llm import OllamaLLMResource
-from plugins.builtin.resources.duckdb_resource import (  # noqa: F401
-    DuckDBResource,
-)
 from .core.stages import PipelineStage
 from .core.plugins import PromptPlugin, ToolPlugin
 from .utils.setup_manager import Layer0SetupManager

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -15,7 +15,6 @@ import yaml
 
 from entity.core.agent import Agent
 from entity.core.plugins import Plugin, ValidationResult
-from entity.core.agent import _AgentBuilder
 from entity.pipeline.config.config_update import update_plugin_configuration
 from entity.pipeline.exceptions import CircuitBreakerTripped
 from entity.pipeline.reliability import CircuitBreaker

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Dict, List
+from typing import Any, Dict, List
 
 from entity.utils.logging import get_logger
 from entity.pipeline.utils import _normalize_stages
@@ -235,7 +235,7 @@ class ResourcePlugin(Plugin):
         try:
             result = await func()
             return result
-        except Exception as exc:
+        except Exception:
             success = False
             raise
         finally:

--- a/src/entity/pipeline/workflow.py
+++ b/src/entity/pipeline/workflow.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Iterable, Mapping, Optional, TYPE_CHECKING
 
-from typing import TYPE_CHECKING
-
-from entity.core.agent import _AgentBuilder
-
 if TYPE_CHECKING:
     from entity.core.agent import AgentRuntime, _AgentBuilder
 else:

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -1,6 +1,5 @@
 from .base import AgentResource, StandardResources
 from .llm import LLM
-from .logging import LoggingResource
 from .memory import Memory
 from .storage import Storage
 from .metrics import MetricsCollectorResource

--- a/src/plugins/builtin/resources/__init__.py
+++ b/src/plugins/builtin/resources/__init__.py
@@ -2,7 +2,6 @@
 
 from .echo_llm import EchoLLMResource
 from .ollama_llm import OllamaLLMResource
-from .duckdb_resource import DuckDBResource
 from .pg_vector_store import PgVectorStore
 
 __all__ = [

--- a/tests/test_builtin_resource_configs.py
+++ b/tests/test_builtin_resource_configs.py
@@ -4,7 +4,6 @@ from entity.resources.memory import Memory
 from entity.resources.logging import LoggingResource
 from entity.resources.llm import LLM
 from entity.resources.storage import Storage
-from entity.core.plugins import ValidationResult
 
 
 @pytest.mark.asyncio

--- a/tests/test_examples_run.py
+++ b/tests/test_examples_run.py
@@ -1,4 +1,3 @@
-import asyncio
 from importlib import import_module
 from pathlib import Path
 

--- a/tests/test_logging_integration.py
+++ b/tests/test_logging_integration.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import types
 

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -3,9 +3,7 @@ import pytest
 
 import sys
 import pathlib
-import types
 
-import pytest
 
 sys.path.insert(0, str(pathlib.Path("src").resolve()))
 


### PR DESCRIPTION
## Summary
- remove stale DuckDBResource import
- clean unused imports via `unimport`
- log sandbox check result

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6872e994bd9083228ce5ff6c1dd3a94f