### PR TITLE
Load secrets env

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ This project uses `mise` for Python version management. The `.python-version` fi
 ```bash
 mise install
 ```
+### Secrets Management
+
+Store API keys and credentials in `secrets/<env>.env` files. The `load_env()` helper first loads `.env` and then overrides values with the matching secrets file, keeping existing environment variables intact. Ensure the `secrets/` directory remains untracked.
+
 
 
 ## Examples

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-18: Added secret env loading and tests
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests

--- a/docs/source/environment.md
+++ b/docs/source/environment.md
@@ -1,0 +1,12 @@
+# Secrets and Environment Variables
+
+Configuration files may reference environment variables using the `${VAR}` syntax. Call `load_env()` before loading your YAML or JSON to populate these values.
+
+`load_env()` reads variables from two places:
+
+1. The project `.env` file.
+2. `secrets/<env>.env` where `<env>` matches the environment name, such as `dev` or `prod`.
+
+Existing process variables are never overwritten. Values from the secrets file override those from `.env` when both define the same key.
+
+Store API keys and other credentials in the `secrets/` directory and keep these files out of version control.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -9,6 +9,7 @@ The pipeline implementation now lives under the ``entity.pipeline`` package. Imp
 :hidden:
 error_handling
 logging
+environment
 ```
 
 The following pages cover core concepts and usage patterns.

--- a/src/entity/config/environment.py
+++ b/src/entity/config/environment.py
@@ -1,14 +1,32 @@
-from __future__ import annotations
-
 """Environment helpers for Entity."""
 
+from __future__ import annotations
+
+import os
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 
 
-def load_env(env_file: str | Path = ".env") -> None:
-    """Load environment variables from ``env_file`` if it exists."""
+def load_env(env_file: str | Path = ".env", env: str | None = None) -> None:
+    """Load variables from ``env_file`` and ``secrets/<env>.env``.
+
+    Existing process variables are never overwritten. Values from
+    ``secrets/<env>.env`` override entries from ``env_file`` when both
+    are present.
+    """
+
+    env_values = {}
+
     env_path = Path(env_file)
     if env_path.exists():
-        load_dotenv(env_path)
+        env_values.update(dotenv_values(env_path))
+
+    env_name = env or os.getenv("ENTITY_ENV")
+    if env_name:
+        secret_path = Path("secrets") / f"{env_name}.env"
+        if secret_path.exists():
+            env_values.update(dotenv_values(secret_path))
+
+    for key, value in env_values.items():
+        os.environ.setdefault(key, value)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,54 @@
+import os
+from entity.config.environment import load_env
+
+
+def test_env_file_loading(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("FOO=env\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("FOO", raising=False)
+
+    load_env(env_file)
+
+    assert os.environ["FOO"] == "env"
+
+
+def test_env_does_not_override_existing(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("BAR=env\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BAR", "os")
+
+    load_env(env_file)
+
+    assert os.environ["BAR"] == "os"
+
+
+def test_secret_overrides_env_file(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("BAZ=env\n")
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    secret_file = secrets / "dev.env"
+    secret_file.write_text("BAZ=secret\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BAZ", raising=False)
+
+    load_env(env_file, env="dev")
+
+    assert os.environ["BAZ"] == "secret"
+
+
+def test_os_env_overrides_secret(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("QUX=env\n")
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    secret_file = secrets / "prod.env"
+    secret_file.write_text("QUX=secret\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("QUX", "os")
+
+    load_env(env_file, env="prod")
+
+    assert os.environ["QUX"] == "os"


### PR DESCRIPTION
## Summary
- expand environment loader to read secrets/<env>.env and respect override order
- document storing API keys and new secret environment behaviour
- add unit tests verifying env precedence
- note update in agents log

## Testing
- `poetry run ruff check src/entity/config/environment.py tests/test_environment.py`
- `poetry run mypy src` *(fails: cannot find modules, missing type annotations)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/test_environment.py -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872ea94b9f48322b586bcfab6285b9d