### PR TITLE
Add automatic config docs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install black isort flake8 mypy pydocstyle
+      - run: pip install .[dev]
+      - run: python docs/generate_config_docs.py --check
       - run: black --check src tests
       - run: isort --check-only src tests
       - run: flake8 src tests

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added config docs generator and CI check
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests

--- a/docs/generate_config_docs.py
+++ b/docs/generate_config_docs.py
@@ -1,0 +1,91 @@
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+from pydantic import BaseModel, fields
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location(
+    "entity_config_models", ROOT / "src/entity/config/models.py"
+)
+models = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(models)
+
+
+def iter_models() -> Iterable[type[BaseModel]]:
+    for _, obj in inspect.getmembers(models):
+        if (
+            inspect.isclass(obj)
+            and issubclass(obj, BaseModel)
+            and obj.__module__ == models.__name__
+        ):
+            yield obj
+
+
+def field_type_str(field: Any) -> str:
+    t = getattr(field, "annotation", None) or getattr(field, "type_", None)
+    return getattr(t, "__name__", str(t))
+
+
+def default_str(field: Any) -> str:
+    if hasattr(field, "is_required"):
+        if field.is_required():
+            return "Required"
+    default = field.default
+    if default is fields.PydanticUndefined:
+        return "Required"
+    return repr(default)
+
+
+def model_section(model_cls: type[BaseModel]) -> str:
+    lines = [f"## {model_cls.__name__}", ""]
+    if model_cls.__doc__:
+        lines.append(model_cls.__doc__.strip())
+        lines.append("")
+    lines.extend(
+        [
+            "| Field | Type | Default | Description |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for name, field in model_cls.model_fields.items():
+        desc = getattr(field, "description", "") or ""
+        lines.append(
+            f"| {name} | {field_type_str(field)} | {default_str(field)} | {desc} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_docs() -> str:
+    sections = ["# Configuration Reference", ""]
+    for model_cls in iter_models():
+        sections.append(model_section(model_cls))
+    return "\n".join(sections).strip() + "\n"
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", nargs="?", default="docs/source/config_reference.md")
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    content = build_docs()
+    path = Path(args.output)
+    if args.check:
+        if not path.exists() or path.read_text() != content:
+            print(
+                "Configuration docs are out of date. Run docs/generate_config_docs.py"
+            )
+            raise SystemExit(1)
+        return
+    path.write_text(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/config_reference.md
+++ b/docs/source/config_reference.md
@@ -1,0 +1,125 @@
+# Configuration Reference
+
+## BreakerSettings
+
+Circuit breaker settings for different resource types.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| database | ForwardRef('CircuitBreakerConfig') | Required |  |
+| external_api | ForwardRef('CircuitBreakerConfig') | Required |  |
+| file_system | ForwardRef('CircuitBreakerConfig') | Required |  |
+
+## CircuitBreakerConfig
+
+Circuit breaker configuration.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| failure_threshold | int | 3 |  |
+| recovery_timeout | float | 60.0 |  |
+| database | int | None | 3 |  |
+| api | int | None | 5 |  |
+| filesystem | int | None | 2 |  |
+
+## EmbeddingModelConfig
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| name | str | Required |  |
+| dimensions | int | None | None |  |
+
+## EntityConfig
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| server | ForwardRef('ServerConfig') | Required |  |
+| plugins | ForwardRef('PluginsSection') | Required |  |
+| workflow | ForwardRef('Dict[str, list[str]] | None') | None |  |
+| tool_registry | ForwardRef('ToolRegistryConfig') | Required |  |
+| runtime_validation_breaker | ForwardRef('CircuitBreakerConfig') | Required |  |
+| breaker_settings | ForwardRef('BreakerSettings') | Required |  |
+
+## LLMConfig
+
+Configuration model for the :class:`~entity.resources.llm.LLM`.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| provider | str | 'default' |  |
+
+## LogOutputConfig
+
+Configuration for a single logging output.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| type | str | 'console' |  |
+| level | str | 'info' |  |
+| path | str | None | None |  |
+| host | str | None | None |  |
+| port | int | None | None |  |
+
+## LoggingConfig
+
+Settings controlling the :class:`LoggingResource`.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| outputs | ForwardRef('list[LogOutputConfig]') | Required |  |
+
+## MemoryConfig
+
+Configuration model for the :class:`~entity.resources.memory.Memory`.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| kv_table | str | 'memory_kv' |  |
+| history_table | str | 'conversation_history' |  |
+
+## PluginConfig
+
+Configuration for a single plugin.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| type | str | Required |  |
+
+## PluginsSection
+
+Collection of user-defined plugins grouped by category.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| infrastructure | ForwardRef('Dict[str, PluginConfig]') | Required |  |
+| resources | ForwardRef('Dict[str, PluginConfig]') | Required |  |
+| agent_resources | ForwardRef('Dict[str, PluginConfig]') | Required |  |
+| custom_resources | ForwardRef('Dict[str, PluginConfig]') | Required |  |
+| tools | ForwardRef('Dict[str, PluginConfig]') | Required |  |
+| adapters | ForwardRef('Dict[str, PluginConfig]') | Required |  |
+| prompts | ForwardRef('Dict[str, PluginConfig]') | Required |  |
+
+## ServerConfig
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| host | str | Required |  |
+| port | int | Required |  |
+| reload | bool | False |  |
+| log_level | str | 'info' |  |
+
+## StorageConfig
+
+Configuration model for the :class:`~entity.resources.storage.Storage`.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| namespace | str | 'default' |  |
+
+## ToolRegistryConfig
+
+Options controlling tool execution.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| concurrency_limit | int | 5 |  |

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -9,6 +9,7 @@ The pipeline implementation now lives under the ``entity.pipeline`` package. Imp
 :hidden:
 error_handling
 logging
+config_reference
 ```
 
 The following pages cover core concepts and usage patterns.


### PR DESCRIPTION
## Summary
- generate config docs from Pydantic models
- add script to build docs and reference new page
- check docs generation in CI
- note work in agents.log

## Testing
- `poetry run black .`
- `poetry run ruff check --fix src tests` *(fails: many errors)*
- `poetry run mypy src` *(fails: found 248 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(failed: ImportError)*
- `pytest tests/test_plugins/ -v` *(failed: ImportError)*
- `pytest tests/test_resources/ -v` *(failed: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6872ea96e3e083229c6d72e624b0ca42