### PR TITLE
Add adapter and workflow config validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-12: Clarified plugin verification log message
+AGENT NOTE - 2025-07-12: Added Pydantic models for tool, adapter, and workflow settings
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -464,16 +464,16 @@ class EntityCLI:
     # -----------------------------------------------------
     async def _verify_plugins(self, config_path: str) -> int:
         async def _run() -> int:
-            if agent._runtime is None:
-                agent._runtime = await agent.builder.build_runtime()
+            from entity.pipeline import SystemInitializer
+            import yaml
+            from pathlib import Path
 
-            if agent._runtime is None:
-                agent._runtime = await agent.builder.build_runtime()
             try:
-                agent = Agent(config_path)
-                await agent._ensure_runtime()
+                data = yaml.safe_load(Path(config_path).read_text()) or {}
+                initializer = SystemInitializer(data)
+                await initializer.initialize()
             except Exception as exc:  # noqa: BLE001
-                logger.error("Plugin loading failed: %s", exc)
+                logger.error("Plugin validation failed: %s", exc)
                 return 1
             logger.info("All plugins loaded successfully")
             return 0

--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -36,6 +36,29 @@ class PluginsSection(BaseModel):
     prompts: Dict[str, PluginConfig] = Field(default_factory=dict)
 
 
+class RateLimitConfig(BaseModel):
+    """Request throttling settings for an adapter."""
+
+    requests: int = Field(ge=1, default=1)
+    interval: int = Field(ge=1, default=60)
+
+
+class AdapterSettings(BaseModel):
+    """Configuration for adapter plugins."""
+
+    stages: list[str] = Field(default_factory=list)
+    auth_tokens: list[str] = Field(default_factory=list)
+    rate_limit: RateLimitConfig | None = None
+    audit_log_path: str | None = None
+    dashboard: bool = False
+
+
+class WorkflowSettings(BaseModel):
+    """Mapping of pipeline stages to plugin names."""
+
+    stages: Dict[str, list[str]] = Field(default_factory=dict)
+
+
 class ServerConfig(BaseModel):
     host: str
     port: int
@@ -125,7 +148,7 @@ class EntityConfig(BaseModel):
         default_factory=lambda: ServerConfig(host="localhost", port=8000)
     )
     plugins: PluginsSection = Field(default_factory=PluginsSection)
-    workflow: Dict[str, list[str]] | None = Field(default=None)
+    workflow: WorkflowSettings | None = Field(default=None)
     tool_registry: ToolRegistryConfig = Field(default_factory=ToolRegistryConfig)
     runtime_validation_breaker: CircuitBreakerConfig = Field(
         default_factory=CircuitBreakerConfig
@@ -154,6 +177,8 @@ __all__ = [
     "EmbeddingModelConfig",
     "PluginsSection",
     "ServerConfig",
+    "RateLimitConfig",
+    "AdapterSettings",
     "ToolRegistryConfig",
     "CircuitBreakerConfig",
     "BreakerSettings",
@@ -162,6 +187,7 @@ __all__ = [
     "StorageConfig",
     "LogOutputConfig",
     "LoggingConfig",
+    "WorkflowSettings",
     "EntityConfig",
     "validate_config",
     "asdict",

--- a/tests/test_config/test_invalid_configs.py
+++ b/tests/test_config/test_invalid_configs.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic import ValidationError
+
+from entity.config.models import validate_config
+
+
+def test_tool_registry_invalid():
+    with pytest.raises(ValidationError):
+        validate_config({"tool_registry": {"concurrency_limit": "bad"}})
+
+
+def test_adapter_rate_limit_invalid():
+    cfg = {
+        "plugins": {
+            "adapters": {"http": {"type": "x", "rate_limit": {"requests": "a"}}}
+        }
+    }
+    with pytest.raises(ValidationError):
+        validate_config(cfg)
+
+
+def test_workflow_invalid():
+    with pytest.raises(ValidationError):
+        validate_config({"workflow": {"INPUT": "not_list"}})


### PR DESCRIPTION
## Summary
- define AdapterSettings with rate-limiting options
- add WorkflowSettings model
- validate full configuration in `entity-cli verify`
- test invalid config examples
- clarify plugin verification log message

## Testing
- `poetry run ruff check --fix src tests` *(fails: 146 errors remain)*
- `poetry run mypy src` *(fails: 248 errors)*
- `poetry run bandit -r src` *(reports 35 low, 10 medium severity issues)*
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6872ea8fee2c83229682ab7f06f386c3