### PR TITLE
Implement generic ResourcePool with LLM pooling

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added generic ResourcePool and pooled LLM tests
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests

--- a/src/entity/resources/interfaces/vector_store.py
+++ b/src/entity/resources/interfaces/vector_store.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Dict, List
 
 from entity.core.plugins import ResourcePlugin, ValidationResult
+from entity.core.resources.container import PoolConfig, ResourcePool
+from contextlib import asynccontextmanager
 
 
 class VectorStoreResource(ResourcePlugin):
@@ -12,6 +14,31 @@ class VectorStoreResource(ResourcePlugin):
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
+        self._pool: ResourcePool | None = None
+
+    async def initialize(self) -> None:
+        pool_cfg = PoolConfig(**self.config.get("pool", {}))
+        self._pool = ResourcePool(self._create_client, pool_cfg)
+        await self._pool.initialize()
+
+    async def _create_client(self) -> "VectorStoreResource":
+        return self
+
+    def get_connection_pool(self) -> ResourcePool:
+        return self._pool or ResourcePool(lambda: self, PoolConfig())
+
+    def get_pool_metrics(self) -> Dict[str, int]:
+        if self._pool is None:
+            return {"total_size": 0, "in_use": 0, "available": 0}
+        return self._pool.metrics()
+
+    @asynccontextmanager
+    async def connection(self):
+        if self._pool is None:
+            yield self
+        else:
+            async with self._pool as client:
+                yield client
 
     async def add_embedding(self, text: str) -> None:  # pragma: no cover - stub
         return None

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -8,6 +8,7 @@ from ..core.plugins import ValidationResult
 from entity.config.models import LLMConfig
 from pydantic import ValidationError
 
+from ..core.resources.container import PoolConfig, ResourcePool
 from .base import AgentResource
 from .interfaces.llm import LLMResource
 
@@ -21,6 +22,34 @@ class LLM(AgentResource):
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
         self.provider: LLMResource | None = None
+        self._pool: ResourcePool[LLMResource] | None = None
+
+    async def initialize(self) -> None:
+        if self.provider is None:
+            return
+        pool_cfg = PoolConfig(**self.config.get("pool", {}))
+        self._pool = ResourcePool(self._create_provider, pool_cfg)
+        await self._pool.initialize()
+
+    async def _create_provider(self) -> LLMResource:
+        assert self.provider is not None
+        return self.provider
+
+    def get_client_pool(self) -> ResourcePool[LLMResource] | None:
+        return self._pool
+
+    def get_pool_metrics(self) -> Dict[str, int]:
+        if self._pool is None:
+            return {"total_size": 0, "in_use": 0, "available": 0}
+        return self._pool.metrics()
+
+    async def generate(self, prompt: str) -> Any:
+        if self.provider is None:
+            return ""
+        if self._pool is None:
+            return await self.provider.generate(prompt)
+        async with self._pool as provider:
+            return await provider.generate(prompt)
 
     @classmethod
     async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:

--- a/src/plugins/builtin/resources/duckdb_resource.py
+++ b/src/plugins/builtin/resources/duckdb_resource.py
@@ -1,0 +1,2 @@
+class DuckDBResource:
+    pass

--- a/tests/test_llm_pool.py
+++ b/tests/test_llm_pool.py
@@ -1,0 +1,41 @@
+import asyncio
+import sys
+import types
+
+import pytest
+
+sys.modules.setdefault(
+    "plugins.builtin.resources.duckdb_resource", types.ModuleType("duckdb_resource")
+)
+
+from entity.core.resources.container import ResourceContainer
+from entity.resources.llm import LLM
+from entity.resources.interfaces.llm import LLMResource
+
+
+class DummyProvider(LLMResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.calls: list[str] = []
+
+    async def generate(self, prompt: str):
+        self.calls.append(prompt)
+        await asyncio.sleep(0.01)
+        return prompt
+
+
+@pytest.mark.asyncio
+async def test_llm_pool_metrics():
+    provider = DummyProvider()
+    llm = LLM({"pool": {"min_size": 1, "max_size": 2}})
+    llm.provider = provider
+    await llm.initialize()
+
+    container = ResourceContainer()
+    await container.add("llm", llm)
+
+    await asyncio.gather(*(llm.generate(str(i)) for i in range(3)))
+
+    metrics = container.get_metrics()
+    assert metrics["llm"]["total_size"] >= 1
+    assert len(provider.calls) == 3


### PR DESCRIPTION
## Summary
- accept generic factories in `ResourcePool`
- add pooling logic to LLM and vector store resources
- expose pool metrics from resources through container
- integration test for pooled LLM usage
- add dummy `DuckDBResource` to satisfy imports
- document update in `agents.log`

## Testing
- `PYTHONPATH=src pytest tests/test_llm_pool.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ea8be1b88322a6135263f58d86b8