### PR TITLE
Add vector store conversation search

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added vector store search to conversation_search
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/tests/test_memory_basic.py
+++ b/tests/test_memory_basic.py
@@ -1,9 +1,12 @@
 import sqlite3
 from contextlib import asynccontextmanager
+from datetime import datetime
 
 import pytest
 from entity.resources import Memory
 from entity.resources.interfaces.database import DatabaseResource
+from entity.resources.interfaces.vector_store import VectorStoreResource
+from entity.core.state import ConversationEntry
 
 
 class SqliteDB(DatabaseResource):
@@ -25,12 +28,43 @@ class SqliteDB(DatabaseResource):
         return self.conn
 
 
+class DummyVector(VectorStoreResource):
+    def __init__(self, results: list[str]) -> None:
+        super().__init__({})
+        self.results = results
+        self.queries: list[str] = []
+
+    async def add_embedding(self, text: str) -> None:
+        return None
+
+    async def query_similar(self, query: str, k: int = 5):
+        self.queries.append(query)
+        return self.results[:k]
+
+
 @pytest.fixture()
 async def simple_memory() -> Memory:
     mem = Memory(config={})
     mem.database = SqliteDB()
     mem.vector_store = None
     await mem.initialize()
+    yield mem
+
+
+@pytest.fixture()
+async def vector_memory() -> Memory:
+    mem = Memory(config={})
+    mem.database = SqliteDB()
+    mem.vector_store = DummyVector(["hello world"])
+    await mem.initialize()
+    await mem.add_conversation_entry(
+        "user1_conv1",
+        ConversationEntry(
+            content="hello world",
+            role="user",
+            timestamp=datetime.now(),
+        ),
+    )
     yield mem
 
 
@@ -45,3 +79,28 @@ async def test_remember_alias(simple_memory: Memory) -> None:
     assert Memory.remember is Memory.store_persistent
     await simple_memory.remember("alpha", 123)
     assert await simple_memory.get("alpha") == 123
+
+
+@pytest.mark.asyncio
+async def test_conversation_search_sql_fallback(simple_memory: Memory) -> None:
+    await simple_memory.add_conversation_entry(
+        "user1_conv1",
+        ConversationEntry(
+            content="where is the meeting",
+            role="user",
+            timestamp=datetime.now(),
+        ),
+    )
+    results = await simple_memory.conversation_search("meeting")
+    assert len(results) == 1
+    assert results[0]["content"] == "where is the meeting"
+
+
+@pytest.mark.asyncio
+async def test_conversation_search_vector(vector_memory: Memory) -> None:
+    results = await vector_memory.conversation_search("hello")
+    assert len(results) == 1
+    assert results[0]["content"] == "hello world"
+    vector = vector_memory.vector_store
+    assert isinstance(vector, DummyVector)
+    assert vector.queries == ["hello"]


### PR DESCRIPTION
## Summary
- add note about new conversation search logic in `agents.log`
- integrate vector store search in `Memory.conversation_search`
- cover vector search via new tests

## Testing
- `poetry run black src/entity/resources/memory.py tests/test_memory_basic.py`
- `poetry run ruff check --fix src tests` *(fails: many errors)*
- `poetry run mypy src` *(fails: 242 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing arguments)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/test_memory_basic.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6872f0656eb88322a0ba16ed5e62b7ed