### PR TITLE
Add plugin scaffolding commands and harness

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-16: Added plugin scaffolding and validation features
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/templates/plugins/adapter.py
+++ b/templates/plugins/adapter.py
@@ -1,0 +1,25 @@
+"""Template for an adapter plugin.
+
+Adapters connect pipeline output to the outside world. Add the generated
+plugin to a workflow so it runs in the ``OUTPUT`` stage:
+
+```
+workflow = {PipelineStage.OUTPUT: ["MyAdapter"]}
+```
+"""
+
+from entity.core.plugins import AdapterPlugin
+from entity.core.stages import PipelineStage
+
+
+class {class_name}(AdapterPlugin):
+    """Example adapter plugin."""
+
+    stages = [PipelineStage.OUTPUT]
+    # List position controls execution order and SystemInitializer preserves it.
+
+    async def _execute_impl(self, context):
+        if await context.reflect("response") is not None:
+            await context.advanced.queue_tool_use(
+                "send", {"text": await context.reflect("response")}
+            )

--- a/templates/plugins/failure.py
+++ b/templates/plugins/failure.py
@@ -1,0 +1,22 @@
+"""Template for a failure plugin.
+
+Failure plugins run when other plugins raise an error. Integrate the
+generated plugin into a workflow as an ``ERROR`` stage handler:
+
+```
+workflow = {PipelineStage.ERROR: ["MyFailureHandler"]}
+```
+"""
+
+from entity.core.plugins import FailurePlugin
+from entity.core.stages import PipelineStage
+
+
+class {class_name}(FailurePlugin):
+    """Example failure plugin."""
+
+    stages = [PipelineStage.ERROR]
+    # List position controls execution order and SystemInitializer preserves it.
+
+    async def _execute_impl(self, context):
+        await context.think("failure_info", context.failure_info)

--- a/templates/plugins/prompt.py
+++ b/templates/plugins/prompt.py
@@ -1,0 +1,28 @@
+"""Template for a prompt plugin.
+
+Prompt plugins drive the conversation. Include the generated class in a
+workflow mapping under the ``THINK`` stage:
+
+```
+workflow = {PipelineStage.THINK: ["MyPromptPlugin"]}
+```
+"""
+
+from entity.core.plugins import PromptPlugin
+from entity.core.stages import PipelineStage
+
+
+class {class_name}(PromptPlugin):
+    """Example prompt plugin."""
+
+    stages = [PipelineStage.THINK]
+    # List position controls execution order and SystemInitializer preserves it.
+
+    async def _execute_impl(self, context):
+        if await context.reflect("answer") is not None:
+            context.say(await context.reflect("answer"))
+            return
+
+        result = await context.tool_use("some_tool", query=context.message)
+        await context.think("answer", result)
+        context.say(result)

--- a/templates/plugins/resource.py
+++ b/templates/plugins/resource.py
@@ -1,0 +1,29 @@
+"""Template for a resource plugin.
+
+Resources prepare data for other plugins. Add the generated resource to a
+workflow mapping so it executes in the ``PARSE`` stage:
+
+```
+workflow = {PipelineStage.PARSE: ["MyResource"]}
+```
+"""
+
+from entity.core.plugins import ResourcePlugin, ValidationResult
+from entity.core.stages import PipelineStage
+
+
+class {class_name}(ResourcePlugin):
+    """Example resource plugin."""
+
+    stages = [PipelineStage.PARSE]
+    # List position controls execution order and SystemInitializer preserves it.
+
+    @classmethod
+    def validate_config(cls, config: dict) -> ValidationResult:
+        return ValidationResult.success_result()
+
+    async def initialize(self) -> None:
+        pass
+
+    async def _execute_impl(self, context) -> None:
+        context.advanced.queue_tool_use("refresh", {})

--- a/templates/plugins/tool.py
+++ b/templates/plugins/tool.py
@@ -1,0 +1,24 @@
+"""Template for a tool plugin.
+
+Tool plugins expose functions that other plugins can call. Register the
+generated tool in a workflow under the ``DO`` stage:
+
+```
+workflow = {PipelineStage.DO: ["MyTool"]}
+```
+"""
+
+from typing import Any, Dict
+
+from entity.core.plugins import ToolPlugin
+from entity.core.stages import PipelineStage
+
+
+class {class_name}(ToolPlugin):
+    """Example tool plugin."""
+
+    stages = [PipelineStage.DO]
+    # List position controls execution order and SystemInitializer preserves it.
+
+    async def execute_function(self, params: Dict[str, Any]) -> Any:
+        return None

--- a/tests/plugins/harness.py
+++ b/tests/plugins/harness.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+from cli.plugin_tool.utils import load_plugin
+
+
+class DummyContext:
+    async def __getattr__(self, _name: str):
+        async def _noop(*_a, **_kw):
+            return None
+
+        return _noop
+
+
+def run_plugin(path: str) -> None:
+    async def _runner() -> None:
+        plugin_cls = load_plugin(path)
+        instance = plugin_cls(getattr(plugin_cls, "config", {}))
+        init = getattr(instance, "initialize", None)
+        if callable(init):
+            if inspect.iscoroutinefunction(init):
+                await init()
+            else:
+                init()
+        execute = getattr(instance, "_execute_impl", None)
+        if callable(execute):
+            ctx = DummyContext()
+            if inspect.iscoroutinefunction(execute):
+                await execute(ctx)
+            else:
+                execute(ctx)
+
+    asyncio.run(_runner())

--- a/tests/plugins/test_harness.py
+++ b/tests/plugins/test_harness.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.plugins.harness import run_plugin
+
+
+def test_run_plugin(tmp_path: Path) -> None:
+    plugin_file = tmp_path / "plug.py"
+    plugin_file.write_text(
+        "from entity.core.plugins import ToolPlugin\n"
+        "from entity.core.stages import PipelineStage\n\n"
+        "class Demo(ToolPlugin):\n"
+        "    stages = [PipelineStage.DO]\n"
+        "    async def execute_function(self, params):\n"
+        "        return params\n"
+    )
+    run_plugin(str(plugin_file))


### PR DESCRIPTION
## Summary
- expand `entity-cli plugin` to scaffold standalone projects and add dependency checks
- synchronize plugin helper CLI with new scaffolding command
- provide plugin templates for all plugin types
- create a simple plugin test harness
- add tests for the new harness

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: many lint errors)*
- `poetry run mypy src` *(fails: 240 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6872f0d62d048322a615115d6e5a29fe