### PR TITLE
Support user scoped persistent memory

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added user_id key prefixing for persistent memory
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -52,19 +52,22 @@ class AdvancedContext:
 
     async def remember(self, key: str, value: Any) -> None:
         if self._parent._memory is not None:
-            namespaced_key = f"{self._parent._user_id}:{key}"
-            await self._parent._memory.store_persistent(namespaced_key, value)
+            await self._parent._memory.store_persistent(
+                key, value, user_id=self._parent._user_id
+            )
 
     async def memory(self, key: str, default: Any | None = None) -> Any:
         if self._parent._memory is None:
             return default
-        namespaced_key = f"{self._parent._user_id}:{key}"
-        return await self._parent._memory.fetch_persistent(namespaced_key, default)
+        return await self._parent._memory.fetch_persistent(
+            key, default, user_id=self._parent._user_id
+        )
 
     async def forget(self, key: str) -> None:
         if self._parent._memory is not None:
-            namespaced_key = f"{self._parent._user_id}:{key}"
-            await self._parent._memory.delete_persistent(namespaced_key)
+            await self._parent._memory.delete_persistent(
+                key, user_id=self._parent._user_id
+            )
 
     def set_metadata(self, key: str, value: Any) -> None:
         self._parent._state.metadata[key] = value
@@ -283,13 +286,13 @@ class PluginContext:
     async def remember(self, key: str, value: Any) -> None:
         """Persist ``value`` under ``key`` for the current user."""
         if self._memory is not None:
-            await self._memory.store_persistent(f"{self._user_id}:{key}", value)
+            await self._memory.store_persistent(key, value, user_id=self._user_id)
 
     async def recall(self, key: str, default: Any | None = None) -> Any:
         """Retrieve a persisted value for ``key``."""
         if self._memory is None:
             return default
-        return await self._memory.fetch_persistent(f"{self._user_id}:{key}", default)
+        return await self._memory.fetch_persistent(key, default, user_id=self._user_id)
 
     # alias for backward compatibility
     memory = recall
@@ -297,7 +300,7 @@ class PluginContext:
     async def forget(self, key: str) -> None:
         """Remove ``key`` from persistent storage."""
         if self._memory is not None:
-            await self._memory.delete_persistent(f"{self._user_id}:{key}")
+            await self._memory.delete_persistent(key, user_id=self._user_id)
 
     def set_metadata(self, key: str, value: Any) -> None:
         warnings.warn(

--- a/tests/test_memory_basic.py
+++ b/tests/test_memory_basic.py
@@ -45,3 +45,12 @@ async def test_remember_alias(simple_memory: Memory) -> None:
     assert Memory.remember is Memory.store_persistent
     await simple_memory.remember("alpha", 123)
     assert await simple_memory.get("alpha") == 123
+
+
+@pytest.mark.asyncio
+async def test_user_isolation(simple_memory: Memory) -> None:
+    await simple_memory.store_persistent("foo", "a", user_id="u1")
+    await simple_memory.store_persistent("foo", "b", user_id="u2")
+    assert await simple_memory.fetch_persistent("foo", user_id="u1") == "a"
+    assert await simple_memory.fetch_persistent("foo", user_id="u2") == "b"
+    assert await simple_memory.fetch_persistent("foo", user_id="u3") is None


### PR DESCRIPTION
## Summary
- namespace persistent memory keys with an optional `user_id`
- pass `user_id` through plugin contexts
- test that memory storage is isolated between users

## Testing
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(failed: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: AttributeError)*
- `poetry run pytest tests/test_architecture/ -v` *(failed: file or directory not found)*
- `poetry run pytest tests/test_plugins/ -v` *(failed: file or directory not found)*
- `poetry run pytest tests/test_resources/ -v`
- `poetry run pytest tests/test_memory_basic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6872f066ea508322b6baa498008b54aa