### PR TITLE
Enhance logging features

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-16: Extended logging with WebSocket broadcasting and file rotation
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -112,6 +112,8 @@ class LogOutputConfig(BaseModel):
     path: str | None = None
     host: str | None = None
     port: int | None = None
+    max_size: str | int | None = None
+    backup_count: int | None = None
 
 
 class LoggingConfig(BaseModel):

--- a/tests/resources/test_logging.py
+++ b/tests/resources/test_logging.py
@@ -1,0 +1,60 @@
+import asyncio
+import json
+
+import pytest
+import websockets
+
+from entity.core.resources.container import ResourceContainer
+from entity.resources.logging import LoggingResource
+
+
+@pytest.mark.asyncio
+async def test_websocket_broadcast(tmp_path, monkeypatch):
+    container = ResourceContainer()
+    monkeypatch.setattr(LoggingResource, "dependencies", [])
+    container.register(
+        "logging",
+        LoggingResource,
+        {"outputs": [{"type": "real_time_stream", "port": 0}]},
+        layer=3,
+    )
+    await container.build_all()
+    logger: LoggingResource = container.get("logging")  # type: ignore[assignment]
+    stream = logger._stream_outputs[0]
+    uri = f"ws://{stream.host}:{stream.port}"
+    async with websockets.connect(uri) as ws1, websockets.connect(uri) as ws2:
+        await logger.log("info", "message", component="test")
+        msg1 = await asyncio.wait_for(ws1.recv(), timeout=2)
+        msg2 = await asyncio.wait_for(ws2.recv(), timeout=2)
+    await container.shutdown_all()
+    assert json.loads(msg1)["message"] == "message"
+    assert msg1 == msg2
+
+
+@pytest.mark.asyncio
+async def test_file_rotation(tmp_path, monkeypatch):
+    log_file = tmp_path / "rot.log"
+    container = ResourceContainer()
+    monkeypatch.setattr(LoggingResource, "dependencies", [])
+    container.register(
+        "logging",
+        LoggingResource,
+        {
+            "outputs": [
+                {
+                    "type": "structured_file",
+                    "path": str(log_file),
+                    "max_size": "1KB",
+                    "backup_count": 1,
+                }
+            ]
+        },
+        layer=3,
+    )
+    await container.build_all()
+    logger: LoggingResource = container.get("logging")  # type: ignore[assignment]
+    for i in range(100):
+        await logger.log("info", f"msg {i}", component="test")
+    await container.shutdown_all()
+    rotated = log_file.with_suffix(".1")
+    assert rotated.exists()


### PR DESCRIPTION
## Summary
- broadcast log entries via websocket
- rotate structured log files
- include host, pid and correlation headers in entries
- use logging resource for pipeline stage events
- test websocket streaming and log rotation

## Testing
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `poetry run pytest tests/test_resources/ -v`
- `poetry run pytest tests/resources/test_logging.py -v`


------
https://chatgpt.com/codex/tasks/task_e_6872f0871a1883229fb4538f3f24b0d3