### PR TITLE
Config loader improvements

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added env interpolation and migration utilities
 AGENT NOTE - 2025-07-12: Clarified plugin verification log message
 AGENT NOTE - 2025-07-12: Added Pydantic models for tool, adapter, and workflow settings
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/docs/source/config_reference.md
+++ b/docs/source/config_reference.md
@@ -1,14 +1,26 @@
 # Configuration Reference
 
+## AdapterSettings
+
+Configuration for adapter plugins.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| stages | list | None |  |
+| auth_tokens | list | None |  |
+| rate_limit | ForwardRef('RateLimitConfig | None') | None |  |
+| audit_log_path | str | None | None |  |
+| dashboard | bool | False |  |
+
 ## BreakerSettings
 
 Circuit breaker settings for different resource types.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| database | ForwardRef('CircuitBreakerConfig') | Required |  |
-| external_api | ForwardRef('CircuitBreakerConfig') | Required |  |
-| file_system | ForwardRef('CircuitBreakerConfig') | Required |  |
+| database | ForwardRef('CircuitBreakerConfig') | None |  |
+| external_api | ForwardRef('CircuitBreakerConfig') | None |  |
+| file_system | ForwardRef('CircuitBreakerConfig') | None |  |
 
 ## CircuitBreakerConfig
 
@@ -33,12 +45,12 @@ Circuit breaker configuration.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| server | ForwardRef('ServerConfig') | Required |  |
-| plugins | ForwardRef('PluginsSection') | Required |  |
-| workflow | ForwardRef('Dict[str, list[str]] | None') | None |  |
-| tool_registry | ForwardRef('ToolRegistryConfig') | Required |  |
-| runtime_validation_breaker | ForwardRef('CircuitBreakerConfig') | Required |  |
-| breaker_settings | ForwardRef('BreakerSettings') | Required |  |
+| server | ForwardRef('ServerConfig') | None |  |
+| plugins | ForwardRef('PluginsSection') | None |  |
+| workflow | ForwardRef('WorkflowSettings | None') | None |  |
+| tool_registry | ForwardRef('ToolRegistryConfig') | None |  |
+| runtime_validation_breaker | ForwardRef('CircuitBreakerConfig') | None |  |
+| breaker_settings | ForwardRef('BreakerSettings') | None |  |
 
 ## LLMConfig
 
@@ -66,7 +78,7 @@ Settings controlling the :class:`LoggingResource`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| outputs | ForwardRef('list[LogOutputConfig]') | Required |  |
+| outputs | ForwardRef('list[LogOutputConfig]') | None |  |
 
 ## MemoryConfig
 
@@ -84,6 +96,9 @@ Configuration for a single plugin.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | type | str | Required |  |
+| dependencies | list | None |  |
+| stage | ForwardRef('PipelineStage | None') | None |  |
+| stages | ForwardRef('list[PipelineStage]') | None |  |
 
 ## PluginsSection
 
@@ -91,13 +106,22 @@ Collection of user-defined plugins grouped by category.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| infrastructure | ForwardRef('Dict[str, PluginConfig]') | Required |  |
-| resources | ForwardRef('Dict[str, PluginConfig]') | Required |  |
-| agent_resources | ForwardRef('Dict[str, PluginConfig]') | Required |  |
-| custom_resources | ForwardRef('Dict[str, PluginConfig]') | Required |  |
-| tools | ForwardRef('Dict[str, PluginConfig]') | Required |  |
-| adapters | ForwardRef('Dict[str, PluginConfig]') | Required |  |
-| prompts | ForwardRef('Dict[str, PluginConfig]') | Required |  |
+| infrastructure | ForwardRef('Dict[str, PluginConfig]') | None |  |
+| resources | ForwardRef('Dict[str, PluginConfig]') | None |  |
+| agent_resources | ForwardRef('Dict[str, PluginConfig]') | None |  |
+| custom_resources | ForwardRef('Dict[str, PluginConfig]') | None |  |
+| tools | ForwardRef('Dict[str, PluginConfig]') | None |  |
+| adapters | ForwardRef('Dict[str, PluginConfig]') | None |  |
+| prompts | ForwardRef('Dict[str, PluginConfig]') | None |  |
+
+## RateLimitConfig
+
+Request throttling settings for an adapter.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| requests | ConstrainedIntValue | 1 |  |
+| interval | ConstrainedIntValue | 60 |  |
 
 ## ServerConfig
 
@@ -123,3 +147,11 @@ Options controlling tool execution.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | concurrency_limit | int | 5 |  |
+
+## WorkflowSettings
+
+Mapping of pipeline stages to plugin names.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| stages | ForwardRef('Dict[str, list[str]]') | None |  |

--- a/src/entity/config/migrations/__init__.py
+++ b/src/entity/config/migrations/__init__.py
@@ -1,0 +1,36 @@
+"""Utilities for migrating configuration schemas between versions."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List
+
+
+class Migration:
+    """Represents a single config migration step."""
+
+    def __init__(
+        self, version: int, upgrade: Callable[[Dict[str, Any]], Dict[str, Any]]
+    ):
+        self.version = version
+        self.upgrade = upgrade
+
+
+class MigrationManager:
+    """Apply registered migrations sequentially."""
+
+    def __init__(self) -> None:
+        self._migrations: List[Migration] = []
+
+    def register(self, migration: Migration) -> None:
+        self._migrations.append(migration)
+        self._migrations.sort(key=lambda m: m.version)
+
+    def upgrade(self, data: Dict[str, Any], current: int) -> tuple[Dict[str, Any], int]:
+        for m in self._migrations:
+            if m.version > current:
+                data = m.upgrade(data)
+                current = m.version
+        return data, current
+
+
+__all__ = ["Migration", "MigrationManager"]

--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -4,16 +4,34 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
+from entity.pipeline.stages import PipelineStage
 
 
 class PluginConfig(BaseModel):
     """Configuration for a single plugin."""
 
     type: str
+    dependencies: list[str] = Field(default_factory=list)
+    stage: PipelineStage | None = None
+    stages: list[PipelineStage] = Field(default_factory=list)
 
     class Config:
         extra = "allow"
+
+    @validator("stage", pre=True)
+    def _validate_stage(cls, value: str | PipelineStage | None) -> PipelineStage | None:
+        if value is None:
+            return None
+        return PipelineStage.ensure(value)
+
+    @validator("stages", pre=True)
+    def _validate_stages(
+        cls, value: list[str | PipelineStage] | None
+    ) -> list[PipelineStage]:
+        if value is None:
+            return []
+        return [PipelineStage.ensure(v) for v in value]
 
 
 class EmbeddingModelConfig(BaseModel):

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+
+from entity.config.environment import load_config
+
+
+def test_load_config_interpolates(monkeypatch, tmp_path):
+    cfg = tmp_path / "base.yaml"
+    cfg.write_text("path: ${TEST_DIR}/data\n")
+    monkeypatch.setenv("TEST_DIR", "/tmp")
+
+    result = load_config(cfg)
+
+    assert result["path"] == "/tmp/data"
+
+
+def test_load_config_with_overlay(monkeypatch, tmp_path):
+    base = tmp_path / "base.yaml"
+    base.write_text("foo: ${VAR}\n")
+    overlay = tmp_path / "override.yaml"
+    overlay.write_text("foo: bar\n")
+    monkeypatch.setenv("VAR", "baz")
+
+    result = load_config(base, overlay)
+
+    assert result["foo"] == "bar"

--- a/tests/config/test_models.py
+++ b/tests/config/test_models.py
@@ -1,0 +1,9 @@
+from entity.config.models import PluginConfig
+from entity.pipeline.stages import PipelineStage
+
+
+def test_plugin_config_parsing():
+    model = PluginConfig(type="x", stage="parse", dependencies=["db"])
+    assert model.stage == PipelineStage.PARSE
+    assert model.dependencies == ["db"]
+    assert model.stages == []


### PR DESCRIPTION
## Summary
- expand `PluginConfig` for stages and dependencies
- support `${VAR}` interpolation in `load_config`
- auto-generate config schema docs
- add migration helpers
- test config loader and models

## Testing
- `poetry run pytest tests/config tests/test_environment.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6872f0bda1188322806448fad0bc681d