### PR TITLE
Add plugin taxonomy validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added plugin taxonomy validation and tests
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/tests/architecture/test_plugin_taxonomy.py
+++ b/tests/architecture/test_plugin_taxonomy.py
@@ -1,0 +1,116 @@
+import yaml
+import pytest
+
+from entity.core.registry_validator import RegistryValidator
+from entity.pipeline.initializer import SystemInitializer, InitializationError
+from entity.core.plugins import (
+    Plugin,
+    AgentResource,
+    InputAdapterPlugin,
+    PromptPlugin,
+)
+from entity.core.stages import PipelineStage
+
+
+class WrongResource(Plugin):
+    stages: list = []
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class DummyResource(AgentResource):
+    stages: list = []
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class BadDepPrompt(PromptPlugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class BadAdapter(InputAdapterPlugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class WrongPrompt(InputAdapterPlugin):
+    stages = [PipelineStage.INPUT]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+def _write_cfg(tmp_path, plugins):
+    cfg = {"plugins": plugins}
+    path = tmp_path / "cfg.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+    return path
+
+
+def test_resource_base_validation(tmp_path):
+    cfg = {
+        "agent_resources": {
+            "bad": {"type": "tests.architecture.test_plugin_taxonomy:WrongResource"}
+        }
+    }
+    path = _write_cfg(tmp_path, cfg)
+    with pytest.raises(SystemError, match="ResourcePlugin"):
+        RegistryValidator(str(path)).run()
+
+
+def test_dependency_name_validation(tmp_path):
+    cfg = {
+        "agent_resources": {
+            "dummy": {"type": "tests.architecture.test_plugin_taxonomy:DummyResource"},
+            "metrics_collector": {
+                "type": "entity.resources.metrics:MetricsCollectorResource"
+            },
+            "logging": {"type": "entity.resources.logging:LoggingResource"},
+            "database": {
+                "type": "tests.architecture.test_plugin_taxonomy:DummyResource"
+            },
+        },
+        "prompts": {
+            "bad": {
+                "type": "tests.architecture.test_plugin_taxonomy:BadDepPrompt",
+                "dependencies": ["missing"],
+            }
+        },
+    }
+    path = _write_cfg(tmp_path, cfg)
+    with pytest.raises(SystemError, match="missing"):
+        RegistryValidator(str(path)).run()
+
+
+def test_stage_mismatch_validation(tmp_path):
+    cfg = {
+        "adapters": {
+            "bad": {"type": "tests.architecture.test_plugin_taxonomy:BadAdapter"}
+        }
+    }
+    path = _write_cfg(tmp_path, cfg)
+    with pytest.raises(SystemError, match="INPUT stage"):
+        RegistryValidator(str(path)).run()
+
+
+def test_discovered_plugin_validation(tmp_path):
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    pyproject = plugin_dir / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.entity.plugins.prompts.bad]
+type = "tests.architecture.test_plugin_taxonomy:WrongPrompt"
+"""
+    )
+    initializer = SystemInitializer()
+    initializer.config["plugin_dirs"] = [str(plugin_dir)]
+    with pytest.raises(InitializationError, match="PromptPlugin"):
+        initializer._discover_plugins()


### PR DESCRIPTION
## Summary
- validate plugin class inheritance and stage assignments
- check dependency names for valid resources
- enforce plugin taxonomy for discovered plugins
- add tests for plugin taxonomy validation

## Testing
- `poetry run ruff check --fix tests/architecture/test_plugin_taxonomy.py src/entity/core/registry_validator.py src/entity/pipeline/initializer.py`
- `poetry run mypy src` *(fails: Found 240 errors)*
- `poetry run bandit -r src`
- `poetry run pytest tests/architecture/test_plugin_taxonomy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f0bc406883229005cfc74be6cb5e