### PR TITLE
Implement conditional workflow execution

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-17: Added conditional workflows with validation and inheritance support
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -58,7 +58,9 @@ class _AgentRuntime:
         from entity.pipeline.pipeline import Pipeline as ExecPipeline, execute_pipeline
 
         if self.workflow is None:
-            return await execute_pipeline(message, self.capabilities, user_id=user_id)
+            return await execute_pipeline(
+                message, self.capabilities, user_id=user_id, workflow=None
+            )
 
         pipeline = ExecPipeline(self.workflow)
         return await pipeline.run_message(message, self.capabilities, user_id=user_id)

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -80,6 +80,7 @@ class Pipeline:
             user_id=user_id,
             state_logger=state_logger,
             state=state,
+            workflow=self.workflow,
             max_iterations=max_iterations,
         )
 
@@ -245,6 +246,7 @@ async def execute_pipeline(
     user_id: str | None = None,
     state_logger: "StateLogger" | None = None,
     state: PipelineState | None = None,
+    workflow: Workflow | None = None,
     max_iterations: int = 5,
 ) -> Dict[str, Any]:
     if capabilities is None:
@@ -280,6 +282,8 @@ async def execute_pipeline(
                     PipelineStage.REVIEW,
                     PipelineStage.OUTPUT,
                 ]:
+                    if workflow and not workflow.should_execute(stage, state):
+                        continue
                     if (
                         state.last_completed_stage is not None
                         and stage.value <= state.last_completed_stage.value

--- a/src/entity/pipeline/workflow.py
+++ b/src/entity/pipeline/workflow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterable, Mapping, Optional, TYPE_CHECKING
+from typing import Iterable, Mapping, Optional, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from entity.core.agent import AgentRuntime, _AgentBuilder
@@ -29,9 +29,22 @@ class Pipeline:
     """Simple pipeline wrapper holding builder and workflow."""
 
     builder: "_AgentBuilder" = field(default_factory=_builder_factory)
-    workflow: Optional[WorkflowMapping] = None
+    workflow: Optional[Union[Workflow, WorkflowMapping]] = None
 
     async def build_runtime(self) -> AgentRuntime:
         """Build an AgentRuntime using the stored builder and workflow."""
 
-        return await self.builder.build_runtime(workflow=self.workflow)
+        wf_obj = (
+            self.workflow
+            if isinstance(self.workflow, Workflow)
+            else (
+                Workflow.from_dict(self.workflow) if self.workflow is not None else None
+            )
+        )
+        if wf_obj is not None:
+            for stage, names in wf_obj.stage_map.items():
+                for name in names:
+                    if not self.builder.has_plugin(name):
+                        raise KeyError(f"Plugin '{name}' not found")
+
+        return await self.builder.build_runtime(workflow=wf_obj)

--- a/src/entity/worker/pipeline_worker.py
+++ b/src/entity/worker/pipeline_worker.py
@@ -18,7 +18,7 @@ class PipelineWorker:
     async def run_stages(self, state: PipelineState) -> Any:
         """Delegate pipeline execution to the existing driver."""
         # user_message is ignored when ``state`` is provided
-        return await execute_pipeline("", self.registries, state=state)
+        return await execute_pipeline("", self.registries, state=state, workflow=None)
 
     async def execute_pipeline(
         self, pipeline_id: str, message: str, *, user_id: str

--- a/src/entity/workflows/base.py
+++ b/src/entity/workflows/base.py
@@ -2,34 +2,84 @@ from __future__ import annotations
 
 """Workflow definitions for pipeline execution."""
 
-from typing import ClassVar, Dict, Iterable, List, Mapping
+from typing import Callable, ClassVar, Dict, Iterable, List, Mapping
 
 from pydantic import BaseModel, Field
 
 from entity.pipeline.stages import PipelineStage
 
 
+from entity.pipeline.state import PipelineState
+
+
 class Workflow(BaseModel):
     """Reusable mapping from :class:`PipelineStage` to plugin names."""
 
     stage_map: ClassVar[Dict[PipelineStage | str, Iterable[str]]] = {}
+    stage_conditions: ClassVar[
+        Dict[PipelineStage | str, Callable[[PipelineState], bool]]
+    ] = {}
+
     stages: Dict[PipelineStage, List[str]] = Field(default_factory=dict)
+    conditions: Dict[PipelineStage, Callable[[PipelineState], bool]] = Field(
+        default_factory=dict
+    )
 
     model_config = {"arbitrary_types_allowed": True}
 
     def __init__(
         self,
         mapping: Mapping[PipelineStage | str, Iterable[str]] | None = None,
+        conditions: (
+            Mapping[PipelineStage | str, Callable[[PipelineState], bool]] | None
+        ) = None,
         **params: str,
     ) -> None:
         values = {}
-        mapping = mapping or self.stage_map
+        mapping = mapping or self.combined_stage_map()
+        conditions = conditions or self.combined_conditions()
         processed: Dict[PipelineStage, List[str]] = {}
         for stage, plugins in mapping.items():
             formatted = [str(p).format(**params) for p in plugins]
             self._assign_to(processed, stage, formatted)
+        cond_map: Dict[PipelineStage, Callable[[PipelineState], bool]] = {}
+        for stage, cond in conditions.items():
+            cond_map[PipelineStage.ensure(stage)] = cond
         values["stages"] = processed
+        values["conditions"] = cond_map
         super().__init__(**values)
+
+    # ------------------------------------------------------------------
+    # Composition helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def combined_stage_map(cls) -> Dict[PipelineStage | str, Iterable[str]]:
+        mapping: Dict[PipelineStage | str, Iterable[str]] = {}
+        for base in reversed(cls.__mro__):
+            if issubclass(base, Workflow) and hasattr(base, "stage_map"):
+                mapping.update(getattr(base, "stage_map", {}))
+        return mapping
+
+    @classmethod
+    def combined_conditions(
+        cls,
+    ) -> Dict[PipelineStage | str, Callable[[PipelineState], bool]]:
+        combined: Dict[PipelineStage | str, Callable[[PipelineState], bool]] = {}
+        for base in reversed(cls.__mro__):
+            if issubclass(base, Workflow) and hasattr(base, "stage_conditions"):
+                combined.update(getattr(base, "stage_conditions", {}))
+        return combined
+
+    # ------------------------------------------------------------------
+    # Execution helpers
+    # ------------------------------------------------------------------
+
+    def should_execute(self, stage: PipelineStage, state: PipelineState) -> bool:
+        condition = self.conditions.get(stage)
+        if condition is not None:
+            return bool(condition(state))
+        return True
 
     @staticmethod
     def _assign_to(

--- a/tests/test_response_control.py
+++ b/tests/test_response_control.py
@@ -66,7 +66,7 @@ async def test_pipeline_terminates_after_say() -> None:
         conversation=[ConversationEntry("hi", "user", datetime.now())],
         pipeline_id="test",
     )
-    result = await execute_pipeline("hi", regs, state=state)
+    result = await execute_pipeline("hi", regs, state=state, workflow=None)
     assert result == "final:x"
 
 
@@ -80,5 +80,5 @@ async def test_pipeline_max_iteration_error() -> None:
         conversation=[ConversationEntry("hi", "user", datetime.now())],
         pipeline_id="pid",
     )
-    await execute_pipeline("hi", regs, state=state, max_iterations=2)
+    await execute_pipeline("hi", regs, state=state, max_iterations=2, workflow=None)
     assert state.failure_info and state.failure_info.error_type == "max_iterations"

--- a/tests/workflow/test_workflow_features.py
+++ b/tests/workflow/test_workflow_features.py
@@ -1,0 +1,50 @@
+import pytest
+
+from entity.core.agent import _AgentBuilder
+from entity.core.plugins import Plugin
+from entity.pipeline.stages import PipelineStage
+from entity.pipeline.workflow import Pipeline
+from entity.workflows.base import Workflow
+
+
+class MarkerPlugin(Plugin):
+    stages = [PipelineStage.THINK]
+    executed = False
+
+    async def _execute_impl(self, context):
+        MarkerPlugin.executed = True
+
+
+class EchoPlugin(Plugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context):
+        context.say("ok")
+
+
+class BaseWF(Workflow):
+    stage_map = {PipelineStage.THINK: ["MarkerPlugin"]}
+
+
+class ChildWF(BaseWF):
+    stage_map = {PipelineStage.OUTPUT: ["EchoPlugin"]}
+
+
+@pytest.mark.asyncio
+async def test_conditional_stage_skip():
+    builder = _AgentBuilder()
+    await builder.add_plugin(MarkerPlugin({}))
+    await builder.add_plugin(EchoPlugin({}))
+
+    wf = ChildWF(conditions={PipelineStage.THINK: lambda _state: False})
+    pipeline = Pipeline(builder=builder, workflow=wf)
+    runtime = await pipeline.build_runtime()
+    result = await runtime.handle("hi")
+    assert result == "ok"
+    assert not MarkerPlugin.executed
+
+
+def test_workflow_inheritance():
+    wf = ChildWF()
+    assert PipelineStage.THINK in wf.stages
+    assert PipelineStage.OUTPUT in wf.stages


### PR DESCRIPTION
## Summary
- allow workflow composition and stage conditions
- validate plugin references during runtime creation
- integrate stage conditions into pipeline execution
- add tests for workflow features

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: Found 146 errors)*
- `poetry run mypy src` *(fails: Found 243 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*
- `pytest` *(fails: 41 failed, 63 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6872f0b7e2ac8322aa2d758dd20e4d19