### PR TITLE
Implement infrastructure template generators

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-17: Added infrastructure generation modules and CLI infra command
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -22,6 +22,7 @@ from entity.utils.logging import get_logger
 from entity.config.environment import load_config
 from importlib import import_module
 import sys
+from entity.infrastructure import DockerInfrastructure, AWSStandardInfrastructure
 
 try:  # Resolve plugin helpers from installed "cli" package
     generate_plugin = import_module("cli.plugin_tool.generate").generate_plugin
@@ -57,6 +58,9 @@ class CLIArgs:
     workflow_name: Optional[str] = None
     fmt: Optional[str] = None
     env: Optional[str] = None
+    infra_cmd: Optional[str] = None
+    infra_type: Optional[str] = None
+    infra_path: Optional[str] = None
 
 
 class EntityCLI:
@@ -148,6 +152,15 @@ class EntityCLI:
         )
         ana.add_argument("path")
 
+        infra = sub.add_parser("infra", help="Infrastructure operations")
+        infra_sub = infra.add_subparsers(dest="infra_cmd", required=True)
+        deploy = infra_sub.add_parser("deploy", help="Deploy infrastructure")
+        deploy.add_argument("--type", required=True, dest="infra_type")
+        deploy.add_argument("--path", dest="infra_path", default="infra")
+        destroy = infra_sub.add_parser("destroy", help="Destroy infrastructure")
+        destroy.add_argument("--type", required=True, dest="infra_type")
+        destroy.add_argument("--path", dest="infra_path", default="infra")
+
         parsed = parser.parse_args()
         return CLIArgs(
             config=getattr(parsed, "config", None),
@@ -165,6 +178,9 @@ class EntityCLI:
             workflow_name=getattr(parsed, "workflow_name", None),
             fmt=getattr(parsed, "fmt", None),
             env=getattr(parsed, "env", None),
+            infra_cmd=getattr(parsed, "infra_cmd", None),
+            infra_type=getattr(parsed, "infra_type", None),
+            infra_path=getattr(parsed, "infra_path", None),
         )
 
     # -----------------------------------------------------
@@ -192,6 +208,8 @@ class EntityCLI:
             return self._search_plugin(self.args.name)
         if cmd == "workflow":
             return self._handle_workflow()
+        if cmd == "infra":
+            return self._handle_infra()
         if cmd == "replay-log":
             assert self.args.file is not None
             from entity.core.state_logger import LogReplayer
@@ -368,6 +386,41 @@ class EntityCLI:
     def _search_plugin(self, name: str) -> int:
         """Placeholder for future plugin marketplace search."""
         logger.info("search-plugin '%s' is not implemented yet", name)
+        return 0
+
+    # -----------------------------------------------------
+    # infrastructure helpers
+    # -----------------------------------------------------
+    def _handle_infra(self) -> int:
+        cmd = self.args.infra_cmd
+        typ = self.args.infra_type or ""
+        path = self.args.infra_path or "infra"
+        if cmd == "deploy":
+            return asyncio.run(self._infra_deploy(typ, path))
+        if cmd == "destroy":
+            return asyncio.run(self._infra_destroy(typ, path))
+        return 0
+
+    async def _infra_deploy(self, typ: str, path: str) -> int:
+        if typ == "docker":
+            infra = DockerInfrastructure({"path": path})
+        elif typ == "aws-standard":
+            infra = AWSStandardInfrastructure(region="us-east-1", config={"path": path})
+        else:
+            logger.error("Unknown infrastructure type %s", typ)
+            return 1
+        await infra.deploy()
+        return 0
+
+    async def _infra_destroy(self, typ: str, path: str) -> int:
+        if typ == "docker":
+            infra = DockerInfrastructure({"path": path})
+        elif typ == "aws-standard":
+            infra = AWSStandardInfrastructure(region="us-east-1", config={"path": path})
+        else:
+            logger.error("Unknown infrastructure type %s", typ)
+            return 1
+        await infra.destroy()
         return 0
 
     @staticmethod

--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -1,7 +1,8 @@
 from .postgres import PostgresInfrastructure
 from .duckdb import DuckDBInfrastructure
 from .docker import DockerInfrastructure
-from .opentofu import OpenTofuInfrastructure, AWSStandardInfrastructure
+from .opentofu import OpenTofuInfrastructure
+from .aws_standard import AWSStandardInfrastructure
 
 __all__ = [
     "PostgresInfrastructure",

--- a/src/entity/infrastructure/aws_standard.py
+++ b/src/entity/infrastructure/aws_standard.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .opentofu import OpenTofuInfrastructure
+
+
+class AWSStandardInfrastructure(OpenTofuInfrastructure):
+    """Basic AWS deployment using ECS, RDS and S3."""
+
+    name = "aws-standard"
+    provider = "aws"
+
+    def __init__(self, region: str = "us-east-1", config: Dict | None = None) -> None:
+        super().__init__("aws", "standard", region, config)
+
+    # -----------------------------------------------------
+    # templates
+    # -----------------------------------------------------
+    def generate_templates(self) -> dict[str, str]:
+        templates = super().generate_templates()
+        templates.update(
+            {
+                "ecs.tf": self._ecs_module(),
+                "rds.tf": self._rds_module(),
+                "s3.tf": self._s3_module(),
+            }
+        )
+        return templates
+
+    def _ecs_module(self) -> str:
+        return (
+            'resource "aws_ecs_cluster" "agent" {}\n'
+            'resource "aws_ecs_service" "agent" {\n'
+            '  name        = "agent"\n'
+            "  cluster     = aws_ecs_cluster.agent.id\n"
+            '  launch_type = "FARGATE"\n'
+            "}\n"
+        )
+
+    def _rds_module(self) -> str:
+        return (
+            'resource "aws_db_instance" "agent" {\n'
+            '  engine               = "postgres"\n'
+            '  instance_class       = "db.t3.micro"\n'
+            "  allocated_storage    = 20\n"
+            '  username             = "agent"\n'
+            '  password             = "password"\n'
+            "  skip_final_snapshot  = true\n"
+            "}\n"
+        )
+
+    def _s3_module(self) -> str:
+        return (
+            'resource "aws_s3_bucket" "agent" {\n'
+            '  bucket = "agent-${var.region}"\n'
+            "}\n"
+        )

--- a/src/entity/infrastructure/docker.py
+++ b/src/entity/infrastructure/docker.py
@@ -20,6 +20,23 @@ class DockerInfrastructure(InfrastructurePlugin):
         self.path = Path(self.config.get("path", ".")).resolve()
         self.deployed = False
 
+    # ---------------------------------------------------------
+    # helpers
+    # ---------------------------------------------------------
+    def generate_compose(self) -> str:
+        """Return minimal docker-compose configuration."""
+
+        lines = [
+            "version: '3.8'",
+            "services:",
+            "  agent:",
+            "    build: .",
+            "    container_name: agent",
+            "    ports:",
+            "      - '8000:8000'",
+        ]
+        return "\n".join(lines) + "\n"
+
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None
 
@@ -27,9 +44,7 @@ class DockerInfrastructure(InfrastructurePlugin):
         """Write Docker configuration files."""
         self.path.mkdir(parents=True, exist_ok=True)
         (self.path / "Dockerfile").write_text("FROM python:3.11-slim\n")
-        (self.path / "docker-compose.yml").write_text(
-            "version: '3'\nservices:\n  agent:\n    build: .\n"
-        )
+        (self.path / "docker-compose.yml").write_text(self.generate_compose())
         self.deployed = True
 
     async def destroy(self) -> None:

--- a/tests/infrastructure/test_templates.py
+++ b/tests/infrastructure/test_templates.py
@@ -1,0 +1,17 @@
+from entity.infrastructure import DockerInfrastructure, AWSStandardInfrastructure
+
+
+def test_docker_generate_compose():
+    infra = DockerInfrastructure()
+    content = infra.generate_compose()
+    assert "services:" in content
+    assert "agent:" in content
+
+
+def test_aws_standard_templates():
+    infra = AWSStandardInfrastructure()
+    templates = infra.generate_templates()
+    assert "provider" in templates["main.tf"]
+    assert "aws_ecs_cluster" in templates["ecs.tf"]
+    assert "aws_db_instance" in templates["rds.tf"]
+    assert "aws_s3_bucket" in templates["s3.tf"]


### PR DESCRIPTION
## Summary
- generate docker-compose config in docker infrastructure
- implement OpenTofu base template generation
- add AWS standard deployment templates
- add infra command to CLI
- test template generation helpers

## Testing
- `poetry run black src tests`
- `poetry run pytest tests` *(fails: PipelineState failure_info attr missing and more)*

------
https://chatgpt.com/codex/tasks/task_e_6872f0adbaa483229a9f4c32afd89bec