### PR TITLE
Improve reliability and add error handling test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-19: Added circuit breaker manager and validation phases
+
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -17,7 +17,7 @@ from entity.core.agent import Agent
 from entity.core.plugins import Plugin, ValidationResult
 from entity.pipeline.config.config_update import update_plugin_configuration
 from entity.pipeline.exceptions import CircuitBreakerTripped
-from entity.pipeline.reliability import CircuitBreaker
+from entity.core.circuit_breaker import CircuitBreaker
 from entity.utils.logging import get_logger
 from entity.config.environment import load_config
 from importlib import import_module

--- a/src/entity/core/circuit_breaker.py
+++ b/src/entity/core/circuit_breaker.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Dict, TypeVar
+
+from entity.config.models import BreakerSettings, CircuitBreakerConfig
+from entity.pipeline.exceptions import CircuitBreakerTripped
+
+T = TypeVar("T")
+
+
+class RetryPolicy:
+    """Retry asynchronous operations with optional backoff."""
+
+    def __init__(self, *, attempts: int = 3, backoff: float = 0.1) -> None:
+        self.attempts = attempts
+        self.backoff = backoff
+
+    async def execute(
+        self, func: Callable[..., Awaitable[T]], *args: object, **kwargs: object
+    ) -> T:
+        for attempt in range(self.attempts):
+            try:
+                return await func(*args, **kwargs)
+            except Exception:  # noqa: BLE001
+                if attempt >= self.attempts - 1:
+                    raise
+                await asyncio.sleep(self.backoff * (2**attempt))
+        raise RuntimeError("unreachable")
+
+
+class CircuitBreaker:
+    """Stop calls when failures exceed a threshold."""
+
+    def __init__(
+        self, *, failure_threshold: int = 3, recovery_timeout: float = 60.0
+    ) -> None:
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self._failure_count = 0
+        self._tripped_at: float | None = None
+
+    def _reset_if_needed(self) -> None:
+        if (
+            self._tripped_at is not None
+            and time.monotonic() - self._tripped_at >= self.recovery_timeout
+        ):
+            self.reset()
+
+    async def call(
+        self, func: Callable[..., Awaitable[T]], *args: object, **kwargs: object
+    ) -> T:
+        self._reset_if_needed()
+        if self._failure_count >= self.failure_threshold:
+            raise CircuitBreakerTripped("circuit breaker open")
+        try:
+            result = await func(*args, **kwargs)
+        except Exception:
+            self._failure_count += 1
+            if self._failure_count >= self.failure_threshold:
+                self._tripped_at = time.monotonic()
+            raise
+        else:
+            self.reset()
+            return result
+
+    def reset(self) -> None:
+        self._failure_count = 0
+        self._tripped_at = None
+
+
+@dataclass
+class BreakerManager:
+    """Provide breakers for resource categories."""
+
+    default: CircuitBreaker
+    category_breakers: Dict[str, CircuitBreaker]
+
+    def get(self, category: str | None) -> CircuitBreaker:
+        if not category:
+            return self.default
+        return self.category_breakers.get(category, self.default)
+
+    @classmethod
+    def from_config(
+        cls, cfg: CircuitBreakerConfig, settings: BreakerSettings
+    ) -> "BreakerManager":
+        cat_breakers = {
+            "database": CircuitBreaker(
+                failure_threshold=cfg.database or settings.database.failure_threshold,
+                recovery_timeout=cfg.recovery_timeout,
+            ),
+            "api": CircuitBreaker(
+                failure_threshold=cfg.api or settings.external_api.failure_threshold,
+                recovery_timeout=cfg.recovery_timeout,
+            ),
+            "filesystem": CircuitBreaker(
+                failure_threshold=cfg.filesystem
+                or settings.file_system.failure_threshold,
+                recovery_timeout=cfg.recovery_timeout,
+            ),
+        }
+        default = CircuitBreaker(
+            failure_threshold=cfg.failure_threshold,
+            recovery_timeout=cfg.recovery_timeout,
+        )
+        return cls(default, cat_breakers)
+
+
+__all__ = ["CircuitBreaker", "CircuitBreakerTripped", "RetryPolicy", "BreakerManager"]

--- a/src/entity/infrastructure/duckdb.py
+++ b/src/entity/infrastructure/duckdb.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Iterator
 import os
 
 from entity.pipeline.exceptions import CircuitBreakerTripped
-from entity.pipeline.reliability import CircuitBreaker
+from entity.core.circuit_breaker import CircuitBreaker
 
 import duckdb
 

--- a/src/entity/infrastructure/postgres.py
+++ b/src/entity/infrastructure/postgres.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from typing import Any, Dict
 
 from entity.pipeline.exceptions import CircuitBreakerTripped
-from entity.pipeline.reliability import CircuitBreaker
+from entity.core.circuit_breaker import CircuitBreaker
 
 from entity.core.plugins import InfrastructurePlugin, ValidationResult
 from entity.core.resources.container import PoolConfig, ResourcePool

--- a/src/entity/pipeline/__init__.py
+++ b/src/entity/pipeline/__init__.py
@@ -4,7 +4,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from .exceptions import CircuitBreakerTripped
-from .reliability import CircuitBreaker, RetryPolicy
+from entity.core.circuit_breaker import CircuitBreaker, RetryPolicy
 
 # Registry classes are no longer imported eagerly.
 # Access ``PluginRegistry`` and related classes via ``registry`` or

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -19,7 +19,7 @@ from entity.utils.logging import configure_logging, get_logger
 from entity.workflows.discovery import discover_workflows, register_module_workflows
 from .config import ConfigLoader
 from .utils import DependencyGraph, resolve_stages, StageResolver
-from .reliability import CircuitBreaker
+from entity.core.circuit_breaker import CircuitBreaker, BreakerManager
 from .exceptions import CircuitBreakerTripped
 from .errors import InitializationError
 
@@ -401,14 +401,14 @@ class SystemInitializer:
                         f"Unknown plugin referenced. Available plugins: {available}",
                     )
 
-        # Validate dependencies declared by each plugin class
-        for plugin_class, _ in registry.all_plugin_classes():
-            result = await plugin_class.validate_dependencies(registry)
+        # Phase 1: syntax validation
+        for plugin_class, config in registry.all_plugin_classes():
+            result = await plugin_class.validate_config(config)
             if not result.success:
                 raise InitializationError(
                     plugin_class.__name__,
-                    "dependency validation",
-                    f"{result.message}. Fix plugin dependencies.",
+                    "syntax validation",
+                    f"{result.message}. Update the plugin configuration.",
                 )
 
         # Register resources early so we can verify canonical ones exist
@@ -422,13 +422,13 @@ class SystemInitializer:
 
         # Phase 2: dependency validation
         self._validate_dependency_graph(registry, dep_graph)
-        for plugin_class, config in registry.all_plugin_classes():
-            result = await plugin_class.validate_config(config)
+        for plugin_class, _ in registry.all_plugin_classes():
+            result = await plugin_class.validate_dependencies(registry)
             if not result.success:
                 raise InitializationError(
                     plugin_class.__name__,
-                    "config validation",
-                    f"{result.message}. Update the plugin configuration.",
+                    "dependency validation",
+                    f"{result.message}. Fix plugin dependencies.",
                 )
 
         # Fail fast if any canonical resources are missing before initialization
@@ -446,28 +446,7 @@ class SystemInitializer:
             cfg = model.runtime_validation_breaker
             settings = model.breaker_settings
 
-            breaker_map = {
-                "database": CircuitBreaker(
-                    failure_threshold=cfg.database
-                    or settings.database.failure_threshold,
-                    recovery_timeout=cfg.recovery_timeout,
-                ),
-                "api": CircuitBreaker(
-                    failure_threshold=cfg.api
-                    or settings.external_api.failure_threshold,
-                    recovery_timeout=cfg.recovery_timeout,
-                ),
-                "filesystem": CircuitBreaker(
-                    failure_threshold=cfg.filesystem
-                    or settings.file_system.failure_threshold,
-                    recovery_timeout=cfg.recovery_timeout,
-                ),
-            }
-
-            default_breaker = CircuitBreaker(
-                failure_threshold=cfg.failure_threshold,
-                recovery_timeout=cfg.recovery_timeout,
-            )
+            breaker_mgr = BreakerManager.from_config(cfg, settings)
 
             tasks: list[asyncio.Task] = []
             resources: list[tuple[str, CircuitBreaker]] = []
@@ -481,7 +460,7 @@ class SystemInitializer:
                 if not category:
                     category = getattr(resource, "infrastructure_type", "").lower()
 
-                breaker = breaker_map.get(category, default_breaker)
+                breaker = breaker_mgr.get(category)
 
                 async def _call_validation(
                     validate=validate,
@@ -587,7 +566,8 @@ class SystemInitializer:
                         plugin_name,
                         "dependency graph validation",
                         (
-                            f"Missing dependency '{dep_name}'. Registered plugins: {available}."
+                            f"Missing dependency '{dep_name}'. "
+                            "Ensure it is registered and declared correctly."
                         ),
                     )
                 if dep_name in graph_map:

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -105,7 +105,7 @@ async def execute_stage(
     _start = time.perf_counter()
     async with start_span(f"stage.{stage.name.lower()}"):
         for plugin in stage_plugins:
-            context = PluginContext(state, registries, user_id)
+            context = PluginContext(state, registries)
             context.set_current_stage(stage)
             name = registries.plugins.get_plugin_name(plugin)
             context.set_current_plugin(name)
@@ -235,7 +235,7 @@ async def execute_stage(
         if state.failure_info and stage != PipelineStage.ERROR:
             await execute_stage(PipelineStage.ERROR, state, registries)
             state.last_completed_stage = PipelineStage.ERROR
-    _ = time.perf_counter() - start
+    _ = time.perf_counter() - _start
 
 
 async def execute_pipeline(

--- a/src/entity/pipeline/reliability.py
+++ b/src/entity/pipeline/reliability.py
@@ -1,72 +1,11 @@
 from __future__ import annotations
 
-import asyncio
-import time
-from typing import Awaitable, Callable, TypeVar
+"""Deprecated reliability utilities."""
 
-from .exceptions import CircuitBreakerTripped
+from entity.core.circuit_breaker import (
+    BreakerManager,
+    CircuitBreaker,
+    RetryPolicy,
+)
 
-T = TypeVar("T")
-
-
-class RetryPolicy:
-    """Retry asynchronous operations with optional backoff."""
-
-    def __init__(self, *, attempts: int = 3, backoff: float = 0.1) -> None:
-        self.attempts = attempts
-        self.backoff = backoff
-
-    async def execute(
-        self, func: Callable[..., Awaitable[T]], *args: object, **kwargs: object
-    ) -> T:
-        for attempt in range(self.attempts):
-            try:
-                return await func(*args, **kwargs)
-            except Exception:  # noqa: BLE001
-                if attempt >= self.attempts - 1:
-                    raise
-                await asyncio.sleep(self.backoff * (2**attempt))
-        raise RuntimeError("unreachable")
-
-
-class CircuitBreaker:
-    """Stop calls when failures exceed a threshold."""
-
-    def __init__(
-        self, *, failure_threshold: int = 3, recovery_timeout: float = 60.0
-    ) -> None:
-        self.failure_threshold = failure_threshold
-        self.recovery_timeout = recovery_timeout
-        self._failure_count = 0
-        self._tripped_at: float | None = None
-
-    def _reset_if_needed(self) -> None:
-        if (
-            self._tripped_at is not None
-            and time.monotonic() - self._tripped_at >= self.recovery_timeout
-        ):
-            self.reset()
-
-    async def call(
-        self, func: Callable[..., Awaitable[T]], *args: object, **kwargs: object
-    ) -> T:
-        self._reset_if_needed()
-        if self._failure_count >= self.failure_threshold:
-            raise CircuitBreakerTripped("circuit breaker open")
-        try:
-            result = await func(*args, **kwargs)
-        except Exception:
-            self._failure_count += 1
-            if self._failure_count >= self.failure_threshold:
-                self._tripped_at = time.monotonic()
-            raise
-        else:
-            self.reset()
-            return result
-
-    def reset(self) -> None:
-        self._failure_count = 0
-        self._tripped_at = None
-
-
-__all__ = ["RetryPolicy", "CircuitBreaker"]
+__all__ = ["RetryPolicy", "CircuitBreaker", "BreakerManager"]

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -1,0 +1,49 @@
+import pytest
+
+from datetime import datetime
+
+from entity.core.context import PluginContext
+from entity.core.plugins import Plugin
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.state import ConversationEntry
+from entity.pipeline.state import PipelineState
+from entity.pipeline.pipeline import execute_pipeline
+from entity.pipeline.stages import PipelineStage
+
+
+class FailingPlugin(Plugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        raise RuntimeError("fail")
+
+
+class CaptureErrorPlugin(Plugin):
+    stages = [PipelineStage.ERROR]
+
+    def __init__(self, config=None) -> None:
+        super().__init__(config or {})
+        self.called = False
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        self.called = True
+        context._state.response = "error handled"
+
+
+@pytest.mark.asyncio
+async def test_plugin_failure_triggers_error_stage():
+    plugins = PluginRegistry()
+    error_plugin = CaptureErrorPlugin()
+    await plugins.register_plugin_for_stage(
+        FailingPlugin({}), PipelineStage.THINK, "fail"
+    )
+    await plugins.register_plugin_for_stage(error_plugin, PipelineStage.ERROR, "err")
+
+    regs = SystemRegistries(resources={}, tools=ToolRegistry(), plugins=plugins)
+    state = PipelineState(
+        conversation=[ConversationEntry("hi", "user", datetime.now())],
+        pipeline_id="pid",
+    )
+    result = await execute_pipeline("hi", regs, state=state)
+    assert result == "error handled"
+    assert error_plugin.called is True

--- a/tests/test_runtime_breaker_by_category.py
+++ b/tests/test_runtime_breaker_by_category.py
@@ -1,7 +1,7 @@
 import pytest
 from entity.pipeline.initializer import SystemInitializer
 from entity.core.plugins import InfrastructurePlugin, ValidationResult
-from entity.pipeline.reliability import CircuitBreaker
+from entity.core.circuit_breaker import CircuitBreaker
 from entity.pipeline.exceptions import CircuitBreakerTripped, InitializationError
 
 


### PR DESCRIPTION
## Summary
- add circuit breaker manager with category mapping
- implement validation phases in system initializer
- integrate circuit breaker manager into initializer
- move circuit breaker utilities to core and update imports
- ensure PluginContext usage in pipeline doesn't require user_id
- add integration test for plugin error handling

## Testing
- `poetry run ruff check --fix src tests` *(fails: many style errors)*
- `poetry run mypy src` *(fails: found 240 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails due to syntax errors in templates)*
- `poetry run unimport src tests` *(fails: invalid syntax in templates)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing arguments)*
- `pytest tests/integration/test_error_handling.py -v`
- `pytest tests/test_runtime_breaker_by_category.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6872f0ab6c848322a62c153b2e929d5d