### PR TITLE
Enforce explicit stages and OUTPUT restrictions

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Log config stage overrides and enforce plugin stage hints
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/src/entity/core/decorators.py
+++ b/src/entity/core/decorators.py
@@ -19,6 +19,9 @@ def plugin(func: Optional[Callable] = None, **hints: Any) -> Callable:
     """
 
     def decorator(f: Callable) -> Callable:
+        if not (hints.get("plugin_class") or hints.get("stage") or hints.get("stages")):
+            raise ValueError("plugin decorator requires 'plugin_class' or stage hints")
+
         plugin_obj = PluginAutoClassifier.classify(f, hints or None)
         setattr(f, "__entity_plugin__", plugin_obj)
         return f

--- a/tests/plugins/test_stage_assignment.py
+++ b/tests/plugins/test_stage_assignment.py
@@ -1,0 +1,68 @@
+import logging
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path("src").resolve()))
+
+from entity.core.context import PluginContext
+from entity.core.plugins import Plugin, PromptPlugin
+from entity.core.registries import ToolRegistry
+from entity.core.state import PipelineState
+from entity.pipeline.errors import PluginContextError
+from entity.pipeline.stages import PipelineStage
+from entity.pipeline.utils import StageResolver
+
+
+class AttrPlugin(Plugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        pass
+
+
+class SayDuringParse(PromptPlugin):
+    stages = [PipelineStage.PARSE]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        context.say("oops")
+
+
+class DummyRegs:
+    def __init__(self) -> None:
+        self.resources = {}
+        self.tools = ToolRegistry()
+
+
+def make_context(stage: PipelineStage) -> PluginContext:
+    state = PipelineState(conversation=[])
+    ctx = PluginContext(state, DummyRegs())
+    ctx.set_current_stage(stage)
+    ctx.set_current_plugin("test")
+    return ctx
+
+
+def test_config_overrides_class_stage(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("stage-test")
+    with caplog.at_level(logging.WARNING):
+        stages, _ = StageResolver._resolve_plugin_stages(
+            AttrPlugin,
+            {"stage": PipelineStage.REVIEW},
+            logger=logger,
+        )
+    assert stages == [PipelineStage.REVIEW]
+    assert "overrides" in caplog.text
+
+
+def test_class_stage_used_without_config() -> None:
+    stages, _ = StageResolver._resolve_plugin_stages(AttrPlugin, {})
+    assert stages == [PipelineStage.DO]
+
+
+@pytest.mark.asyncio
+async def test_say_only_allowed_for_output() -> None:
+    ctx = make_context(PipelineStage.PARSE)
+    plugin = SayDuringParse({})
+    with pytest.raises(PluginContextError):
+        await plugin.execute(ctx)

--- a/tests/test_decorator_plugin.py
+++ b/tests/test_decorator_plugin.py
@@ -1,5 +1,6 @@
 import pathlib
 import sys
+import pytest
 
 sys.path.insert(0, str(pathlib.Path("src").resolve()))
 
@@ -33,8 +34,7 @@ async def hinted(_context):
     pass
 
 
-@plugin
-async def default(_context):
+async def _noop(_context):
     pass
 
 
@@ -45,6 +45,5 @@ def test_plugin_with_hints():
 
 
 def test_plugin_without_hints():
-    obj = default.__entity_plugin__
-    assert obj.stages == [PipelineStage.THINK]
-    assert obj.base_class is PromptPlugin
+    with pytest.raises(ValueError):
+        plugin(_noop)


### PR DESCRIPTION
## Summary
- log warnings when config overrides declared plugin stages
- require plugin decorator hints to avoid implicit THINK stage
- test stage resolution warning and OUTPUT restrictions
- document change in agents log

## Testing
- `poetry run pytest tests/plugins/test_stage_assignment.py::test_config_overrides_class_stage -q`
- `poetry run pytest tests/plugins/test_stage_assignment.py -q`
- `poetry run pytest tests/test_decorator_plugin.py::test_plugin_with_hints tests/test_decorator_plugin.py::test_plugin_without_hints -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f0a8d7f08322a1ae93f0135538ac