### PR TITLE
Implement per-user namespaced memory

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Implement multi-user namespacing in Memory and pipeline
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -52,19 +52,22 @@ class AdvancedContext:
 
     async def remember(self, key: str, value: Any) -> None:
         if self._parent._memory is not None:
-            namespaced_key = f"{self._parent._user_id}:{key}"
-            await self._parent._memory.store_persistent(namespaced_key, value)
+            await self._parent._memory.store_persistent(
+                key, value, user_id=self._parent._user_id
+            )
 
     async def memory(self, key: str, default: Any | None = None) -> Any:
         if self._parent._memory is None:
             return default
-        namespaced_key = f"{self._parent._user_id}:{key}"
-        return await self._parent._memory.fetch_persistent(namespaced_key, default)
+        return await self._parent._memory.fetch_persistent(
+            key, default, user_id=self._parent._user_id
+        )
 
     async def forget(self, key: str) -> None:
         if self._parent._memory is not None:
-            namespaced_key = f"{self._parent._user_id}:{key}"
-            await self._parent._memory.delete_persistent(namespaced_key)
+            await self._parent._memory.delete_persistent(
+                key, user_id=self._parent._user_id
+            )
 
     def set_metadata(self, key: str, value: Any) -> None:
         self._parent._state.metadata[key] = value

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -52,11 +52,13 @@ class Memory(AgentResource):
     # ------------------------------------------------------------------
     # Key-value helpers
     # ------------------------------------------------------------------
-    async def get(self, key: str, default: Any | None = None) -> Any:
-        return await self.fetch_persistent(key, default)
+    async def get(
+        self, key: str, default: Any | None = None, *, user_id: str = "default"
+    ) -> Any:
+        return await self.fetch_persistent(key, default, user_id=user_id)
 
-    async def set(self, key: str, value: Any) -> None:
-        await self.store_persistent(key, value)
+    async def set(self, key: str, value: Any, *, user_id: str = "default") -> None:
+        await self.store_persistent(key, value, user_id=user_id)
 
     # ``store_persistent`` and ``fetch_persistent`` are implemented below.
 
@@ -70,8 +72,13 @@ class Memory(AgentResource):
     # Conversation helpers
     # ------------------------------------------------------------------
     async def save_conversation(
-        self, conversation_id: str, history: List[ConversationEntry]
+        self,
+        pipeline_id: str,
+        history: List[ConversationEntry],
+        *,
+        user_id: str = "default",
     ) -> None:
+        conversation_id = f"{user_id}_{pipeline_id}"
         if self._pool is None:
             return
         async with self.database.connection() as conn:
@@ -91,7 +98,10 @@ class Memory(AgentResource):
                     ),
                 )
 
-    async def load_conversation(self, conversation_id: str) -> List[ConversationEntry]:
+    async def load_conversation(
+        self, pipeline_id: str, *, user_id: str = "default"
+    ) -> List[ConversationEntry]:
+        conversation_id = f"{user_id}_{pipeline_id}"
         if self._pool is None:
             return []
         async with self.database.connection() as conn:
@@ -153,50 +163,63 @@ class Memory(AgentResource):
             return []
         return await self.vector_store.query_similar(query, k)
 
-    async def batch_store(self, key_value_pairs: Dict[str, Any]) -> None:
+    async def batch_store(
+        self, key_value_pairs: Dict[str, Any], *, user_id: str = "default"
+    ) -> None:
         """Store multiple key/value pairs efficiently."""
         if self._pool is None:
             return
-        rows = [(key, json.dumps(value)) for key, value in key_value_pairs.items()]
+        rows = [
+            (f"{user_id}:{key}", json.dumps(value))
+            for key, value in key_value_pairs.items()
+        ]
         async with self.database.connection() as conn:
             conn.executemany(
                 f"INSERT OR REPLACE INTO {self._kv_table} VALUES (?, ?)", rows
             )
 
-    async def store_persistent(self, key: str, value: Any) -> None:
+    async def store_persistent(
+        self, key: str, value: Any, *, user_id: str = "default"
+    ) -> None:
         """Persist ``value`` under ``key``."""
         if self._pool is None:
             return
+        namespaced_key = f"{user_id}:{key}"
         async with self.database.connection() as conn:
             conn.execute(
                 f"INSERT OR REPLACE INTO {self._kv_table} VALUES (?, ?)",
-                (key, json.dumps(value)),
+                (namespaced_key, json.dumps(value)),
             )
 
-    async def fetch_persistent(self, key: str, default: Any = None) -> Any:
+    async def fetch_persistent(
+        self, key: str, default: Any = None, *, user_id: str = "default"
+    ) -> Any:
         """Retrieve a persisted value."""
         if self._pool is None:
             return default
+        namespaced_key = f"{user_id}:{key}"
         async with self.database.connection() as conn:
             row = conn.execute(
                 f"SELECT value FROM {self._kv_table} WHERE key = ?",
-                (key,),
+                (namespaced_key,),
             ).fetchone()
         return json.loads(row[0]) if row else default
 
-    async def delete_persistent(self, key: str) -> None:
+    async def delete_persistent(self, key: str, *, user_id: str = "default") -> None:
         """Remove ``key`` from persistent storage."""
         if self._pool is None:
             return
+        namespaced_key = f"{user_id}:{key}"
         async with self.database.connection() as conn:
             conn.execute(
                 f"DELETE FROM {self._kv_table} WHERE key = ?",
-                (key,),
+                (namespaced_key,),
             )
 
     async def add_conversation_entry(
-        self, conversation_id: str, entry: ConversationEntry
+        self, pipeline_id: str, entry: ConversationEntry, *, user_id: str = "default"
     ) -> None:
+        conversation_id = f"{user_id}_{pipeline_id}"
         """Append a single entry to ``conversation_id``."""
         if self._pool is None:
             return

--- a/src/entity/worker/pipeline_worker.py
+++ b/src/entity/worker/pipeline_worker.py
@@ -24,15 +24,14 @@ class PipelineWorker:
         self, pipeline_id: str, message: str, *, user_id: str
     ) -> Any:
         """Process ``message`` using the pipeline identified by ``pipeline_id`` and ``user_id``."""
-        conversation_id = f"{user_id}_{pipeline_id}"
         memory = self.registries.resources.get("memory")
-        conversation = await memory.load_conversation(conversation_id)
+        conversation = await memory.load_conversation(pipeline_id, user_id=user_id)
         conversation.append(
             ConversationEntry(content=message, role="user", timestamp=datetime.now())
         )
         state = PipelineState(conversation=conversation, pipeline_id=pipeline_id)
         result = await self.run_stages(state)
-        await memory.save_conversation(conversation_id, state.conversation)
+        await memory.save_conversation(pipeline_id, state.conversation, user_id=user_id)
         return result
 
 

--- a/tests/integration/test_multi_user.py
+++ b/tests/integration/test_multi_user.py
@@ -1,0 +1,37 @@
+import types
+import pytest
+
+from entity.worker.pipeline_worker import PipelineWorker
+from entity.core.plugins import Plugin
+from entity.core.registries import PluginRegistry
+from entity.pipeline.stages import PipelineStage
+
+
+class EchoStorePlugin(Plugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context):
+        await context.remember("last", context.conversation()[-1].content)
+        context.say(context.conversation()[-1].content)
+
+
+@pytest.mark.asyncio
+async def test_user_isolation(memory_db):
+    regs = types.SimpleNamespace(
+        resources={"memory": memory_db}, tools=types.SimpleNamespace()
+    )
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(EchoStorePlugin({}), PipelineStage.OUTPUT)
+    regs.plugins = plugins
+    worker = PipelineWorker(regs)
+
+    await worker.execute_pipeline("chat", "hello", user_id="alice")
+    await worker.execute_pipeline("chat", "world", user_id="bob")
+
+    hist_a = await memory_db.load_conversation("chat", user_id="alice")
+    hist_b = await memory_db.load_conversation("chat", user_id="bob")
+
+    assert [e.content for e in hist_a] == ["hello"]
+    assert [e.content for e in hist_b] == ["world"]
+    assert await memory_db.get("last", user_id="alice") == "hello"
+    assert await memory_db.get("last", user_id="bob") == "world"

--- a/tests/test_memory_basic.py
+++ b/tests/test_memory_basic.py
@@ -36,12 +36,12 @@ async def simple_memory() -> Memory:
 
 @pytest.mark.asyncio
 async def test_set_get(simple_memory: Memory) -> None:
-    await simple_memory.set("foo", "bar")
-    assert await simple_memory.get("foo") == "bar"
+    await simple_memory.set("foo", "bar", user_id="default")
+    assert await simple_memory.get("foo", user_id="default") == "bar"
 
 
 @pytest.mark.asyncio
 async def test_remember_alias(simple_memory: Memory) -> None:
     assert Memory.remember is Memory.store_persistent
-    await simple_memory.remember("alpha", 123)
-    assert await simple_memory.get("alpha") == 123
+    await simple_memory.remember("alpha", 123, user_id="default")
+    assert await simple_memory.get("alpha", user_id="default") == 123

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -32,12 +32,14 @@ class DummyMemory:
         self.saved_id = None
         self.history = []
 
-    async def load_conversation(self, conversation_id: str):
-        self.loaded_id = conversation_id
+    async def load_conversation(self, pipeline_id: str, *, user_id: str = "default"):
+        self.loaded_id = f"{user_id}_{pipeline_id}"
         return list(self.history)
 
-    async def save_conversation(self, conversation_id: str, history):
-        self.saved_id = conversation_id
+    async def save_conversation(
+        self, pipeline_id: str, history, *, user_id: str = "default"
+    ):
+        self.saved_id = f"{user_id}_{pipeline_id}"
         self.history = list(history)
 
 
@@ -172,7 +174,7 @@ async def test_pipeline_persists_conversation(memory_db):
     await worker.execute_pipeline("pipe1", "hello", user_id="u1")
     await worker.execute_pipeline("pipe1", "world", user_id="u1")
 
-    history = await regs.resources["memory"].load_conversation("u1_pipe1")
+    history = await regs.resources["memory"].load_conversation("pipe1", user_id="u1")
     assert [e.content for e in history] == ["first", "second"]
 
 

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -147,16 +147,16 @@ def test_memory_persists_between_instances() -> None:
     mem1.database = db
     mem1.vector_store = None
     asyncio.get_event_loop().run_until_complete(mem1.initialize())
-    loop.run_until_complete(mem1.set("foo", "bar"))
+    loop.run_until_complete(mem1.set("foo", "bar", user_id="default"))
     entry = ConversationEntry("hi", "user", datetime.now())
-    asyncio.run(mem1.save_conversation("cid", [entry]))
+    asyncio.run(mem1.save_conversation("cid", [entry], user_id="default"))
 
     mem2 = Memory(config={})
     mem2.database = db
     mem2.vector_store = None
     asyncio.get_event_loop().run_until_complete(mem2.initialize())
-    assert loop.run_until_complete(mem2.get("foo")) == "bar"
-    history = loop.run_until_complete(mem2.load_conversation("cid"))
+    assert loop.run_until_complete(mem2.get("foo", user_id="default")) == "bar"
+    history = loop.run_until_complete(mem2.load_conversation("cid", user_id="default"))
     assert history == [entry]
 
 
@@ -167,16 +167,16 @@ def test_memory_persists_with_connection_pool() -> None:
     mem1.database = pool
     mem1.vector_store = None
     asyncio.get_event_loop().run_until_complete(mem1.initialize())
-    loop.run_until_complete(mem1.set("foo", "bar"))
+    loop.run_until_complete(mem1.set("foo", "bar", user_id="default"))
     entry = ConversationEntry("hi", "user", datetime.now())
-    asyncio.run(mem1.save_conversation("cid", [entry]))
+    asyncio.run(mem1.save_conversation("cid", [entry], user_id="default"))
 
     mem2 = Memory(config={})
     mem2.database = pool
     mem2.vector_store = None
     asyncio.get_event_loop().run_until_complete(mem2.initialize())
-    assert loop.run_until_complete(mem2.get("foo")) == "bar"
-    history = loop.run_until_complete(mem2.load_conversation("cid"))
+    assert loop.run_until_complete(mem2.get("foo", user_id="default")) == "bar"
+    history = loop.run_until_complete(mem2.load_conversation("cid", user_id="default"))
     assert history == [entry]
 
 

--- a/tests/test_stateless_worker.py
+++ b/tests/test_stateless_worker.py
@@ -67,7 +67,7 @@ async def test_workers_share_state_across_instances() -> None:
     worker2 = PipelineWorker(regs2)
     await worker2.execute_pipeline("pipe", "there", user_id="u1")
 
-    history = await regs2.resources["memory"].load_conversation("u1_pipe")
+    history = await regs2.resources["memory"].load_conversation("pipe", user_id="u1")
     assert [e.content for e in history] == ["hello", "there"]
 
 
@@ -80,5 +80,5 @@ async def test_worker_does_not_cache_state() -> None:
     await worker.execute_pipeline("pipe", "first", user_id="u1")
     await worker.execute_pipeline("pipe", "second", user_id="u1")
 
-    history = await regs.resources["memory"].load_conversation("u1_pipe")
+    history = await regs.resources["memory"].load_conversation("pipe", user_id="u1")
     assert [e.content for e in history] == ["first", "second"]

--- a/user_plugins/prompts/complex_prompt.py
+++ b/user_plugins/prompts/complex_prompt.py
@@ -33,7 +33,9 @@ class ComplexPrompt(PromptPlugin):
 
         history: List[ConversationEntry] = []
         if memory:
-            history = await memory.load_conversation(context.pipeline_id)
+            history = await memory.load_conversation(
+                context.pipeline_id, user_id=context.user_id
+            )
         history_text = "\n".join(f"{h.role}: {h.content}" for h in history)
 
         last_message = ""
@@ -60,4 +62,6 @@ class ComplexPrompt(PromptPlugin):
 
         await context.think("complex_response", response.content)
         if memory:
-            await memory.save_conversation(context.pipeline_id, context.conversation())
+            await memory.save_conversation(
+                context.pipeline_id, context.conversation(), user_id=context.user_id
+            )


### PR DESCRIPTION
## Summary
- propagate `user_id` through pipeline stages
- namespace Memory conversation and persistent keys by user
- update plugins and workers for new Memory API
- add integration test for user data isolation

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src` *(fails: 240 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/integration/test_multi_user.py -v` *(failed: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_6872f0a5328c832282d927606e751c6c