### PR TITLE
Implement vector search and analytics in Memory

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added vector search and analytics tests for Memory resource
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -211,20 +211,26 @@ class Memory(AgentResource):
                     entry.timestamp.isoformat(),
                 ),
             )
+        if self.vector_store is not None:
+            await self.vector_store.add_embedding(entry.content)
 
     async def conversation_search(
-        self, query: str, user_id: str | None = None, days: int | None = None
+        self,
+        query: str,
+        user_id: str | None = None,
+        days: int | None = None,
+        k: int = 5,
     ) -> List[Dict[str, Any]]:
-        """Search conversation history using simple text matching."""
+        """Search conversation history using vector similarity when possible."""
         if self._pool is None:
             return []
-
         sql = (
             f"SELECT conversation_id, role, content, metadata, timestamp "
             f"FROM {self._history_table}"
         )
-        clauses = []
+        clauses: List[str] = []
         params: List[Any] = []
+
         if user_id:
             clauses.append("conversation_id LIKE ?")
             params.append(f"{user_id}%")
@@ -232,9 +238,19 @@ class Memory(AgentResource):
             since = (datetime.now() - timedelta(days=days)).isoformat()
             clauses.append("timestamp >= ?")
             params.append(since)
+
         if query:
-            clauses.append("content LIKE ?")
-            params.append(f"%{query}%")
+            if self.vector_store is not None:
+                similar = await self.vector_store.query_similar(query, k)
+                if not similar:
+                    return []
+                placeholders = ", ".join("?" for _ in similar)
+                clauses.append(f"content IN ({placeholders})")
+                params.extend(similar)
+            else:
+                clauses.append("content LIKE ?")
+                params.append(f"%{query}%")
+
         if clauses:
             sql += " WHERE " + " AND ".join(clauses)
         sql += " ORDER BY timestamp DESC"
@@ -253,22 +269,30 @@ class Memory(AgentResource):
         ]
 
     async def conversation_statistics(self, user_id: str) -> Dict[str, Any]:
-        """Return simple statistics for a user's conversations."""
+        """Return message counts and durations for ``user_id`` conversations."""
         if self._pool is None:
             return {}
         async with self.database.connection() as conn:
-            conv_rows = conn.execute(
-                f"SELECT DISTINCT conversation_id FROM {self._history_table} "
-                "WHERE conversation_id LIKE ?",
+            rows = conn.execute(
+                f"SELECT conversation_id, COUNT(*) as count, "
+                f"MIN(timestamp) as start, MAX(timestamp) as end "
+                f"FROM {self._history_table} "
+                "WHERE conversation_id LIKE ? GROUP BY conversation_id",
                 (f"{user_id}%",),
             ).fetchall()
-            total_messages = conn.execute(
-                f"SELECT COUNT(*) FROM {self._history_table} WHERE conversation_id LIKE ?",
-                (f"{user_id}%",),
-            ).fetchone()[0]
+
+        stats: Dict[str, float] = {}
+        total_messages = 0
+        for row in rows:
+            total_messages += row[1]
+            start = datetime.fromisoformat(row[2])
+            end = datetime.fromisoformat(row[3])
+            stats[row[0]] = (end - start).total_seconds()
+
         return {
-            "conversations": len(conv_rows),
+            "conversations": len(rows),
             "messages": total_messages,
+            "durations": stats,
         }
 
     # ------------------------------------------------------------------

--- a/tests/resources/test_memory.py
+++ b/tests/resources/test_memory.py
@@ -1,0 +1,87 @@
+import sqlite3
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta
+
+import pytest
+
+from entity.resources import Memory
+from entity.resources.interfaces.database import DatabaseResource
+from entity.resources.interfaces.vector_store import VectorStoreResource
+from entity.core.state import ConversationEntry
+
+
+class SqliteDB(DatabaseResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
+        )
+
+    @asynccontextmanager
+    async def connection(self):
+        yield self.conn
+
+    def get_connection_pool(self):
+        return self.conn
+
+
+class DummyVector(VectorStoreResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.entries: list[str] = []
+
+    async def add_embedding(self, text: str) -> None:
+        self.entries.append(text)
+
+    async def query_similar(self, query: str, k: int = 5):
+        return [t for t in self.entries if query in t][:k]
+
+
+@pytest.fixture()
+async def memory_with_vector() -> Memory:
+    mem = Memory(config={})
+    mem.database = SqliteDB()
+    mem.vector_store = DummyVector()
+    await mem.initialize()
+    yield mem
+
+
+@pytest.mark.asyncio
+async def test_conversation_search_vector(memory_with_vector: Memory) -> None:
+    await memory_with_vector.add_conversation_entry(
+        "user_conv",
+        ConversationEntry(content="hello world", role="user", timestamp=datetime.now()),
+    )
+    results = await memory_with_vector.conversation_search("hello", user_id="user")
+    assert len(results) == 1
+    assert results[0]["content"] == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_conversation_statistics(memory_with_vector: Memory) -> None:
+    now = datetime.now()
+    await memory_with_vector.add_conversation_entry(
+        "user_c1",
+        ConversationEntry(content="hi", role="user", timestamp=now),
+    )
+    await memory_with_vector.add_conversation_entry(
+        "user_c1",
+        ConversationEntry(
+            content="bye", role="assistant", timestamp=now + timedelta(seconds=30)
+        ),
+    )
+    await memory_with_vector.add_conversation_entry(
+        "user_c2",
+        ConversationEntry(
+            content="ping", role="user", timestamp=now + timedelta(seconds=60)
+        ),
+    )
+    stats = await memory_with_vector.conversation_statistics("user")
+    assert stats["conversations"] == 2
+    assert stats["messages"] == 3
+    assert stats["durations"]["user_c1"] == 30.0
+    assert stats["durations"]["user_c2"] == 0.0


### PR DESCRIPTION
## Summary
- add vector store support when searching conversations
- persist embeddings as conversations are stored
- compute conversation durations in analytics
- test vector search and analytics

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run pytest tests/resources/test_memory.py -v`
- `poetry run pytest tests/test_resources/ -v`

------
https://chatgpt.com/codex/tasks/task_e_6872f094525883228abc4202f6989788