### PR TITLE
Improve layer validation and tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-12: Added layer validation checks and architecture tests
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent
 AGENT NOTE - 2025-07-12: Removed sandbox infrastructure and unused plugins

--- a/tests/architecture/test_container_architecture.py
+++ b/tests/architecture/test_container_architecture.py
@@ -1,0 +1,86 @@
+import asyncio
+import pytest
+
+from entity.core.resources.container import ResourceContainer, DependencyGraph
+from entity.core.plugins import InfrastructurePlugin, ResourcePlugin, AgentResource
+from entity.pipeline.errors import InitializationError
+
+
+class SimpleInfra(InfrastructurePlugin):
+    infrastructure_type = "infra"
+    stages: list = []
+    dependencies: list = []
+
+
+SimpleInfra.dependencies = []
+
+
+class OtherInfra(InfrastructurePlugin):
+    infrastructure_type = "other"
+    stages: list = []
+    dependencies: list = []
+
+
+OtherInfra.dependencies = []
+
+
+class BadInterface(ResourcePlugin):
+    stages: list = []
+    dependencies: list = []
+
+
+BadInterface.dependencies = []
+
+
+class CustomResource(AgentResource):
+    stages: list = []
+    dependencies = []
+
+
+CustomResource.dependencies = []
+
+
+def test_layer1_missing_infrastructure_type():
+    class BadInfra(InfrastructurePlugin):
+        stages: list = []
+        dependencies: list = []
+
+    BadInfra.dependencies = []
+
+    container = ResourceContainer()
+    container.register("bad", BadInfra, {}, layer=1)
+
+    with pytest.raises(InitializationError, match="infrastructure_type"):
+        asyncio.run(container.build_all())
+
+
+def test_layer1_with_dependencies():
+    class DepInfra(InfrastructurePlugin):
+        infrastructure_type = "dep"
+        stages: list = []
+        dependencies = ["other"]
+
+    DepInfra.dependencies = ["other"]
+
+    container = ResourceContainer()
+    container.register("other", OtherInfra, {}, layer=1)
+    container.register("bad", DepInfra, {}, layer=1)
+
+    with pytest.raises(InitializationError, match="cannot have dependencies"):
+        asyncio.run(container.build_all())
+
+
+def test_layer2_missing_infrastructure_dependencies():
+    container = ResourceContainer()
+    container.register("infra", SimpleInfra, {}, layer=1)
+    container.register("iface", BadInterface, {}, layer=2)
+
+    with pytest.raises(InitializationError, match="infrastructure_dependencies"):
+        asyncio.run(container.build_all())
+
+
+def test_dependency_graph_cycle_detection():
+    graph = {"a": ["b"], "b": ["a"]}
+    dg = DependencyGraph(graph)
+    with pytest.raises(InitializationError, match="Circular dependency detected"):
+        dg.topological_sort()


### PR DESCRIPTION
## Summary
- expand `_validate_layers` with explicit checks for infrastructure and interface plugins
- raise `InitializationError` for circular dependencies during ordering
- add architecture tests covering layer validation and dependency cycles
- log note about the new validations

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(failed: Command not found)*
- `poetry run unimport --remove-all src tests` *(failed: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/test_plugin_* -v` *(failed: 3 failed, 9 passed)*
- `poetry run pytest tests/test_resources -v`


------
https://chatgpt.com/codex/tasks/task_e_6872f08a335083229ac5430d52c08875