### PR TITLE
Fix timer variable in pipeline

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Removed unused start measurement in execute_stage
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -246,7 +246,7 @@ async def execute_stage(
         if state.failure_info and stage != PipelineStage.ERROR:
             await execute_stage(PipelineStage.ERROR, state, registries, user_id=user_id)
             state.last_completed_stage = PipelineStage.ERROR
-    _ = time.perf_counter() - _start
+    # elapsed time could be logged here if needed
 
 
 async def execute_pipeline(


### PR DESCRIPTION
## Summary
- remove unused start measurement in `execute_stage`
- record note in agents log

## Testing
- `poetry run pytest tests/test_agent_runtime.py tests/test_default_agent.py tests/test_pipeline_worker.py tests/test_stateless_worker.py -q` *(fails: DummyRegistries has no attribute 'plugins')*

------
https://chatgpt.com/codex/tasks/task_e_687313529ed083228fdede6653711eea