### PR TITLE
Update stage decorator tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-19: Updated decorator test to check builder._added_plugins
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -19,20 +19,23 @@ _DEFINITIONS = [
 
 
 def _stage_of(decorator):
-    _ = Agent()
+    ag = Agent()
 
-    @decorator
+    bound = getattr(ag, decorator.__name__)
+
+    @bound
     async def dummy(context):
         pass
 
-    return dummy.__entity_plugin__.stages
+    return ag.builder._added_plugins[-1]
 
 
 for dec, stage in _DEFINITIONS:
 
     def _make_test(dec=dec, stage=stage):
         def test_func():
-            assert _stage_of(dec) == [stage]
+            plugin = _stage_of(dec)
+            assert plugin.stages == [stage]
 
         return test_func
 


### PR DESCRIPTION
## Summary
- update _stage_of in tests to inspect agent.builder._added_plugins
- ensure dynamic tests check plugin stages directly
- document change in agents.log

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402, F821, etc.)*
- `poetry run mypy src` *(fails: found 263 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: missing model, coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: missing model, coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: requires --config)*
- `pytest tests/architecture -v` *(fails: ModuleNotFoundError: 'entity')*
- `pytest tests/plugins -v` *(fails: ModuleNotFoundError: 'entity')*
- `pytest tests/resources -v` *(fails: ModuleNotFoundError: 'entity')*
- `pytest tests/test_decorators.py -v` *(fails: ModuleNotFoundError: 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873135b65ac83228b099286505e51f4