### PR TITLE
Fix StageResolver explicit fallback

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated StageResolver explicit logic and plugin harness tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/src/cli/plugin_tool/utils.py
+++ b/src/cli/plugin_tool/utils.py
@@ -17,7 +17,12 @@ def load_plugin(path: str) -> Type[Plugin]:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     for obj in module.__dict__.values():
-        if inspect.isclass(obj) and issubclass(obj, Plugin) and obj is not Plugin:
+        if (
+            inspect.isclass(obj)
+            and issubclass(obj, Plugin)
+            and obj is not Plugin
+            and obj.__module__ == module.__name__
+        ):
             return obj
     raise RuntimeError("No plugin class found")
 

--- a/src/entity/pipeline/utils/__init__.py
+++ b/src/entity/pipeline/utils/__init__.py
@@ -46,9 +46,14 @@ class StageResolver:
         logger: Any | None = None,
     ) -> tuple[list[PipelineStage], bool]:
         cfg_value = config.get("stages") or config.get("stage")
-        class_value = getattr(plugin_class, "stages", None) or getattr(
-            plugin_class, "stage", None
+        class_value = plugin_class.__dict__.get("stages") or plugin_class.__dict__.get(
+            "stage"
         )
+        inherited_value = None
+        if class_value is None:
+            inherited_value = getattr(plugin_class, "stages", None) or getattr(
+                plugin_class, "stage", None
+            )
 
         if cfg_value is not None:
             stages = _normalize_stages(cfg_value)
@@ -65,6 +70,8 @@ class StageResolver:
                 )
         elif class_value is not None:
             stages = _normalize_stages(class_value)
+        elif inherited_value is not None:
+            stages = _normalize_stages(inherited_value)
         else:
             stages = [PipelineStage.THINK]
 

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -1,4 +1,4 @@
-from entity.core.plugins import Plugin
+from entity.core.plugins import Plugin, PromptPlugin
 from entity.pipeline.utils import StageResolver
 from entity.core.stages import PipelineStage
 
@@ -11,6 +11,11 @@ class AttrPrompt(Plugin):
 
 
 class InferredPrompt(Plugin):
+    async def _execute_impl(self, context):
+        pass
+
+
+class DerivedPrompt(PromptPlugin):
     async def _execute_impl(self, context):
         pass
 
@@ -69,6 +74,15 @@ def test_initializer_fallback_stage():
     plugin = InferredPrompt({})
 
     stages, explicit = StageResolver._resolve_plugin_stages(InferredPrompt, {}, plugin)
+
+    assert stages == [PipelineStage.THINK]
+    assert explicit is False
+
+
+def test_initializer_inherited_stage_not_explicit():
+    plugin = DerivedPrompt({})
+
+    stages, explicit = StageResolver._resolve_plugin_stages(DerivedPrompt, {}, plugin)
 
     assert stages == [PipelineStage.THINK]
     assert explicit is False


### PR DESCRIPTION
## Summary
- handle inherited stage attributes in `_resolve_plugin_stages`
- prefer local classes when loading plugins for harness
- allow tool plugins in tests to run even without custom `_execute_impl`
- test explicit flag for inherited stages
- note repository update

## Testing
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v`
- `poetry run pytest tests/resources -v` *(fails: InitializationError, assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_687313723e888322b45806837971115c