### PR TITLE
Add metrics collector to validator tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added metrics_collector to validator test configs
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/tests/architecture/test_plugin_taxonomy.py
+++ b/tests/architecture/test_plugin_taxonomy.py
@@ -57,7 +57,10 @@ def _write_cfg(tmp_path, plugins):
 def test_resource_base_validation(tmp_path):
     cfg = {
         "agent_resources": {
-            "bad": {"type": "tests.architecture.test_plugin_taxonomy:WrongResource"}
+            "bad": {"type": "tests.architecture.test_plugin_taxonomy:WrongResource"},
+            "metrics_collector": {
+                "type": "entity.resources.metrics:MetricsCollectorResource"
+            },
         }
     }
     path = _write_cfg(tmp_path, cfg)

--- a/tests/core/test_dependency_injection.py
+++ b/tests/core/test_dependency_injection.py
@@ -21,6 +21,9 @@ def test_register_plugins_appends_dependencies():
                 "llm": {"type": "entity.resources.llm:LLM"},
                 "storage": {"type": "entity.resources.storage:Storage"},
                 "logging": {"type": "entity.resources.logging:LoggingResource"},
+                "metrics_collector": {
+                    "type": "entity.resources.metrics:MetricsCollectorResource"
+                },
             },
             "tools": {"dummy": {"type": f"{__name__}:DummyTool"}},
         },

--- a/tests/test_cli_validate_failures.py
+++ b/tests/test_cli_validate_failures.py
@@ -66,6 +66,9 @@ def _base_resources(resource_cls):
         "memory": {"type": f"tests.test_cli_validate_failures:{resource_cls.__name__}"},
         "llm": {"type": "tests.test_cli_validate_failures:DummyResource"},
         "storage": {"type": "tests.test_cli_validate_failures:DummyResource"},
+        "metrics_collector": {
+            "type": "entity.resources.metrics:MetricsCollectorResource"
+        },
     }
 
 

--- a/tests/test_initializer_canonical_resources.py
+++ b/tests/test_initializer_canonical_resources.py
@@ -18,6 +18,9 @@ def test_initializer_fails_without_memory():
             "agent_resources": {
                 "llm": {"type": "entity.resources.llm:LLM"},
                 "storage": {"type": "entity.resources.storage:Storage"},
+                "metrics_collector": {
+                    "type": "entity.resources.metrics:MetricsCollectorResource"
+                },
             }
         },
         "workflow": {},
@@ -33,6 +36,9 @@ def test_initializer_fails_without_llm():
             "agent_resources": {
                 "memory": {"type": "entity.resources.memory:Memory"},
                 "storage": {"type": "entity.resources.storage:Storage"},
+                "metrics_collector": {
+                    "type": "entity.resources.metrics:MetricsCollectorResource"
+                },
             }
         },
         "workflow": {},
@@ -48,6 +54,9 @@ def test_initializer_fails_without_storage():
             "agent_resources": {
                 "memory": {"type": "entity.resources.memory:Memory"},
                 "llm": {"type": "entity.resources.llm:LLM"},
+                "metrics_collector": {
+                    "type": "entity.resources.metrics:MetricsCollectorResource"
+                },
             }
         },
         "workflow": {},
@@ -64,6 +73,9 @@ def test_initializer_fails_without_logging():
                 "memory": {"type": "entity.resources.memory:Memory"},
                 "llm": {"type": "entity.resources.llm:LLM"},
                 "storage": {"type": "entity.resources.storage:Storage"},
+                "metrics_collector": {
+                    "type": "entity.resources.metrics:MetricsCollectorResource"
+                },
             }
         },
         "workflow": {},
@@ -82,6 +94,9 @@ def test_initializer_accepts_all_canonical_resources(monkeypatch):
                 "llm": {"type": "entity.resources.llm:LLM"},
                 "storage": {"type": "entity.resources.storage:Storage"},
                 "logging": {"type": "entity.resources.logging:LoggingResource"},
+                "metrics_collector": {
+                    "type": "entity.resources.metrics:MetricsCollectorResource"
+                },
             }
         },
         "workflow": {},

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -174,7 +174,10 @@ def test_complex_prompt_requires_vector_store(tmp_path):
             "complex_prompt": {"type": "tests.test_registry_validator:ComplexPrompt"}
         },
         "agent_resources": {
-            "database": {"type": "tests.test_registry_validator:DBInterface"}
+            "database": {"type": "tests.test_registry_validator:DBInterface"},
+            "metrics_collector": {
+                "type": "entity.resources.metrics:MetricsCollectorResource"
+            },
         },
     }
     path = _write_config(tmp_path, plugins)
@@ -190,6 +193,9 @@ def test_complex_prompt_with_vector_store(tmp_path):
                 "type": "tests.test_registry_validator:VectorStoreResource"
             },
             "database": {"type": "tests.test_registry_validator:DBInterface"},
+            "metrics_collector": {
+                "type": "entity.resources.metrics:MetricsCollectorResource"
+            },
         },
         "prompts": {
             "complex_prompt": {"type": "tests.test_registry_validator:ComplexPrompt"}
@@ -207,6 +213,9 @@ def test_memory_requires_postgres(tmp_path):
                 "type": "plugins.builtin.resources.pg_vector_store:PgVectorStore"
             },
             "database": {"type": "tests.test_registry_validator:A"},
+            "metrics_collector": {
+                "type": "entity.resources.metrics:MetricsCollectorResource"
+            },
         }
     }
     path = _write_config(tmp_path, plugins)
@@ -222,6 +231,9 @@ def test_memory_with_postgres(tmp_path):
                 "type": "plugins.builtin.resources.pg_vector_store:PgVectorStore"
             },
             "database": {"type": "tests.test_registry_validator:PostgresResource"},
+            "metrics_collector": {
+                "type": "entity.resources.metrics:MetricsCollectorResource"
+            },
         },
     }
     path = _write_config(tmp_path, plugins)


### PR DESCRIPTION
## Summary
- extend all validator test configs with metrics_collector
- update note in agents.log

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `PYTHONPATH=src poetry run pytest tests/architecture/ -v`
- `PYTHONPATH=src poetry run pytest tests/plugins/ -v` *(fails: NotImplementedError)*
- `PYTHONPATH=src poetry run pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68731370d3888322baba9c783738ddf4