### PR TITLE
Fix response control test import

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated test_response_control import path to pipeline.state
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/tests/test_response_control.py
+++ b/tests/test_response_control.py
@@ -8,7 +8,7 @@ import pytest
 from entity.core.context import PluginContext
 from entity.core.plugins import PromptPlugin
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
-from entity.core.state import ConversationEntry, PipelineState
+from entity.pipeline.state import PipelineState, ConversationEntry
 from entity.pipeline.stages import PipelineStage
 from entity.pipeline.pipeline import execute_pipeline
 from entity.pipeline.errors import PluginContextError


### PR DESCRIPTION
## Summary
- update `tests/test_response_control.py` to import `PipelineState` and `ConversationEntry` from `entity.pipeline.state`
- record note about import update in `agents.log`

## Testing
- `poetry run black tests/test_response_control.py`
- `poetry run ruff check --fix tests/test_response_control.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `pytest tests/test_architecture/ -v`
- `pytest tests/test_plugins/ -v`
- `pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6873136f1cc48322b29805fb604b4c59