### PR TITLE
Reuse helper for reload tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Reused run_reload helper in reload tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/tests/test_reload_runtime_validation.py
+++ b/tests/test_reload_runtime_validation.py
@@ -75,7 +75,7 @@ async def test_reload_aborts_on_failed_runtime_validation(tmp_path):
     cfg_file = tmp_path / "reload.yaml"
     cfg_file.write_text(yaml.safe_dump(cfg))
 
-    result = cli._reload_config(agent, str(cfg_file))
+    result = await run_reload(cli, agent, cfg_file)
     assert result == 1
 
 
@@ -95,7 +95,7 @@ async def test_reload_successful_reconfiguration(tmp_path):
     cfg_file = tmp_path / "reload.yaml"
     cfg_file.write_text(yaml.safe_dump(cfg))
 
-    result = cli._reload_config(agent, str(cfg_file))
+    result = await run_reload(cli, agent, cfg_file)
     assert result == 0
     assert plugin.config["value"] == 2
     assert plugin.config_version == 2
@@ -118,7 +118,7 @@ async def test_reload_failed_reconfiguration(tmp_path):
     cfg_file = tmp_path / "reload.yaml"
     cfg_file.write_text(yaml.safe_dump(cfg))
 
-    result = cli._reload_config(agent, str(cfg_file))
+    result = await run_reload(cli, agent, cfg_file)
     assert result == 1
     assert plugin.config["value"] == 1
     assert plugin.config_version == 1

--- a/tests/test_reload_unknown_plugin.py
+++ b/tests/test_reload_unknown_plugin.py
@@ -7,6 +7,8 @@ from entity.core.plugins import Plugin, ValidationResult
 from entity.core.stages import PipelineStage
 from entity.cli import EntityCLI
 
+from .test_reload_runtime_validation import run_reload
+
 
 class SimplePlugin(Plugin):
     name = "simple"
@@ -32,5 +34,5 @@ async def test_reload_requires_restart_when_plugin_missing(tmp_path: Path) -> No
     cfg_file = tmp_path / "reload.yaml"
     cfg_file.write_text(yaml.safe_dump(cfg))
 
-    result = cli._reload_config(agent, str(cfg_file))
+    result = await run_reload(cli, agent, cfg_file)
     assert result == 2


### PR DESCRIPTION
## Summary
- reuse the `run_reload` helper in `test_reload_runtime_validation.py`
- import and use `run_reload` in the unknown plugin reload test
- record agent note

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix tests/test_reload_runtime_validation.py tests/test_reload_unknown_plugin.py`
- `poetry run mypy src` *(fails: 263 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: Model 'llama3' missing)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: Model 'llama3' missing)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873136e72208322acb2542e1a484e2b