### PR TITLE
Include PluginRegistry in worker tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added PluginRegistry to dummy registries for worker tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -167,7 +167,9 @@ async def test_conversation_id_generation():
 @pytest.mark.asyncio
 async def test_pipeline_persists_conversation(memory_db):
     regs = types.SimpleNamespace(
-        resources={"memory": memory_db}, tools=types.SimpleNamespace()
+        resources={"memory": memory_db},
+        tools=types.SimpleNamespace(),
+        plugins=PluginRegistry(),
     )
     worker = PipelineWorker(regs)
 

--- a/tests/test_stateless_worker.py
+++ b/tests/test_stateless_worker.py
@@ -7,6 +7,7 @@ import pytest
 from entity.resources import Memory
 from entity.resources.interfaces.database import DatabaseResource
 from entity.pipeline.worker import PipelineWorker
+from entity.core.registries import PluginRegistry
 
 
 class DummyConnection:
@@ -53,6 +54,7 @@ class DummyRegistries:
         mem.database = db
         self.resources = {"memory": mem}
         self.tools = types.SimpleNamespace()
+        self.plugins = PluginRegistry()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update worker test fixtures to provide a `PluginRegistry`
- document the change in agents log

## Testing
- `poetry run pytest tests/test_pipeline_worker.py tests/test_stateless_worker.py -q` *(fails: Model 'llama3' missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873136c30388322a235362960255c0c