### PR TITLE
Fix runtime validation tests import

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added import for CircuitBreaker in infrastructure runtime test
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/tests/test_infrastructure_validate_runtime.py
+++ b/tests/test_infrastructure_validate_runtime.py
@@ -2,6 +2,7 @@ import pytest
 from contextlib import asynccontextmanager
 
 from entity.infrastructure import DuckDBInfrastructure, PostgresInfrastructure
+from entity.pipeline.reliability import CircuitBreaker
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add CircuitBreaker import to the runtime validation tests
- document the change in `agents.log`

## Testing
- `poetry run pytest tests/test_infrastructure_validate_runtime.py -q`
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v` *(fails: NotImplementedError)*
- `poetry run pytest tests/test_resources/ -v`

------
https://chatgpt.com/codex/tasks/task_e_6873136503188322aa90ca4bd5d2cc6c