### PR TITLE
Improve WebSocket logging tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-19: Added retry logic for WebSocket tests and explicit connection closure
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/tests/test_logging_resource.py
+++ b/tests/test_logging_resource.py
@@ -10,6 +10,15 @@ import os
 import socket
 
 
+async def _connect(uri: str, attempts: int = 10, delay: float = 0.05):
+    for _ in range(attempts):
+        try:
+            return await websockets.connect(uri)
+        except (ConnectionRefusedError, OSError):
+            await asyncio.sleep(delay)
+    raise RuntimeError("WebSocket server not ready")
+
+
 @pytest.mark.asyncio
 async def test_logging_file_and_console(tmp_path, capsys, monkeypatch):
     log_file = tmp_path / "log.jsonl"
@@ -47,9 +56,13 @@ async def test_logging_stream_output(tmp_path, monkeypatch):
     logger: LoggingResource = container.get("logging")  # type: ignore[assignment]
     stream = next(o for o in logger._stream_outputs)
     uri = f"ws://{stream.host}:{stream.port}"
-    async with websockets.connect(uri) as ws:
-        await logger.log("info", "hi", component="resource")
-        msg = await asyncio.wait_for(ws.recv(), timeout=2)
+    ws = await _connect(uri)
+    await logger.log("info", "hi", component="resource")
+    msg = await asyncio.wait_for(ws.recv(), timeout=2)
+    try:
+        await ws.close()
+    except websockets.exceptions.ConnectionClosedOK:
+        pass
     await container.shutdown_all()
     data = json.loads(msg)
     assert data["message"] == "hi"


### PR DESCRIPTION
## Summary
- retry connecting to the test WebSocket server
- close WebSocket connections before shutting down the container
- document the change in `agents.log`

## Testing
- `poetry run black tests/test_logging_resource.py tests/resources/test_logging.py`
- `poetry run ruff check --fix tests/test_logging_resource.py tests/resources/test_logging.py`
- `poetry run mypy src` *(fails: 263 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(failed: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873136a1a7883229258be98a295614e