### PR TITLE
Fix logging console output

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated logging test configuration to include console output.
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent

--- a/tests/test_logging_resource.py
+++ b/tests/test_logging_resource.py
@@ -18,7 +18,12 @@ async def test_logging_file_and_console(tmp_path, capsys, monkeypatch):
     container.register(
         "logging",
         LoggingResource,
-        {"outputs": [{"type": "structured_file", "path": str(log_file)}]},
+        {
+            "outputs": [
+                {"type": "structured_file", "path": str(log_file)},
+                {"type": "console"},
+            ]
+        },
         layer=3,
     )
     await container.build_all()


### PR DESCRIPTION
## Summary
- capture console output in logging test by adding console output config
- note the change in agents log

## Testing
- `poetry run black tests/test_logging_resource.py`
- `poetry run ruff check --fix tests/test_logging_resource.py`
- `poetry run mypy src` *(fails: 263 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config ...` *(failed: missing model)*
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v` *(fails: NotImplementedError)*
- `poetry run pytest tests/resources -v` *(fails: InitializationError)*


------
https://chatgpt.com/codex/tasks/task_e_6873136a1ac483228e7f6a75803a4264