### PR TITLE
Convert memory persistence tests to async

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Converted memory persistence tests to async and removed module-level loop setup
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks
 AGENT NOTE - 2025-07-12: Verified metrics_collector removal; file already absent


### PR DESCRIPTION
## Summary
- switch memory persistence tests to pytest.mark.asyncio style
- record agent note about the test change

## Testing
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v` *(fails: NotImplementedError)*
- `poetry run pytest tests/resources -v` *(fails: InitializationError)*
- `poetry run pytest tests/test_plugin_context_memory.py::test_memory_persists_between_instances -vv`
- `poetry run pytest tests/test_plugin_context_memory.py::test_memory_persists_with_connection_pool -vv`
- `poetry run pytest tests/test_plugin_context_memory.py::test_memory_roundtrip -vv`


------
https://chatgpt.com/codex/tasks/task_e_6873136cc0fc832298abbadfb80f4502