### PR TITLE
Update decorator tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated decorator tests for plugin stage verification
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(pathlib.Path("src").resolve()))
 from entity import agent
 from entity.core.stages import PipelineStage
 from entity import Agent
+import pytest
 
 
 _DEFINITIONS = [
@@ -18,28 +19,17 @@ _DEFINITIONS = [
 ]
 
 
-def _stage_of(decorator):
+@pytest.mark.parametrize("decorator, stage", _DEFINITIONS)
+def test_agent_decorator_adds_stage(decorator, stage):
     ag = Agent()
-
     bound = getattr(ag, decorator.__name__)
 
     @bound
     async def dummy(context):
         pass
 
-    return ag.builder._added_plugins[-1]
-
-
-for dec, stage in _DEFINITIONS:
-
-    def _make_test(dec=dec, stage=stage):
-        def test_func():
-            plugin = _stage_of(dec)
-            assert plugin.stages == [stage]
-
-        return test_func
-
-    globals()[f"test_{dec.__name__}_decorator"] = _make_test()
+    plugin = ag.builder._added_plugins[-1]
+    assert plugin.stages == [stage]
 
 
 def test_agent_tool_method_default_stage():


### PR DESCRIPTION
## Summary
- parametrize decorator stage tests
- keep tests verifying default stages for prompt and tool
- add agent note

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402, E741)*
- `poetry run mypy src` *(fails: Found 264 errors)*
- `poetry run bandit -r src` *(fails: 9 medium, 41 low issues)*
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: Model 'llama3' missing)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: Model 'llama3' missing)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_68732185696c832284a8c57b8dfe2f9d