### PR TITLE
Fix import order in runtime validation test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Verified CircuitBreaker and asynccontextmanager imports in tests/test_infrastructure_validate_runtime.py
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_infrastructure_validate_runtime.py
+++ b/tests/test_infrastructure_validate_runtime.py
@@ -1,5 +1,6 @@
-import pytest
 from contextlib import asynccontextmanager
+
+import pytest
 
 from entity.infrastructure import DuckDBInfrastructure, PostgresInfrastructure
 from entity.pipeline.reliability import CircuitBreaker


### PR DESCRIPTION
## Summary
- reorder imports in `tests/test_infrastructure_validate_runtime.py`
- log verification note in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 150 remaining errors)*
- `poetry run mypy src` *(fails with 264 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873218143c083229f2b1f31d46b281d