### PR TITLE
Fix decorator tests to inspect builder

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-21: Updated decorator tests to inspect added plugins
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -3,43 +3,46 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path("src").resolve()))
 
-from entity import agent
+from entity import Agent, agent
 from entity.core.stages import PipelineStage
-from entity import Agent
 
 
-_DEFINITIONS = [
-    (agent.input, PipelineStage.INPUT),
-    (agent.parse, PipelineStage.PARSE),
-    (agent.prompt, PipelineStage.THINK),
-    (agent.tool, PipelineStage.DO),
-    (agent.review, PipelineStage.REVIEW),
-    (agent.output, PipelineStage.OUTPUT),
-]
-
-
-def _stage_of(decorator):
-    ag = Agent()
-
-    bound = getattr(ag, decorator.__name__)
-
-    @bound
+def _plugin_for(decorator):
+    @decorator
     async def dummy(context):
         pass
 
-    return ag.builder._added_plugins[-1]
+    return agent.builder._added_plugins.pop()
 
 
-for dec, stage in _DEFINITIONS:
+def test_input_decorator():
+    plugin = _plugin_for(agent.input)
+    assert plugin.stages == [PipelineStage.INPUT]
 
-    def _make_test(dec=dec, stage=stage):
-        def test_func():
-            plugin = _stage_of(dec)
-            assert plugin.stages == [stage]
 
-        return test_func
+def test_parse_decorator():
+    plugin = _plugin_for(agent.parse)
+    assert plugin.stages == [PipelineStage.PARSE]
 
-    globals()[f"test_{dec.__name__}_decorator"] = _make_test()
+
+def test_prompt_decorator():
+    plugin = _plugin_for(agent.prompt)
+    assert plugin.stages == [PipelineStage.THINK]
+
+
+def test_tool_decorator():
+    plugin = _plugin_for(agent.tool)
+    assert plugin.stages == [PipelineStage.DO]
+
+
+def test_review_decorator():
+    plugin = _plugin_for(agent.review)
+    assert plugin.stages == [PipelineStage.REVIEW]
+
+
+def test_output_decorator():
+    plugin = _plugin_for(agent.output)
+    assert plugin.stages == [PipelineStage.OUTPUT]
 
 
 def test_agent_tool_method_default_stage():


### PR DESCRIPTION
## Summary
- update decorator tests to inspect the added plugin rather than using `__entity_plugin__`
- record note in `agents.log`

## Testing
- `poetry run pytest tests/test_decorators.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687321355240832294c90001ae7fc5bf