### PR TITLE
Fix agent runtime test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated tests to wrap workflow with Pipeline
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -3,6 +3,7 @@ import pytest
 from entity.core.agent import Agent, _AgentBuilder
 from entity.core.plugins import Plugin
 from entity.pipeline.stages import PipelineStage
+from entity.pipeline.workflow import Pipeline
 from entity.workflows.base import Workflow
 
 
@@ -40,8 +41,9 @@ async def test_agent_handle_runs_workflow():
     agent = Agent()
     await agent.add_plugin(ThoughtPlugin({}))
     await agent.add_plugin(EchoPlugin({}))
-    agent.pipeline = Workflow(
+    wf = Workflow(
         {PipelineStage.THINK: ["ThoughtPlugin"], PipelineStage.OUTPUT: ["EchoPlugin"]}
     )
+    agent.pipeline = Pipeline(workflow=wf)
     result = await agent.handle("bye")
     assert result == "bye!"


### PR DESCRIPTION
## Summary
- log current change in `agents.log`
- use a `Pipeline` object in agent runtime tests

## Testing
- `poetry run pytest tests/test_agent_runtime.py -q` *(fails: InitializationError: logging layer mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6873211712148322984efbc3615f9497