### PR TITLE
Ensure load_env imports load_dotenv

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Ensure load_env imports load_dotenv and passes tests
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/src/entity/config/environment.py
+++ b/src/entity/config/environment.py
@@ -9,7 +9,8 @@ from typing import Any, MutableMapping, Mapping
 
 import yaml
 
-from dotenv import dotenv_values, load_dotenv
+from dotenv import dotenv_values
+from dotenv import load_dotenv
 
 
 def load_env(env_file: str | Path = ".env", env: str | None = None) -> None:


### PR DESCRIPTION
## Summary
- import `load_dotenv` alongside `dotenv_values`
- log note about ensuring environment helpers work

## Testing
- `poetry run pytest tests/test_environment.py::test_env_file_loading -vv`
- `poetry run pytest tests/test_environment.py::test_env_does_not_override_existing -vv`
- `poetry run pytest tests/test_environment.py::test_secret_overrides_env_file -vv`
- `poetry run pytest tests/test_environment.py::test_os_env_overrides_secret -vv`
- `poetry run ruff check --fix src tests` *(fails: E402 module level import not at top of file)*
- `poetry run mypy src` *(fails: found 264 errors)*
- `poetry run bandit -r src` *(shows several B101 and B608 issues)*
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: Model 'llama3' missing)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: Model 'llama3' missing)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_68732113da80832287b92cddd0a9800c