### PR TITLE
Fix default agent pipeline test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Wrapped workflow dict with Pipeline in tests
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_default_agent.py
+++ b/tests/test_default_agent.py
@@ -1,6 +1,8 @@
 import asyncio
 
 from entity import agent
+from entity.pipeline.pipeline import Pipeline
+from entity.pipeline.stages import PipelineStage
 from plugins.builtin.resources.ollama_llm import OllamaLLMResource
 
 
@@ -20,6 +22,9 @@ def test_agent_handle(monkeypatch):
         return "ok"
 
     monkeypatch.setattr(OllamaLLMResource, "generate", fake_generate, False)
+    agent.pipeline = Pipeline(
+        {PipelineStage.DO: ["add"], PipelineStage.OUTPUT: ["final"]}
+    )
     result = asyncio.run(agent.handle("hi"))
     assert result == "2"
 


### PR DESCRIPTION
## Summary
- register default agent's workflow with `Pipeline`
- log the testing update

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: Module level import not at top of file)*
- `poetry run mypy src` *(fails: found 264 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: Model 'llama3' missing)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: Model 'llama3' missing)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config argument)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_68732183eb348322921f2bfa24e7b2ee