### PR TITLE
Fix AsyncClient patch in tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Verified AsyncClient patch uses monkeypatch.setattr
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_examples_run.py
+++ b/tests/test_examples_run.py
@@ -13,11 +13,11 @@ def test_zero_config_example_runs(monkeypatch):
         pytest.skip("default_setup example not present")
 
     async def fake_post(self, url, json):
-        class R:
+        class Response:
             def json(self):
                 return {"response": "ok"}
 
-        return R()
+        return Response()
 
     monkeypatch.setattr(AsyncClient, "post", fake_post)
 


### PR DESCRIPTION
## Summary
- verify AsyncClient patch uses `monkeypatch.setattr`
- note verification in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 150 remaining)*
- `poetry run mypy src` *(errors: 264)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: missing model & arg)*
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v`
- `poetry run pytest tests/resources -v` *(fails: 5 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6873218213408322a4856c8ddc088f3a