### PR TITLE
Refactor plugin context memory tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Converted memory context tests to asyncio
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -131,10 +131,11 @@ def make_context(tmp_path) -> PluginContext:
     return PluginContext(state, regs)
 
 
-def test_memory_roundtrip(tmp_path) -> None:
+@pytest.mark.asyncio
+async def test_memory_roundtrip(tmp_path) -> None:
     ctx = make_context(tmp_path)
-    asyncio.run(ctx.remember("foo", "bar"))
-    assert asyncio.run(ctx.recall("foo")) == "bar"
+    await ctx.remember("foo", "bar")
+    assert await ctx.recall("foo") == "bar"
 
 
 @pytest.mark.asyncio
@@ -181,7 +182,8 @@ async def test_memory_persists_with_connection_pool() -> None:
     assert history == [entry]
 
 
-def test_initialize_without_database_raises_error() -> None:
+@pytest.mark.asyncio
+async def test_initialize_without_database_raises_error() -> None:
     mem = Memory(config={})
     with pytest.raises(ResourceInitializationError):
-        asyncio.run(mem.initialize())
+        await mem.initialize()


### PR DESCRIPTION
## Summary
- convert memory context tests to async functions
- note changes in agents log

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 154 errors)*
- `poetry run mypy src` *(fails: 264 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873217a9a9c8322bec5154d4de6b80d