### PR TITLE
docs: confirm reload helper

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Confirmed reload tests already use run_reload
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks


### PR DESCRIPTION
## Summary
- document that reload tests already await `run_reload`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402, E741, etc)*
- `poetry run mypy src` *(fails: module errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: model 'llama3' missing)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: model 'llama3' missing)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: config arg missing)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873217937b88322834b500ce66be5ce