### PR TITLE
Fix StageResolver restoration in tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-21: Restored StageResolver for stage precedence tests
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -1,6 +1,13 @@
 from entity.core.plugins import Plugin, PromptPlugin
-from entity.pipeline.utils import StageResolver
+import importlib
+import entity.pipeline.utils as pipeline_utils
 from entity.core.stages import PipelineStage
+
+# Reload pipeline utilities to restore the original StageResolver in case other
+# tests have replaced it.  This ensures explicit stage detection works as
+# expected in these tests.
+pipeline_utils = importlib.reload(pipeline_utils)
+StageResolver = pipeline_utils.StageResolver
 
 
 class AttrPrompt(Plugin):


### PR DESCRIPTION
## Summary
- restore `StageResolver` in `tests/test_stage_precedence.py` to prevent interference from other tests
- log this decision

## Testing
- `poetry run black tests/test_stage_precedence.py`
- `poetry run ruff check --fix tests/test_stage_precedence.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: unrecognized arguments)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873217689008322912e13a4e1505032