### PR TITLE
Fix stateless worker tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-21: Initialized memory in DummyRegistries for stateless worker tests
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks


### PR DESCRIPTION
## Summary
- ensure DummyRegistries initializes Memory correctly
- add PluginRegistry and connection pool for DummyDatabase
- update unit tests for stateless worker
- record agent note about memory initialization

## Testing
- `poetry run pytest tests/test_stateless_worker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68732175d3dc8322b08d5e260b95eb9a