### PR TITLE
Update stage resolution fallback tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-20: Marked fallback THINK stage as explicit in StageResolver tests
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -393,7 +393,14 @@ class SystemInitializer:
     def _resolve_plugin_stages(
         self, cls: type[Plugin], instance: Plugin, config: Dict
     ) -> tuple[List[PipelineStage], bool]:
-        """Determine final stages and whether they were explicit."""
+        """Determine final stages and whether they were explicit.
+
+        This mirrors :meth:`StageResolver._resolve_plugin_stages` but
+        operates on an instantiated plugin. The returned ``explicit`` flag
+        is ``True`` when stage information originates from configuration,
+        the instance, or class attributes. If no stage is defined, the
+        fallback ``THINK`` stage is considered explicit.
+        """
 
         stages = resolve_stages(cls, config)
         explicit = bool(
@@ -402,6 +409,8 @@ class SystemInitializer:
             or getattr(cls, "stages", None)
             or getattr(cls, "stage", None)
         )
+        if not explicit:
+            explicit = True
         return stages, explicit
 
     def _register_plugins(

--- a/src/entity/pipeline/utils/__init__.py
+++ b/src/entity/pipeline/utils/__init__.py
@@ -45,6 +45,19 @@ class StageResolver:
         _instance: Any | None = None,
         logger: Any | None = None,
     ) -> tuple[list[PipelineStage], bool]:
+        """Return stages and whether they were explicitly provided.
+
+        Stages are resolved in the following order:
+        1. ``stage``/``stages`` keys in ``config``.
+        2. ``stage`` or ``stages`` attributes on ``plugin_class``.
+        3. Inherited stage attributes on parent classes.
+        4. Fallback to ``PipelineStage.THINK``.
+
+        The returned ``explicit`` flag is ``True`` when a stage comes from
+        configuration, the plugin instance (``_explicit_stages``), or a class
+        attribute. When an instance is supplied and no explicit stage is found,
+        the fallback stage is also treated as explicit.
+        """
         cfg_value = config.get("stages") or config.get("stage")
         class_value = plugin_class.__dict__.get("stages") or plugin_class.__dict__.get(
             "stage"
@@ -82,6 +95,8 @@ class StageResolver:
         explicit_class = bool(class_value)
 
         explicit = explicit_cfg or explicit_instance or explicit_class
+        if _instance is not None and not explicit:
+            explicit = True
 
         return stages, explicit
 

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -76,7 +76,8 @@ def test_initializer_fallback_stage():
     stages, explicit = StageResolver._resolve_plugin_stages(InferredPrompt, {}, plugin)
 
     assert stages == [PipelineStage.THINK]
-    assert explicit is False
+    # The initializer treats the default THINK stage as explicit
+    assert explicit is True
 
 
 def test_initializer_inherited_stage_not_explicit():


### PR DESCRIPTION
## Summary
- mark fallback THINK stage as explicit in StageResolver
- document explicit fallback semantics in StageResolver and initializer
- update stage precedence tests accordingly

## Testing
- `poetry run ruff check --fix src tests` *(fails: E402 module level import not at top of file)*
- `poetry run mypy src` *(fails: 264 errors in 53 files)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config <config>` *(failed: missing model)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*


------
https://chatgpt.com/codex/tasks/task_e_6873214a2d2083229da8ea3bd562d918