### PR TITLE
Fix worker tests registries

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Extended DummyRegistries with PluginRegistry for worker tests
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -95,7 +95,7 @@ class DummyDatabase(DatabaseResource):
 
 
 class DummyRegistries:
-    def __init__(self) -> None:
+    def __init__(self, *, plugins: PluginRegistry | None = None) -> None:
         class _Resources(dict):
             async def __aenter__(self):
                 return self
@@ -106,7 +106,7 @@ class DummyRegistries:
         self.resources = _Resources(memory=DummyMemory())
         self.tools = types.SimpleNamespace()
         self.validators = None
-        self.plugins = PluginRegistry()
+        self.plugins = plugins or PluginRegistry()
 
 
 class DBRegistries:
@@ -153,7 +153,6 @@ class EchoPlugin(Plugin):
 @pytest.mark.asyncio
 async def test_conversation_id_generation():
     regs = DummyRegistries()
-    regs.plugins = PluginRegistry()
     await regs.plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.OUTPUT)
     worker = PipelineWorker(regs)
     result = await worker.execute_pipeline("pipe1", "hello", user_id="u123")
@@ -183,7 +182,6 @@ async def test_pipeline_persists_conversation(memory_db):
 @pytest.mark.asyncio
 async def test_thoughts_do_not_leak_between_executions():
     regs = DummyRegistries()
-    regs.plugins = PluginRegistry()
     await regs.plugins.register_plugin_for_stage(ThoughtPlugin({}), PipelineStage.THINK)
     await regs.plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.OUTPUT)
 

--- a/tests/test_stateless_worker.py
+++ b/tests/test_stateless_worker.py
@@ -49,12 +49,14 @@ class DummyDatabase(DatabaseResource):
 
 
 class DummyRegistries:
-    def __init__(self, db: DummyDatabase) -> None:
+    def __init__(
+        self, db: DummyDatabase, *, plugins: PluginRegistry | None = None
+    ) -> None:
         mem = Memory(config={})
         mem.database = db
         self.resources = {"memory": mem}
         self.tools = types.SimpleNamespace()
-        self.plugins = PluginRegistry()
+        self.plugins = plugins or PluginRegistry()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- include a `PluginRegistry` when constructing `DummyRegistries`
- simplify plugin registry setup in pipeline worker tests
- document the update in `agents.log`

## Testing
- `poetry run ruff check --fix tests/test_pipeline_worker.py tests/test_stateless_worker.py`
- `poetry run pytest tests/test_pipeline_worker.py tests/test_stateless_worker.py -q` *(fails: System error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68732141a194832288175ad53e7bf284