### PR TITLE
Refactor plugin context memory tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Refactored plugin context memory tests to use asyncio.run per test
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -132,53 +132,60 @@ def make_context(tmp_path) -> PluginContext:
 
 
 def test_memory_roundtrip(tmp_path) -> None:
-    ctx = make_context(tmp_path)
-    asyncio.run(ctx.remember("foo", "bar"))
-    assert asyncio.run(ctx.recall("foo")) == "bar"
+    async def run_test() -> None:
+        ctx = make_context(tmp_path)
+        await ctx.remember("foo", "bar")
+        assert await ctx.recall("foo") == "bar"
+
+    asyncio.run(run_test())
 
 
-@pytest.mark.asyncio
-async def test_memory_persists_between_instances() -> None:
-    db = DummyDatabase()
+def test_memory_persists_between_instances() -> None:
+    async def run_test() -> None:
+        db = DummyDatabase()
 
-    mem1 = Memory(config={})
-    mem1.database = db
-    mem1.vector_store = None
-    await mem1.initialize()
-    await mem1.set("foo", "bar", user_id="default")
-    entry = ConversationEntry("hi", "user", datetime.now())
-    await mem1.save_conversation("cid", [entry], user_id="default")
+        mem1 = Memory(config={})
+        mem1.database = db
+        mem1.vector_store = None
+        await mem1.initialize()
+        await mem1.set("foo", "bar", user_id="default")
+        entry = ConversationEntry("hi", "user", datetime.now())
+        await mem1.save_conversation("cid", [entry], user_id="default")
 
-    mem2 = Memory(config={})
-    mem2.database = db
-    mem2.vector_store = None
-    await mem2.initialize()
+        mem2 = Memory(config={})
+        mem2.database = db
+        mem2.vector_store = None
+        await mem2.initialize()
 
-    assert await mem2.get("foo", user_id="default") == "bar"
-    history = await mem2.load_conversation("cid", user_id="default")
-    assert history == [entry]
+        assert await mem2.get("foo", user_id="default") == "bar"
+        history = await mem2.load_conversation("cid", user_id="default")
+        assert history == [entry]
+
+    asyncio.run(run_test())
 
 
-@pytest.mark.asyncio
-async def test_memory_persists_with_connection_pool() -> None:
-    pool = DummyPool()
+def test_memory_persists_with_connection_pool() -> None:
+    async def run_test() -> None:
+        pool = DummyPool()
 
-    mem1 = Memory(config={})
-    mem1.database = pool
-    mem1.vector_store = None
-    await mem1.initialize()
-    await mem1.set("foo", "bar", user_id="default")
-    entry = ConversationEntry("hi", "user", datetime.now())
-    await mem1.save_conversation("cid", [entry], user_id="default")
+        mem1 = Memory(config={})
+        mem1.database = pool
+        mem1.vector_store = None
+        await mem1.initialize()
+        await mem1.set("foo", "bar", user_id="default")
+        entry = ConversationEntry("hi", "user", datetime.now())
+        await mem1.save_conversation("cid", [entry], user_id="default")
 
-    mem2 = Memory(config={})
-    mem2.database = pool
-    mem2.vector_store = None
-    await mem2.initialize()
+        mem2 = Memory(config={})
+        mem2.database = pool
+        mem2.vector_store = None
+        await mem2.initialize()
 
-    assert await mem2.get("foo", user_id="default") == "bar"
-    history = await mem2.load_conversation("cid", user_id="default")
-    assert history == [entry]
+        assert await mem2.get("foo", user_id="default") == "bar"
+        history = await mem2.load_conversation("cid", user_id="default")
+        assert history == [entry]
+
+    asyncio.run(run_test())
 
 
 def test_initialize_without_database_raises_error() -> None:


### PR DESCRIPTION
## Summary
- ensure each plugin context memory test runs in its own loop via `asyncio.run`
- log the test refactor in `agents.log`

## Testing
- `poetry run black tests/test_plugin_context_memory.py`
- `poetry run ruff check --fix tests/test_plugin_context_memory.py`
- `poetry run mypy src` *(fails: 264 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests | head`
- `poetry run unimport src tests | head`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: model 'llama3' missing)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: model 'llama3' missing)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: model 'llama3' missing)*
- `poetry run pytest tests/architecture/ -v`
- `poetry run pytest tests/plugins/ -v`
- `poetry run pytest tests/resources/ -v` *(fails: 5 tests failed)*
- `poetry run pytest tests/test_plugin_context_memory.py -v --asyncio-mode=strict` *(fails: asyncio.run cannot be called from running event loop)*

------
https://chatgpt.com/codex/tasks/task_e_68732143546c83228ccfe7fb2c74d74c