### PR TITLE
Fix stateless worker tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated DummyRegistries and tests for PluginRegistry and Memory initialization
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_stateless_worker.py
+++ b/tests/test_stateless_worker.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import types
 from contextlib import asynccontextmanager
@@ -13,22 +14,42 @@ from entity.core.registries import PluginRegistry
 class DummyConnection:
     def __init__(self, store: dict) -> None:
         self.store = store
+        self._last_query: str | None = None
+        self._last_params: tuple | None = None
 
-    async def execute(self, query: str, params: tuple | None = None) -> None:
+    def execute(self, query: str, params: tuple | None = None) -> None:
+        self._last_query = query
+        self._last_params = params
         if query.startswith("DELETE FROM conversation_history"):
-            cid = params
+            cid = params[0]
             self.store["history"].pop(cid, None)
         elif query.startswith("INSERT INTO conversation_history"):
             cid, role, content, metadata, ts = params
             self.store.setdefault("history", {}).setdefault(cid, []).append(
                 (role, content, json.loads(metadata), ts)
             )
+        return self
 
-    async def fetch(self, query: str, params: tuple) -> list:
+    def fetchall(self):
+        query = self._last_query or ""
+        params = self._last_params
         if query.startswith(
             "SELECT role, content, metadata, timestamp FROM conversation_history"
         ):
-            cid = params
+            cid = params[0]
+            return [
+                (role, content, metadata, ts)
+                for role, content, metadata, ts in self.store.get("history", {}).get(
+                    cid, []
+                )
+            ]
+        return []
+
+    def fetch(self, query: str, params: tuple) -> list:
+        if query.startswith(
+            "SELECT role, content, metadata, timestamp FROM conversation_history"
+        ):
+            cid = params[0]
             return [
                 (role, content, metadata, ts)
                 for role, content, metadata, ts in self.store.get("history", {}).get(
@@ -47,11 +68,15 @@ class DummyDatabase(DatabaseResource):
     async def connection(self):
         yield DummyConnection(self.data)
 
+    def get_connection_pool(self):
+        return DummyConnection(self.data)
+
 
 class DummyRegistries:
     def __init__(self, db: DummyDatabase) -> None:
         mem = Memory(config={})
         mem.database = db
+        mem.vector_store = None
         self.resources = {"memory": mem}
         self.tools = types.SimpleNamespace()
         self.plugins = PluginRegistry()
@@ -62,10 +87,12 @@ async def test_workers_share_state_across_instances() -> None:
     db = DummyDatabase()
 
     regs1 = DummyRegistries(db)
+    await regs1.resources["memory"].initialize()
     worker1 = PipelineWorker(regs1)
     await worker1.execute_pipeline("pipe", "hello", user_id="u1")
 
     regs2 = DummyRegistries(db)
+    await regs2.resources["memory"].initialize()
     worker2 = PipelineWorker(regs2)
     await worker2.execute_pipeline("pipe", "there", user_id="u1")
 
@@ -77,6 +104,7 @@ async def test_workers_share_state_across_instances() -> None:
 async def test_worker_does_not_cache_state() -> None:
     db = DummyDatabase()
     regs = DummyRegistries(db)
+    await regs.resources["memory"].initialize()
     worker = PipelineWorker(regs)
 
     await worker.execute_pipeline("pipe", "first", user_id="u1")


### PR DESCRIPTION
## Summary
- ensure `DummyRegistries` uses a `PluginRegistry` and initialize `Memory`
- fix DummyConnection behavior so Memory can persist conversation
- record agent note

## Testing
- `poetry run pytest tests/test_stateless_worker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873212bbdd08322beec19413c1f682e