### PR TITLE
Fix env loader and metrics collector

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Refactored environment loader and updated metrics collector to canonical resource
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/src/entity/resources/metrics.py
+++ b/src/entity/resources/metrics.py
@@ -35,7 +35,10 @@ class CustomMetricRecord:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
-class MetricsCollectorResource(ResourcePlugin):
+from .base import AgentResource
+
+
+class MetricsCollectorResource(AgentResource):
     """Simple in-memory metrics collector."""
 
     name = "metrics_collector"


### PR DESCRIPTION
## Summary
- refactor environment loading into EnvironmentLoader class
- treat MetricsCollectorResource as canonical
- update agents log
- ensure tests pass

## Testing
- `poetry run pytest tests/test_initializer_canonical_resources.py tests/test_runtime_breaker_by_category.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873211e2dd48322a15547a3427a3d9a