### PR TITLE
Fix timer reference in pipeline

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Fixed timer reference in pipeline
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -246,7 +246,7 @@ async def execute_stage(
         if state.failure_info and stage != PipelineStage.ERROR:
             await execute_stage(PipelineStage.ERROR, state, registries, user_id=user_id)
             state.last_completed_stage = PipelineStage.ERROR
-    # elapsed time could be logged here if needed
+    _ = time.perf_counter() - _start
 
 
 async def execute_pipeline(


### PR DESCRIPTION
## Summary
- fix perf counter variable reference in `execute_stage`
- log note

## Testing
- `poetry run black src/entity/pipeline/pipeline.py`
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 154 errors)*
- `poetry run mypy src` *(fails: found 264 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: Model 'llama3' missing)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: Model 'llama3' missing)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_68732115f84883228a637fdef2cd7f4d