### PR TITLE
Patch StageResolver fixture

### DIFF
--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -11,13 +11,16 @@ from entity.resources.interfaces.database import DatabaseResource
 import entity.pipeline.utils as pipeline_utils
 
 
-class StageResolver:
-    @staticmethod
-    def _resolve_plugin_stages(cls, config, logger=None):
-        return pipeline_utils.resolve_stages(cls, config), True
+@pytest.fixture()
+def patched_stage_resolver(monkeypatch):
+    class StageResolver:
+        @staticmethod
+        def _resolve_plugin_stages(cls, config, logger=None):
+            return pipeline_utils.resolve_stages(cls, config), True
 
+    monkeypatch.setattr(pipeline_utils, "StageResolver", StageResolver)
+    yield
 
-pipeline_utils.StageResolver = StageResolver
 
 from entity.pipeline import pipeline as pipeline_module  # noqa: E402
 from entity.worker.pipeline_worker import PipelineWorker
@@ -151,7 +154,7 @@ class EchoPlugin(Plugin):
 
 
 @pytest.mark.asyncio
-async def test_conversation_id_generation():
+async def test_conversation_id_generation(patched_stage_resolver):
     regs = DummyRegistries()
     regs.plugins = PluginRegistry()
     await regs.plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.OUTPUT)
@@ -165,7 +168,7 @@ async def test_conversation_id_generation():
 
 
 @pytest.mark.asyncio
-async def test_pipeline_persists_conversation(memory_db):
+async def test_pipeline_persists_conversation(patched_stage_resolver, memory_db):
     regs = types.SimpleNamespace(
         resources={"memory": memory_db},
         tools=types.SimpleNamespace(),
@@ -181,7 +184,7 @@ async def test_pipeline_persists_conversation(memory_db):
 
 
 @pytest.mark.asyncio
-async def test_thoughts_do_not_leak_between_executions():
+async def test_thoughts_do_not_leak_between_executions(patched_stage_resolver):
     regs = DummyRegistries()
     regs.plugins = PluginRegistry()
     await regs.plugins.register_plugin_for_stage(ThoughtPlugin({}), PipelineStage.THINK)


### PR DESCRIPTION
## Summary
- patch StageResolver with a fixture in tests

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v`
- `poetry run pytest tests/resources -v`
- `poetry run pytest tests/test_pipeline_worker.py -v`


------
https://chatgpt.com/codex/tasks/task_e_6873217dc7548322a7fed06c49f1a6cb