### PR TITLE
Add plugin registry to test registries

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-21: Added PluginRegistry to DummyRegistries tests
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -105,8 +105,8 @@ class DummyRegistries:
 
         self.resources = _Resources(memory=DummyMemory())
         self.tools = types.SimpleNamespace()
+        self.plugins: PluginRegistry = PluginRegistry()
         self.validators = None
-        self.plugins = PluginRegistry()
 
 
 class DBRegistries:
@@ -126,8 +126,8 @@ class DBRegistries:
         asyncio.run(mem.initialize())
         self.resources = _Resources(memory=mem)
         self.tools = types.SimpleNamespace()
+        self.plugins: PluginRegistry = PluginRegistry()
         self.validators = None
-        self.plugins = PluginRegistry()
 
 
 class ThoughtPlugin(Plugin):
@@ -153,7 +153,6 @@ class EchoPlugin(Plugin):
 @pytest.mark.asyncio
 async def test_conversation_id_generation():
     regs = DummyRegistries()
-    regs.plugins = PluginRegistry()
     await regs.plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.OUTPUT)
     worker = PipelineWorker(regs)
     result = await worker.execute_pipeline("pipe1", "hello", user_id="u123")
@@ -183,7 +182,6 @@ async def test_pipeline_persists_conversation(memory_db):
 @pytest.mark.asyncio
 async def test_thoughts_do_not_leak_between_executions():
     regs = DummyRegistries()
-    regs.plugins = PluginRegistry()
     await regs.plugins.register_plugin_for_stage(ThoughtPlugin({}), PipelineStage.THINK)
     await regs.plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.OUTPUT)
 

--- a/tests/test_stateless_worker.py
+++ b/tests/test_stateless_worker.py
@@ -54,7 +54,7 @@ class DummyRegistries:
         mem.database = db
         self.resources = {"memory": mem}
         self.tools = types.SimpleNamespace()
-        self.plugins = PluginRegistry()
+        self.plugins: PluginRegistry = PluginRegistry()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update DummyRegistries definitions to always include PluginRegistry
- streamline pipeline worker tests
- document the change in agents.log

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 150 errors)*
- `poetry run mypy src` *(fails: Found 264 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests` *(fails: invalid syntax in templates)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing argument --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*


------
https://chatgpt.com/codex/tasks/task_e_6873217ca78483229434cab8717f9a4c