### PR TITLE
Reset validator test plugin deps

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Reset dependencies in registry validator test plugins
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -26,6 +26,10 @@ class A(AgentResource):
         pass
 
 
+A.dependencies = []
+A.stages = []
+
+
 class B(Plugin):
     stages = [PipelineStage.THINK]
     dependencies = ["a"]
@@ -36,6 +40,9 @@ class B(Plugin):
 
     async def _execute_impl(self, context):
         pass
+
+
+B.dependencies = ["a"]
 
 
 class C(Plugin):
@@ -51,6 +58,9 @@ class C(Plugin):
         pass
 
 
+C.dependencies = ["missing"]
+
+
 class D(Plugin):
     stages = [PipelineStage.PARSE]
     dependencies = ["e"]
@@ -60,6 +70,9 @@ class D(Plugin):
 
     async def _execute_impl(self, context):
         pass
+
+
+D.dependencies = ["e"]
 
 
 class E(Plugin):
@@ -73,6 +86,9 @@ class E(Plugin):
         pass
 
 
+E.dependencies = ["d"]
+
+
 class VectorStoreResource(AgentResource):
     stages = [PipelineStage.PARSE]
 
@@ -80,11 +96,18 @@ class VectorStoreResource(AgentResource):
         pass
 
 
+VectorStoreResource.dependencies = []
+VectorStoreResource.stages = []
+
+
 class PostgresResource(AgentResource):
     stages: list = []
 
     async def _execute_impl(self, context):  # pragma: no cover - stub
         pass
+
+
+PostgresResource.dependencies = []
 
 
 class DBInterface(ResourcePlugin):
@@ -95,12 +118,18 @@ class DBInterface(ResourcePlugin):
         pass
 
 
+DBInterface.dependencies = []
+
+
 class InfraDatabase(InfrastructurePlugin):
     infrastructure_type = "database"
     stages: list = []
 
     async def _execute_impl(self, context):
         pass
+
+
+InfraDatabase.dependencies = []
 
 
 class BadPromptInterface(Plugin):
@@ -111,12 +140,18 @@ class BadPromptInterface(Plugin):
         pass
 
 
+BadPromptInterface.dependencies = ["db_interface"]
+
+
 class BadPromptInfra(Plugin):
     stages = [PipelineStage.THINK]
     dependencies = ["infra_db"]
 
     async def _execute_impl(self, context):
         pass
+
+
+BadPromptInfra.dependencies = ["infra_db"]
 
 
 class ComplexPrompt(Plugin):
@@ -131,6 +166,9 @@ class ComplexPrompt(Plugin):
 
     async def _execute_impl(self, context):
         pass
+
+
+ComplexPrompt.dependencies = ["memory"]
 
 
 def _write_config(tmp_path, plugins):


### PR DESCRIPTION
## Summary
- avoid plugin auto-dependency side effects in `tests/test_registry_validator.py`
- log a note about the change

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: Found 154 errors)*
- `poetry run mypy src` *(fails: Found 264 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: invalid syntax in templates)*
- `poetry run unimport src tests` *(errors for template syntax)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: missing model, coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: missing model, coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `poetry run pytest tests/architecture/ -v`
- `poetry run pytest tests/test_plugins/ -v` *(no tests run)*
- `poetry run pytest tests/test_resources/ -v`
- `poetry run pytest tests/test_registry_validator.py::test_validator_success -q` *(fails: Plugin 'b' must inherit from PromptPlugin)*

------
https://chatgpt.com/codex/tasks/task_e_68732179c49883229bc43f34d3db0392