### PR TITLE
Refactor memory context tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Converted memory context tests to use per-test asyncio loops
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks


### PR DESCRIPTION
## Summary
- make DummyRegistries async-safe
- use pytest.mark.asyncio in memory context tests
- note improvements in agents log

## Testing
- `poetry run pytest tests/test_plugin_context_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687321224bf4832288b3ea1b7197a115