### PR TITLE
Fix response control import

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-21: Updated response control test import path
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_response_control.py
+++ b/tests/test_response_control.py
@@ -8,7 +8,8 @@ import pytest
 from entity.core.context import PluginContext
 from entity.core.plugins import PromptPlugin
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
-from entity.pipeline.state import PipelineState, ConversationEntry
+from entity.pipeline.state import PipelineState
+from entity.core.state import ConversationEntry
 from entity.pipeline.stages import PipelineStage
 from entity.pipeline.pipeline import execute_pipeline
 from entity.pipeline.errors import PluginContextError


### PR DESCRIPTION
## Summary
- simplify the import in tests/test_response_control.py
- note update in agents.log

## Testing
- `poetry run ruff check --fix tests/test_response_control.py`
- `poetry run mypy tests/test_response_control.py` *(fails: class cannot subclass `PromptPlugin`)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: syntax errors in template files)*
- `poetry run unimport src tests` *(reports syntax errors in templates)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing `--config` argument)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873212726b083229e04d6bde82fbb94