### PR TITLE
Fix StageResolver precedence test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Fixed StageResolver patching in tests
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -1,6 +1,10 @@
 from entity.core.plugins import Plugin, PromptPlugin
-from entity.pipeline.utils import StageResolver
 from entity.core.stages import PipelineStage
+import importlib
+import entity.pipeline.utils as pipeline_utils
+
+# Reload pipeline_utils to ensure the original StageResolver is used
+StageResolver = importlib.reload(pipeline_utils).StageResolver
 
 
 class AttrPrompt(Plugin):


### PR DESCRIPTION
## Summary
- reload `StageResolver` in stage precedence tests so explicit stages are detected
- note fix in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 154 errors)*
- `poetry run mypy src` *(fails: 264 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: invalid syntax in templates)*
- `poetry run unimport src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: model missing)*
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v`
- `poetry run pytest tests/resources -v` *(fails: 5 tests failed)*
- `poetry run pytest tests/test_stage_precedence.py -v`


------
https://chatgpt.com/codex/tasks/task_e_6873212a8f1c83229b8ed12a9c648e13