### PR TITLE
Fix env load for secrets

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added load_dotenv usage for environment secrets
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/src/entity/config/environment.py
+++ b/src/entity/config/environment.py
@@ -22,6 +22,7 @@ def load_env(env_file: str | Path = ".env", env: str | None = None) -> None:
 
     env_path = Path(env_file)
     env_values = dotenv_values(env_path) if env_path.exists() else {}
+    secret_path: Path | None = None
 
     if env:
         secret_path = Path("secrets") / f"{env}.env"
@@ -31,7 +32,10 @@ def load_env(env_file: str | Path = ".env", env: str | None = None) -> None:
     for key, value in env_values.items():
         os.environ.setdefault(key, value)
 
-    load_dotenv(env_path, override=False)
+    if env_path.exists():
+        load_dotenv(env_path, override=False)
+    if secret_path and secret_path.exists():
+        load_dotenv(secret_path, override=False)
 
 
 def _merge(


### PR DESCRIPTION
## Summary
- ensure load_env uses load_dotenv to read secret env files
- document the change in agents.log

## Testing
- `poetry run black src/entity/config/environment.py`
- `poetry run ruff check --fix src/entity/config/environment.py`
- `poetry run pytest tests/test_environment.py -q`
- `poetry run pytest tests/architecture -q`
- `poetry run pytest tests/plugins -q`
- `poetry run pytest tests/resources -q` *(fails: Resource 'fail' failed during layer validation)*

------
https://chatgpt.com/codex/tasks/task_e_6873217027408322a3013d464883420d