### PR TITLE
Fix response control imports and async calls

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Fixed PipelineState import in response control test and awaited async helpers
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_response_control.py
+++ b/tests/test_response_control.py
@@ -8,7 +8,8 @@ import pytest
 from entity.core.context import PluginContext
 from entity.core.plugins import PromptPlugin
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
-from entity.pipeline.state import PipelineState, ConversationEntry
+from entity.core.state import ConversationEntry
+from entity.pipeline.state import PipelineState
 from entity.pipeline.stages import PipelineStage
 from entity.pipeline.pipeline import execute_pipeline
 from entity.pipeline.errors import PluginContextError
@@ -38,14 +39,14 @@ class Thinker(PromptPlugin):
     stages = [PipelineStage.THINK]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        context.think("data", "x")
+        await context.think("data", "x")
 
 
 class Responder(PromptPlugin):
     stages = [PipelineStage.OUTPUT]
 
     async def _execute_impl(self, context: PluginContext) -> None:
-        val = context.reflect("data")
+        val = await context.reflect("data")
         context.say(f"final:{val}")
 
 


### PR DESCRIPTION
## Summary
- update `test_response_control.py` to import `PipelineState` from `entity.pipeline.state`
- await async context helpers so `failure_info` assertions succeed
- log the change

## Testing
- `poetry run pytest tests/test_response_control.py -q`
- `poetry run pytest tests/test_plugin_context_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687321487584832294b1b2ab78250c18