### PR TITLE
Update reload tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated reload tests to use asyncio.to_thread
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_reload_runtime_validation.py
+++ b/tests/test_reload_runtime_validation.py
@@ -51,8 +51,7 @@ class FailingReconfigPlugin(Plugin):
 
 
 async def run_reload(cli: EntityCLI, agent: Agent, cfg_path: Path) -> int:
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, cli._reload_config, agent, str(cfg_path))
+    return await asyncio.to_thread(cli._reload_config, agent, str(cfg_path))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- run cli._reload_config via asyncio.to_thread in reload tests
- document the hot reload test update in agents.log

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: Found 154 errors)*
- `poetry run mypy src` *(fails: Found 264 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove src tests` *(errors: invalid syntax in templates)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873214725888322a84a99882c3761fe