### PR TITLE
Fix runtime tests import

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Verified CircuitBreaker import and runtime tests
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_infrastructure_validate_runtime.py
+++ b/tests/test_infrastructure_validate_runtime.py
@@ -1,5 +1,6 @@
-import pytest
 from contextlib import asynccontextmanager
+
+import pytest
 
 from entity.infrastructure import DuckDBInfrastructure, PostgresInfrastructure
 from entity.pipeline.reliability import CircuitBreaker


### PR DESCRIPTION
## Summary
- reorder imports in runtime validation tests
- log test verification notes

## Testing
- `poetry run pytest tests/test_infrastructure_validate_runtime.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873213a55888322ac95e08784bfe187