### PR TITLE
Fix pipeline tests to use new interface

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated agent runtime tests to use Pipeline interface
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -3,6 +3,7 @@ import pytest
 from entity.core.agent import Agent, _AgentBuilder
 from entity.core.plugins import Plugin
 from entity.pipeline.stages import PipelineStage
+from entity.pipeline.workflow import Pipeline
 from entity.workflows.base import Workflow
 
 
@@ -28,9 +29,13 @@ async def test_builder_runtime_executes_workflow():
     await builder.add_plugin(ThoughtPlugin({}))
     await builder.add_plugin(EchoPlugin({}))
     wf = Workflow(
-        {PipelineStage.THINK: ["ThoughtPlugin"], PipelineStage.OUTPUT: ["EchoPlugin"]}
+        {
+            PipelineStage.THINK: ["ThoughtPlugin"],
+            PipelineStage.OUTPUT: ["EchoPlugin"],
+        }
     )
-    runtime = await builder.build_runtime(workflow=wf)
+    pipeline = Pipeline(builder=builder, workflow=wf)
+    runtime = await pipeline.build_runtime()
     result = await runtime.handle("hello")
     assert result == "hello!"
 
@@ -40,8 +45,11 @@ async def test_agent_handle_runs_workflow():
     agent = Agent()
     await agent.add_plugin(ThoughtPlugin({}))
     await agent.add_plugin(EchoPlugin({}))
-    agent.pipeline = Workflow(
-        {PipelineStage.THINK: ["ThoughtPlugin"], PipelineStage.OUTPUT: ["EchoPlugin"]}
+    agent.pipeline = Pipeline(
+        workflow={
+            PipelineStage.THINK: ["ThoughtPlugin"],
+            PipelineStage.OUTPUT: ["EchoPlugin"],
+        }
     )
     result = await agent.handle("bye")
     assert result == "bye!"


### PR DESCRIPTION
## Summary
- record agent note about updated runtime tests
- use Pipeline instances in runtime tests

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src` *(fails: Command not found)*
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/test_agent_runtime.py -q` *(fails: InitializationError)*

------
https://chatgpt.com/codex/tasks/task_e_687321330efc8322a10b128b64cbab33