### PR TITLE
Update default agent test to use Pipeline

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated default_agent test to use Pipeline for workflow
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-12: Verified sandbox references removed and executed quality checks

--- a/tests/test_default_agent.py
+++ b/tests/test_default_agent.py
@@ -1,7 +1,10 @@
 import asyncio
 
 from entity import agent
+from entity.pipeline.pipeline import Pipeline
+from entity.pipeline.stages import PipelineStage
 from plugins.builtin.resources.ollama_llm import OllamaLLMResource
+from entity.resources.logging import LoggingResource
 
 
 @agent.tool
@@ -15,11 +18,16 @@ async def final(ctx):
     ctx.say(str(result))
 
 
+# Explicit workflow using the custom output plugin
+agent.pipeline = Pipeline({PipelineStage.OUTPUT: ["final"]})
+
+
 def test_agent_handle(monkeypatch):
     async def fake_generate(self, prompt: str):
         return "ok"
 
     monkeypatch.setattr(OllamaLLMResource, "generate", fake_generate, False)
+    monkeypatch.setattr(LoggingResource, "dependencies", [], False)
     result = asyncio.run(agent.handle("hi"))
     assert result == "2"
 


### PR DESCRIPTION
## Summary
- wrap custom workflow in Pipeline when configuring the default agent test
- note test update in agents.log

## Testing
- `poetry run black tests/test_default_agent.py`
- `poetry run pytest tests/test_default_agent.py -q`
- `poetry run ruff check --fix src tests` *(fails: E402 errors)*
- `poetry run mypy src` *(fails: 264 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: missing model)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: missing model)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing config)*
- `poetry run pytest tests/test_resources/ -v`

------
https://chatgpt.com/codex/tasks/task_e_68732118fab48322b2f689c10acc4404