### PR TITLE
Add Memory vector and batch tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added tests for Memory.batch_store, vector_search and add_embedding
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics


### PR DESCRIPTION
## Summary
- add tests for Memory.batch_store
- test Memory.vector_search
- test Memory.add_embedding

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing arguments)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/test_memory_basic.py::test_batch_store -v`
- `poetry run pytest tests/test_memory_basic.py::test_vector_search -v`
- `poetry run pytest tests/test_memory_basic.py::test_add_embedding -v`


------
https://chatgpt.com/codex/tasks/task_e_68732e3a57f88322a95abcaf4ab81d3d