### PR TITLE
Implement OpenTofu and Docker deploy enhancements

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-21: Enhanced infrastructure deploy templates and tests
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics

--- a/src/entity/infrastructure/aws_standard.py
+++ b/src/entity/infrastructure/aws_standard.py
@@ -28,6 +28,10 @@ class AWSStandardInfrastructure(OpenTofuInfrastructure):
         )
         return templates
 
+    async def deploy(self) -> None:
+        """Write AWS resources using the OpenTofu backend."""
+        await super().deploy()
+
     def _ecs_module(self) -> str:
         return (
             'resource "aws_ecs_cluster" "agent" {}\n'

--- a/src/entity/infrastructure/docker.py
+++ b/src/entity/infrastructure/docker.py
@@ -24,7 +24,7 @@ class DockerInfrastructure(InfrastructurePlugin):
     # helpers
     # ---------------------------------------------------------
     def generate_compose(self) -> str:
-        """Return minimal docker-compose configuration."""
+        """Return full docker-compose configuration."""
 
         lines = [
             "version: '3.8'",
@@ -32,8 +32,17 @@ class DockerInfrastructure(InfrastructurePlugin):
             "  agent:",
             "    build: .",
             "    container_name: agent",
+            "    image: agent:latest",
             "    ports:",
             "      - '8000:8000'",
+            "    volumes:",
+            "      - agent-data:/data",
+            "    networks:",
+            "      - agent-net",
+            "volumes:",
+            "  agent-data:",
+            "networks:",
+            "  agent-net:",
         ]
         return "\n".join(lines) + "\n"
 

--- a/src/entity/infrastructure/opentofu.py
+++ b/src/entity/infrastructure/opentofu.py
@@ -34,10 +34,16 @@ class OpenTofuInfrastructure(InfrastructurePlugin):
     def _provider_block(self) -> str:
         return f'provider "{self.provider}" {{\n  region = "{self.region}"\n}}\n'
 
+    def _variables_block(self) -> str:
+        return 'variable "region" {\n' f'  default = "{self.region}"\n' "}\n"
+
     def generate_templates(self) -> dict[str, str]:
         """Return Terraform/OpenTofu configuration files."""
 
-        return {"main.tf": self._provider_block()}
+        return {
+            "main.tf": self._provider_block(),
+            "variables.tf": self._variables_block(),
+        }
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None

--- a/tests/test_infrastructure_deploy.py
+++ b/tests/test_infrastructure_deploy.py
@@ -9,6 +9,9 @@ async def test_docker_deploy_creates_files(tmp_path):
     await infra.deploy()
     assert (tmp_path / "Dockerfile").exists()
     assert (tmp_path / "docker-compose.yml").exists()
+    compose_content = (tmp_path / "docker-compose.yml").read_text()
+    assert "volumes:" in compose_content
+    assert "networks:" in compose_content
     assert infra.deployed
 
     await infra.destroy()
@@ -24,6 +27,10 @@ async def test_opentofu_deploy_creates_main(tmp_path):
     )
     await infra.deploy()
     assert (tmp_path / "main.tf").exists()
+    assert (tmp_path / "ecs.tf").exists()
+    assert (tmp_path / "rds.tf").exists()
+    assert (tmp_path / "s3.tf").exists()
+    assert (tmp_path / "variables.tf").exists()
     assert infra.deployed
 
     await infra.destroy()


### PR DESCRIPTION
## Summary
- expand docker compose generation with volumes and networks
- add Terraform template outputs for OpenTofu infrastructure
- ensure AWS standard deploy uses OpenTofu backend
- test file generation after infrastructure deploys

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 163 errors)*
- `poetry run mypy src` *(fails: found 269 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config` *(fails: missing argument)*
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v`
- `poetry run pytest tests/resources -v` *(fails: 5 tests failed)*
- `poetry run pytest tests/test_infrastructure_deploy.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68732e2317788322b1c9cbe57bf5c5ba