### PR TITLE
Add memory state serialization tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-22: Added memory serialization and interoperability tests
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics

--- a/tests/state/test_anthropomorphic_api.py
+++ b/tests/state/test_anthropomorphic_api.py
@@ -1,0 +1,58 @@
+import sqlite3
+from contextlib import asynccontextmanager
+import types
+import pytest
+
+from entity.core.context import PluginContext
+from entity.core.state import PipelineState
+from entity.resources import Memory
+from entity.resources.interfaces.database import DatabaseResource
+
+
+class InMemoryDB(DatabaseResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
+        )
+
+    @asynccontextmanager
+    async def connection(self):
+        yield self.conn
+
+    def get_connection_pool(self):
+        return self.conn
+
+
+class DummyRegistries:
+    def __init__(self, mem: Memory) -> None:
+        self.resources = {"memory": mem}
+        self.tools = types.SimpleNamespace()
+
+
+@pytest.fixture()
+async def context() -> PluginContext:
+    mem = Memory(config={})
+    mem.database = InMemoryDB()
+    mem.vector_store = None
+    await mem.initialize()
+    regs = DummyRegistries(mem)
+    return PluginContext(PipelineState(conversation=[]), regs)
+
+
+@pytest.mark.asyncio
+async def test_remember_recall_interop(context: PluginContext) -> None:
+    await context.remember("foo", "bar")
+    assert await context._memory.fetch_persistent("foo", user_id="default") == "bar"
+    await context._memory.store_persistent("baz", 123, user_id="default")
+    assert await context.recall("baz") == 123
+
+
+@pytest.mark.asyncio
+async def test_think_reflect_roundtrip(context: PluginContext) -> None:
+    await context.think("idea", 42)
+    assert await context.reflect("idea") == 42

--- a/tests/state/test_memory_advanced.py
+++ b/tests/state/test_memory_advanced.py
@@ -1,0 +1,64 @@
+import sqlite3
+from contextlib import asynccontextmanager
+import pytest
+
+from entity.resources import Memory
+from entity.resources.interfaces.database import DatabaseResource
+from entity.resources.interfaces.vector_store import VectorStoreResource
+
+
+class InMemoryDB(DatabaseResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
+        )
+
+    @asynccontextmanager
+    async def connection(self):
+        yield self.conn
+
+    def get_connection_pool(self):
+        return self.conn
+
+
+class DummyVector(VectorStoreResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.entries: list[str] = []
+
+    async def add_embedding(self, text: str) -> None:
+        self.entries.append(text)
+
+    async def query_similar(self, query: str, k: int = 5):
+        return [t for t in self.entries if query in t][:k]
+
+
+@pytest.fixture()
+async def memory() -> Memory:
+    mem = Memory(config={})
+    mem.database = InMemoryDB()
+    mem.vector_store = DummyVector()
+    await mem.initialize()
+    yield mem
+
+
+@pytest.mark.asyncio
+async def test_sql_query(memory: Memory) -> None:
+    await memory.set("foo", "bar")
+    rows = await memory.query(
+        "SELECT value FROM memory_kv WHERE key = ?",
+        ["default:foo"],
+    )
+    assert rows and rows[0]["value"] == '"bar"'
+
+
+@pytest.mark.asyncio
+async def test_vector_search(memory: Memory) -> None:
+    await memory.add_embedding("hello there")
+    result = await memory.vector_search("hello")
+    assert result == ["hello there"]

--- a/tests/state/test_memory_serialization.py
+++ b/tests/state/test_memory_serialization.py
@@ -1,0 +1,55 @@
+import sqlite3
+from contextlib import asynccontextmanager
+from datetime import datetime
+import pytest
+
+from entity.resources import Memory
+from entity.resources.interfaces.database import DatabaseResource
+from entity.core.state import ConversationEntry, PipelineState, ToolCall
+
+
+class InMemoryDB(DatabaseResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
+        )
+
+    @asynccontextmanager
+    async def connection(self):
+        yield self.conn
+
+    def get_connection_pool(self):
+        return self.conn
+
+
+@pytest.fixture()
+async def memory() -> Memory:
+    mem = Memory(config={})
+    mem.database = InMemoryDB()
+    mem.vector_store = None
+    await mem.initialize()
+    yield mem
+
+
+def _create_state() -> PipelineState:
+    state = PipelineState(
+        conversation=[ConversationEntry("hi", "user", datetime.now())],
+        pipeline_id="pid",
+    )
+    state.stage_results["x"] = 1
+    state.pending_tool_calls.append(ToolCall(name="t", params={"a": 1}, result_key="r"))
+    return state
+
+
+@pytest.mark.asyncio
+async def test_pipeline_state_roundtrip(memory: Memory) -> None:
+    state = _create_state()
+    data = state.to_dict()
+    await memory.set("state", data)
+    loaded = await memory.get("state")
+    assert loaded == data


### PR DESCRIPTION
## Summary
- confirm PipelineWorker keeps no internal state
- add Memory serialization and advanced operation tests
- verify anthropomorphic API interacts with direct memory calls
- note testing results in agents log

## Testing
- `poetry run pytest tests/state/test_memory_serialization.py tests/state/test_anthropomorphic_api.py tests/state/test_memory_advanced.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68732e15e9bc83228e75d144350a0d05