### PR TITLE
Log stage mismatch warnings

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Log warning when resolved stages differ from plugin declaration
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -1,9 +1,8 @@
 from entity.core.plugins import Plugin, PromptPlugin
 import importlib
+import logging
 import entity.pipeline.utils as pipeline_utils
 from entity.core.stages import PipelineStage
-import importlib
-import entity.pipeline.utils as pipeline_utils
 
 # Reload pipeline_utils to ensure the original StageResolver is used
 StageResolver = importlib.reload(pipeline_utils).StageResolver
@@ -105,3 +104,12 @@ def test_initializer_inherited_stage_not_explicit():
 
     assert stages == [PipelineStage.THINK]
     assert explicit is False
+
+
+def test_warning_for_stage_override(caplog):
+    plugin = AttrPrompt({})
+    with caplog.at_level(logging.WARNING):
+        StageResolver._resolve_plugin_stages(
+            AttrPrompt, {"stage": PipelineStage.REVIEW}, plugin
+        )
+    assert any("differ from declared" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- emit warnings when resolved stages differ from plugin declarations
- verify warning through new test

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src` *(failed: Command not found)*
- `poetry run vulture src tests` *(failed: Command not found)*
- `poetry run unimport --remove-all src tests` *(failed: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `pytest tests/test_architecture/ -v`
- `pytest tests/test_plugins/ -v`
- `pytest tests/test_resources/ -v`
- `pytest tests/test_stage_precedence.py::test_warning_for_stage_override -v`


------
https://chatgpt.com/codex/tasks/task_e_68732e226dcc832280de4dccf157b19c