### PR TITLE
Improve plugin-tool with docs and test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,23 @@
 [![Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://entity.readthedocs.io/en/latest/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
+## Plugin Tool
+
+Generate a new prompt plugin:
+
+```bash
+plugin-tool generate my_prompt --type prompt
+```
+
+Run the plugin in isolation:
+
+```bash
+plugin-tool test src/my_prompt.py
+```
+
+Create Markdown docs from the plugin docstring:
+
+```bash
+plugin-tool docs src/my_prompt.py --out docs
+```
+

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-22: Added plugin tool docs/test enhancements
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics

--- a/tests/test_plugin_tool_test.py
+++ b/tests/test_plugin_tool_test.py
@@ -1,0 +1,47 @@
+import logging
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path("src").resolve()))
+
+from cli.plugin_tool.main import PluginToolCLI, PluginToolArgs
+
+
+def _make_cli(path: str) -> PluginToolCLI:
+    cli = PluginToolCLI.__new__(PluginToolCLI)
+    cli.args = PluginToolArgs(command="test", path=path)
+    return cli
+
+
+def test_test_command_runs_pipeline(tmp_path, caplog):
+    plugin_file = tmp_path / "plug.py"
+    plugin_file.write_text(
+        "from entity.core.plugins import Plugin\n"
+        "from entity.pipeline.stages import PipelineStage\n\n"
+        "class Demo(Plugin):\n"
+        "    stages=[PipelineStage.OUTPUT]\n"
+        "    async def _execute_impl(self, ctx):\n"
+        '        ctx.say("ok")\n'
+    )
+    cli = _make_cli(str(plugin_file))
+    with caplog.at_level(logging.INFO):
+        result = cli._test()
+    assert result == 0
+    log = "\n".join(r.message for r in caplog.records)
+    assert "Pipeline result" in log
+
+
+def test_test_command_tool_plugin(tmp_path, caplog):
+    plugin_file = tmp_path / "tool.py"
+    plugin_file.write_text(
+        "from entity.core.plugins import ToolPlugin\n"
+        "class Demo(ToolPlugin):\n"
+        "    async def execute_function(self, params):\n"
+        "        return 'ok'\n"
+    )
+    cli = _make_cli(str(plugin_file))
+    with caplog.at_level(logging.INFO):
+        result = cli._test()
+    assert result == 0
+    log = "\n".join(r.message for r in caplog.records)
+    assert "tool function" in log


### PR DESCRIPTION
## Summary
- add plugin-tool isolated pipeline runner
- document plugin-tool usage in README
- log note for plugin-tool changes
- test plugin-tool test command

## Testing
- `poetry run ruff check --fix src tests` *(fails: Module level import not at top of file)*
- `poetry run mypy src` *(fails: found errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing required arguments)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68732e2ebb288322877f58eb3fbd2e6b