### PR TITLE
Enhance plugin reload validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-22: Extended runtime config validation with history
+
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics


### PR DESCRIPTION
## Summary
- track plugin config changes and reject unknown fields
- record prior plugin configs when reload fails
- test runtime validation for invalid keys

## Testing
- `poetry run ruff check --fix tests/test_reload_runtime_validation.py src/entity/pipeline/config/config_update.py`
- `poetry run black tests/test_reload_runtime_validation.py src/entity/pipeline/config/config_update.py`
- `poetry run pytest tests/test_reload_runtime_validation.py::test_invalid_config_keys_require_restart -q`


------
https://chatgpt.com/codex/tasks/task_e_68732e3463a0832296bbf82eec1c186d