### PR TITLE
Improve setup helper and docs

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-22: Added Ollama download helper and setup instructions
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics

--- a/docs/source/environment.md
+++ b/docs/source/environment.md
@@ -10,3 +10,19 @@ Configuration files may reference environment variables using the `${VAR}` synta
 Existing process variables are never overwritten. Values from the secrets file override those from `.env` when both define the same key.
 
 Store API keys and other credentials in the `secrets/` directory and keep these files out of version control.
+
+## Local Setup Helper
+
+``Layer0SetupManager`` prepares a working environment by creating the default
+`agent_memory.duckdb` database and the `agent_files/` directory. It verifies that
+Ollama is running and downloads the configured model when needed.
+
+```python
+from entity.utils.setup_manager import Layer0SetupManager
+import asyncio
+
+asyncio.run(Layer0SetupManager().setup())
+```
+
+If dependencies like DuckDB are missing the helper prints clear instructions
+instead of raising errors.

--- a/tests/plugins/harness.py
+++ b/tests/plugins/harness.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import sys
+import pathlib
 from entity.core.plugins import Plugin
 
+sys.path.insert(0, str(pathlib.Path("src").resolve()))
 from cli.plugin_tool.utils import load_plugin
 
 

--- a/tests/setup/test_layer0_setup.py
+++ b/tests/setup/test_layer0_setup.py
@@ -39,8 +39,18 @@ async def test_ensure_ollama_missing_model(monkeypatch):
 
         return R()
 
+    async def fake_exec(*args, **kwargs):
+        class P:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+        return P()
+
     monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
-    assert await mgr.ensure_ollama() is False
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    assert await mgr.ensure_ollama() is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -82,7 +82,7 @@ async def test_ensure_ollama_pulls_when_missing(monkeypatch):
 
     mgr = Layer0SetupManager()
     result = await mgr.ensure_ollama()
-    assert result is False
+    assert result is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add note about new setup steps
- download ollama models automatically when missing
- recover from missing DuckDB dependency
- update docs to show setup helper usage
- adjust tests for new setup behaviour

## Testing
- `poetry run black src/entity/utils/setup_manager.py src/entity/infrastructure/duckdb.py`
- `poetry run black tests/plugins/harness.py tests/setup/test_layer0_setup.py tests/test_environment.py`
- `PYTHONPATH=src poetry run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68732e27eb60832292faab7bba73f6c5