### PR TITLE
Add config schema generation and migration utility

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-22: Added config schema generator and migration utility
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics

--- a/docs/source/config_schema.json
+++ b/docs/source/config_schema.json
@@ -1,0 +1,961 @@
+{
+  "AdapterSettings": {
+    "$defs": {
+      "RateLimitConfig": {
+        "description": "Request throttling settings for an adapter.",
+        "properties": {
+          "interval": {
+            "default": 60,
+            "minimum": 1,
+            "title": "Interval",
+            "type": "integer"
+          },
+          "requests": {
+            "default": 1,
+            "minimum": 1,
+            "title": "Requests",
+            "type": "integer"
+          }
+        },
+        "title": "RateLimitConfig",
+        "type": "object"
+      }
+    },
+    "description": "Configuration for adapter plugins.",
+    "properties": {
+      "audit_log_path": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Audit Log Path"
+      },
+      "auth_tokens": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Auth Tokens",
+        "type": "array"
+      },
+      "dashboard": {
+        "default": false,
+        "title": "Dashboard",
+        "type": "boolean"
+      },
+      "rate_limit": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/RateLimitConfig"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "stages": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Stages",
+        "type": "array"
+      }
+    },
+    "title": "AdapterSettings",
+    "type": "object"
+  },
+  "BreakerSettings": {
+    "$defs": {
+      "CircuitBreakerConfig": {
+        "additionalProperties": true,
+        "description": "Circuit breaker configuration.",
+        "properties": {
+          "api": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 5,
+            "title": "Api"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 3,
+            "title": "Database"
+          },
+          "failure_threshold": {
+            "default": 3,
+            "title": "Failure Threshold",
+            "type": "integer"
+          },
+          "filesystem": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 2,
+            "title": "Filesystem"
+          },
+          "recovery_timeout": {
+            "default": 60.0,
+            "title": "Recovery Timeout",
+            "type": "number"
+          }
+        },
+        "title": "CircuitBreakerConfig",
+        "type": "object"
+      }
+    },
+    "description": "Circuit breaker settings for different resource types.",
+    "properties": {
+      "database": {
+        "$ref": "#/$defs/CircuitBreakerConfig"
+      },
+      "external_api": {
+        "$ref": "#/$defs/CircuitBreakerConfig"
+      },
+      "file_system": {
+        "$ref": "#/$defs/CircuitBreakerConfig"
+      }
+    },
+    "title": "BreakerSettings",
+    "type": "object"
+  },
+  "CircuitBreakerConfig": {
+    "additionalProperties": true,
+    "description": "Circuit breaker configuration.",
+    "properties": {
+      "api": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": 5,
+        "title": "Api"
+      },
+      "database": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": 3,
+        "title": "Database"
+      },
+      "failure_threshold": {
+        "default": 3,
+        "title": "Failure Threshold",
+        "type": "integer"
+      },
+      "filesystem": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": 2,
+        "title": "Filesystem"
+      },
+      "recovery_timeout": {
+        "default": 60.0,
+        "title": "Recovery Timeout",
+        "type": "number"
+      }
+    },
+    "title": "CircuitBreakerConfig",
+    "type": "object"
+  },
+  "EmbeddingModelConfig": {
+    "additionalProperties": true,
+    "properties": {
+      "dimensions": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Dimensions"
+      },
+      "name": {
+        "title": "Name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "title": "EmbeddingModelConfig",
+    "type": "object"
+  },
+  "EntityConfig": {
+    "$defs": {
+      "BreakerSettings": {
+        "description": "Circuit breaker settings for different resource types.",
+        "properties": {
+          "database": {
+            "$ref": "#/$defs/CircuitBreakerConfig"
+          },
+          "external_api": {
+            "$ref": "#/$defs/CircuitBreakerConfig"
+          },
+          "file_system": {
+            "$ref": "#/$defs/CircuitBreakerConfig"
+          }
+        },
+        "title": "BreakerSettings",
+        "type": "object"
+      },
+      "CircuitBreakerConfig": {
+        "additionalProperties": true,
+        "description": "Circuit breaker configuration.",
+        "properties": {
+          "api": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 5,
+            "title": "Api"
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 3,
+            "title": "Database"
+          },
+          "failure_threshold": {
+            "default": 3,
+            "title": "Failure Threshold",
+            "type": "integer"
+          },
+          "filesystem": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 2,
+            "title": "Filesystem"
+          },
+          "recovery_timeout": {
+            "default": 60.0,
+            "title": "Recovery Timeout",
+            "type": "number"
+          }
+        },
+        "title": "CircuitBreakerConfig",
+        "type": "object"
+      },
+      "PipelineStage": {
+        "description": "Ordered pipeline stages.",
+        "enum": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+        ],
+        "title": "PipelineStage",
+        "type": "integer"
+      },
+      "PluginConfig": {
+        "additionalProperties": true,
+        "description": "Configuration for a single plugin.",
+        "properties": {
+          "dependencies": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Dependencies",
+            "type": "array"
+          },
+          "stage": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/PipelineStage"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "stages": {
+            "items": {
+              "$ref": "#/$defs/PipelineStage"
+            },
+            "title": "Stages",
+            "type": "array"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "PluginConfig",
+        "type": "object"
+      },
+      "PluginsSection": {
+        "description": "Collection of user-defined plugins grouped by category.",
+        "properties": {
+          "adapters": {
+            "additionalProperties": {
+              "$ref": "#/$defs/PluginConfig"
+            },
+            "title": "Adapters",
+            "type": "object"
+          },
+          "agent_resources": {
+            "additionalProperties": {
+              "$ref": "#/$defs/PluginConfig"
+            },
+            "title": "Agent Resources",
+            "type": "object"
+          },
+          "custom_resources": {
+            "additionalProperties": {
+              "$ref": "#/$defs/PluginConfig"
+            },
+            "title": "Custom Resources",
+            "type": "object"
+          },
+          "infrastructure": {
+            "additionalProperties": {
+              "$ref": "#/$defs/PluginConfig"
+            },
+            "title": "Infrastructure",
+            "type": "object"
+          },
+          "prompts": {
+            "additionalProperties": {
+              "$ref": "#/$defs/PluginConfig"
+            },
+            "title": "Prompts",
+            "type": "object"
+          },
+          "resources": {
+            "additionalProperties": {
+              "$ref": "#/$defs/PluginConfig"
+            },
+            "title": "Resources",
+            "type": "object"
+          },
+          "tools": {
+            "additionalProperties": {
+              "$ref": "#/$defs/PluginConfig"
+            },
+            "title": "Tools",
+            "type": "object"
+          }
+        },
+        "title": "PluginsSection",
+        "type": "object"
+      },
+      "ServerConfig": {
+        "properties": {
+          "host": {
+            "title": "Host",
+            "type": "string"
+          },
+          "log_level": {
+            "default": "info",
+            "title": "Log Level",
+            "type": "string"
+          },
+          "port": {
+            "title": "Port",
+            "type": "integer"
+          },
+          "reload": {
+            "default": false,
+            "title": "Reload",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "host",
+          "port"
+        ],
+        "title": "ServerConfig",
+        "type": "object"
+      },
+      "ToolRegistryConfig": {
+        "description": "Options controlling tool execution.",
+        "properties": {
+          "concurrency_limit": {
+            "default": 5,
+            "title": "Concurrency Limit",
+            "type": "integer"
+          }
+        },
+        "title": "ToolRegistryConfig",
+        "type": "object"
+      },
+      "WorkflowSettings": {
+        "description": "Mapping of pipeline stages to plugin names.",
+        "properties": {
+          "stages": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "title": "Stages",
+            "type": "object"
+          }
+        },
+        "title": "WorkflowSettings",
+        "type": "object"
+      }
+    },
+    "properties": {
+      "breaker_settings": {
+        "$ref": "#/$defs/BreakerSettings"
+      },
+      "plugins": {
+        "$ref": "#/$defs/PluginsSection"
+      },
+      "runtime_validation_breaker": {
+        "$ref": "#/$defs/CircuitBreakerConfig"
+      },
+      "server": {
+        "$ref": "#/$defs/ServerConfig"
+      },
+      "tool_registry": {
+        "$ref": "#/$defs/ToolRegistryConfig"
+      },
+      "workflow": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/WorkflowSettings"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      }
+    },
+    "title": "EntityConfig",
+    "type": "object"
+  },
+  "LLMConfig": {
+    "additionalProperties": false,
+    "description": "Configuration model for the :class:`~entity.resources.llm.LLM`.",
+    "properties": {
+      "provider": {
+        "default": "default",
+        "title": "Provider",
+        "type": "string"
+      }
+    },
+    "title": "LLMConfig",
+    "type": "object"
+  },
+  "LogOutputConfig": {
+    "description": "Configuration for a single logging output.",
+    "properties": {
+      "backup_count": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Backup Count"
+      },
+      "host": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Host"
+      },
+      "level": {
+        "default": "info",
+        "title": "Level",
+        "type": "string"
+      },
+      "max_size": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Max Size"
+      },
+      "path": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Path"
+      },
+      "port": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Port"
+      },
+      "type": {
+        "default": "console",
+        "title": "Type",
+        "type": "string"
+      }
+    },
+    "title": "LogOutputConfig",
+    "type": "object"
+  },
+  "LoggingConfig": {
+    "$defs": {
+      "LogOutputConfig": {
+        "description": "Configuration for a single logging output.",
+        "properties": {
+          "backup_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Backup Count"
+          },
+          "host": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Host"
+          },
+          "level": {
+            "default": "info",
+            "title": "Level",
+            "type": "string"
+          },
+          "max_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Max Size"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Path"
+          },
+          "port": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Port"
+          },
+          "type": {
+            "default": "console",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "title": "LogOutputConfig",
+        "type": "object"
+      }
+    },
+    "description": "Settings controlling the :class:`LoggingResource`.",
+    "properties": {
+      "host_name": {
+        "title": "Host Name",
+        "type": "string"
+      },
+      "outputs": {
+        "items": {
+          "$ref": "#/$defs/LogOutputConfig"
+        },
+        "title": "Outputs",
+        "type": "array"
+      },
+      "process_id": {
+        "title": "Process Id",
+        "type": "integer"
+      }
+    },
+    "title": "LoggingConfig",
+    "type": "object"
+  },
+  "MemoryConfig": {
+    "additionalProperties": false,
+    "description": "Configuration model for the :class:`~entity.resources.memory.Memory`.",
+    "properties": {
+      "history_table": {
+        "default": "conversation_history",
+        "title": "History Table",
+        "type": "string"
+      },
+      "kv_table": {
+        "default": "memory_kv",
+        "title": "Kv Table",
+        "type": "string"
+      }
+    },
+    "title": "MemoryConfig",
+    "type": "object"
+  },
+  "PluginConfig": {
+    "$defs": {
+      "PipelineStage": {
+        "description": "Ordered pipeline stages.",
+        "enum": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+        ],
+        "title": "PipelineStage",
+        "type": "integer"
+      }
+    },
+    "additionalProperties": true,
+    "description": "Configuration for a single plugin.",
+    "properties": {
+      "dependencies": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Dependencies",
+        "type": "array"
+      },
+      "stage": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/PipelineStage"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "stages": {
+        "items": {
+          "$ref": "#/$defs/PipelineStage"
+        },
+        "title": "Stages",
+        "type": "array"
+      },
+      "type": {
+        "title": "Type",
+        "type": "string"
+      }
+    },
+    "required": [
+      "type"
+    ],
+    "title": "PluginConfig",
+    "type": "object"
+  },
+  "PluginsSection": {
+    "$defs": {
+      "PipelineStage": {
+        "description": "Ordered pipeline stages.",
+        "enum": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+        ],
+        "title": "PipelineStage",
+        "type": "integer"
+      },
+      "PluginConfig": {
+        "additionalProperties": true,
+        "description": "Configuration for a single plugin.",
+        "properties": {
+          "dependencies": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Dependencies",
+            "type": "array"
+          },
+          "stage": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/PipelineStage"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "stages": {
+            "items": {
+              "$ref": "#/$defs/PipelineStage"
+            },
+            "title": "Stages",
+            "type": "array"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "PluginConfig",
+        "type": "object"
+      }
+    },
+    "description": "Collection of user-defined plugins grouped by category.",
+    "properties": {
+      "adapters": {
+        "additionalProperties": {
+          "$ref": "#/$defs/PluginConfig"
+        },
+        "title": "Adapters",
+        "type": "object"
+      },
+      "agent_resources": {
+        "additionalProperties": {
+          "$ref": "#/$defs/PluginConfig"
+        },
+        "title": "Agent Resources",
+        "type": "object"
+      },
+      "custom_resources": {
+        "additionalProperties": {
+          "$ref": "#/$defs/PluginConfig"
+        },
+        "title": "Custom Resources",
+        "type": "object"
+      },
+      "infrastructure": {
+        "additionalProperties": {
+          "$ref": "#/$defs/PluginConfig"
+        },
+        "title": "Infrastructure",
+        "type": "object"
+      },
+      "prompts": {
+        "additionalProperties": {
+          "$ref": "#/$defs/PluginConfig"
+        },
+        "title": "Prompts",
+        "type": "object"
+      },
+      "resources": {
+        "additionalProperties": {
+          "$ref": "#/$defs/PluginConfig"
+        },
+        "title": "Resources",
+        "type": "object"
+      },
+      "tools": {
+        "additionalProperties": {
+          "$ref": "#/$defs/PluginConfig"
+        },
+        "title": "Tools",
+        "type": "object"
+      }
+    },
+    "title": "PluginsSection",
+    "type": "object"
+  },
+  "RateLimitConfig": {
+    "description": "Request throttling settings for an adapter.",
+    "properties": {
+      "interval": {
+        "default": 60,
+        "minimum": 1,
+        "title": "Interval",
+        "type": "integer"
+      },
+      "requests": {
+        "default": 1,
+        "minimum": 1,
+        "title": "Requests",
+        "type": "integer"
+      }
+    },
+    "title": "RateLimitConfig",
+    "type": "object"
+  },
+  "ServerConfig": {
+    "properties": {
+      "host": {
+        "title": "Host",
+        "type": "string"
+      },
+      "log_level": {
+        "default": "info",
+        "title": "Log Level",
+        "type": "string"
+      },
+      "port": {
+        "title": "Port",
+        "type": "integer"
+      },
+      "reload": {
+        "default": false,
+        "title": "Reload",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "host",
+      "port"
+    ],
+    "title": "ServerConfig",
+    "type": "object"
+  },
+  "StorageConfig": {
+    "additionalProperties": false,
+    "description": "Configuration model for the :class:`~entity.resources.storage.Storage`.",
+    "properties": {
+      "namespace": {
+        "default": "default",
+        "title": "Namespace",
+        "type": "string"
+      }
+    },
+    "title": "StorageConfig",
+    "type": "object"
+  },
+  "ToolRegistryConfig": {
+    "description": "Options controlling tool execution.",
+    "properties": {
+      "concurrency_limit": {
+        "default": 5,
+        "title": "Concurrency Limit",
+        "type": "integer"
+      }
+    },
+    "title": "ToolRegistryConfig",
+    "type": "object"
+  },
+  "WorkflowSettings": {
+    "description": "Mapping of pipeline stages to plugin names.",
+    "properties": {
+      "stages": {
+        "additionalProperties": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": "Stages",
+        "type": "object"
+      }
+    },
+    "title": "WorkflowSettings",
+    "type": "object"
+  }
+}

--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -11,3 +11,17 @@ poetry run entity-cli --config config/dev.yaml --env prod run
 ```
 
 This command loads `config/dev.yaml` and then applies the settings from `config/prod.yaml` before starting the agent.
+
+## Generating JSON Schema
+
+Run `python docs/generate_config_docs.py` to create `config_schema.json` describing all configuration models.
+
+## Migrating Legacy Configs
+
+Use :class:`entity.config.ConfigMigrator` to rename fields in older YAML files.
+```python
+from entity.config import ConfigMigrator
+
+migrator = ConfigMigrator({"old_name": "new_name"})
+migrator.migrate_file("config/dev.yaml")
+```

--- a/src/entity/config/__init__.py
+++ b/src/entity/config/__init__.py
@@ -1,0 +1,6 @@
+"""Configuration helpers and migration utilities."""
+
+from .environment import load_env, load_config
+from .migrate import ConfigMigrator
+
+__all__ = ["load_env", "load_config", "ConfigMigrator"]

--- a/src/entity/config/migrate.py
+++ b/src/entity/config/migrate.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Utilities for migrating configuration files."""
+
+from pathlib import Path
+from typing import Any, Mapping, Dict
+
+import yaml
+
+
+def _rename_fields(obj: Any, mapping: Mapping[str, str]) -> Any:
+    if isinstance(obj, dict):
+        return {mapping.get(k, k): _rename_fields(v, mapping) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_rename_fields(v, mapping) for v in obj]
+    return obj
+
+
+class ConfigMigrator:
+    """Rename fields in configuration dictionaries and files."""
+
+    def __init__(self, field_map: Mapping[str, str]) -> None:
+        self.field_map = dict(field_map)
+
+    def migrate_data(self, data: Mapping[str, Any]) -> Dict[str, Any]:
+        return _rename_fields(dict(data), self.field_map)
+
+    def migrate_file(self, path: str | Path) -> Dict[str, Any]:
+        p = Path(path)
+        data = yaml.safe_load(p.read_text()) or {}
+        migrated = self.migrate_data(data)
+        p.write_text(yaml.safe_dump(migrated, sort_keys=False))
+        return migrated
+
+
+__all__ = ["ConfigMigrator", "_rename_fields"]


### PR DESCRIPTION
## Summary
- document schema generation and basic config migration
- implement ConfigMigrator
- emit JSON schema for all config models

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 157 errors)*
- `poetry run mypy src` *(fails: 270 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: entity)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: entity)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: entity)*

------
https://chatgpt.com/codex/tasks/task_e_68732e2c5d1883229020ef185999aa02