### PR TITLE
Add health checks and restart helper

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added health check and restart support for resources
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -303,6 +303,21 @@ class ResourcePlugin(Plugin):
                     metadata=metadata,
                 )
 
+    async def health_check(self) -> bool:
+        """Return ``True`` when the resource is healthy."""
+
+        return True
+
+    async def restart(self) -> None:
+        """Restart the resource using ``shutdown`` and ``initialize`` hooks."""
+
+        shutdown = getattr(self, "shutdown", None)
+        if callable(shutdown):
+            await shutdown()
+        init = getattr(self, "initialize", None)
+        if callable(init):
+            await init()
+
 
 class AgentResource(ResourcePlugin):
     """Layer 3 canonical or custom agent resource."""


### PR DESCRIPTION
## Summary
- add optional `health_check` and `restart` hooks on `ResourcePlugin`
- expose `restart_resource` helper on `ResourceContainer`
- validate canonical layer ordering
- test container health checks and restart behaviour

## Testing
- `poetry run ruff check --fix src tests` *(fails: 163 errors)*
- `poetry run mypy src` *(fails: Found 269 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: invalid syntax messages)*
- `poetry run unimport src tests` *(fails: invalid syntax messages)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: missing llama3 model)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing config argument)*
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v`
- `poetry run pytest tests/resources -v` *(fails: InitializationError)*
- `poetry run pytest tests/test_resource_container.py::test_health_check_failure_on_build tests/test_resource_container.py::test_restart_resource -v`

------
https://chatgpt.com/codex/tasks/task_e_68732e2d417083228e401840b56b5d37