### PR TITLE
Add namespaced memory tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added pipeline worker memory prefix tests
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics

--- a/src/entity/worker/pipeline_worker.py
+++ b/src/entity/worker/pipeline_worker.py
@@ -15,10 +15,16 @@ class PipelineWorker:
     def __init__(self, registries: SystemRegistries) -> None:
         self.registries = registries
 
-    async def run_stages(self, state: PipelineState) -> Any:
+    async def run_stages(self, state: PipelineState, user_id: str) -> Any:
         """Delegate pipeline execution to the existing driver."""
         # user_message is ignored when ``state`` is provided
-        return await execute_pipeline("", self.registries, state=state, workflow=None)
+        return await execute_pipeline(
+            "",
+            self.registries,
+            state=state,
+            workflow=None,
+            user_id=user_id,
+        )
 
     async def execute_pipeline(
         self, pipeline_id: str, message: str, *, user_id: str
@@ -30,7 +36,7 @@ class PipelineWorker:
             ConversationEntry(content=message, role="user", timestamp=datetime.now())
         )
         state = PipelineState(conversation=conversation, pipeline_id=pipeline_id)
-        result = await self.run_stages(state)
+        result = await self.run_stages(state, user_id)
         await memory.save_conversation(pipeline_id, state.conversation, user_id=user_id)
         return result
 

--- a/tests/test_pipeline_worker.py
+++ b/tests/test_pipeline_worker.py
@@ -151,7 +151,17 @@ class EchoPlugin(Plugin):
 
     async def _execute_impl(self, context):
         thought = await context.reflect("thought")
+        if thought is None:
+            thought = context.conversation()[-1].content
         context.say(thought)
+
+
+class EchoStorePlugin(Plugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context):
+        await context.remember("last", context.conversation()[-1].content)
+        context.say(context.conversation()[-1].content)
 
 
 @pytest.mark.asyncio
@@ -173,6 +183,7 @@ async def test_pipeline_persists_conversation(patched_stage_resolver, memory_db)
         resources={"memory": memory_db},
         tools=types.SimpleNamespace(),
         plugins=PluginRegistry(),
+        validators=None,
     )
     worker = PipelineWorker(regs)
 
@@ -180,7 +191,7 @@ async def test_pipeline_persists_conversation(patched_stage_resolver, memory_db)
     await worker.execute_pipeline("pipe1", "world", user_id="u1")
 
     history = await regs.resources["memory"].load_conversation("pipe1", user_id="u1")
-    assert [e.content for e in history] == ["first", "second"]
+    assert [e.content for e in history] == ["hello", "world"]
 
 
 @pytest.mark.asyncio
@@ -198,3 +209,58 @@ async def test_thoughts_do_not_leak_between_executions(patched_stage_resolver):
 
     assert first == "one"
     assert second == "two"
+
+
+@pytest.mark.asyncio
+async def test_conversation_and_memory_namespaces(patched_stage_resolver, memory_db):
+    regs = types.SimpleNamespace(
+        resources={"memory": memory_db},
+        tools=types.SimpleNamespace(),
+        plugins=PluginRegistry(),
+        validators=None,
+    )
+    await regs.plugins.register_plugin_for_stage(
+        EchoStorePlugin({}), PipelineStage.OUTPUT
+    )
+    worker = PipelineWorker(regs)
+
+    await worker.execute_pipeline("chat", "hi", user_id="alice")
+
+    async with memory_db.database.connection() as conn:
+        convo_ids = {
+            row[0]
+            for row in conn.execute(
+                "SELECT conversation_id FROM conversation_history"
+            ).fetchall()
+        }
+        kv_keys = {
+            row[0] for row in conn.execute("SELECT key FROM memory_kv").fetchall()
+        }
+
+    assert convo_ids == {"alice_chat"}
+    assert kv_keys == {"alice:last"}
+
+
+@pytest.mark.asyncio
+async def test_user_data_isolated(patched_stage_resolver, memory_db):
+    regs = types.SimpleNamespace(
+        resources={"memory": memory_db},
+        tools=types.SimpleNamespace(),
+        plugins=PluginRegistry(),
+        validators=None,
+    )
+    await regs.plugins.register_plugin_for_stage(
+        EchoStorePlugin({}), PipelineStage.OUTPUT
+    )
+    worker = PipelineWorker(regs)
+
+    await worker.execute_pipeline("chat", "hello", user_id="alice")
+    await worker.execute_pipeline("chat", "world", user_id="bob")
+
+    hist_a = await memory_db.load_conversation("chat", user_id="alice")
+    hist_b = await memory_db.load_conversation("chat", user_id="bob")
+
+    assert hist_a[0].content == "hello"
+    assert hist_b[0].content == "world"
+    assert await memory_db.get("last", user_id="alice") == "hello"
+    assert await memory_db.get("last", user_id="bob") == "world"


### PR DESCRIPTION
## Summary
- add regression tests for PipelineWorker user namespacing
- update PipelineWorker to forward user_id to pipeline engine

## Testing
- `poetry run pytest tests/test_pipeline_worker.py -vv`
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v`
- `poetry run pytest tests/resources -v` *(fails: InitializationError and assertion failures)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*

------
https://chatgpt.com/codex/tasks/task_e_68732e364d408322afa32c20c4ee71c5