### PR TITLE
Add conversation analytics

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added conversation analytics CLI and extended memory stats
 AGENT NOTE - 2025-07-13: Added tests for Memory.batch_store, vector_search and add_embedding
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests

--- a/docs/source/config_reference.md
+++ b/docs/source/config_reference.md
@@ -91,6 +91,19 @@ Configuration model for the :class:`~entity.resources.memory.Memory`.
 | kv_table | str | 'memory_kv' |  |
 | history_table | str | 'conversation_history' |  |
 
+## Conversation Analytics API
+
+Use ``entity-cli get-conversation-stats`` to retrieve metrics stored by the
+``Memory`` resource. Provide the configuration file and a user ID:
+
+```bash
+entity-cli --config config/dev.yaml get-conversation-stats USER123
+```
+
+The command outputs YAML containing total conversations, message counts,
+average conversation length, durations per conversation, the most active hours,
+and the last activity timestamp for the user.
+
 ## PluginConfig
 
 Configuration for a single plugin.

--- a/tests/resources/test_memory.py
+++ b/tests/resources/test_memory.py
@@ -65,23 +65,29 @@ async def test_conversation_search_vector(memory_with_vector: Memory) -> None:
 async def test_conversation_statistics(memory_with_vector: Memory) -> None:
     now = datetime.now()
     await memory_with_vector.add_conversation_entry(
-        "user_c1",
+        "c1",
         ConversationEntry(content="hi", role="user", timestamp=now),
+        user_id="user",
     )
     await memory_with_vector.add_conversation_entry(
-        "user_c1",
+        "c1",
         ConversationEntry(
             content="bye", role="assistant", timestamp=now + timedelta(seconds=30)
         ),
+        user_id="user",
     )
     await memory_with_vector.add_conversation_entry(
-        "user_c2",
+        "c2",
         ConversationEntry(
             content="ping", role="user", timestamp=now + timedelta(seconds=60)
         ),
+        user_id="user",
     )
     stats = await memory_with_vector.conversation_statistics("user")
     assert stats["conversations"] == 2
     assert stats["messages"] == 3
+    assert stats["average_length"] == 1.5
     assert stats["durations"]["user_c1"] == 30.0
     assert stats["durations"]["user_c2"] == 0.0
+    assert stats["most_active_periods"] == [now.hour]
+    assert stats["last_activity"] == (now + timedelta(seconds=60)).isoformat()

--- a/tests/test_cli_get_stats.py
+++ b/tests/test_cli_get_stats.py
@@ -1,0 +1,39 @@
+import pytest
+from datetime import datetime
+
+from entity.cli import EntityCLI
+from entity.core.agent import Agent, _AgentRuntime
+from entity.core.state import ConversationEntry
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.resources.container import ResourceContainer
+from entity.resources import Memory
+from tests.resources.test_memory import SqliteDB, DummyVector
+
+
+@pytest.mark.asyncio
+async def test_cli_get_conversation_stats(capsys) -> None:
+    mem = Memory(config={})
+    mem.database = SqliteDB()
+    mem.vector_store = DummyVector()
+    await mem.initialize()
+    await mem.add_conversation_entry(
+        "c1",
+        ConversationEntry(content="hi", role="user", timestamp=datetime.now()),
+        user_id="user",
+    )
+
+    resources = ResourceContainer()
+    await resources.add("memory", mem)
+    runtime = _AgentRuntime(
+        SystemRegistries(
+            resources=resources, tools=ToolRegistry(), plugins=PluginRegistry()
+        )
+    )
+    agent = Agent()
+    agent._runtime = runtime
+
+    cli = EntityCLI.__new__(EntityCLI)
+    result = await cli._get_conversation_stats(agent, "user")
+    captured = capsys.readouterr().out
+    assert result == 0
+    assert "conversations" in captured


### PR DESCRIPTION
## Summary
- extend Memory.conversation_statistics with more metrics
- add `get-conversation-stats` command to CLI
- document analytics command in config reference
- test new metrics and CLI helper

## Testing
- `poetry run black src/entity/cli/__init__.py src/entity/resources/memory.py tests/resources/test_memory.py tests/test_cli_get_stats.py`
- `poetry run ruff check --fix src tests` *(fails: 163 errors)*
- `poetry run mypy src` *(fails: 269 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: Validation failed)*
- `poetry run pytest tests/resources/test_memory.py::test_conversation_statistics tests/test_cli_get_stats.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68732e32683083228db60b51bc020604