### PR TITLE
Fix plugin context memory test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-22: Updated context creation call in test_memory_roundtrip to await make_context
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -133,7 +133,7 @@ async def make_context(tmp_path) -> PluginContext:
 
 @pytest.mark.asyncio
 async def test_memory_roundtrip(tmp_path) -> None:
-    ctx = make_context(tmp_path)
+    ctx = await make_context(tmp_path)
     await ctx.remember("foo", "bar")
     assert await ctx.recall("foo") == "bar"
 


### PR DESCRIPTION
## Summary
- adjust plugin context memory test to await context creation
- add an agent note about the change

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: Found 164 errors)*
- `poetry run mypy src` *(fails: Found 278 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: --config required)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*


------
https://chatgpt.com/codex/tasks/task_e_687332d15a388322b06267ed9e98fa26