### PR TITLE
Mock ollama pull in setup tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-22: Mocked subprocess in ensure_ollama tests to avoid real CLI calls
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests

--- a/tests/setup/test_layer0_setup.py
+++ b/tests/setup/test_layer0_setup.py
@@ -1,5 +1,4 @@
-import asyncio
-from pathlib import Path
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -39,18 +38,12 @@ async def test_ensure_ollama_missing_model(monkeypatch):
 
         return R()
 
-    async def fake_exec(*args, **kwargs):
-        class P:
-            returncode = 0
-
-            async def communicate(self):
-                return b"", b""
-
-        return P()
+    pull_mock = AsyncMock(return_value=True)
 
     monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr("entity.utils.setup_manager.pull_model", pull_mock)
     assert await mgr.ensure_ollama() is True
+    pull_mock.assert_awaited_once_with("foo", logger=mgr.logger)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- avoid calling external subprocess when verifying Layer0 setup
- check that the mocked pull function was awaited
- note this repo state in `agents.log`

## Testing
- `poetry run black tests/setup/test_layer0_setup.py src/entity/utils/setup_manager.py`
- `poetry run ruff check --fix tests/setup/test_layer0_setup.py src/entity/utils/setup_manager.py`
- `poetry run mypy src` *(fails: 278 errors)*
- `poetry run bandit -r src` *(reports low/medium issues)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: CancelledError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing argument --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687332d5167c83228433569b7a326518