### PR TITLE
Fix plugin harness import path

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Inserted sys.path modification in tests harness
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests

--- a/tests/plugins/harness.py
+++ b/tests/plugins/harness.py
@@ -4,9 +4,10 @@ import asyncio
 import inspect
 import sys
 import pathlib
-from entity.core.plugins import Plugin
 
 sys.path.insert(0, str(pathlib.Path("src").resolve()))
+
+from entity.core.plugins import Plugin
 from cli.plugin_tool.utils import load_plugin
 
 


### PR DESCRIPTION
## Summary
- insert sys.path adjustment before plugin imports in tests
- document note in agents.log

## Testing
- `poetry run ruff check --fix src tests` *(fails: 155 errors)*
- `poetry run mypy src` *(fails: 278 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml`
- `poetry run pytest tests/test_architecture/ -v` *(fails: 1 failed, 2 passed)*
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_687332cc8fa0832292971c80c425e34e