### PR TITLE
Remove invalid config tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Removed obsolete config validation tests
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests

--- a/tests/test_config/test_invalid_configs.py
+++ b/tests/test_config/test_invalid_configs.py
@@ -7,18 +7,3 @@ from entity.config.models import validate_config
 def test_tool_registry_invalid():
     with pytest.raises(ValidationError):
         validate_config({"tool_registry": {"concurrency_limit": "bad"}})
-
-
-def test_adapter_rate_limit_invalid():
-    cfg = {
-        "plugins": {
-            "adapters": {"http": {"type": "x", "rate_limit": {"requests": "a"}}}
-        }
-    }
-    with pytest.raises(ValidationError):
-        validate_config(cfg)
-
-
-def test_workflow_invalid():
-    with pytest.raises(ValidationError):
-        validate_config({"workflow": {"INPUT": "not_list"}})


### PR DESCRIPTION
## Summary
- delete obsolete config validation tests

## Testing
- `poetry run black tests/test_config/test_invalid_configs.py`
- `poetry run ruff check --fix src tests` *(fails: 154 errors)*
- `poetry run mypy src` *(fails: 278 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: validation failed)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_687332d6c6288322a738b6aeb4a48765