### PR TITLE
Fix integration tests with logging registries

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -5,6 +5,7 @@ import types
 import pytest
 
 from entity.resources import Memory, MetricsCollectorResource
+from entity.resources.logging import LoggingResource
 from entity.pipeline.worker import PipelineWorker
 from entity.core.registries import PluginRegistry
 from entity.core.plugins import Plugin
@@ -51,6 +52,8 @@ class ErrorPlugin(Plugin):
 async def registries(memory_db: Memory) -> types.SimpleNamespace:
     metrics = MetricsCollectorResource({})
     await metrics.initialize()
+    logging_res = LoggingResource({})
+    await logging_res.initialize()
 
     class _Resources(dict):
         async def __aenter__(self):
@@ -59,7 +62,9 @@ async def registries(memory_db: Memory) -> types.SimpleNamespace:
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-    resources = _Resources(memory=memory_db, metrics_collector=metrics)
+    resources = _Resources(
+        memory=memory_db, metrics_collector=metrics, logging=logging_res
+    )
     resources.get = lambda name: resources[name]
 
     return types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- provide LoggingResource in full pipeline tests
- inject LoggingResource and validators into multi-user registries
- update assertions for assistant messages
- log note

## Testing
- `poetry run pytest tests/integration/test_full_pipeline.py::test_standard_workflow -q`
- `poetry run pytest tests/integration/test_multi_user.py::test_user_isolation -q`


------
https://chatgpt.com/codex/tasks/task_e_687332d383a0832297f1a9db0bc35123