### PR TITLE
Fix canonical resource layer expectations

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-22: Canonical resource validation now treats AgentResource as layer 3
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -434,7 +434,7 @@ class ResourceContainer:
             is_canonical = issubclass(cls, (CanonicalResource, PluginAgentResource))
 
             expected = (
-                1 if is_infra else 3 if is_canonical else 2 if is_interface else 4
+                3 if is_canonical else 1 if is_infra else 2 if is_interface else 4
             )
 
             if layer != expected:

--- a/tests/test_architecture/test_validate_layers.py
+++ b/tests/test_architecture/test_validate_layers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from entity.core.plugins import InfrastructurePlugin, ResourcePlugin
+from entity.core.plugins import InfrastructurePlugin
 from entity.core.resources.container import ResourceContainer
 from entity.resources.base import AgentResource as CanonicalBase
 from entity.pipeline.errors import InitializationError
@@ -37,9 +37,14 @@ async def test_invalid_layer_number():
 
 
 @pytest.mark.asyncio
-async def test_mismatched_class_layer():
+async def test_canonical_layer_validation():
     container = ResourceContainer()
     container.register("canon", CanonicalRes, {}, layer=3)
+    # should pass without error
+    container._validate_layers()
+
+    container = ResourceContainer()
+    container.register("canon", CanonicalRes, {}, layer=2)
     with pytest.raises(InitializationError, match="Incorrect layer"):
         container._validate_layers()
 


### PR DESCRIPTION
## Summary
- fix `_validate_layers` so canonical resources subclassing AgentResource expect layer 3
- update layer validation tests accordingly
- note canonical layer update in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 155 errors)*
- `poetry run mypy src` *(fails: found 278 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_687332cfd8e0832288e8e99bed725e47