### PR TITLE
Add architecture isolation tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-21: Added simple architecture tests for layer rules and user isolation
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics

--- a/tests/architecture/test_dependency_injection.py
+++ b/tests/architecture/test_dependency_injection.py
@@ -1,0 +1,76 @@
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import datetime
+import sqlite3
+
+import pytest
+
+from entity.core.plugins import ValidationResult, InfrastructurePlugin, ResourcePlugin
+from entity.pipeline.errors import InitializationError
+from entity.resources.base import AgentResource
+from entity.resources import Memory
+from entity.core.state import ConversationEntry
+
+
+class SqliteDB(InfrastructurePlugin):
+    infrastructure_type = "database"
+    stages: list = []
+    dependencies: list = []
+
+    def __init__(self, config=None) -> None:
+        super().__init__(config or {})
+        self.conn = sqlite3.connect(":memory:")
+
+    def get_connection_pool(self):
+        return self.conn
+
+    @asynccontextmanager
+    async def connection(self):
+        yield self.conn
+
+
+class DBInterface(ResourcePlugin):
+    infrastructure_dependencies = ["database"]
+    stages: list = []
+    dependencies: list = []
+
+    def __init__(self, config=None) -> None:
+        super().__init__(config or {})
+        self.database = None
+
+
+class DepResource(AgentResource):
+    dependencies = ["db"]
+    stages: list = []
+
+    def __init__(self, config=None) -> None:
+        super().__init__(config or {})
+        self.db = None
+
+    @classmethod
+    async def validate_dependencies(cls, registry):
+        return ValidationResult.error_result("bad dependency")
+
+
+DBInterface.dependencies = []
+SqliteDB.dependencies = []
+DepResource.dependencies = ["db"]
+
+
+@pytest.mark.asyncio
+async def test_memory_user_isolation() -> None:
+    mem = Memory(config={})
+    mem.database = SqliteDB()
+    mem.vector_store = None
+    await mem.initialize()
+
+    entry1 = ConversationEntry(content="one", role="user", timestamp=datetime.now())
+    entry2 = ConversationEntry(content="two", role="user", timestamp=datetime.now())
+    await mem.save_conversation("pipe", [entry1], user_id="u1")
+    await mem.save_conversation("pipe", [entry2], user_id="u2")
+
+    hist1 = await mem.load_conversation("pipe", user_id="u1")
+    hist2 = await mem.load_conversation("pipe", user_id="u2")
+
+    assert [e.content for e in hist1] == ["one"]
+    assert [e.content for e in hist2] == ["two"]

--- a/tests/architecture/test_layer_boundaries.py
+++ b/tests/architecture/test_layer_boundaries.py
@@ -1,0 +1,40 @@
+import asyncio
+import pytest
+
+from entity.core.resources.container import ResourceContainer
+from entity.core.plugins import InfrastructurePlugin, ResourcePlugin
+from entity.resources.base import AgentResource
+from entity.pipeline.errors import InitializationError
+
+
+class Infra(InfrastructurePlugin):
+    infrastructure_type = "db"
+    stages: list = []
+    dependencies: list = []
+
+
+class Interface(ResourcePlugin):
+    infrastructure_dependencies = ["db"]
+    stages: list = []
+    dependencies: list = []
+
+
+class BadResource(AgentResource):
+    dependencies = ["db"]
+    stages: list = []
+
+
+Infra.dependencies = []
+Interface.dependencies = []
+BadResource.dependencies = ["db"]
+
+
+@pytest.mark.asyncio
+async def test_layer_boundary_violation() -> None:
+    container = ResourceContainer()
+    container.register("db", Infra, {}, layer=1)
+    container.register("iface", Interface, {}, layer=2)
+    container.register("bad", BadResource, {}, layer=3)
+
+    with pytest.raises(InitializationError, match="Incorrect layer"):
+        await container.build_all()

--- a/tests/architecture/test_stage_assignment.py
+++ b/tests/architecture/test_stage_assignment.py
@@ -1,0 +1,30 @@
+from entity.core.plugins import Plugin
+from entity.pipeline.utils import resolve_stages
+from entity.core.stages import PipelineStage
+
+
+class AttrPlugin(Plugin):
+    stages = [PipelineStage.DO]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+class NoStagePlugin(Plugin):
+    async def _execute_impl(self, context):
+        pass
+
+
+def test_config_overrides_class_stage() -> None:
+    stages = resolve_stages(AttrPlugin, {"stage": PipelineStage.PARSE})
+    assert stages == [PipelineStage.PARSE]
+
+
+def test_class_stage_used_when_no_config() -> None:
+    stages = resolve_stages(AttrPlugin, {})
+    assert stages == [PipelineStage.DO]
+
+
+def test_stage_falls_back_to_think() -> None:
+    stages = resolve_stages(NoStagePlugin, {})
+    assert stages == [PipelineStage.THINK]


### PR DESCRIPTION
## Summary
- add simple architecture tests for layer boundaries and stage rules
- add basic memory isolation test
- log note about new tests

## Testing
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v`
- `poetry run pytest tests/resources -v` *(fails: Resource initialization errors)*

------
https://chatgpt.com/codex/tasks/task_e_68732e16db1483229d1ae5b21100de3a