### PR TITLE
Fix log rotation timing

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated log rotation logic and tests
 AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper

--- a/tests/test_logging_resource.py
+++ b/tests/test_logging_resource.py
@@ -113,8 +113,15 @@ async def test_log_rotation(tmp_path, monkeypatch):
     rotated = log_file.with_name(log_file.name + ".1")
     assert rotated.exists()
     with rotated.open("r", encoding="utf-8") as handle:
-        first_entry = json.loads(handle.readline())
+        lines = handle.readlines()
+    assert len(lines) == 1
+    first_entry = json.loads(lines[0])
     assert first_entry["message"] == "first"
+    with log_file.open("r", encoding="utf-8") as handle:
+        current_lines = handle.readlines()
+    assert len(current_lines) == 1
+    second_entry = json.loads(current_lines[0])
+    assert second_entry["message"] == "second"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- rotate log files before writing when needed
- ensure rotation tests check old entry only

## Testing
- `poetry run black src/entity/resources/logging.py tests/test_logging_resource.py tests/resources/test_logging.py`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing arguments)*
- `poetry run pytest tests/test_architecture/ -v`
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/resources/test_logging.py::test_file_rotation tests/resources/test_logging.py::test_file_rotation_no_data_loss -v`


------
https://chatgpt.com/codex/tasks/task_e_6873397145cc8322a7649616e92a40ce