### PR TITLE
Fix run_test order in memory tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Fixed run_test scope to avoid NameError in memory tests
 AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -131,6 +131,27 @@ async def make_context(tmp_path) -> PluginContext:
     return PluginContext(state, regs)
 
 
+async def run_test() -> None:
+    db = DummyDatabase()
+
+    mem1 = Memory(config={})
+    mem1.database = db
+    mem1.vector_store = None
+    await mem1.initialize()
+    await mem1.set("foo", "bar", user_id="default")
+    entry = ConversationEntry("hi", "user", datetime.now())
+    await mem1.save_conversation("cid", [entry], user_id="default")
+
+    mem2 = Memory(config={})
+    mem2.database = db
+    mem2.vector_store = None
+    await mem2.initialize()
+
+    assert await mem2.get("foo", user_id="default") == "bar"
+    history = await mem2.load_conversation("cid", user_id="default")
+    assert history == [entry]
+
+
 @pytest.mark.asyncio
 async def test_memory_roundtrip(tmp_path) -> None:
     ctx = await make_context(tmp_path)
@@ -141,26 +162,6 @@ async def test_memory_roundtrip(tmp_path) -> None:
 
 
 def test_memory_persists_between_instances() -> None:
-    async def run_test() -> None:
-        db = DummyDatabase()
-
-        mem1 = Memory(config={})
-        mem1.database = db
-        mem1.vector_store = None
-        await mem1.initialize()
-        await mem1.set("foo", "bar", user_id="default")
-        entry = ConversationEntry("hi", "user", datetime.now())
-        await mem1.save_conversation("cid", [entry], user_id="default")
-
-        mem2 = Memory(config={})
-        mem2.database = db
-        mem2.vector_store = None
-        await mem2.initialize()
-
-        assert await mem2.get("foo", user_id="default") == "bar"
-        history = await mem2.load_conversation("cid", user_id="default")
-        assert history == [entry]
-
     asyncio.run(run_test())
 
 
@@ -180,6 +181,11 @@ def test_memory_persists_with_connection_pool() -> None:
         mem2.database = pool
         mem2.vector_store = None
         await mem2.initialize()
+        assert await mem2.get("foo", user_id="default") == "bar"
+        history = await mem2.load_conversation("cid", user_id="default")
+        assert history == [entry]
+
+    asyncio.run(run_test())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move the helper `run_test` above its first use
- call `run_test` from both tests
- complete the connection pool test

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 156 remaining errors)*
- `poetry run mypy src` *(fails with 284 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*


------
https://chatgpt.com/codex/tasks/task_e_6873397b43bc8322aa1bb11d746889ef