### PR TITLE
Standardize stage mismatch warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ pytest tests/performance/ -m benchmark
 - **Import restrictions:** Plugins must NOT import core modules directly (enforces architectural boundaries)
 - **Allowed imports:** Plugin base classes, resource interfaces, and utility functions are permitted
 - **Stage assignment:** Always explicitly declare plugin stages in configuration or class definition
+- **Stage mismatch warnings:** When configuration overrides class stages the initializer logs a message like `MyPlugin configured stages [REVIEW] override class stages [DO]`.
 - **Dependencies:** Use explicit dependency declarations rather than constructor injection
 
 ### Plugin Testing

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Standardized stage mismatch warnings
 AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper

--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -31,8 +31,9 @@ This command executes Phases&nbsp;1 and&nbsp;2 and reports any problems before t
 ### Stage Mismatch Warnings
 
 By default the initializer only logs a warning when a plugin's configured stages
-override those declared on the class. Run the CLI with ``--strict-stages`` to
-escalate these warnings into errors.
+override those declared on the class. The warning message reads:
+``MyPlugin configured stages [REVIEW] override class stages [DO]``.
+Run the CLI with ``--strict-stages`` to escalate these warnings into errors.
 
 ## Tuning Circuit Breaker Thresholds
 

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -501,7 +501,7 @@ class SystemInitializer:
             if cfg_stages != class_stages:
                 msg = (
                     f"{cls.__name__} configured stages {cfg_stages} "
-                    f"differ from class stages {class_stages}"
+                    f"override class stages {class_stages}"
                 )
                 if self.strict_stages:
                     raise InitializationError(cls.__name__, "stage validation", msg)

--- a/src/entity/pipeline/utils/__init__.py
+++ b/src/entity/pipeline/utils/__init__.py
@@ -84,7 +84,7 @@ class StageResolver:
             and logger is not None
         ):
             logger.warning(
-                "%s resolved stages %s differ from declared stages %s",
+                "%s resolved stages %s override class stages %s",
                 plugin_class.__name__,
                 stages,
                 _normalize_stages(declared_value),

--- a/tests/plugins/test_stage_assignment.py
+++ b/tests/plugins/test_stage_assignment.py
@@ -52,7 +52,7 @@ def test_config_overrides_class_stage(caplog: pytest.LogCaptureFixture) -> None:
             logger=logger,
         )
     assert stages == [PipelineStage.REVIEW]
-    assert "overrides" in caplog.text
+    assert "override" in caplog.text
 
 
 def test_class_stage_used_without_config() -> None:

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -112,4 +112,4 @@ def test_warning_for_stage_override(caplog):
         StageResolver._resolve_plugin_stages(
             AttrPrompt, {"stage": PipelineStage.REVIEW}, plugin
         )
-    assert any("differ from declared" in r.message for r in caplog.records)
+    assert any("override class stages" in r.message for r in caplog.records)

--- a/tests/test_strict_stages.py
+++ b/tests/test_strict_stages.py
@@ -1,10 +1,19 @@
-import asyncio
 import logging
 import pytest
 
 from entity.pipeline.initializer import SystemInitializer
 from entity.pipeline.stages import PipelineStage
 from entity.core.plugins import PromptPlugin
+from entity.resources.interfaces.database import DatabaseResource
+from entity.resources.base import AgentResource as CanonicalResource  # noqa: F401
+import entity.core.resources.container as container
+
+container.CanonicalResource = CanonicalResource
+
+
+class DummyDB(DatabaseResource):
+    async def _execute_impl(self, context):
+        pass
 
 
 class MyPlugin(PromptPlugin):
@@ -20,6 +29,7 @@ async def test_stage_mismatch_warning(caplog):
         "plugins": {
             "agent_resources": {
                 "memory": {"type": "entity.resources.memory:Memory"},
+                "database": {"type": __name__ + ":DummyDB"},
                 "llm": {"type": "entity.resources.llm:LLM"},
                 "storage": {"type": "entity.resources.storage:Storage"},
             },
@@ -30,7 +40,7 @@ async def test_stage_mismatch_warning(caplog):
     init = SystemInitializer(cfg)
     with caplog.at_level(logging.WARNING):
         await init.initialize()
-    assert any("differ from class stages" in r.message for r in caplog.records)
+    assert any("override class stages" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -39,6 +49,7 @@ async def test_stage_mismatch_strict():
         "plugins": {
             "agent_resources": {
                 "memory": {"type": "entity.resources.memory:Memory"},
+                "database": {"type": __name__ + ":DummyDB"},
                 "llm": {"type": "entity.resources.llm:LLM"},
                 "storage": {"type": "entity.resources.storage:Storage"},
             },


### PR DESCRIPTION
## Summary
- unify wording for stage mismatch warning
- document the warning text in contributor docs
- note change in `agents.log`

## Testing
- `poetry run ruff check --fix src/entity/pipeline/utils/__init__.py src/entity/pipeline/initializer.py tests/test_stage_precedence.py tests/test_strict_stages.py tests/plugins/test_stage_assignment.py`
- `poetry run mypy src/entity/pipeline/utils/__init__.py src/entity/pipeline/initializer.py`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run pytest tests/test_architecture/ -v`
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`
- `poetry run pytest tests/test_stage_precedence.py::test_warning_for_stage_override tests/test_strict_stages.py::test_stage_mismatch_warning tests/plugins/test_stage_assignment.py::test_config_overrides_class_stage -q`

------
https://chatgpt.com/codex/tasks/task_e_68733976e0b48322b33e7c91c8016592