### PR TITLE
Handle optional validators

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Allowed pipelines to run when validators are absent
 AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -72,7 +72,7 @@ class Pipeline:
             resources=capabilities.resources,
             tools=capabilities.tools,
             plugins=plugin_reg,
-            validators=capabilities.validators,
+            validators=getattr(capabilities, "validators", None),
         )
         return await execute_pipeline(
             message,
@@ -115,8 +115,9 @@ async def execute_stage(
             context.set_current_stage(stage)
             name = registries.plugins.get_plugin_name(plugin)
             context.set_current_plugin(name)
-            if registries.validators is not None:
-                await registries.validators.validate(stage, context)
+            validators = getattr(registries, "validators", None)
+            if validators is not None:
+                await validators.validate(stage, context)
             try:
                 await plugin.execute(context)
                 if stage == PipelineStage.OUTPUT and state.response is not None:

--- a/tests/test_pipeline_no_validators.py
+++ b/tests/test_pipeline_no_validators.py
@@ -1,0 +1,27 @@
+import types
+import pytest
+
+from entity.core.plugins import Plugin
+from entity.core.registries import PluginRegistry
+from entity.pipeline.stages import PipelineStage
+from entity.pipeline.pipeline import execute_pipeline
+
+
+class EchoPlugin(Plugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context):
+        msg = context.conversation()[-1].content
+        context.say(msg)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_without_validators_runs():
+    caps = types.SimpleNamespace(
+        resources={},
+        tools=types.SimpleNamespace(),
+        plugins=PluginRegistry(),
+    )
+    await caps.plugins.register_plugin_for_stage(EchoPlugin({}), PipelineStage.OUTPUT)
+    result = await execute_pipeline("hi", caps)
+    assert result == "hi"


### PR DESCRIPTION
## Summary
- allow pipelines without validators via `getattr`
- test pipeline execution when validators are missing

## Testing
- `poetry run pytest tests/test_architecture/ -v`
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`
- `poetry run pytest tests/test_pipeline_no_validators.py -v`
- `poetry run ruff check --fix src tests` *(fails: 157 errors)*
- `poetry run mypy src` *(fails: found 284 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing argument --config)*

------
https://chatgpt.com/codex/tasks/task_e_68733975bfb48322b188b596e2099d79