### PR TITLE
Fix RegistryValidator config validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-22: RegistryValidator config stripping and canonical resource tests added
 AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag
 AGENT NOTE - 2025-07-21: Updated runtime tests to use Pipeline wrapper

--- a/src/entity/core/registry_validator.py
+++ b/src/entity/core/registry_validator.py
@@ -256,7 +256,12 @@ class RegistryValidator:
 
                 result = ValidationResult.success_result()
             else:
-                result = validate(cfg)
+                clean_cfg = {
+                    k: v
+                    for k, v in cfg.items()
+                    if k not in {"type", "dependencies", "stage", "stages"}
+                }
+                result = validate(clean_cfg)
                 if inspect.isawaitable(result):
                     result = asyncio.run(result)
             if not result.success:


### PR DESCRIPTION
## Summary
- clean config dict before passing to `validate_config`
- test canonical resources validate using `RegistryValidator`
- add agent note

## Testing
- `poetry run pytest tests/test_registry_validator.py::test_canonical_resources_validate -v`
- `poetry run pytest tests/test_architecture/ -v`
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`
- `poetry run ruff check --fix src tests` *(fails: 168 errors)*
- `poetry run mypy src` *(fails: 284 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: Plugin 'database' in 'resources' must inherit from ResourcePlugin)*

------
https://chatgpt.com/codex/tasks/task_e_6873396f6e5c832283859d6090b6f2a5