### PR TITLE
Fix DatabaseResource import in context memory test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test
 AGENT NOTE - 2025-07-22: RegistryValidator config stripping and canonical resource tests added
 AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests
 AGENT NOTE - 2025-07-21: Added strict stage checks and CLI flag

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from entity.core.context import PluginContext  # noqa: E402
 from entity.core.state import PipelineState, ConversationEntry  # noqa: E402
 from entity.resources import Memory  # noqa: E402
+from entity.resources.interfaces.database import DatabaseResource
 from plugins.builtin.resources.duckdb_resource import DuckDBResource
 from entity.infrastructure.duckdb import DuckDBInfrastructure
 from entity.pipeline.errors import ResourceInitializationError  # noqa: E402
@@ -142,7 +143,7 @@ async def test_memory_roundtrip(tmp_path) -> None:
     await ctx.remember("foo", "bar")
     assert await ctx.recall("foo") == "bar"
 
-    asyncio.run(run_test())
+    await run_test()
 
 
 def test_memory_persists_between_instances() -> None:


### PR DESCRIPTION
## Summary
- fix missing `DatabaseResource` import
- await `run_test()` coroutine in `test_memory_roundtrip`
- log update in `agents.log`

## Testing
- `poetry run pytest tests/test_plugin_context_memory.py::test_memory_roundtrip -vv`
- `poetry run pytest` *(fails: InitializationError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68733dfef95883229d4aeadd2119ac7d