### PR TITLE
Improve StageResolver warnings

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: StageResolver now logs with module logger if none provided
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test
 AGENT NOTE - 2025-07-22: RegistryValidator config stripping and canonical resource tests added
 AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests

--- a/src/entity/pipeline/utils/__init__.py
+++ b/src/entity/pipeline/utils/__init__.py
@@ -2,6 +2,7 @@
 
 from entity.core.resources.container import DependencyGraph
 from typing import Any, Iterable, List, Mapping, Type
+import logging
 from ..stages import PipelineStage
 
 
@@ -36,7 +37,11 @@ get_plugin_stages = resolve_stages
 
 
 class StageResolver:
-    """Compatibility layer providing stage resolution helpers."""
+    """Compatibility layer providing stage resolution helpers.
+
+    If ``logger`` is not supplied, :meth:`_resolve_plugin_stages` uses
+    ``logging.getLogger(__name__)`` so warnings are emitted by default.
+    """
 
     @staticmethod
     def _resolve_plugin_stages(
@@ -57,7 +62,12 @@ class StageResolver:
         configuration, the plugin instance (``_explicit_stages``), or a class
         attribute. When an instance is supplied and no explicit stage is found,
         the fallback stage is also treated as explicit.
+
+        When ``logger`` is ``None`` the method uses ``logging.getLogger(__name__)``
+        so warnings are emitted even without an explicit logger.
         """
+        logger = logger or logging.getLogger(__name__)
+
         cfg_value = config.get("stages") or config.get("stage")
         declared_value = getattr(plugin_class, "stages", None) or getattr(
             plugin_class, "stage", None


### PR DESCRIPTION
## Summary
- log plugin stage override warnings even when no logger is given
- note the default logger behaviour in the docs

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 154 errors)*
- `poetry run mypy src` *(fails: 287 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing argument)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68733ff93d388322a14f8b563b017569