### PR TITLE
Allow custom resources without deps at layer 3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,8 @@ class Memory(AgentResource):  # Layer 3
         pass
 ```
 
+Custom resources without dependencies may optionally be placed in **Layer 3**.
+
 **Decision #4: Stage Assignment Precedence**
 ```python
 # ✅ GOOD: Explicit stage assignment

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test
 AGENT NOTE - 2025-07-22: RegistryValidator config stripping and canonical resource tests added
 AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -464,14 +464,21 @@ class ResourceContainer:
                 )
             )
 
-            if layer != expected:
+            allowed_layers = {expected}
+            if expected == 4 and not self._deps.get(name):
+                allowed_layers.add(3)
+
+            if layer not in allowed_layers:
                 message = (
                     f"Provided layer {layer} for {cls.__name__} is invalid."
                     if expected == 3
                     else f"Incorrect layer {layer} for {cls.__name__}. Expected {expected}."
                 )
                 raise InitializationError(
-                    name, "layer validation", message, kind="Resource"
+                    name,
+                    "layer validation",
+                    message,
+                    kind="Resource",
                 )
 
             if is_infra:

--- a/tests/test_architecture/test_validate_layers.py
+++ b/tests/test_architecture/test_validate_layers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from entity.core.plugins import InfrastructurePlugin, ResourcePlugin
+from entity.core.plugins import InfrastructurePlugin
 from entity.core.resources.container import ResourceContainer
 from entity.resources.base import AgentResource as CanonicalBase
 from entity.pipeline.errors import InitializationError
@@ -28,6 +28,11 @@ class CustomRes:
     dependencies = ["infra"]
 
 
+class NoDepRes:
+    stages: list = []
+    dependencies: list = []
+
+
 @pytest.mark.asyncio
 async def test_invalid_layer_number():
     container = ResourceContainer()
@@ -51,3 +56,10 @@ async def test_dependency_layer_violation():
     container.register("custom", CustomRes, {}, layer=4)
     with pytest.raises(InitializationError, match="layer rules"):
         container._validate_layers()
+
+
+@pytest.mark.asyncio
+async def test_custom_no_dep_allowed_in_layer3():
+    container = ResourceContainer()
+    container.register("nodep", NoDepRes, {}, layer=3)
+    container._validate_layers()


### PR DESCRIPTION
## Summary
- permit layer 3 registration when custom resources lack dependencies
- clarify contributor guide with note on layer 3 for simple custom resources
- test layer validation allows no-dependency resources at layer 3
- log decision in agents log

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402 and others)*
- `poetry run mypy src` *(fails: found 287 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: invalid syntax in templates)*
- `poetry run unimport src tests` *(fails: invalid syntax in templates)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*


------
https://chatgpt.com/codex/tasks/task_e_68733ff63ec0832288cce6adaea4624c