### PR TITLE
Fix logging resource initialization order

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Updated logging resource registration and tests
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test
 AGENT NOTE - 2025-07-22: RegistryValidator config stripping and canonical resource tests added
 AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests

--- a/tests/test_initializer_canonical_resources.py
+++ b/tests/test_initializer_canonical_resources.py
@@ -58,7 +58,7 @@ def test_initializer_fails_without_storage():
         asyncio.run(init.initialize())
 
 
-def test_initializer_fails_without_logging():
+def test_initializer_succeeds_without_logging_config():
     cfg = {
         "plugins": {
             "agent_resources": {


### PR DESCRIPTION
## Summary
- auto-register logging resource before validating canonical resources
- ensure initialization succeeds with no logging config

## Testing
- `poetry run black src/entity/pipeline/initializer.py tests/test_initializer_canonical_resources.py`
- `poetry run ruff check --fix src/entity/pipeline/initializer.py tests/test_initializer_canonical_resources.py`
- `poetry run mypy src/entity/pipeline/initializer.py`
- `poetry run bandit -r src/entity/pipeline/initializer.py`
- `poetry run vulture src/entity/pipeline/initializer.py tests/test_initializer_canonical_resources.py`
- `poetry run unimport src/entity/pipeline/initializer.py tests/test_initializer_canonical_resources.py`
- `pytest tests/test_initializer_canonical_resources.py::test_initializer_succeeds_without_logging_config -q`

------
https://chatgpt.com/codex/tasks/task_e_68733ff74f588322b94caccb86e143f5