### PR TITLE
Auto register canonical resources

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-24: Auto-register canonical resources in AgentBuilder and tests verify runtime initialization without setup
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test
 AGENT NOTE - 2025-07-22: RegistryValidator config stripping and canonical resource tests added
 AGENT NOTE - 2025-07-13: Added logging resource to integration registries for PipelineWorker tests

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -50,3 +50,15 @@ async def test_agent_handle_runs_workflow():
     agent.pipeline = Pipeline(workflow=wf)
     result = await agent.handle("bye")
     assert result == "bye!"
+
+
+@pytest.mark.asyncio
+async def test_builder_registers_default_resources() -> None:
+    builder = _AgentBuilder()
+    runtime = await builder.build_runtime()
+    assert runtime is not None
+    assert builder.resource_registry.get("memory") is not None
+    assert builder.resource_registry.get("llm") is not None
+    assert builder.resource_registry.get("storage") is not None
+    mem = builder.resource_registry.get("memory")
+    assert getattr(mem, "database", None) is not None


### PR DESCRIPTION
## Summary
- auto register canonical resources in `AgentBuilder`
- test runtime builder without setup

## Testing
- `poetry run black src/entity/core/agent.py tests/test_agent_runtime.py`
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402 Module level import not at top of file)*
- `poetry run mypy src` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine 'EntityCLI._verify_plugins' was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine 'EntityCLI._verify_plugins' was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: the following arguments are required: --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68733ff4bd148322a74dba6b2c4fe01b