### PR TITLE
Fix DuckDBResource layering

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test
 AGENT NOTE - 2025-07-22: RegistryValidator config stripping and canonical resource tests added

--- a/src/plugins/builtin/resources/duckdb_resource.py
+++ b/src/plugins/builtin/resources/duckdb_resource.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import Any, Dict, Iterator
+from typing import Any, AsyncIterator, Dict
 
-from entity.resources.interfaces.database import DatabaseResource
 from entity.infrastructure.duckdb import DuckDBInfrastructure
 from entity.core.resources.container import PoolConfig, ResourcePool
+from entity.core.plugins import AgentResource
 
 
-class DuckDBResource(DatabaseResource):
+class DuckDBResource(AgentResource):  # type: ignore[misc]
     """Database resource backed by :class:`DuckDBInfrastructure`."""
 
-    infrastructure_dependencies = ["database"]
+    infrastructure_dependencies = ["database_backend"]
 
-    def __init__(self, config: Dict | None = None) -> None:
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
         super().__init__(config or {})
         self.database: DuckDBInfrastructure | None = None
 
@@ -23,7 +23,7 @@ class DuckDBResource(DatabaseResource):
         return ResourcePool(lambda: None, PoolConfig())
 
     @asynccontextmanager
-    async def connection(self) -> Iterator[Any]:
+    async def connection(self) -> AsyncIterator[Any]:
         if self.database is None:
             yield None
         else:


### PR DESCRIPTION
## Summary
- subclass AgentResource for DuckDBResource so it validates as layer 3
- depend on `database_backend`
- document the change in agents.log

## Testing
- `mypy src/plugins/builtin/resources/duckdb_resource.py`
- `bandit -q -r src/plugins/builtin/resources/duckdb_resource.py`
- `vulture src/plugins/builtin/resources/duckdb_resource.py tests`
- `unimport --remove-all src/plugins/builtin/resources/duckdb_resource.py`

------
https://chatgpt.com/codex/tasks/task_e_6873bfeb04e0832293bd5c4b751b8ab2