### PR TITLE
Implement pipeline branching and checkpoints

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added branching and checkpoint support in Pipeline
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -91,6 +91,18 @@ class AdvancedContext:
         """Remove all temporary thoughts stored via ``think_temp``."""
         self._parent._temporary_thoughts.clear()
 
+    # ------------------------------------------------------------------
+    # Stage control helpers
+    # ------------------------------------------------------------------
+
+    def skip_stage(self, stage: PipelineStage) -> None:
+        """Skip ``stage`` when the pipeline runs."""
+        self._parent._state.skip_stages.add(stage)
+
+    def jump_to_stage(self, stage: PipelineStage) -> None:
+        """Resume pipeline execution from ``stage``."""
+        self._parent._state.next_stage = stage
+
 
 class PluginContext:
     """Runtime context passed to plugins."""

--- a/src/entity/pipeline/__init__.py
+++ b/src/entity/pipeline/__init__.py
@@ -102,6 +102,7 @@ def __getattr__(name: str) -> Any:
         "Workflow": "entity.pipeline.workflow",
         "PipelineWorker": "entity.worker.pipeline_worker",
         "execute_pipeline": "entity.pipeline.pipeline",
+        "visualize_execution_plan": "entity.pipeline.pipeline",
         "create_default_response": "entity.pipeline.pipeline",
         "create_static_error_response": "entity.pipeline.errors",
         "ConfigUpdateResult": "entity.pipeline.config.config_update",

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -36,6 +36,15 @@ from .workflow import Workflow
 
 logger = get_logger(__name__)
 
+STAGE_ORDER = [
+    PipelineStage.INPUT,
+    PipelineStage.PARSE,
+    PipelineStage.THINK,
+    PipelineStage.DO,
+    PipelineStage.REVIEW,
+    PipelineStage.OUTPUT,
+]
+
 
 @asynccontextmanager
 async def _noop_async_cm():
@@ -260,22 +269,29 @@ async def execute_pipeline(
     state: PipelineState | None = None,
     workflow: Workflow | None = None,
     max_iterations: int = 5,
+    checkpoint_key: str | None = None,
 ) -> Dict[str, Any]:
     if capabilities is None:
         raise TypeError("capabilities is required")
     user_id = user_id or "default"
+    memory = capabilities.resources.get("memory") if capabilities.resources else None
     if state is None:
-        state = PipelineState(
-            conversation=[
-                ConversationEntry(
-                    content=user_message,
-                    role="user",
-                    timestamp=datetime.now(),
-                )
-            ],
-            pipeline_id=f"{user_id}_{generate_pipeline_id()}",
-        )
-        state.stage_results.clear()
+        if checkpoint_key and memory:
+            saved = await memory.fetch_persistent(checkpoint_key, None, user_id=user_id)
+            if saved:
+                state = PipelineState.from_dict(saved)
+        if state is None:
+            state = PipelineState(
+                conversation=[
+                    ConversationEntry(
+                        content=user_message,
+                        role="user",
+                        timestamp=datetime.now(),
+                    )
+                ],
+                pipeline_id=f"{user_id}_{generate_pipeline_id()}",
+            )
+            state.stage_results.clear()
     _start = time.time()
     resource_manager = (
         capabilities.resources
@@ -286,14 +302,14 @@ async def execute_pipeline(
         async with start_span("pipeline.execute"):
             while True:
                 state.iteration += 1
-                for stage in [
-                    PipelineStage.INPUT,
-                    PipelineStage.PARSE,
-                    PipelineStage.THINK,
-                    PipelineStage.DO,
-                    PipelineStage.REVIEW,
-                    PipelineStage.OUTPUT,
-                ]:
+                start_stage = state.next_stage or STAGE_ORDER[0]
+                if state.next_stage is not None:
+                    state.next_stage = None
+                start_index = STAGE_ORDER.index(start_stage)
+                for stage in STAGE_ORDER[start_index:]:
+                    if stage in state.skip_stages:
+                        state.skip_stages.discard(stage)
+                        continue
                     if workflow and not workflow.should_execute(stage, state):
                         continue
                     if (
@@ -320,12 +336,23 @@ async def execute_pipeline(
                                 pipeline_id=state.pipeline_id,
                                 iteration=state.iteration,
                             )
+                        if checkpoint_key and memory:
+                            await memory.store_persistent(
+                                checkpoint_key, state.to_dict(), user_id=user_id
+                            )
+                    if state.next_stage is not None:
+                        state.last_completed_stage = stage
+                        break
                     if state.failure_info or state.response is not None:
                         break
                     state.last_completed_stage = stage
 
                 if state.response is not None:
                     break
+
+                if state.next_stage is not None:
+                    state.last_completed_stage = None
+                    continue
 
                 if state.failure_info is not None or state.iteration >= max_iterations:
                     if (
@@ -374,6 +401,24 @@ async def execute_pipeline(
         return result
 
 
+def visualize_execution_plan(workflow: Workflow, state: PipelineState) -> str:
+    """Return a GraphViz dot diagram of the planned execution."""
+    lines = ["digraph pipeline {"]
+    lines.append("    rankdir=LR")
+    prev = "START"
+    for stage in STAGE_ORDER:
+        if stage in state.skip_stages:
+            continue
+        if workflow and not workflow.should_execute(stage, state):
+            continue
+        lines.append(f'    "{prev}" -> "{stage.name}"')
+        prev = stage.name
+        for plugin in workflow.stage_map.get(stage, []):
+            lines.append(f'    "{stage.name}" -> "{plugin}" [style=dotted]')
+    lines.append("}")
+    return "\n".join(lines)
+
+
 __all__ = [
     "Workflow",
     "Pipeline",
@@ -381,4 +426,5 @@ __all__ = [
     "create_default_response",
     "execute_stage",
     "execute_pipeline",
+    "visualize_execution_plan",
 ]


### PR DESCRIPTION
## Summary
- expand `PipelineState` with branching fields and helpers
- enable stage skipping and resuming in `execute_pipeline`
- add GraphViz rendering of the execution plan
- expose new function in pipeline `__init__`
- log note about branching support

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: many lint errors)*
- `poetry run mypy src` *(fails: many type errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873d5f391f4832291c0fd1cd80db9fb