### PR TITLE
Add runtime validation for plugin registration

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added runtime plugin validation for stage assignments and dependencies
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -1,9 +1,12 @@
-from __future__ import annotations
-
 """Simplified plugin and resource registries."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List
+
+from entity.core.validation import verify_dependencies, verify_stage_assignment
+from entity.pipeline.stages import PipelineStage
 
 
 class PluginRegistry:
@@ -14,10 +17,16 @@ class PluginRegistry:
         self._names: Dict[Any, str] = {}
 
     async def register_plugin_for_stage(
-        self, plugin: Any, stage: str, name: str | None = None
+        self, plugin: Any, stage: str | PipelineStage, name: str | None = None
     ) -> None:
+        stage_enum = PipelineStage.ensure(stage)
         plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
-        self._stage_plugins.setdefault(stage, []).append(plugin)
+
+        verify_stage_assignment(plugin, stage_enum)
+        verify_dependencies(plugin, self._names.values())
+
+        key = str(stage_enum)
+        self._stage_plugins.setdefault(key, []).append(plugin)
         self._names[plugin] = plugin_name
 
     def get_plugins_for_stage(self, stage: str) -> List[Any]:

--- a/src/entity/core/validation/__init__.py
+++ b/src/entity/core/validation/__init__.py
@@ -1,3 +1,10 @@
-from .input import PluginInputValidator, validate_params, sanitize_text
+from .input import PluginInputValidator, sanitize_text, validate_params
+from .plugin import verify_dependencies, verify_stage_assignment
 
-__all__ = ["PluginInputValidator", "validate_params", "sanitize_text"]
+__all__ = [
+    "PluginInputValidator",
+    "validate_params",
+    "sanitize_text",
+    "verify_stage_assignment",
+    "verify_dependencies",
+]

--- a/src/entity/core/validation/plugin.py
+++ b/src/entity/core/validation/plugin.py
@@ -1,0 +1,46 @@
+"""Runtime plugin validation helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from entity.pipeline.stages import PipelineStage
+from entity.pipeline.utils import StageResolver
+from entity.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def verify_stage_assignment(plugin: Any, stage: PipelineStage) -> None:
+    """Ensure ``stage`` is allowed for ``plugin``."""
+
+    stages, explicit = StageResolver._resolve_plugin_stages(
+        plugin.__class__, getattr(plugin, "config", {}), plugin, logger=logger
+    )
+    if not explicit:
+        raise ValueError(
+            f"Plugin '{plugin.__class__.__name__}' must declare stages explicitly"
+        )
+    if stage not in stages:
+        raise ValueError(
+            f"Plugin '{plugin.__class__.__name__}' cannot execute in {stage}."
+            f" Declared stages: {[s.name for s in stages]}"
+        )
+
+
+def verify_dependencies(plugin: Any, names: Iterable[str]) -> None:
+    """Ensure ``plugin`` dependencies exist within ``names``."""
+
+    plugin_name = getattr(plugin, "name", plugin.__class__.__name__)
+    for dep in getattr(plugin, "dependencies", []):
+        optional = str(dep).endswith("?")
+        dep_name = str(dep)[:-1] if optional else str(dep)
+        if dep_name == plugin_name:
+            raise ValueError(f"Plugin '{plugin_name}' cannot depend on itself")
+        if dep_name not in names and not optional:
+            available = ", ".join(sorted(names))
+            raise ValueError(
+                f"Plugin '{plugin_name}' requires '{dep_name}' but it's not registered. "
+                f"Available: {available}"
+            )


### PR DESCRIPTION
## Summary
- add plugin stage & dependency validators
- expose validators in core.validation
- call validators during plugin registration
- log update note

## Testing
- `poetry run ruff check --fix src/entity/core/validation/plugin.py src/entity/core/validation/__init__.py src/entity/core/registries.py`
- `poetry run mypy src/entity/core/validation/plugin.py src/entity/core/validation/__init__.py src/entity/core/registries.py`
- `poetry run bandit -r src/entity/core/validation/plugin.py src/entity/core/validation/__init__.py src/entity/core/registries.py`
- `poetry run vulture src/entity/core/validation/plugin.py src/entity/core/validation/__init__.py src/entity/core/registries.py` *(fails: Command not found)*
- `poetry run unimport --remove-all src/entity/core/validation/plugin.py src/entity/core/validation/__init__.py src/entity/core/registries.py` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: RuntimeWarning)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: RuntimeWarning)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: AttributeError)*
- `poetry run python -m src.entity.core.registry_validator --config config/prod.yaml` *(fails: AttributeError)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873d5f075b08322b4cdaac1dc291a9d