### PR TITLE
Implement tool intent filtering

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-25: ToolRegistry discovery now filters by intents
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -95,6 +95,8 @@ def tool(func=None, **hints):
             async def execute_function(self, params_dict):
                 return await f(**params_dict)
 
+        _WrappedTool.intents = list(hints.get("intents", []))
+
         asyncio.run(agent.builder.tool_registry.add(f.__name__, _WrappedTool({})))
         return f
 

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -332,6 +332,7 @@ class ToolPlugin(Plugin):
     """Utility plugin executed via ``tool_use`` calls."""
 
     stages = [PipelineStage.DO]
+    intents: list[str] = []
     required_params: List[str] = []
 
     async def execute_function(self, params: Dict[str, Any]) -> Any:

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Simplified plugin and resource registries."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List
@@ -68,11 +68,14 @@ class ToolRegistry:
             items = [(k, v) for k, v in items if n in k.lower()]
         if intent is not None:
             i = intent.lower()
-            items = [
-                (k, v)
-                for k, v in items
-                if any(i in t.lower() for t in getattr(v, "intents", []))
-            ]
+
+            def _match(tool: Any) -> bool:
+                declared = getattr(
+                    tool, "intents", getattr(tool.__class__, "intents", [])
+                )
+                return any(i == str(t).lower() for t in declared)
+
+            items = [(k, v) for k, v in items if _match(v)]
         return items
 
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,37 @@
+import pytest
+
+from entity.core.registries import ToolRegistry
+from entity.core.plugins import ToolPlugin
+from entity.core.stages import PipelineStage
+
+
+class AlphaTool(ToolPlugin):
+    stages = [PipelineStage.DO]
+    intents = ["calc"]
+
+    async def execute_function(self, params):
+        return "a"
+
+
+class BetaTool(ToolPlugin):
+    stages = [PipelineStage.DO]
+    intents = ["text"]
+
+    async def execute_function(self, params):
+        return "b"
+
+
+@pytest.mark.asyncio
+async def test_discover_tools_by_intent() -> None:
+    registry = ToolRegistry()
+    await registry.add("alpha", AlphaTool())
+    await registry.add("beta", BetaTool())
+
+    found = registry.discover(intent="calc")
+    assert len(found) == 1
+    assert found[0][0] == "alpha"
+    assert isinstance(found[0][1], AlphaTool)
+
+    found_ci = registry.discover(intent="CALC")
+    assert len(found_ci) == 1
+    assert found_ci[0][0] == "alpha"

--- a/user_plugins/tools/calculator_tool.py
+++ b/user_plugins/tools/calculator_tool.py
@@ -77,6 +77,7 @@ class CalculatorTool(ToolPlugin):
     """
 
     stages = [PipelineStage.DO]
+    intents = ["math"]
     _evaluator = SafeEvaluator()
 
     class Params(BaseModel):


### PR DESCRIPTION
## Summary
- track addition of ToolRegistry intent filtering in `agents.log`
- let `tool()` decorator store intents on generated tool classes
- default `ToolPlugin` to include an `intents` list
- ensure built-in CalculatorTool declares `intents`
- filter by declared intent in `ToolRegistry.discover`
- add unit test for discovery filtering

## Testing
- `poetry run ruff check --fix src/entity/__init__.py src/entity/core/plugins/base.py src/entity/core/registries.py user_plugins/tools/calculator_tool.py tests/test_tool_registry.py`
- `poetry run mypy src` *(fails: Function is missing a return type annotation)*
- `poetry run bandit -r src`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine 'EntityCLI._verify_plugins' was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine 'EntityCLI._verify_plugins' was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: the following arguments are required: --config)*
- `poetry run bash -c 'PYTHONPATH=src pytest tests/test_architecture/ -v'` *(fails: test_mismatched_class_layer)*
- `poetry run bash -c 'PYTHONPATH=src pytest tests/test_plugins/ -v'`
- `poetry run bash -c 'PYTHONPATH=src pytest tests/test_resources/ -v'`
- `poetry run bash -c 'PYTHONPATH=src pytest tests/test_tool_registry.py -v'`

------
https://chatgpt.com/codex/tasks/task_e_6873d5f033b88322bb1a086f6a5c5de4