### PR TITLE
Add plugin examples for INPUT/PARSE/REVIEW

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-25: Added plugin examples for INPUT, PARSE, and REVIEW stages
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -10,6 +10,7 @@ The pipeline implementation now lives under the ``entity.pipeline`` package. Imp
 error_handling
 logging
 configuration
+plugin_examples
 ```
 
 The following pages cover core concepts and usage patterns.

--- a/docs/source/plugin_examples.md
+++ b/docs/source/plugin_examples.md
@@ -1,0 +1,55 @@
+# Plugin Examples
+
+The `examples/plugins/` directory contains minimal plugins for each pipeline stage.
+These demonstrate how to interact with the `PluginContext` and which methods
+are appropriate for different stages.
+
+## InputLogger
+
+`InputLogger` runs during the **INPUT** stage and saves the raw user message for
+later steps.
+
+```python
+from examples.plugins.input_logger import InputLogger
+```
+
+```python
+class InputLogger(InputAdapterPlugin):
+    stages = [PipelineStage.INPUT]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        message = context.conversation()[-1].content if context.conversation() else ""
+        await context.think("raw_input", message)
+```
+
+## MessageParser
+
+`MessageParser` executes in the **PARSE** stage and normalizes the user's
+message.
+
+```python
+class MessageParser(PromptPlugin):
+    stages = [PipelineStage.PARSE]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        raw = context.conversation()[-1].content if context.conversation() else ""
+        await context.think("parsed_input", raw.strip().lower())
+```
+
+## ResponseReviewer
+
+`ResponseReviewer` runs in the **REVIEW** stage to modify the final response if
+needed.
+
+```python
+class ResponseReviewer(PromptPlugin):
+    stages = [PipelineStage.REVIEW]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        if not context.has_response():
+            return
+        updated = context.response.replace("badword", "***")
+        context.update_response(lambda _old: updated)
+```
+
+These examples can be imported and registered in a workflow for quick testing.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,7 @@ Each subdirectory contains a small agent showcasing different features.
 
 - **kitchen_sink** – demonstrates a ReAct loop with tool usage.
 - **zero_config_agent** – uses `@agent.tool` and `@agent.output` decorators.
+- **plugins** – minimal plugins for INPUT, PARSE, and REVIEW stages.
 
 Run any example with:
 

--- a/examples/plugins/__init__.py
+++ b/examples/plugins/__init__.py
@@ -1,0 +1,7 @@
+"""Simple plugins illustrating different stages."""
+
+from .input_logger import InputLogger
+from .message_parser import MessageParser
+from .response_reviewer import ResponseReviewer
+
+__all__ = ["InputLogger", "MessageParser", "ResponseReviewer"]

--- a/examples/plugins/input_logger.py
+++ b/examples/plugins/input_logger.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from entity.core.context import PluginContext
+from entity.core.plugins import InputAdapterPlugin
+from entity.core.stages import PipelineStage
+
+
+class InputLogger(InputAdapterPlugin):
+    """Record the raw user message."""
+
+    stages = [PipelineStage.INPUT]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        message = context.conversation()[-1].content if context.conversation() else ""
+        await context.think("raw_input", message)

--- a/examples/plugins/message_parser.py
+++ b/examples/plugins/message_parser.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from entity.core.context import PluginContext
+from entity.core.plugins import PromptPlugin
+from entity.core.stages import PipelineStage
+
+
+class MessageParser(PromptPlugin):
+    """Normalize user input for later stages."""
+
+    stages = [PipelineStage.PARSE]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        raw = context.conversation()[-1].content if context.conversation() else ""
+        await context.think("parsed_input", raw.strip().lower())

--- a/examples/plugins/response_reviewer.py
+++ b/examples/plugins/response_reviewer.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from entity.core.context import PluginContext
+from entity.core.plugins import PromptPlugin
+from entity.core.stages import PipelineStage
+
+
+class ResponseReviewer(PromptPlugin):
+    """Sanitize the final response before delivery."""
+
+    stages = [PipelineStage.REVIEW]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        if not context.has_response():
+            return
+        updated = context.response.replace("badword", "***")
+        context.update_response(lambda _old: updated)


### PR DESCRIPTION
## Summary
- create simple example plugins for INPUT, PARSE and REVIEW stages
- document these examples in a new `plugin_examples` page
- reference plugin examples from docs index and examples README
- record note about the new examples

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 163 errors)*
- `poetry run mypy src` *(fails: found 285 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_6873d5eee34483228bab20777aefc5ac