### PR TITLE
Validate workflow plugins at init

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-24: Pipeline now validates workflow plugins during initialization
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/pipeline/workflow.py
+++ b/src/entity/pipeline/workflow.py
@@ -31,9 +31,21 @@ class Pipeline:
     builder: "_AgentBuilder" = field(default_factory=_builder_factory)
     workflow: Optional[Union[Workflow, WorkflowMapping]] = None
 
+    def __post_init__(self) -> None:
+        """Validate workflow plugins using the builder's registry."""
+        if self.workflow is None:
+            return
+
+        wf_obj = (
+            self.workflow
+            if isinstance(self.workflow, Workflow)
+            else Workflow.from_dict(self.workflow)
+        )
+        wf_obj.validate_plugins(self.builder.plugin_registry)
+        self.workflow = wf_obj
+
     async def build_runtime(self) -> AgentRuntime:
         """Build an AgentRuntime using the stored builder and workflow."""
-
         wf_obj = (
             self.workflow
             if isinstance(self.workflow, Workflow)
@@ -41,10 +53,4 @@ class Pipeline:
                 Workflow.from_dict(self.workflow) if self.workflow is not None else None
             )
         )
-        if wf_obj is not None:
-            for stage, names in wf_obj.stage_map.items():
-                for name in names:
-                    if not self.builder.has_plugin(name):
-                        raise KeyError(f"Plugin '{name}' not found")
-
         return await self.builder.build_runtime(workflow=wf_obj)

--- a/tests/workflow/test_pipeline_validation.py
+++ b/tests/workflow/test_pipeline_validation.py
@@ -1,0 +1,23 @@
+import pytest
+
+from entity.core.plugins import Plugin
+from entity.core.agent import _AgentBuilder
+from entity.pipeline.stages import PipelineStage
+from entity.pipeline.workflow import Pipeline
+
+
+class EchoPlugin(Plugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context):
+        context.say("ok")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_raises_on_unknown_plugin():
+    builder = _AgentBuilder()
+    await builder.add_plugin(EchoPlugin({}))
+
+    mapping = {PipelineStage.OUTPUT: ["EchoPlugin", "MissingPlugin"]}
+    with pytest.raises(KeyError, match="MissingPlugin"):
+        Pipeline(builder=builder, workflow=mapping)


### PR DESCRIPTION
## Summary
- validate workflow plugins when creating a `Pipeline`
- add unit test covering validation failure

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(failed: AttributeError)*
- `poetry run python -m src.entity.core.registry_validator --config config/prod.yaml` *(failed: AttributeError)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/workflow/test_pipeline_validation.py -v` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873d5ec681c8322895126ddae9bc35a