### PR TITLE
Add workflow param to Agent

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Agent constructor now accepts optional workflow parameter and workflow validation added
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test


### PR DESCRIPTION
## Summary
- support passing Workflow directly to Agent
- validate workflow plugin names
- keep a list of plugin names in `_AgentBuilder`
- note the change

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src/entity/core/agent.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run pytest tests/test_architecture/ -v` *(fails: one test failed)*
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6873d5eb1e9c8322aafb62788257d344