### PR TITLE
Fix pipeline thought clearing

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Stage results cleared after pipeline completion and tests added for thought accumulation
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -276,7 +276,11 @@ class PluginContext:
         return self._state.stage_results.get(key, default)
 
     async def clear_thoughts(self) -> None:
-        """Remove all stored stage results."""
+        """Remove all stored stage results.
+
+        This is invoked automatically at the end of a pipeline run so that
+        interim reasoning does not leak between user messages.
+        """
         self._state.stage_results.clear()
 
     # ------------------------------------------------------------------

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -275,7 +275,6 @@ async def execute_pipeline(
             ],
             pipeline_id=f"{user_id}_{generate_pipeline_id()}",
         )
-        state.stage_results.clear()
     _start = time.time()
     resource_manager = (
         capabilities.resources
@@ -371,6 +370,8 @@ async def execute_pipeline(
             result = create_default_response("No response generated", state.pipeline_id)
         else:
             result = state.response
+
+        state.stage_results.clear()
         return result
 
 

--- a/tests/test_thought_persistence.py
+++ b/tests/test_thought_persistence.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+import pytest
+
+from entity.core.plugins import Plugin
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.pipeline.stages import PipelineStage
+from entity.pipeline.state import PipelineState, ConversationEntry
+from entity.pipeline.pipeline import execute_pipeline
+
+
+class Counter(Plugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context) -> None:
+        count = await context.reflect("count", 0)
+        await context.think("count", count + 1)
+
+
+class TerminateOnThree(Plugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context) -> None:
+        count = await context.reflect("count", 0)
+        if count >= 3:
+            context.say(str(count))
+
+
+@pytest.mark.asyncio
+async def test_thoughts_accumulate_across_iterations() -> None:
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(Counter({}), PipelineStage.THINK)
+    await plugins.register_plugin_for_stage(TerminateOnThree({}), PipelineStage.OUTPUT)
+    regs = SystemRegistries(resources={}, tools=ToolRegistry(), plugins=plugins)
+    state = PipelineState(
+        conversation=[ConversationEntry("hi", "user", datetime.now())],
+        pipeline_id="pid",
+    )
+    result = await execute_pipeline(
+        "hi", regs, state=state, workflow=None, max_iterations=5
+    )
+    assert result == "3"
+    assert state.iteration == 3
+
+
+@pytest.mark.asyncio
+async def test_thoughts_reset_after_run() -> None:
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(Counter({}), PipelineStage.THINK)
+    await plugins.register_plugin_for_stage(TerminateOnThree({}), PipelineStage.OUTPUT)
+    regs = SystemRegistries(resources={}, tools=ToolRegistry(), plugins=plugins)
+    state = PipelineState(
+        conversation=[ConversationEntry("hi", "user", datetime.now())],
+        pipeline_id="pid",
+    )
+    await execute_pipeline("hi", regs, state=state, workflow=None, max_iterations=5)
+    assert state.stage_results == {}
+
+    state.conversation.append(ConversationEntry("again", "user", datetime.now()))
+    state.response = None
+    state.failure_info = None
+    state.iteration = 0
+    state.last_completed_stage = None
+
+    result = await execute_pipeline(
+        "", regs, state=state, workflow=None, max_iterations=5
+    )
+    assert result == "3"
+    assert state.iteration == 3


### PR DESCRIPTION
## Summary
- reset stage results only after a pipeline run finishes
- clarify usage in `clear_thoughts`
- test that thoughts accumulate across iterations and reset for the next message

## Testing
- `poetry install --with dev`
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402, SyntaxError, F821 ...)*
- `poetry run mypy src` *(fails: Found 285 errors in 54 files)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found: vulture)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found: unimport)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `poetry run pytest tests/test_architecture/ -v` *(fails: test_mismatched_class_layer DID NOT RAISE)*
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`
- `poetry run pytest tests/test_thought_persistence.py -v`


------
https://chatgpt.com/codex/tasks/task_e_6873d5e5c4048322bce583236aae4d5c