### PR TITLE
Fix stage result reset logic

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Adjust stage result clearing to persist across iterations but reset between messages
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -247,7 +247,7 @@ async def execute_stage(
         if state.failure_info and stage != PipelineStage.ERROR:
             await execute_stage(PipelineStage.ERROR, state, registries, user_id=user_id)
             state.last_completed_stage = PipelineStage.ERROR
-    elapsed = time.perf_counter() - _start
+    _elapsed = time.perf_counter() - _start
     # elapsed time could be logged here if needed
 
 
@@ -275,7 +275,9 @@ async def execute_pipeline(
             ],
             pipeline_id=f"{user_id}_{generate_pipeline_id()}",
         )
-        state.stage_results.clear()
+    # Clear stage results at the start of each message so that
+    # thoughts from previous executions do not leak into the next one.
+    state.stage_results.clear()
     _start = time.time()
     resource_manager = (
         capabilities.resources

--- a/tests/test_iterative_results.py
+++ b/tests/test_iterative_results.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+import pytest
+
+from entity.core.plugins import Plugin
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.state import ConversationEntry
+from entity.pipeline.pipeline import execute_pipeline
+from entity.pipeline.state import PipelineState
+from entity.pipeline.stages import PipelineStage
+
+
+class StoreOnce(Plugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        if context._state.iteration == 1:
+            await context.think("msg", context.conversation()[-1].content)
+
+
+class DelayedEcho(Plugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context):
+        if context._state.iteration < 2:
+            return
+        msg = await context.reflect("msg")
+        context.say(msg)
+
+
+@pytest.mark.asyncio
+async def test_stage_results_persist_between_iterations():
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(StoreOnce({}), PipelineStage.THINK, "store")
+    await plugins.register_plugin_for_stage(
+        DelayedEcho({}), PipelineStage.OUTPUT, "echo"
+    )
+    regs = SystemRegistries(resources={}, tools=ToolRegistry(), plugins=plugins)
+    state = PipelineState(
+        conversation=[ConversationEntry("hi", "user", datetime.now())],
+        pipeline_id="test",
+    )
+    result = await execute_pipeline(
+        "hi", regs, state=state, max_iterations=3, workflow=None
+    )
+    assert result == "hi"
+    assert state.iteration == 2


### PR DESCRIPTION
## Summary
- clear stage results once per message instead of per iteration
- ensure elapsed timing variable isn't reported as unused
- add regression test for iterative stage results
- log update in agents.log

## Testing
- `poetry run ruff check --fix src/entity/pipeline/pipeline.py tests/test_iterative_results.py`
- `poetry run mypy src` *(fails: Function is missing a return type annotation, etc.)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing required arguments)*
- `poetry run pytest tests/test_architecture/ -v` *(failed: test_mismatched_class_layer)*
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`
- `poetry run pytest tests/test_iterative_results.py -v`


------
https://chatgpt.com/codex/tasks/task_e_6873d5e45d748322abc5cd553762a007