### PR TITLE
Add plugin capabilities tracking

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-24: Added plugin capabilities and compatibility matrix with pipeline benchmarks
+
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/core/compatibility.py
+++ b/src/entity/core/compatibility.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Simple version compatibility matrix."""
+
+from typing import Dict, List
+
+# Map current version -> list of supported upgrade targets
+COMPATIBILITY_MATRIX: Dict[str, List[str]] = {
+    "0.0.1": ["0.0.1"],
+}
+
+
+def register_compatibility(current: str, targets: List[str]) -> None:
+    """Register upgrade paths for ``current`` version."""
+    COMPATIBILITY_MATRIX[current] = targets
+
+
+def is_upgrade_supported(current: str, target: str) -> bool:
+    """Return ``True`` if ``current`` can upgrade to ``target``."""
+    return target in COMPATIBILITY_MATRIX.get(current, [])
+
+
+__all__ = ["COMPATIBILITY_MATRIX", "register_compatibility", "is_upgrade_supported"]

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -6,12 +6,21 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List
 
 
+@dataclass
+class PluginCapabilities:
+    """Describe a plugin's declared capabilities."""
+
+    supported_stages: list[str]
+    required_resources: list[str]
+
+
 class PluginRegistry:
-    """Register plugins for each pipeline stage."""
+    """Register plugins for each pipeline stage and track capabilities."""
 
     def __init__(self) -> None:
         self._stage_plugins: Dict[str, List[Any]] = {}
         self._names: Dict[Any, str] = {}
+        self._capabilities: Dict[Any, PluginCapabilities] = {}
 
     async def register_plugin_for_stage(
         self, plugin: Any, stage: str, name: str | None = None
@@ -19,6 +28,33 @@ class PluginRegistry:
         plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
         self._stage_plugins.setdefault(stage, []).append(plugin)
         self._names[plugin] = plugin_name
+        caps = self._capabilities.get(plugin)
+        if caps is None:
+            deps = list(getattr(plugin, "dependencies", []))
+            caps = PluginCapabilities([], deps)
+            self._capabilities[plugin] = caps
+        if stage not in caps.supported_stages:
+            caps.supported_stages.append(stage)
+
+    async def declare_capabilities(
+        self,
+        plugin: Any,
+        *,
+        stages: list[str] | None = None,
+        required_resources: list[str] | None = None,
+    ) -> None:
+        caps = self._capabilities.setdefault(
+            plugin,
+            PluginCapabilities([], list(getattr(plugin, "dependencies", []))),
+        )
+        if stages is not None:
+            for st in stages:
+                if st not in caps.supported_stages:
+                    caps.supported_stages.append(st)
+        if required_resources is not None:
+            for dep in required_resources:
+                if dep not in caps.required_resources:
+                    caps.required_resources.append(dep)
 
     def get_plugins_for_stage(self, stage: str) -> List[Any]:
         return list(self._stage_plugins.get(stage, []))
@@ -39,6 +75,9 @@ class PluginRegistry:
         for plist in self._stage_plugins.values():
             plugins.extend(plist)
         return plugins
+
+    def get_capabilities(self, plugin: Any) -> PluginCapabilities | None:
+        return self._capabilities.get(plugin)
 
     def get_plugin_name(self, plugin: Any) -> str:
         name = self._names.get(plugin)
@@ -82,3 +121,6 @@ class SystemRegistries:
     tools: ToolRegistry
     plugins: PluginRegistry
     validators: Any | None = None
+
+
+__all__ = ["PluginCapabilities", "PluginRegistry", "ToolRegistry", "SystemRegistries"]

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -349,6 +349,12 @@ async def execute_pipeline(
 
                 state.last_completed_stage = None
 
+        metrics = (
+            capabilities.resources.get("metrics_collector")
+            if capabilities.resources
+            else None
+        )
+
         if state.failure_info:
             try:
                 if state.last_completed_stage != PipelineStage.ERROR:
@@ -371,6 +377,13 @@ async def execute_pipeline(
             result = create_default_response("No response generated", state.pipeline_id)
         else:
             result = state.response
+        elapsed_ms = (time.time() - _start) * 1000
+        if metrics is not None:
+            await metrics.record_custom_metric(
+                pipeline_id=state.pipeline_id,
+                metric_name="pipeline_duration_ms",
+                value=elapsed_ms,
+            )
         return result
 
 

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -142,3 +142,4 @@ async def test_performance_metrics(registries: SystemRegistries) -> None:
     metrics = registries.metrics
     assert len(metrics.plugin_executions) == 3
     assert elapsed > 0
+    assert any(m.metric_name == "pipeline_duration_ms" for m in metrics.custom_metrics)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,10 @@
+from entity.core.compatibility import (
+    register_compatibility,
+    is_upgrade_supported,
+)
+
+
+def test_upgrade_matrix() -> None:
+    register_compatibility("0.0.1", ["0.0.2"])
+    assert is_upgrade_supported("0.0.1", "0.0.2")
+    assert not is_upgrade_supported("0.0.1", "1.0.0")

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -1,0 +1,25 @@
+import pytest
+
+from entity.core.registries import PluginRegistry
+from entity.core.plugins import Plugin
+from entity.core.stages import PipelineStage
+
+
+class _CapPlugin(Plugin):
+    stages = [PipelineStage.THINK]
+    dependencies = ["memory", "llm"]
+
+    async def _execute_impl(self, context):  # pragma: no cover - stub
+        return None
+
+
+@pytest.mark.asyncio
+async def test_registry_tracks_capabilities() -> None:
+    registry = PluginRegistry()
+    plugin = _CapPlugin({})
+    await registry.register_plugin_for_stage(plugin, str(PipelineStage.THINK))
+    caps = registry.get_capabilities(plugin)
+    assert caps is not None
+    assert str(PipelineStage.THINK) in caps.supported_stages
+    assert "memory" in caps.required_resources
+    assert "llm" in caps.required_resources


### PR DESCRIPTION
## Summary
- track plugin capabilities in the registry
- maintain a version compatibility matrix
- record pipeline execution time with the metrics collector
- test capability tracking and compatibility matrix
- check pipeline duration metric in integration test

## Testing
- `poetry run black src/entity/core/registries.py src/entity/pipeline/pipeline.py src/entity/core/compatibility.py tests/test_compatibility.py tests/test_plugin_capabilities.py tests/integration/test_full_pipeline.py`
- `poetry run ruff check --fix src tests` *(fails: many existing violations)*
- `poetry run mypy src` *(fails: many errors)*
- `bandit -r src` *(command failed or produced no output)*
- `vulture src tests` *(command not found)*
- `unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*
- `poetry run pytest tests/test_plugin_capabilities.py tests/test_compatibility.py tests/integration/test_full_pipeline.py::test_performance_metrics -v`

------
https://chatgpt.com/codex/tasks/task_e_6873d5f8e2a48322a2c9f346f1273922