### PR TITLE
Add adaptive resource pool with health checks

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-25: Extended ResourcePool with scaling and health checks
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/resources/interfaces/vector_store.py
+++ b/src/entity/resources/interfaces/vector_store.py
@@ -18,7 +18,10 @@ class VectorStoreResource(ResourcePlugin):
 
     async def initialize(self) -> None:
         pool_cfg = PoolConfig(**self.config.get("pool", {}))
-        self._pool = ResourcePool(self._create_client, pool_cfg)
+        self._pool = ResourcePool(self._create_client, pool_cfg, "vector_store")
+        metrics = getattr(self, "metrics_collector", None)
+        if metrics is not None:
+            self._pool.set_metrics_collector(metrics)
         await self._pool.initialize()
 
     async def _create_client(self) -> "VectorStoreResource":

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -28,7 +28,10 @@ class LLM(AgentResource):
         if self.provider is None:
             return
         pool_cfg = PoolConfig(**self.config.get("pool", {}))
-        self._pool = ResourcePool(self._create_provider, pool_cfg)
+        self._pool = ResourcePool(self._create_provider, pool_cfg, "llm_provider")
+        metrics = getattr(self, "metrics_collector", None)
+        if metrics is not None:
+            self._pool.set_metrics_collector(metrics)
         await self._pool.initialize()
 
     async def _create_provider(self) -> LLMResource:

--- a/tests/test_llm_pool.py
+++ b/tests/test_llm_pool.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import asyncio
 import sys
 import types
@@ -11,6 +12,7 @@ sys.modules.setdefault(
 from entity.core.resources.container import ResourceContainer
 from entity.resources.llm import LLM
 from entity.resources.interfaces.llm import LLMResource
+from entity.resources.metrics import MetricsCollectorResource
 
 
 class DummyProvider(LLMResource):
@@ -39,3 +41,54 @@ async def test_llm_pool_metrics():
     metrics = container.get_metrics()
     assert metrics["llm"]["total_size"] >= 1
     assert len(provider.calls) == 3
+
+
+class UnstableProvider(LLMResource):
+    def __init__(self) -> None:
+        super().__init__({})
+        self.healthy = True
+
+    async def generate(self, prompt: str):
+        return prompt
+
+    async def health_check(self) -> bool:
+        return self.healthy
+
+    async def restart(self) -> None:
+        self.healthy = True
+
+
+@pytest.mark.asyncio
+async def test_pool_recovers_unhealthy_resource():
+    provider = UnstableProvider()
+    metrics = MetricsCollectorResource({})
+    llm = LLM({"pool": {"min_size": 1, "max_size": 2}})
+    llm.provider = provider
+    llm.metrics_collector = metrics
+    await llm.initialize()
+
+    async with llm.get_client_pool() as _:
+        provider.healthy = False
+
+    async with llm.get_client_pool() as _:
+        pass
+
+    assert provider.healthy
+
+
+@pytest.mark.asyncio
+async def test_pool_scales_with_load():
+    provider = DummyProvider()
+    metrics = MetricsCollectorResource({})
+    llm = LLM({"pool": {"min_size": 1, "max_size": 3, "scale_threshold": 0.5}})
+    llm.provider = provider
+    llm.metrics_collector = metrics
+    await llm.initialize()
+
+    async def call(i: int) -> None:
+        await llm.generate(str(i))
+
+    await asyncio.gather(*(call(i) for i in range(4)))
+
+    pool_metrics = llm.get_pool_metrics()
+    assert pool_metrics["total_size"] > 1


### PR DESCRIPTION
## Summary
- adjust `ResourcePool` capacity using recent utilization
- auto-recover unhealthy pool resources
- track pool metrics via `MetricsCollector`
- hook metrics into LLM, vector store, and DuckDB infrastructure
- test dynamic scaling and recovery

## Testing
- `poetry run pytest tests/test_llm_pool.py::test_llm_pool_metrics -q`
- `poetry run pytest tests/test_llm_pool.py::test_pool_recovers_unhealthy_resource -q`
- `poetry run pytest tests/test_llm_pool.py::test_pool_scales_with_load -q`
- `poetry run ruff check --fix src/entity/core/resources/container.py src/entity/infrastructure/duckdb.py src/entity/resources/interfaces/vector_store.py src/entity/resources/llm.py tests/test_llm_pool.py`
- `poetry run mypy src/entity/core/resources/container.py src/entity/resources/llm.py src/entity/resources/interfaces/vector_store.py src/entity/infrastructure/duckdb.py` *(fails: 12 errors in 1 file)*
- `poetry run bandit -r src` *(fails: command not found)*
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: usage error)*
- `poetry run pytest tests/test_architecture/ -v` *(failed: 1 failed, 3 passed)*
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/resources/ -v` *(failed: 1 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6873d5f2303883229ee813a7a5999592