### PR TITLE
Add BasicErrorHandler and tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added BasicErrorHandler plugin for error handling in zero config
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -8,6 +8,7 @@ from .resources import LLM, Memory, Storage
 from plugins.builtin.resources.ollama_llm import OllamaLLMResource
 from .core.stages import PipelineStage
 from .core.plugins import PromptPlugin, ToolPlugin
+from .plugins.prompts.basic_error_handler import BasicErrorHandler
 from .utils.setup_manager import Layer0SetupManager
 from entity.core.registries import SystemRegistries
 from entity.core.runtime import AgentRuntime
@@ -52,6 +53,7 @@ def _create_default_agent() -> Agent:
         tools=builder.tool_registry,
         plugins=builder.plugin_registry,
     )
+    asyncio.run(builder.add_plugin(BasicErrorHandler({})))
     agent._runtime = AgentRuntime(caps)
     return agent
 

--- a/src/entity/plugins/prompts/__init__.py
+++ b/src/entity/plugins/prompts/__init__.py
@@ -2,5 +2,6 @@
 
 from .chain_of_thought import ChainOfThoughtPrompt
 from .react import ReActPrompt
+from .basic_error_handler import BasicErrorHandler
 
-__all__ = ["ChainOfThoughtPrompt", "ReActPrompt"]
+__all__ = ["ChainOfThoughtPrompt", "ReActPrompt", "BasicErrorHandler"]

--- a/src/entity/plugins/prompts/basic_error_handler.py
+++ b/src/entity/plugins/prompts/basic_error_handler.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.context import PluginContext
+from ...core.plugins import FailurePlugin
+from ...core.stages import PipelineStage
+
+
+class BasicErrorHandler(FailurePlugin):
+    """Log failure information and generate a fallback message."""
+
+    dependencies = ["logging"]
+    stages = [PipelineStage.ERROR]
+
+    async def _execute_impl(self, context: PluginContext) -> Any:
+        logging_res = context.get_resource("logging")
+        info = context.failure_info
+        if info is None:
+            if logging_res is not None:
+                await logging_res.log(
+                    "error",
+                    "pipeline failure",
+                    component="pipeline",
+                    user_id=context.user_id,
+                    pipeline_id=context.pipeline_id,
+                    stage=str(context.current_stage),
+                )
+            message = {
+                "error": "System error occurred",
+                "message": "An unexpected error prevented processing your request.",
+                "error_id": context.pipeline_id,
+                "type": "static_fallback",
+            }
+        else:
+            if logging_res is not None:
+                await logging_res.log(
+                    "error",
+                    "plugin failure",
+                    component="pipeline",
+                    user_id=context.user_id,
+                    pipeline_id=context.pipeline_id,
+                    stage=info.stage,
+                    plugin_name=info.plugin_name,
+                    error_type=info.error_type,
+                    error=info.error_message,
+                )
+            message = {
+                "error": info.error_message,
+                "message": "Unable to process request",
+                "error_id": context.pipeline_id,
+                "plugin": info.plugin_name,
+                "stage": info.stage,
+                "type": "plugin_error",
+            }
+        context._state.response = message

--- a/src/entity/plugins/prompts/chain_of_thought.py
+++ b/src/entity/plugins/prompts/chain_of_thought.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import List
 
-from ..core.context import ConversationEntry, PluginContext
-from ..core.plugins import PromptPlugin
-from ..core.stages import PipelineStage
+from ...core.context import ConversationEntry, PluginContext
+from ...core.plugins import PromptPlugin
+from ...core.stages import PipelineStage
 
 
 class ChainOfThoughtPrompt(PromptPlugin):

--- a/src/entity/plugins/prompts/react.py
+++ b/src/entity/plugins/prompts/react.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple
 
-from ..core.context import ConversationEntry, PluginContext
-from ..core.plugins import PromptPlugin
-from ..core.stages import PipelineStage
+from ...core.context import ConversationEntry, PluginContext
+from ...core.plugins import PromptPlugin
+from ...core.stages import PipelineStage
 
 
 class ReActPrompt(PromptPlugin):

--- a/tests/integration/test_basic_error_handler.py
+++ b/tests/integration/test_basic_error_handler.py
@@ -1,0 +1,54 @@
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from entity.core.plugins import Plugin
+from entity.core.context import PluginContext
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.state import ConversationEntry
+from entity.pipeline.state import PipelineState
+from entity.pipeline.pipeline import execute_pipeline
+from entity.pipeline.stages import PipelineStage
+from entity.resources.logging import LoggingResource
+from entity.plugins.prompts.basic_error_handler import BasicErrorHandler
+
+
+class FailPlugin(Plugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_basic_error_handler(monkeypatch):
+    logs = []
+
+    async def fake_log(self, level, message, **kwargs):
+        logs.append((level, message, kwargs))
+
+    monkeypatch.setattr(LoggingResource, "log", fake_log)
+
+    plugins = PluginRegistry()
+    await plugins.register_plugin_for_stage(FailPlugin({}), PipelineStage.THINK, "fail")
+    await plugins.register_plugin_for_stage(
+        BasicErrorHandler({}), PipelineStage.ERROR, "handler"
+    )
+
+    logging_res = LoggingResource({})
+    await logging_res.initialize()
+
+    regs = SystemRegistries(
+        resources={"logging": logging_res}, tools=ToolRegistry(), plugins=plugins
+    )
+    state = PipelineState(
+        conversation=[ConversationEntry("hi", "user", datetime.now())],
+        pipeline_id="pid",
+    )
+
+    result = await execute_pipeline("hi", regs, state=state)
+
+    assert result["error"] == "boom"
+    assert result["stage"] == "think"
+    assert logs


### PR DESCRIPTION
## Summary
- implement `BasicErrorHandler` failure plugin that logs errors and returns a standard fallback
- expose the plugin via prompts package and register it in the zero‑config setup
- fix relative imports in built-in prompt plugins
- test error-stage execution of the new plugin
- record the change in `agents.log`

## Testing
- `poetry run pytest tests/integration/test_basic_error_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873d5ee34a08322901c0dec5c8c2565