### PR TITLE
Add logging injection

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added automatic logging resource injection and tests
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -289,6 +289,19 @@ class SystemInitializer:
         """Metrics collector is optional; do nothing by default."""
         return
 
+    def _assign_shared_resources(
+        self, instance: Any, resource_container: "ResourceContainer"
+    ) -> None:
+        """Attach metrics and logging resources to ``instance`` if available."""
+
+        metrics = resource_container.get("metrics_collector")
+        if metrics is not None:
+            setattr(instance, "metrics_collector", metrics)
+
+        logger_res = resource_container.get("logging")
+        if logger_res is not None:
+            setattr(instance, "logging", logger_res)
+
     def _validate_plugin_attributes(
         self, name: str, cls: type[Plugin], section: str, cfg: Dict
     ) -> None:
@@ -722,12 +735,7 @@ class SystemInitializer:
             self.tool_registry = tool_registry
             for name, cls, config in registry.named_tool_classes():
                 instance = cls(config)
-                metrics = resource_container.get("metrics_collector")
-                if metrics is not None:
-                    setattr(instance, "metrics_collector", metrics)
-                log_res = resource_container.get("logging")
-                if log_res is not None:
-                    setattr(instance, "logging", log_res)
+                self._assign_shared_resources(instance, resource_container)
                 await tool_registry.add(name, instance)
 
             # Phase 4: instantiate prompt and adapter plugins
@@ -735,12 +743,7 @@ class SystemInitializer:
             self.plugin_registry = plugin_registry
             for cls, config in registry.non_resource_non_tool_classes():
                 instance = cls(config)
-                metrics = resource_container.get("metrics_collector")
-                if metrics is not None:
-                    setattr(instance, "metrics_collector", metrics)
-                log_res = resource_container.get("logging")
-                if log_res is not None:
-                    setattr(instance, "logging", log_res)
+                self._assign_shared_resources(instance, resource_container)
                 stages, _ = StageResolver._resolve_plugin_stages(
                     cls, config, instance, logger=logger
                 )

--- a/tests/test_logging_injection.py
+++ b/tests/test_logging_injection.py
@@ -1,0 +1,33 @@
+import pytest
+
+from entity.pipeline.initializer import SystemInitializer
+from entity.resources.logging import LoggingResource
+from entity.core.plugins import PromptPlugin
+from entity.core.context import PluginContext
+from entity.core.resources.container import ResourceContainer
+from entity.core.stages import PipelineStage
+
+
+class DummyPrompt(PromptPlugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> str:
+        return "ok"
+
+
+DummyPrompt.dependencies = []
+
+
+@pytest.mark.asyncio
+async def test_assign_shared_logging():
+    container = ResourceContainer()
+    LoggingResource.dependencies = []
+    container.register("logging", LoggingResource, {}, layer=3)
+    await container.build_all()
+
+    init = SystemInitializer({"plugins": {}, "workflow": {}})
+    plugin = DummyPrompt({})
+    init._assign_shared_resources(plugin, container)
+
+    assert plugin.logging is not None
+    await container.shutdown_all()


### PR DESCRIPTION
## Summary
- inject logging resource alongside metrics collector for each plugin
- test logging resource injection
- note logging support in agents log

## Testing
- `poetry run ruff check --fix src tests` *(fails: E402 etc.)*
- `poetry run mypy src` *(fails: 285 errors)*
- `poetry run bandit -r src` *(fails: Command not found)*
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run pytest tests/test_architecture/ -v` *(fails: DID NOT RAISE InitializationError)*
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`
- `poetry run pytest tests/test_logging_injection.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6873d5e98af083228e47887d36376823