### PR TITLE
Implement plugin lifecycle state tracking

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Implemented plugin lifecycle state tracking and metrics logging
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -62,6 +62,8 @@ class BasePlugin:
         self.config_version: int = 1
         self.metrics_collector = None  # injected by container
         self.logging = None  # injected by container
+        self.is_initialized: bool = False
+        self.is_shutdown: bool = False
 
     # -----------------------------------------------------
     def supports_runtime_reconfiguration(self) -> bool:
@@ -161,12 +163,66 @@ class Plugin(BasePlugin):
     async def initialize(self) -> None:
         """Optional startup hook for plugins."""
 
-        return None
+        if self.is_initialized and not self.is_shutdown:
+            return
+
+        start = time.perf_counter()
+        self.is_initialized = True
+        self.is_shutdown = False
+
+        logger = getattr(self, "logging", None)
+        if logger is not None:
+            await logger.log(
+                "info",
+                "Plugin initialized",
+                component="plugin",
+                plugin_name=self.__class__.__name__,
+                pipeline_id="system",
+            )
+
+        duration = (time.perf_counter() - start) * 1000
+        metrics = getattr(self, "metrics_collector", None)
+        if metrics is not None:
+            await metrics.record_resource_operation(
+                pipeline_id="system",
+                resource_name=self.__class__.__name__,
+                operation="initialize",
+                duration_ms=duration,
+                success=True,
+                metadata={},
+            )
 
     async def shutdown(self) -> None:
         """Optional shutdown hook for plugins."""
 
-        return None
+        if self.is_shutdown:
+            return
+
+        start = time.perf_counter()
+        self.is_initialized = False
+        self.is_shutdown = True
+
+        logger = getattr(self, "logging", None)
+        if logger is not None:
+            await logger.log(
+                "info",
+                "Plugin shutdown",
+                component="plugin",
+                plugin_name=self.__class__.__name__,
+                pipeline_id="system",
+            )
+
+        duration = (time.perf_counter() - start) * 1000
+        metrics = getattr(self, "metrics_collector", None)
+        if metrics is not None:
+            await metrics.record_resource_operation(
+                pipeline_id="system",
+                resource_name=self.__class__.__name__,
+                operation="shutdown",
+                duration_ms=duration,
+                success=True,
+                metadata={},
+            )
 
     async def _handle_reconfiguration(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
@@ -248,6 +304,26 @@ class ResourcePlugin(Plugin):
     infrastructure_dependencies: List[str] = []
     resource_category: str = ""
     stages: List[PipelineStage] = []
+
+    async def initialize(self) -> None:
+        if self.is_initialized and not self.is_shutdown:
+            return
+
+        async def _init() -> None:
+            self.is_initialized = True
+            self.is_shutdown = False
+
+        await self._track_operation(operation="initialize", func=_init)
+
+    async def shutdown(self) -> None:
+        if self.is_shutdown:
+            return
+
+        async def _shut() -> None:
+            self.is_initialized = False
+            self.is_shutdown = True
+
+        await self._track_operation(operation="shutdown", func=_shut)
 
     async def _track_operation(
         self,

--- a/tests/test_plugins/test_plugin_lifecycle.py
+++ b/tests/test_plugins/test_plugin_lifecycle.py
@@ -1,0 +1,47 @@
+import pytest
+
+from entity.core.plugins.base import Plugin, ResourcePlugin
+from entity.resources.metrics import MetricsCollectorResource
+
+
+class DummyPlugin(Plugin):
+    stages = []
+
+    async def _execute_impl(self, context):
+        return None
+
+
+class DummyResource(ResourcePlugin):
+    stages = []
+    name = "dummy"
+
+    async def _execute_impl(self, context):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_plugin_lifecycle_metrics():
+    plugin = DummyPlugin({})
+    metrics = MetricsCollectorResource()
+    plugin.metrics_collector = metrics
+    await plugin.initialize()
+    assert plugin.is_initialized
+    await plugin.shutdown()
+    assert plugin.is_shutdown
+    operations = [op.operation for op in metrics.resource_operations]
+    assert "initialize" in operations
+    assert "shutdown" in operations
+
+
+@pytest.mark.asyncio
+async def test_resource_plugin_lifecycle_metrics():
+    resource = DummyResource({})
+    metrics = MetricsCollectorResource()
+    resource.metrics_collector = metrics
+    await resource.initialize()
+    assert resource.is_initialized
+    await resource.shutdown()
+    assert resource.is_shutdown
+    ops = [op for op in metrics.resource_operations if op.resource_name == "dummy"]
+    assert any(o.operation == "initialize" for o in ops)
+    assert any(o.operation == "shutdown" for o in ops)


### PR DESCRIPTION
## Summary
- add lifecycle state flags to plugin base classes
- log initialize/shutdown events via metrics collector
- implement resource plugin lifecycle hooks
- test plugin lifecycle metrics

## Testing
- `poetry run ruff check --fix src tests` *(fails: Found 163 errors)*
- `poetry run mypy src` *(fails: Found 285 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: argument required)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873d5e279988322b07f2b7debad3a37