### PR TITLE
Enforce adapter stage registration

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Enforced adapter stage registration and added tests
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -168,6 +168,11 @@ class Plugin(BasePlugin):
 
         return None
 
+    def validate_registration_stage(self, stage: PipelineStage) -> None:
+        """Verify plugin registration ``stage`` is allowed."""
+
+        return None
+
     async def _handle_reconfiguration(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
@@ -361,11 +366,35 @@ class InputAdapterPlugin(AdapterPlugin):
 
     stages = [PipelineStage.INPUT]
 
+    def __init_subclass__(cls, **kwargs: Any) -> None:  # type: ignore[override]
+        super().__init_subclass__(**kwargs)
+        if _normalize_stages(getattr(cls, "stages", [])) != [PipelineStage.INPUT]:
+            raise ConfigurationError("InputAdapterPlugin must use PipelineStage.INPUT")
+
+    def validate_registration_stage(self, stage: PipelineStage) -> None:
+        if PipelineStage.ensure(stage) != PipelineStage.INPUT:
+            raise ConfigurationError(
+                "InputAdapterPlugin can only register for PipelineStage.INPUT"
+            )
+
 
 class OutputAdapterPlugin(AdapterPlugin):
     """Adapter executed in the ``OUTPUT`` stage."""
 
     stages = [PipelineStage.OUTPUT]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:  # type: ignore[override]
+        super().__init_subclass__(**kwargs)
+        if _normalize_stages(getattr(cls, "stages", [])) != [PipelineStage.OUTPUT]:
+            raise ConfigurationError(
+                "OutputAdapterPlugin must use PipelineStage.OUTPUT"
+            )
+
+    def validate_registration_stage(self, stage: PipelineStage) -> None:
+        if PipelineStage.ensure(stage) != PipelineStage.OUTPUT:
+            raise ConfigurationError(
+                "OutputAdapterPlugin can only register for PipelineStage.OUTPUT"
+            )
 
 
 class FailurePlugin(Plugin):

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List
 
+from entity.pipeline.stages import PipelineStage
+
 
 class PluginRegistry:
     """Register plugins for each pipeline stage."""
@@ -17,6 +19,9 @@ class PluginRegistry:
         self, plugin: Any, stage: str, name: str | None = None
     ) -> None:
         plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
+        validator = getattr(plugin, "validate_registration_stage", None)
+        if callable(validator):
+            validator(PipelineStage.ensure(stage))
         self._stage_plugins.setdefault(stage, []).append(plugin)
         self._names[plugin] = plugin_name
 

--- a/tests/test_plugins/test_adapter_registration.py
+++ b/tests/test_plugins/test_adapter_registration.py
@@ -1,0 +1,32 @@
+import pytest
+
+from entity.core.plugins import InputAdapterPlugin, OutputAdapterPlugin
+from entity.core.plugins.base import ConfigurationError
+from entity.core.registries import PluginRegistry
+from entity.pipeline.stages import PipelineStage
+
+
+class DummyInput(InputAdapterPlugin):
+    async def _execute_impl(self, context):
+        pass
+
+
+class DummyOutput(OutputAdapterPlugin):
+    async def _execute_impl(self, context):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_input_adapter_registration_restricted():
+    registry = PluginRegistry()
+    plugin = DummyInput({})
+    with pytest.raises(ConfigurationError):
+        await registry.register_plugin_for_stage(plugin, PipelineStage.OUTPUT)
+
+
+@pytest.mark.asyncio
+async def test_output_adapter_registration_restricted():
+    registry = PluginRegistry()
+    plugin = DummyOutput({})
+    with pytest.raises(ConfigurationError):
+        await registry.register_plugin_for_stage(plugin, PipelineStage.INPUT)


### PR DESCRIPTION
## Summary
- validate that InputAdapterPlugin and OutputAdapterPlugin only register
  with the correct pipeline stage
- validate during plugin registration
- add regression tests for invalid stage registration

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402, F821, etc.)*
- `poetry run mypy src` *(fails: found 289 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(warnings, model download)*
- `poetry run entity-cli --config config/prod.yaml verify` *(warnings, model download)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `poetry run pytest tests/test_architecture/ -v` *(1 failed)*
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6873d5e0c92083228fd9bc16176be914