### PR TITLE
Ensure plugin registry preserves registration order

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-24: PluginRegistry now preserves registration order with OrderedDict
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -10,6 +10,7 @@ The pipeline implementation now lives under the ``entity.pipeline`` package. Imp
 error_handling
 logging
 configuration
+plugins
 ```
 
 The following pages cover core concepts and usage patterns.

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -1,0 +1,8 @@
+# Plugin Execution Order
+
+Plugins are executed in the order they are registered. The `PluginRegistry`
+uses an ordered dictionary so iteration yields plugins in the same sequence
+in which they were added. Workflows select which plugins run at each stage,
+but the registry guarantees deterministic execution when multiple plugins
+share a stage.
+

--- a/tests/test_plugins/test_plugin_registry_order.py
+++ b/tests/test_plugins/test_plugin_registry_order.py
@@ -1,0 +1,41 @@
+import pytest
+
+from entity.core.plugins import Plugin
+from entity.core.registries import PluginRegistry
+from entity.pipeline.stages import PipelineStage
+
+
+class DummyPlugin(Plugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_registry_preserves_stage_order():
+    registry = PluginRegistry()
+    a = DummyPlugin({})
+    b = DummyPlugin({})
+    c = DummyPlugin({})
+
+    await registry.register_plugin_for_stage(a, PipelineStage.THINK, "a")
+    await registry.register_plugin_for_stage(b, PipelineStage.THINK, "b")
+    await registry.register_plugin_for_stage(c, PipelineStage.THINK, "c")
+
+    assert registry.get_plugins_for_stage(PipelineStage.THINK) == [a, b, c]
+    assert registry.list_plugins() == [a, b, c]
+
+
+@pytest.mark.asyncio
+async def test_list_plugins_uses_insertion_order():
+    registry = PluginRegistry()
+    a = DummyPlugin({})
+    b = DummyPlugin({})
+    c = DummyPlugin({})
+
+    await registry.register_plugin_for_stage(a, PipelineStage.THINK, "a")
+    await registry.register_plugin_for_stage(b, PipelineStage.DO, "b")
+    await registry.register_plugin_for_stage(c, PipelineStage.INPUT, "c")
+
+    assert registry.list_plugins() == [a, b, c]


### PR DESCRIPTION
## Summary
- maintain insertion order in `PluginRegistry`
- test that plugin registry returns plugins in registration order
- document execution order guarantee
- add agent log entry

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src/entity/core/registries.py tests/test_plugins/test_plugin_registry_order.py`
- `poetry run mypy src` *(fails: Found 285 errors in 54 files)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(error: --config missing)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873d5df50288322891eb873a11f65b0