### PR TITLE
Implement DuckDB vector store

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-25: Added DuckDBVectorStore and zero-config registration
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .core.agent import Agent
 from .infrastructure import DuckDBInfrastructure
 from .resources import LLM, Memory, Storage
+from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
 from plugins.builtin.resources.ollama_llm import OllamaLLMResource
 from .core.stages import PipelineStage
 from .core.plugins import PromptPlugin, ToolPlugin
@@ -32,16 +33,21 @@ def _create_default_agent() -> Agent:
     llm = LLM({})
     memory = Memory({})
     storage = Storage({})
+    vector_store = DuckDBVectorStore({})
 
     llm.provider = llm_provider
     memory.database = db
+    vector_store.database = db
+    memory.vector_store = vector_store
 
     resources = ResourceContainer()
     import asyncio
 
     asyncio.run(db.initialize())
+    asyncio.run(vector_store.initialize())
     asyncio.run(memory.initialize())
     asyncio.run(resources.add("database", db))
+    asyncio.run(resources.add("vector_store", vector_store))
     asyncio.run(resources.add("llm_provider", llm_provider))
     asyncio.run(resources.add("llm", llm))
     asyncio.run(resources.add("memory", memory))

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -298,6 +298,13 @@ class _AgentBuilder:
 
             container.register("database", DuckDBResource, {}, layer=3)
 
+        if not container.has_plugin("vector_store"):
+            from entity.resources.interfaces.duckdb_vector_store import (
+                DuckDBVectorStore,
+            )
+
+            container.register("vector_store", DuckDBVectorStore, {}, layer=2)
+
         if not container.has_plugin("memory"):
             from entity.resources.memory import Memory
 

--- a/src/entity/resources/interfaces/__init__.py
+++ b/src/entity/resources/interfaces/__init__.py
@@ -1,11 +1,13 @@
 from .database import DatabaseResource
 from .vector_store import VectorStoreResource
+from .duckdb_vector_store import DuckDBVectorStore
 from .llm import LLMResource
 from .storage import StorageResource
 
 __all__ = [
     "DatabaseResource",
     "VectorStoreResource",
+    "DuckDBVectorStore",
     "LLMResource",
     "StorageResource",
 ]

--- a/src/entity/resources/interfaces/duckdb_vector_store.py
+++ b/src/entity/resources/interfaces/duckdb_vector_store.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, Dict, Iterator, List
+
+from entity.pipeline.errors import ResourceInitializationError
+
+try:
+    import duckdb
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    duckdb = None
+
+from .vector_store import VectorStoreResource
+
+
+class DuckDBVectorStore(VectorStoreResource):
+    """Simple vector store using a DuckDB table."""
+
+    name = "duckdb_vector_store"
+    infrastructure_dependencies = ["database_backend"]
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.database: Any = None
+        self._table = self.config.get("table", "vector_mem")
+        self._pool = None
+
+    def _maybe_commit(self, conn: Any) -> None:
+        commit = getattr(conn, "commit", None)
+        if callable(commit):
+            commit()
+
+    async def initialize(self) -> None:
+        if duckdb is None:
+            raise RuntimeError("duckdb package not installed")
+        if self.database is None:
+            raise ResourceInitializationError("Database backend not injected")
+        self._pool = self.database.get_connection_pool()
+        async with self.database.connection() as conn:
+            conn.execute(f"CREATE TABLE IF NOT EXISTS {self._table} (text TEXT)")
+            self._maybe_commit(conn)
+
+    @asynccontextmanager
+    async def connection(self) -> Iterator[Any]:
+        if self.database is None:
+            yield None
+        else:
+            async with self.database.connection() as conn:
+                yield conn
+
+    async def add_embedding(self, text: str) -> None:
+        if self.database is None:
+            return
+        async with self.database.connection() as conn:
+            conn.execute(f"INSERT INTO {self._table} VALUES (?)", (text,))
+            self._maybe_commit(conn)
+
+    async def query_similar(self, query: str, k: int = 5) -> List[str]:
+        if self.database is None:
+            return []
+        async with self.database.connection() as conn:
+            rows = conn.execute(
+                f"SELECT text FROM {self._table} WHERE text LIKE ? LIMIT ?",
+                (f"%{query}%", k),
+            ).fetchall()
+        return [row[0] for row in rows]
+
+
+__all__ = ["DuckDBVectorStore"]


### PR DESCRIPTION
## Summary
- implement `DuckDBVectorStore` storing plain text in a DuckDB table
- expose the new vector store in interface exports
- auto-register this store during zero-config initialization
- add the store to the default agent builder
- log development note in `agents.log`

## Testing
- `poetry run pytest` *(fails: Resource 'llm_provider' failed)*

------
https://chatgpt.com/codex/tasks/task_e_6873d5dde9cc83228055f2d2b7c191ce