### PR TITLE
Add default workflow with setup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ Create Markdown docs from the plugin docstring:
 plugin-tool docs src/my_prompt.py --out docs
 ```
 
+## Default Workflow
+
+`Layer0SetupManager` creates basic resources and provides `DefaultWorkflow`.
+The global `agent` uses this workflow automatically.
+
+```python
+import asyncio
+from entity import agent
+from entity.utils.setup_manager import Layer0SetupManager
+
+asyncio.run(Layer0SetupManager().setup())
+print(asyncio.run(agent.handle("Hello")))
+```
+

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-13: Added DefaultWorkflow and zero-config setup
+
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -52,7 +52,7 @@ def _create_default_agent() -> Agent:
         tools=builder.tool_registry,
         plugins=builder.plugin_registry,
     )
-    agent._runtime = AgentRuntime(caps)
+    agent._runtime = AgentRuntime(caps, workflow=setup.workflow)
     return agent
 
 

--- a/src/entity/utils/setup_manager.py
+++ b/src/entity/utils/setup_manager.py
@@ -12,6 +12,8 @@ except ModuleNotFoundError:  # pragma: no cover - environment may omit duckdb
     duckdb = None
 
 from .logging import get_logger
+from entity.workflows.default import DefaultWorkflow
+from entity.workflows import Workflow
 
 
 logger = get_logger(__name__)
@@ -55,12 +57,14 @@ class Layer0SetupManager:
         model: str = "llama3",
         base_url: str = "http://localhost:11434",
         logger: Logger | None = None,
+        workflow: Workflow | None = None,
     ) -> None:
         self.db_path = Path(db_path)
         self.files_dir = Path(files_dir)
         self.model = model
         self.base_url = base_url.rstrip("/")
         self.logger = logger or get_logger(self.__class__.__name__)
+        self.workflow = workflow or DefaultWorkflow()
 
     async def ensure_ollama(self) -> bool:
         """Return ``True`` when Ollama and the desired model are available."""

--- a/src/entity/workflows/__init__.py
+++ b/src/entity/workflows/__init__.py
@@ -2,10 +2,12 @@
 
 from .base import Workflow
 from .builtin import ChainOfThoughtWorkflow, ReActWorkflow, StandardWorkflow
+from .default import DefaultWorkflow
 
 __all__ = [
     "Workflow",
     "StandardWorkflow",
     "ReActWorkflow",
     "ChainOfThoughtWorkflow",
+    "DefaultWorkflow",
 ]

--- a/src/entity/workflows/default.py
+++ b/src/entity/workflows/default.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Default minimal workflow."""
+
+from entity.pipeline.stages import PipelineStage
+
+from .base import Workflow
+
+
+class DefaultWorkflow(Workflow):
+    """Simple INPUT -> THINK -> OUTPUT workflow."""
+
+    stage_map = {
+        PipelineStage.INPUT: [],
+        PipelineStage.THINK: [],
+        PipelineStage.OUTPUT: [],
+    }


### PR DESCRIPTION
## Summary
- add `DefaultWorkflow` to simplify testing
- expose default workflow via `Layer0SetupManager`
- hook workflow into default agent startup
- document zero-config usage

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src` *(fails: Function is missing a type annotation)*
- `poetry run bandit -r src`
- `vulture src tests` *(errors: invalid syntax in template files)*
- `unimport src tests` *(errors: invalid syntax in template files)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: the following arguments are required: --config)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873d5dbeae4832299de678570d86120