### PR TITLE
Add infrastructure_type to AWSStandardInfrastructure

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added infrastructure_type to AWSStandardInfrastructure
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/infrastructure/aws_standard.py
+++ b/src/entity/infrastructure/aws_standard.py
@@ -9,6 +9,7 @@ class AWSStandardInfrastructure(OpenTofuInfrastructure):
     """Basic AWS deployment using ECS, RDS and S3."""
 
     name = "aws-standard"
+    infrastructure_type = "cloud"
     provider = "aws"
 
     def __init__(self, region: str = "us-east-1", config: Dict | None = None) -> None:


### PR DESCRIPTION
## Summary
- set `infrastructure_type` in `AWSStandardInfrastructure`
- record note in `agents.log`

## Testing
- `poetry run black src/entity/infrastructure/aws_standard.py`
- `poetry run ruff check --fix src/entity/infrastructure/aws_standard.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config argument)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873d5d8959883229d772f66d2d494cd