### PR TITLE
Update DuckDB resource plugin

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-25: Changed DuckDBResource to subclass ResourcePlugin and adjusted default layer
 AGENT NOTE - 2025-07-24: Updated DuckDBResource to subclass AgentResource and use database_backend
 AGENT NOTE - 2025-07-23: Allow layer 3 for custom resources without dependencies
 AGENT NOTE - 2025-07-23: Fixed DatabaseResource import and updated async usage in plugin context memory test

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -296,7 +296,7 @@ class _AgentBuilder:
         if not container.has_plugin("database"):
             from plugins.builtin.resources.duckdb_resource import DuckDBResource
 
-            container.register("database", DuckDBResource, {}, layer=3)
+            container.register("database", DuckDBResource, {}, layer=2)
 
         if not container.has_plugin("memory"):
             from entity.resources.memory import Memory

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -824,7 +824,7 @@ class SystemInitializer:
         if "database" not in registered:
             from plugins.builtin.resources.duckdb_resource import DuckDBResource
 
-            container.register("database", DuckDBResource, {}, layer=3)
+            container.register("database", DuckDBResource, {}, layer=2)
             registered.add("database")
 
         required = {"memory", "llm", "storage"}

--- a/src/plugins/builtin/resources/duckdb_resource.py
+++ b/src/plugins/builtin/resources/duckdb_resource.py
@@ -5,10 +5,10 @@ from typing import Any, AsyncIterator, Dict
 
 from entity.infrastructure.duckdb import DuckDBInfrastructure
 from entity.core.resources.container import PoolConfig, ResourcePool
-from entity.core.plugins import AgentResource
+from entity.core.plugins import ResourcePlugin
 
 
-class DuckDBResource(AgentResource):  # type: ignore[misc]
+class DuckDBResource(ResourcePlugin):  # type: ignore[misc]
     """Database resource backed by :class:`DuckDBInfrastructure`."""
 
     infrastructure_dependencies = ["database_backend"]


### PR DESCRIPTION
## Summary
- subclass `ResourcePlugin` instead of `AgentResource` in `DuckDBResource`
- register the database resource at layer 2
- note the change in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402, E741 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873d5b3634c8322abbf2ee537727ad4