### PR TITLE
Resolve plugin registry conflicts

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-30: Merged plugin registry features for capabilities and order preservation
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from collections import OrderedDict
 from typing import Any, Awaitable, Callable, Dict, List
 
-<<<<<<< HEAD
 from entity.core.validation import verify_dependencies, verify_stage_assignment
 from entity.pipeline.stages import PipelineStage
 
@@ -18,54 +17,37 @@ class PluginCapabilities:
     supported_stages: list[str]
     required_resources: list[str]
 
-=======
-from entity.pipeline.stages import PipelineStage
-
->>>>>>> pr-1436
 
 class PluginRegistry:
-<<<<<<< HEAD
-    """Register plugins for each pipeline stage and track capabilities."""
-
-    def __init__(self) -> None:
-        self._stage_plugins: Dict[str, List[Any]] = {}
-        self._names: Dict[Any, str] = {}
-        self._capabilities: Dict[Any, PluginCapabilities] = {}
-=======
-    """Register plugins for each pipeline stage preserving insertion order."""
+    """Register plugins for pipeline stages preserving order and capabilities."""
 
     def __init__(self) -> None:
         self._stage_plugins: Dict[str, OrderedDict[Any, str]] = {}
-        self._names: "OrderedDict[Any, str]" = OrderedDict()
->>>>>>> pr-1437
+        self._names: OrderedDict[Any, str] = OrderedDict()
+        self._capabilities: Dict[Any, PluginCapabilities] = {}
 
     async def register_plugin_for_stage(
         self, plugin: Any, stage: str | PipelineStage, name: str | None = None
     ) -> None:
         stage_enum = PipelineStage.ensure(stage)
         plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
-<<<<<<< HEAD
-<<<<<<< HEAD
 
         verify_stage_assignment(plugin, stage_enum)
         verify_dependencies(plugin, self._names.values())
 
         key = str(stage_enum)
-        self._stage_plugins.setdefault(key, []).append(plugin)
-=======
-        validator = getattr(plugin, "validate_registration_stage", None)
-        if callable(validator):
-            validator(PipelineStage.ensure(stage))
-        self._stage_plugins.setdefault(stage, []).append(plugin)
->>>>>>> pr-1436
+        if key not in self._stage_plugins:
+            self._stage_plugins[key] = OrderedDict()
+
+        self._stage_plugins[key][plugin] = plugin_name
         self._names[plugin] = plugin_name
         caps = self._capabilities.get(plugin)
         if caps is None:
             deps = list(getattr(plugin, "dependencies", []))
             caps = PluginCapabilities([], deps)
             self._capabilities[plugin] = caps
-        if stage not in caps.supported_stages:
-            caps.supported_stages.append(stage)
+        if key not in caps.supported_stages:
+            caps.supported_stages.append(key)
 
     async def declare_capabilities(
         self,
@@ -86,13 +68,6 @@ class PluginRegistry:
             for dep in required_resources:
                 if dep not in caps.required_resources:
                     caps.required_resources.append(dep)
-=======
-        if stage not in self._stage_plugins:
-            self._stage_plugins[stage] = OrderedDict()
-        self._stage_plugins[stage][plugin] = plugin_name
-        if plugin not in self._names:
-            self._names[plugin] = plugin_name
->>>>>>> pr-1437
 
     def get_plugins_for_stage(self, stage: str) -> List[Any]:
         plugins = self._stage_plugins.get(stage)


### PR DESCRIPTION
## Summary
- merge ordered registry and plugin capability features
- keep dependency and stage validation when registering plugins
- add an agent note about the registry merge

## Testing
- `poetry run pytest tests/test_tool_registry.py tests/test_iterative_results.py tests/plugins/test_hot_reload.py tests/plugins/test_stage_assignment.py -q` *(fails: SyntaxError in __init__.py)*

------
https://chatgpt.com/codex/tasks/task_e_6873e03346dc832295d5b893e4965f3d