### PR TITLE
Add adapter plugin stage validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-24: Added strict stage registration checks for adapter plugins
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -227,7 +227,13 @@ class Plugin(BasePlugin):
     def validate_registration_stage(self, stage: PipelineStage) -> None:
         """Verify plugin registration ``stage`` is allowed."""
 
-        return None
+        stage_enum = PipelineStage.ensure(stage)
+        allowed = set(_normalize_stages(getattr(self, "stages", [])))
+        if stage_enum not in allowed:
+            names = ", ".join(s.name for s in allowed)
+            raise ConfigurationError(
+                f"{self.__class__.__name__} can only register for {names}"
+            )
 
     async def _handle_reconfiguration(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]

--- a/tests/test_plugins/test_adapter_registration.py
+++ b/tests/test_plugins/test_adapter_registration.py
@@ -30,3 +30,23 @@ async def test_output_adapter_registration_restricted():
     plugin = DummyOutput({})
     with pytest.raises(ConfigurationError):
         await registry.register_plugin_for_stage(plugin, PipelineStage.INPUT)
+
+
+def test_input_adapter_class_stage_restricted():
+    with pytest.raises(ConfigurationError):
+
+        class BadInput(InputAdapterPlugin):
+            stages = [PipelineStage.OUTPUT]
+
+            async def _execute_impl(self, context):
+                pass
+
+
+def test_output_adapter_class_stage_restricted():
+    with pytest.raises(ConfigurationError):
+
+        class BadOutput(OutputAdapterPlugin):
+            stages = [PipelineStage.INPUT]
+
+            async def _execute_impl(self, context):
+                pass


### PR DESCRIPTION
## Summary
- enforce plugin registration only on declared stages
- test adapter class and registration restrictions
- document stage restriction in agents.log

## Testing
- `poetry run pytest tests/test_plugins/test_adapter_registration.py -v` *(fails: SyntaxError in src/entity/__init__.py)*

------
https://chatgpt.com/codex/tasks/task_e_6873e74a680483229a92bf691711fcdf