### PR TITLE
Shift adapter stage checks to registration

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Removed init_subclass stage validation in adapter plugins
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -443,12 +443,9 @@ class InputAdapterPlugin(AdapterPlugin):
 
     stages = [PipelineStage.INPUT]
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:  # type: ignore[override]
-        super().__init_subclass__(**kwargs)
-        if _normalize_stages(getattr(cls, "stages", [])) != [PipelineStage.INPUT]:
-            raise ConfigurationError("InputAdapterPlugin must use PipelineStage.INPUT")
-
     def validate_registration_stage(self, stage: PipelineStage) -> None:
+        if _normalize_stages(getattr(self, "stages", [])) != [PipelineStage.INPUT]:
+            raise ConfigurationError("InputAdapterPlugin must use PipelineStage.INPUT")
         if PipelineStage.ensure(stage) != PipelineStage.INPUT:
             raise ConfigurationError(
                 "InputAdapterPlugin can only register for PipelineStage.INPUT"
@@ -460,14 +457,11 @@ class OutputAdapterPlugin(AdapterPlugin):
 
     stages = [PipelineStage.OUTPUT]
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:  # type: ignore[override]
-        super().__init_subclass__(**kwargs)
-        if _normalize_stages(getattr(cls, "stages", [])) != [PipelineStage.OUTPUT]:
+    def validate_registration_stage(self, stage: PipelineStage) -> None:
+        if _normalize_stages(getattr(self, "stages", [])) != [PipelineStage.OUTPUT]:
             raise ConfigurationError(
                 "OutputAdapterPlugin must use PipelineStage.OUTPUT"
             )
-
-    def validate_registration_stage(self, stage: PipelineStage) -> None:
         if PipelineStage.ensure(stage) != PipelineStage.OUTPUT:
             raise ConfigurationError(
                 "OutputAdapterPlugin can only register for PipelineStage.OUTPUT"


### PR DESCRIPTION
## Summary
- remove class-level stage checks from input and output adapters
- validate adapter stages during plugin registration
- log new note

## Testing
- `poetry run black src/entity/core/plugins/base.py tests`
- `poetry run ruff check --fix src tests` *(fails: SyntaxError in registries.py)*
- `poetry run mypy src` *(fails: invalid syntax in src/entity/__init__.py)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: invalid syntax in multiple files)*
- `poetry run unimport -r src tests` *(fails: invalid syntax in templates)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: invalid syntax in src/entity/__init__.py)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: invalid syntax in src/entity/__init__.py)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: invalid syntax in src/entity/__init__.py)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873e6467c0083229ba93e737125c009