### PR TITLE
Update PluginAutoClassifier to set stage config

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added config stages to AutoClassifier plugin objects
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======

--- a/src/entity/core/plugin_utils.py
+++ b/src/entity/core/plugin_utils.py
@@ -127,6 +127,9 @@ class PluginAutoClassifier:
             name=name,
             base_class=cast(Type, base_cls),
         )
+        plugin_obj.config["stages" if len(plugin_obj.stages) > 1 else "stage"] = (
+            plugin_obj.stages if len(plugin_obj.stages) > 1 else plugin_obj.stages[0]
+        )
         plugin_obj._explicit_stages = explicit
         return plugin_obj
 


### PR DESCRIPTION
## Summary
- add stage info to agents log
- set `plugin_obj.config["stages"]` in `PluginAutoClassifier.classify`

## Testing
- `poetry run black src/entity/core/plugin_utils.py`
- `poetry run black src tests` *(fails: cannot format due to merge conflict markers)*
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: command not found)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: invalid syntax)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: invalid syntax)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: invalid syntax)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873e647274883229d6a46a22fd555ef