### PR TITLE
Add reminder to run tests with Poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ asyncio.run(Layer0SetupManager().setup())
 print(asyncio.run(agent.handle("Hello")))
 ```
 
+
+## Running Tests
+
+Use Poetry:
+```bash
+poetry install --with dev
+poetry run pytest
+```
+Running tests outside Poetry often hit import errors.
+

--- a/agents.log
+++ b/agents.log
@@ -1,8 +1,6 @@
-<<<<<<< HEAD
+AGENT NOTE - 2025-08-01: Documented running tests via Poetry and pytest
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
-=======
 AGENT NOTE - 2025-07-13: Integrated pipeline duration metric and cleared stage results after execution
->>>>>>> pr-1448
 AGENT NOTE - 2025-07-13: Verified merge conflict cleanup and preserved all notes
 AGENT NOTE - 2025-07-31: Resolved merge conflicts in pipeline and CLI after PRs 1416-1427
 AGENT NOTE - 2025-07-25: ToolRegistry discovery now filters by intents
@@ -13,19 +11,13 @@ AGENT NOTE - 2025-07-13: Added config inheritance, linting, and diff tools
 AGENT NOTE - 2025-07-13: Adjust stage result clearing to persist across iterations but reset between messages
 AGENT NOTE - 2025-07-25: Extended ResourcePool with scaling and health checks
 AGENT NOTE - 2025-07-24: Added plugin capabilities and compatibility matrix with pipeline benchmarks
-<<<<<<< HEAD
-=======
 
->>>>>>> pr-1448
 AGENT NOTE - 2025-07-25: Changed DuckDBResource to subclass ResourcePlugin and adjusted default layer
 AGENT NOTE - 2025-07-13: Added infrastructure_type to AWSStandardInfrastructure
 AGENT NOTE - 2025-07-13: Added vector store and logging to default setup
 AGENT NOTE - 2025-07-13: No resource interface modules found to move, canonical resources already depend on interfaces.
 AGENT NOTE - 2025-07-13: Added DefaultWorkflow and zero-config setup
-<<<<<<< HEAD
-=======
 
->>>>>>> pr-1448
 AGENT NOTE - 2025-07-25: Added DuckDBVectorStore and zero-config registration
 AGENT NOTE - 2025-07-24: PluginRegistry now preserves registration order with OrderedDict
 AGENT NOTE - 2025-07-13: Enforced adapter stage registration and added tests


### PR DESCRIPTION
## Summary
- document running tests via Poetry
- log this documentation update

## Testing
- `poetry run black .` *(fails: Cannot parse for target version Python 3.11)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873e648c9a88322b98268a295e326a4