### PR TITLE
Improve resource layer validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Improved layer validation with recursive traversal and cycle detection
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======


### PR DESCRIPTION
## Summary
- implement recursive layer validation in `ResourceContainer`
- verify no circular dependencies across resources
- test for multiple-node cycles
- log change in `agents.log`

## Testing
- `poetry run black src/entity/core/resources/container.py tests/test_architecture/test_validate_layers.py`
- `poetry run ruff check --fix src/entity/core/resources/container.py tests/test_architecture/test_validate_layers.py`
- `poetry run mypy src` *(fails: invalid syntax in src/entity/__init__.py)*
- `poetry run bandit -r src` *(reports issues)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: invalid syntax in src/entity/__init__.py)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: invalid syntax in src/entity/__init__.py)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: invalid syntax in src/entity/__init__.py)*
- `pytest tests/test_architecture -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources -v` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873e74f7fc0832284538b20b65636f2