### PR TITLE
Validate workflow plugins on creation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Validated workflow plugin names against registry on pipeline creation
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======

--- a/src/entity/pipeline/workflow.py
+++ b/src/entity/pipeline/workflow.py
@@ -41,7 +41,17 @@ class Pipeline:
             if isinstance(self.workflow, Workflow)
             else Workflow.from_dict(self.workflow)
         )
-        wf_obj.validate_plugins(self.builder.plugin_registry)
+
+        for stage, plugins in wf_obj.stages.items():
+            for name in plugins:
+                if not self.builder.plugin_registry.has_plugin(name):
+                    available = []
+                    if hasattr(self.builder.plugin_registry, "list_plugins"):
+                        available = self.builder.plugin_registry.list_plugins()
+                    raise KeyError(
+                        f"Plugin '{name}' referenced in stage '{stage}' is not registered. Available plugins: {available}"
+                    )
+
         self.workflow = wf_obj
 
     async def build_runtime(self) -> AgentRuntime:

--- a/tests/workflow/test_pipeline_validation.py
+++ b/tests/workflow/test_pipeline_validation.py
@@ -19,5 +19,8 @@ async def test_pipeline_raises_on_unknown_plugin():
     await builder.add_plugin(EchoPlugin({}))
 
     mapping = {PipelineStage.OUTPUT: ["EchoPlugin", "MissingPlugin"]}
-    with pytest.raises(KeyError, match="MissingPlugin"):
+    with pytest.raises(
+        KeyError,
+        match="Plugin 'MissingPlugin' referenced in stage 'output' is not registered",
+    ):
         Pipeline(builder=builder, workflow=mapping)


### PR DESCRIPTION
## Summary
- check plugin names when creating a Pipeline
- improve error message and test it
- log a note about the change

## Testing
- `poetry run black src/entity/pipeline/workflow.py tests/workflow/test_pipeline_validation.py`
- `poetry run pytest tests/workflow/test_pipeline_validation.py::test_pipeline_raises_on_unknown_plugin -q` *(fails: ImportError while loading conftest)*
- `poetry run black src tests` *(fails to reformat files with merge conflicts)*
- `poetry run ruff check --fix src tests`
- `poetry run mypy src` *(fails: invalid syntax in __init__)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: SyntaxError in __init__)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: SyntaxError in __init__)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: SyntaxError in __init__)*
- `poetry run pytest tests/test_architecture/ -v` *(fails: ImportError while loading conftest)*
- `poetry run pytest tests/test_plugins/ -v` *(fails: ImportError while loading conftest)*
- `poetry run pytest tests/test_resources/ -v` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_6873e755c9288322af00d1786683adff