### PR TITLE
Add example plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ asyncio.run(Layer0SetupManager().setup())
 print(asyncio.run(agent.handle("Hello")))
 ```
 
+## Example Plugins
+
+Check the `examples/plugins` directory for minimal plugins demonstrating the
+INPUT, PARSE, and REVIEW stages. Each shows how to interact with the
+`PluginContext` during execution. The rendered source is available in the
+[Plugin Examples](https://entity.readthedocs.io/en/latest/plugin_examples.html)
+documentation.
+

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-01: Document example plugins with literalinclude
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======

--- a/docs/source/plugin_examples.md
+++ b/docs/source/plugin_examples.md
@@ -9,17 +9,9 @@ are appropriate for different stages.
 `InputLogger` runs during the **INPUT** stage and saves the raw user message for
 later steps.
 
-```python
-from examples.plugins.input_logger import InputLogger
-```
-
-```python
-class InputLogger(InputAdapterPlugin):
-    stages = [PipelineStage.INPUT]
-
-    async def _execute_impl(self, context: PluginContext) -> None:
-        message = context.conversation()[-1].content if context.conversation() else ""
-        await context.think("raw_input", message)
+```{literalinclude} ../../examples/plugins/input_logger.py
+:language: python
+:caption: InputLogger
 ```
 
 ## MessageParser
@@ -27,13 +19,9 @@ class InputLogger(InputAdapterPlugin):
 `MessageParser` executes in the **PARSE** stage and normalizes the user's
 message.
 
-```python
-class MessageParser(PromptPlugin):
-    stages = [PipelineStage.PARSE]
-
-    async def _execute_impl(self, context: PluginContext) -> None:
-        raw = context.conversation()[-1].content if context.conversation() else ""
-        await context.think("parsed_input", raw.strip().lower())
+```{literalinclude} ../../examples/plugins/message_parser.py
+:language: python
+:caption: MessageParser
 ```
 
 ## ResponseReviewer
@@ -41,15 +29,9 @@ class MessageParser(PromptPlugin):
 `ResponseReviewer` runs in the **REVIEW** stage to modify the final response if
 needed.
 
-```python
-class ResponseReviewer(PromptPlugin):
-    stages = [PipelineStage.REVIEW]
-
-    async def _execute_impl(self, context: PluginContext) -> None:
-        if not context.has_response():
-            return
-        updated = context.response.replace("badword", "***")
-        context.update_response(lambda _old: updated)
+```{literalinclude} ../../examples/plugins/response_reviewer.py
+:language: python
+:caption: ResponseReviewer
 ```
 
 These examples can be imported and registered in a workflow for quick testing.


### PR DESCRIPTION
## Summary
- embed example plugins with literalincludes
- highlight plugin examples in README
- note documentation update

## Testing
- `poetry run black examples/plugins`
- `poetry run ruff check --fix examples/plugins`
- `pytest tests/test_plugins/test_plugin_examples.py -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: SyntaxError in src/entity/__init__.py)*

------
https://chatgpt.com/codex/tasks/task_e_6873e75b044c8322832ff438aa7fcd7c