### PR TITLE
Add default_workflow instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,17 @@ plugin-tool docs src/my_prompt.py --out docs
 
 ## Default Workflow
 
-`Layer0SetupManager` creates basic resources and provides `DefaultWorkflow`.
-The global `agent` uses this workflow automatically.
+`Layer0SetupManager` creates local resources and ships with a ready-made
+`default_workflow`. The global `agent` picks up this workflow automatically,
+so no extra configuration is required.
 
 ```python
 import asyncio
 from entity import agent
 from entity.utils.setup_manager import Layer0SetupManager
+from entity.workflows import default_workflow
 
+# uses `default_workflow` when none is provided
 asyncio.run(Layer0SetupManager().setup())
 print(asyncio.run(agent.handle("Hello")))
 ```

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added default_workflow constant and updated SetupManager
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======

--- a/src/entity/utils/setup_manager.py
+++ b/src/entity/utils/setup_manager.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError:  # pragma: no cover - environment may omit duckdb
     duckdb = None
 
 from .logging import get_logger
-from entity.workflows.default import DefaultWorkflow
+from entity.workflows.default import default_workflow
 from entity.workflows import Workflow
 
 
@@ -64,7 +64,7 @@ class Layer0SetupManager:
         self.model = model
         self.base_url = base_url.rstrip("/")
         self.logger = logger or get_logger(self.__class__.__name__)
-        self.workflow = workflow or DefaultWorkflow()
+        self.workflow = workflow or default_workflow
 
     async def ensure_ollama(self) -> bool:
         """Return ``True`` when Ollama and the desired model are available."""

--- a/src/entity/workflows/__init__.py
+++ b/src/entity/workflows/__init__.py
@@ -2,7 +2,7 @@
 
 from .base import Workflow
 from .builtin import ChainOfThoughtWorkflow, ReActWorkflow, StandardWorkflow
-from .default import DefaultWorkflow
+from .default import DefaultWorkflow, default_workflow
 
 __all__ = [
     "Workflow",
@@ -10,4 +10,5 @@ __all__ = [
     "ReActWorkflow",
     "ChainOfThoughtWorkflow",
     "DefaultWorkflow",
+    "default_workflow",
 ]

--- a/src/entity/workflows/default.py
+++ b/src/entity/workflows/default.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# ruff: noqa: E402
+
 """Default minimal workflow."""
 
 from entity.pipeline.stages import PipelineStage
@@ -15,3 +17,7 @@ class DefaultWorkflow(Workflow):
         PipelineStage.THINK: [],
         PipelineStage.OUTPUT: [],
     }
+
+
+# Convenient pre-built instance for quick startup
+default_workflow = DefaultWorkflow()


### PR DESCRIPTION
## Summary
- add `default_workflow` instance
- use it in `Layer0SetupManager`
- document default workflow usage

## Testing
- `poetry run black src/entity/workflows/default.py src/entity/utils/setup_manager.py src/entity/workflows/__init__.py`
- `poetry run ruff check --fix src/entity/workflows/default.py src/entity/utils/setup_manager.py src/entity/workflows/__init__.py`
- `poetry run mypy src` *(fails: invalid syntax in src/entity/__init__.py)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: syntax errors)*
- `python -m unimport --remove src tests` *(fails: syntax errors)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: invalid syntax)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: invalid syntax)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: invalid syntax)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873e74463748322af2898dd54715a76