### PR TITLE
Fix tool discovery intent filtering

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-01: Updated ToolRegistry discover filtering and added tests
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======

--- a/src/cli/templates/tool.py
+++ b/src/cli/templates/tool.py
@@ -18,6 +18,7 @@ class {class_name}(ToolPlugin):
     """Example tool plugin."""
 
     stages = [PipelineStage.DO]
+    intents: list[str] = []
     # List position controls execution order and SystemInitializer preserves it.
 
     async def execute_function(self, params: Dict[str, Any]) -> Any:

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -145,7 +145,7 @@ class ToolRegistry:
             items = [
                 (k, v)
                 for k, v in items
-                if any(i in t.lower() for t in getattr(v, "intents", []))
+                if i in {t.lower() for t in getattr(v, "intents", [])}
             ]
         return items
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -21,11 +21,20 @@ class BetaTool(ToolPlugin):
         return "b"
 
 
+class MultiTool(ToolPlugin):
+    stages = [PipelineStage.DO]
+    intents = ["calc", "text"]
+
+    async def execute_function(self, params):
+        return "c"
+
+
 @pytest.mark.asyncio
 async def test_discover_tools_by_intent() -> None:
     registry = ToolRegistry()
     await registry.add("alpha", AlphaTool())
     await registry.add("beta", BetaTool())
+    await registry.add("multi", MultiTool())
 
     found = registry.discover(intent="calc")
     assert len(found) == 1
@@ -35,3 +44,8 @@ async def test_discover_tools_by_intent() -> None:
     found_ci = registry.discover(intent="CALC")
     assert len(found_ci) == 1
     assert found_ci[0][0] == "alpha"
+
+    found_text = registry.discover(intent="text")
+    assert len(found_text) == 2
+    names = {name for name, _ in found_text}
+    assert names == {"beta", "multi"}


### PR DESCRIPTION
## Summary
- refine ToolRegistry.discover intent checks
- document `intents` in tool template
- test multi-intent discovery
- add agent note about registry update

## Testing
- `poetry run black tests/test_tool_registry.py`
- `poetry run black src/entity/core/registries.py` *(fails: Cannot parse for target version Python 3.11)*
- `poetry run black src/cli/templates/tool.py` *(fails: Cannot parse for target version Python 3.11)*
- `poetry run ruff check --fix tests/test_tool_registry.py`
- `poetry run ruff check --fix src/entity/core/registries.py src/cli/templates/tool.py tests/test_tool_registry.py` *(fails due to syntax errors)*
- `poetry run mypy src/entity/core/registries.py tests/test_tool_registry.py` *(fails due to syntax errors)*
- `poetry run bandit -r src/entity/core/registries.py tests/test_tool_registry.py`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails due to syntax errors)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails due to syntax errors)*
- `poetry run python -m src.entity.core.registry_validator` *(fails due to syntax errors)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: No module named 'entity')*
- `pytest tests/test_tool_registry.py::test_discover_tools_by_intent -vv` *(fails: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873e75bf8f88322a964fc75bbfbfa48