### PR TITLE
Add workflow param to agent runtime

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-14: Added workflow validation in AgentRuntime constructor
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -6,11 +6,7 @@ from .core.agent import Agent
 from .infrastructure import DuckDBInfrastructure
 from .resources import LLM, Memory, Storage
 from .resources.logging import LoggingResource
-<<<<<<< HEAD
 from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
-=======
-from .resources.interfaces.vector_store import VectorStoreResource
->>>>>>> pr-1448
 from plugins.builtin.resources.ollama_llm import OllamaLLMResource
 from .core.stages import PipelineStage
 from .core.plugins import PromptPlugin, ToolPlugin
@@ -44,10 +40,7 @@ def _create_default_agent() -> Agent:
 
     llm.provider = llm_provider
     memory.database = db
-<<<<<<< HEAD
     vector_store.database = db
-=======
->>>>>>> pr-1448
     memory.vector_store = vector_store
 
     resources = ResourceContainer()
@@ -73,13 +66,9 @@ def _create_default_agent() -> Agent:
         tools=builder.tool_registry,
         plugins=builder.plugin_registry,
     )
-<<<<<<< HEAD
     asyncio.run(builder.add_plugin(BasicErrorHandler({})))
     workflow = getattr(setup, "workflow", DefaultWorkflow())
     agent._runtime = AgentRuntime(caps, workflow=workflow)
-=======
-    agent._runtime = AgentRuntime(caps)
->>>>>>> pr-1448
     return agent
 
 

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -49,6 +49,8 @@ class _AgentRuntime:
     ) -> None:
         self.capabilities = capabilities
         self.workflow = workflow
+        if self.workflow is not None:
+            self.workflow.validate_plugins(capabilities.plugins)
         self.__post_init__()
 
     def __post_init__(self) -> None:
@@ -410,7 +412,7 @@ class _AgentBuilder:
                 continue
 
 
-@dataclass
+@dataclass(init=False)
 class Agent:
     """High level agent wrapper combining builder and runtime."""
 
@@ -420,6 +422,19 @@ class Agent:
     _builder: _AgentBuilder | None = field(default=None, init=False)
     _runtime: AgentRuntime | None = field(default=None, init=False)
     _workflows: dict[str, type] = field(default_factory=dict, init=False)
+
+    def __init__(
+        self,
+        config_path: str | None = None,
+        pipeline: Pipeline | None = None,
+        workflow: Workflow | None = None,
+    ) -> None:
+        self.config_path = config_path
+        self.pipeline = pipeline
+        self.workflow = workflow
+        self._builder = None
+        self._runtime = None
+        self._workflows = {}
 
     @property
     def builder(self) -> _AgentBuilder:

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List
 
-<<<<<<< HEAD
 from entity.core.validation import verify_stage_assignment
 from entity.pipeline.stages import PipelineStage
 
@@ -21,27 +20,16 @@ class PluginCapabilities:
 
 class PluginRegistry:
     """Register plugins for each pipeline stage preserving insertion order and track capabilities."""
-=======
-from entity.pipeline.stages import PipelineStage
-
-
-class PluginRegistry:
-    """Register plugins for each pipeline stage preserving insertion order."""
->>>>>>> pr-1448
 
     def __init__(self) -> None:
         self._stage_plugins: Dict[str, OrderedDict[Any, str]] = {}
         self._names: "OrderedDict[Any, str]" = OrderedDict()
-<<<<<<< HEAD
         self._capabilities: Dict[Any, PluginCapabilities] = {}
-=======
->>>>>>> pr-1448
 
     async def register_plugin_for_stage(
         self, plugin: Any, stage: str | PipelineStage, name: str | None = None
     ) -> None:
         stage_enum = PipelineStage.ensure(stage)
-<<<<<<< HEAD
         plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
         verify_stage_assignment(plugin, stage_enum)
 
@@ -50,16 +38,11 @@ class PluginRegistry:
             validator(stage_enum)
 
         key = str(stage_enum)
-=======
-        key = str(stage_enum)
-        plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
->>>>>>> pr-1448
         if key not in self._stage_plugins:
             self._stage_plugins[key] = OrderedDict()
         self._stage_plugins[key][plugin] = plugin_name
         if plugin not in self._names:
             self._names[plugin] = plugin_name
-<<<<<<< HEAD
         caps = self._capabilities.get(plugin)
         if caps is None:
             deps = list(getattr(plugin, "dependencies", []))
@@ -87,8 +70,6 @@ class PluginRegistry:
             for dep in required_resources:
                 if dep not in caps.required_resources:
                     caps.required_resources.append(dep)
-=======
->>>>>>> pr-1448
 
     def get_plugins_for_stage(self, stage: str | PipelineStage) -> List[Any]:
         key = str(PipelineStage.ensure(stage))

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -407,10 +407,6 @@ async def execute_pipeline(
             result = create_default_response("No response generated", state.pipeline_id)
         else:
             result = state.response
-<<<<<<< HEAD
-
-=======
->>>>>>> pr-1448
         elapsed_ms = (time.time() - _start) * 1000
         if metrics is not None:
             await metrics.record_custom_metric(
@@ -418,10 +414,6 @@ async def execute_pipeline(
                 metric_name="pipeline_duration_ms",
                 value=elapsed_ms,
             )
-<<<<<<< HEAD
-=======
-
->>>>>>> pr-1448
         state.stage_results.clear()
         return result
 


### PR DESCRIPTION
## Summary
- allow AgentRuntime to validate workflows
- expose workflow parameter on Agent constructor
- fix leftover merge markers in base modules

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 170 errors)*
- `poetry run mypy src` *(fails with 296 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: BasicErrorHandler not defined)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: BasicErrorHandler not defined)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: BasicErrorHandler not defined)*
- `pytest tests/test_architecture/ -v` *(failed: ModuleNotFoundError: 'entity')*
- `pytest tests/test_plugins/ -v` *(failed: ModuleNotFoundError: 'entity')*
- `pytest tests/test_resources/ -v` *(failed: ModuleNotFoundError: 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873e7545974832290374d8f68c3d15c