### PR TITLE
Ensure logging injected into AgentBuilder plugins

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-13: Added logging resource injection for AgentBuilder
+
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -337,6 +337,17 @@ class _AgentBuilder:
 
             container.register("storage", Storage, {}, layer=3)
 
+    def _assign_shared_resources(self, plugin: Plugin) -> None:
+        """Attach common resources to ``plugin`` if available."""
+
+        metrics = self.resource_registry.get("metrics_collector")
+        if metrics is not None:
+            setattr(plugin, "metrics_collector", metrics)
+
+        logger_res = self.resource_registry.get("logging")
+        if logger_res is not None:
+            setattr(plugin, "logging", logger_res)
+
     # ------------------------------ runtime build -----------------------------
     async def build_runtime(
         self, workflow: Mapping[PipelineStage | str, Iterable[str]] | None = None
@@ -344,6 +355,7 @@ class _AgentBuilder:
         self._register_default_resources()
         await self.resource_registry.build_all()
         for plugin in self._added_plugins:
+            self._assign_shared_resources(plugin)
             init = getattr(plugin, "initialize", None)
             if callable(init):
                 await init()

--- a/tests/test_builder_logging_injection.py
+++ b/tests/test_builder_logging_injection.py
@@ -1,0 +1,32 @@
+import pytest
+from entity.core.agent import _AgentBuilder
+from entity.core.plugins import PromptPlugin
+from entity.resources.logging import LoggingResource
+from entity.resources.metrics import MetricsCollectorResource
+from entity.core.stages import PipelineStage
+
+
+class DummyPrompt(PromptPlugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        return "ok"
+
+
+DummyPrompt.dependencies = []
+
+
+@pytest.mark.asyncio
+async def test_builder_assigns_logging():
+    builder = _AgentBuilder()
+    container = builder.resource_registry
+    LoggingResource.dependencies = []
+    MetricsCollectorResource.dependencies = []
+    container.register("logging", LoggingResource, {}, layer=3)
+    container.register("metrics_collector", MetricsCollectorResource, {}, layer=3)
+    await builder.add_plugin(DummyPrompt({}))
+    await builder.build_runtime()
+    plugin = builder._added_plugins[0]
+    assert plugin.logging is not None
+    assert plugin.metrics_collector is not None
+    await container.shutdown_all()


### PR DESCRIPTION
## Summary
- inject shared resources into `_AgentBuilder` plugins
- test logging and metrics injection during AgentBuilder runtime
- note logging injection in `agents.log`

## Testing
- `poetry run ruff check --fix src/entity/core/agent.py tests/test_builder_logging_injection.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: invalid syntax)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: invalid syntax)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: invalid syntax)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError)*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873e752e2ac8322be08fa016e1dd754