### PR TITLE
Fix thought persistence clearing

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,8 +1,6 @@
-<<<<<<< HEAD
+AGENT NOTE - 2025-07-13: Ensured thoughts clear after message, not each iteration
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
-=======
 AGENT NOTE - 2025-07-13: Integrated pipeline duration metric and cleared stage results after execution
->>>>>>> pr-1448
 AGENT NOTE - 2025-07-13: Verified merge conflict cleanup and preserved all notes
 AGENT NOTE - 2025-07-31: Resolved merge conflicts in pipeline and CLI after PRs 1416-1427
 AGENT NOTE - 2025-07-25: ToolRegistry discovery now filters by intents
@@ -13,19 +11,11 @@ AGENT NOTE - 2025-07-13: Added config inheritance, linting, and diff tools
 AGENT NOTE - 2025-07-13: Adjust stage result clearing to persist across iterations but reset between messages
 AGENT NOTE - 2025-07-25: Extended ResourcePool with scaling and health checks
 AGENT NOTE - 2025-07-24: Added plugin capabilities and compatibility matrix with pipeline benchmarks
-<<<<<<< HEAD
-=======
-
->>>>>>> pr-1448
 AGENT NOTE - 2025-07-25: Changed DuckDBResource to subclass ResourcePlugin and adjusted default layer
 AGENT NOTE - 2025-07-13: Added infrastructure_type to AWSStandardInfrastructure
 AGENT NOTE - 2025-07-13: Added vector store and logging to default setup
 AGENT NOTE - 2025-07-13: No resource interface modules found to move, canonical resources already depend on interfaces.
 AGENT NOTE - 2025-07-13: Added DefaultWorkflow and zero-config setup
-<<<<<<< HEAD
-=======
-
->>>>>>> pr-1448
 AGENT NOTE - 2025-07-25: Added DuckDBVectorStore and zero-config registration
 AGENT NOTE - 2025-07-24: PluginRegistry now preserves registration order with OrderedDict
 AGENT NOTE - 2025-07-13: Enforced adapter stage registration and added tests

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -6,11 +6,7 @@ from .core.agent import Agent
 from .infrastructure import DuckDBInfrastructure
 from .resources import LLM, Memory, Storage
 from .resources.logging import LoggingResource
-<<<<<<< HEAD
 from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
-=======
-from .resources.interfaces.vector_store import VectorStoreResource
->>>>>>> pr-1448
 from plugins.builtin.resources.ollama_llm import OllamaLLMResource
 from .core.stages import PipelineStage
 from .core.plugins import PromptPlugin, ToolPlugin
@@ -44,10 +40,7 @@ def _create_default_agent() -> Agent:
 
     llm.provider = llm_provider
     memory.database = db
-<<<<<<< HEAD
     vector_store.database = db
-=======
->>>>>>> pr-1448
     memory.vector_store = vector_store
 
     resources = ResourceContainer()
@@ -73,13 +66,9 @@ def _create_default_agent() -> Agent:
         tools=builder.tool_registry,
         plugins=builder.plugin_registry,
     )
-<<<<<<< HEAD
     asyncio.run(builder.add_plugin(BasicErrorHandler({})))
     workflow = getattr(setup, "workflow", DefaultWorkflow())
     agent._runtime = AgentRuntime(caps, workflow=workflow)
-=======
-    agent._runtime = AgentRuntime(caps)
->>>>>>> pr-1448
     return agent
 
 

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List
 
-<<<<<<< HEAD
 from entity.core.validation import verify_stage_assignment
 from entity.pipeline.stages import PipelineStage
 
@@ -21,27 +20,16 @@ class PluginCapabilities:
 
 class PluginRegistry:
     """Register plugins for each pipeline stage preserving insertion order and track capabilities."""
-=======
-from entity.pipeline.stages import PipelineStage
-
-
-class PluginRegistry:
-    """Register plugins for each pipeline stage preserving insertion order."""
->>>>>>> pr-1448
 
     def __init__(self) -> None:
         self._stage_plugins: Dict[str, OrderedDict[Any, str]] = {}
         self._names: "OrderedDict[Any, str]" = OrderedDict()
-<<<<<<< HEAD
         self._capabilities: Dict[Any, PluginCapabilities] = {}
-=======
->>>>>>> pr-1448
 
     async def register_plugin_for_stage(
         self, plugin: Any, stage: str | PipelineStage, name: str | None = None
     ) -> None:
         stage_enum = PipelineStage.ensure(stage)
-<<<<<<< HEAD
         plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
         verify_stage_assignment(plugin, stage_enum)
 
@@ -50,16 +38,11 @@ class PluginRegistry:
             validator(stage_enum)
 
         key = str(stage_enum)
-=======
-        key = str(stage_enum)
-        plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
->>>>>>> pr-1448
         if key not in self._stage_plugins:
             self._stage_plugins[key] = OrderedDict()
         self._stage_plugins[key][plugin] = plugin_name
         if plugin not in self._names:
             self._names[plugin] = plugin_name
-<<<<<<< HEAD
         caps = self._capabilities.get(plugin)
         if caps is None:
             deps = list(getattr(plugin, "dependencies", []))
@@ -87,8 +70,6 @@ class PluginRegistry:
             for dep in required_resources:
                 if dep not in caps.required_resources:
                     caps.required_resources.append(dep)
-=======
->>>>>>> pr-1448
 
     def get_plugins_for_stage(self, stage: str | PipelineStage) -> List[Any]:
         key = str(PipelineStage.ensure(stage))

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -292,9 +292,9 @@ async def execute_pipeline(
                 pipeline_id=f"{user_id}_{generate_pipeline_id()}",
             )
 
-    # Clear stage results at the start of each message so that
-    # thoughts from previous executions do not leak into the next one.
-    state.stage_results.clear()
+    # Thoughts persist for the duration of a single message run
+    # so they can be referenced across iterations. They are cleared
+    # only once the message has been fully processed.
     _start = time.time()
     resource_manager = (
         capabilities.resources
@@ -407,10 +407,6 @@ async def execute_pipeline(
             result = create_default_response("No response generated", state.pipeline_id)
         else:
             result = state.response
-<<<<<<< HEAD
-
-=======
->>>>>>> pr-1448
         elapsed_ms = (time.time() - _start) * 1000
         if metrics is not None:
             await metrics.record_custom_metric(
@@ -418,10 +414,6 @@ async def execute_pipeline(
                 metric_name="pipeline_duration_ms",
                 value=elapsed_ms,
             )
-<<<<<<< HEAD
-=======
-
->>>>>>> pr-1448
         state.stage_results.clear()
         return result
 


### PR DESCRIPTION
## Summary
- clear stage results only after pipeline run
- resolve merge markers in entity modules
- add regression test for preexisting thoughts
- maintain agent log

## Testing
- `poetry run black src/entity/__init__.py src/entity/core/registries.py src/entity/pipeline/pipeline.py tests/test_thought_persistence.py`
- `poetry run ruff check --fix src tests` *(fails: 170 errors)*
- `poetry run mypy src` *(fails: found 296 errors)*
- `poetry run bandit -r src` *(fails: Command not found)*
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `pytest tests/test_thought_persistence.py::test_preexisting_thoughts_available_at_start -v` *(fails: NameError: BasicErrorHandler not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6873e74edb7c8322ac464dc8dd46d324