### PR TITLE
Ensure plugin registry preserves ordering

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Plugin registry now preserves registration order using OrderedDict
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Cleaned merge markers and updated default agent setup
 =======

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -1,8 +1,8 @@
 # Plugin Execution Order
 
 Plugins are executed in the order they are registered. The `PluginRegistry`
-uses an ordered dictionary so iteration yields plugins in the same sequence
-in which they were added. Workflows select which plugins run at each stage,
-but the registry guarantees deterministic execution when multiple plugins
-share a stage.
+stores plugins in an `OrderedDict` so iteration yields them in exactly the
+same sequence in which they were added. Both `get_plugins_for_stage()` and
+`list_plugins()` return plugins in registration order, guaranteeing
+deterministic execution whenever multiple plugins share a stage.
 

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -6,12 +6,9 @@ from .core.agent import Agent
 from .infrastructure import DuckDBInfrastructure
 from .resources import LLM, Memory, Storage
 from .resources.logging import LoggingResource
-<<<<<<< HEAD
 from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
-=======
-from .resources.interfaces.vector_store import VectorStoreResource
->>>>>>> pr-1448
 from plugins.builtin.resources.ollama_llm import OllamaLLMResource
+from entity.plugins.prompts import BasicErrorHandler
 from .core.stages import PipelineStage
 from .core.plugins import PromptPlugin, ToolPlugin
 from .utils.setup_manager import Layer0SetupManager
@@ -44,10 +41,7 @@ def _create_default_agent() -> Agent:
 
     llm.provider = llm_provider
     memory.database = db
-<<<<<<< HEAD
     vector_store.database = db
-=======
->>>>>>> pr-1448
     memory.vector_store = vector_store
 
     resources = ResourceContainer()
@@ -73,13 +67,9 @@ def _create_default_agent() -> Agent:
         tools=builder.tool_registry,
         plugins=builder.plugin_registry,
     )
-<<<<<<< HEAD
     asyncio.run(builder.add_plugin(BasicErrorHandler({})))
     workflow = getattr(setup, "workflow", DefaultWorkflow())
     agent._runtime = AgentRuntime(caps, workflow=workflow)
-=======
-    agent._runtime = AgentRuntime(caps)
->>>>>>> pr-1448
     return agent
 
 

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List
 
-<<<<<<< HEAD
 from entity.core.validation import verify_stage_assignment
 from entity.pipeline.stages import PipelineStage
 
@@ -21,45 +20,28 @@ class PluginCapabilities:
 
 class PluginRegistry:
     """Register plugins for each pipeline stage preserving insertion order and track capabilities."""
-=======
-from entity.pipeline.stages import PipelineStage
-
-
-class PluginRegistry:
-    """Register plugins for each pipeline stage preserving insertion order."""
->>>>>>> pr-1448
 
     def __init__(self) -> None:
-        self._stage_plugins: Dict[str, OrderedDict[Any, str]] = {}
+        self._stage_plugins: "OrderedDict[str, OrderedDict[Any, str]]" = OrderedDict()
         self._names: "OrderedDict[Any, str]" = OrderedDict()
-<<<<<<< HEAD
         self._capabilities: Dict[Any, PluginCapabilities] = {}
-=======
->>>>>>> pr-1448
 
     async def register_plugin_for_stage(
         self, plugin: Any, stage: str | PipelineStage, name: str | None = None
     ) -> None:
         stage_enum = PipelineStage.ensure(stage)
-<<<<<<< HEAD
         plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
-        verify_stage_assignment(plugin, stage_enum)
-
         validator = getattr(plugin, "validate_registration_stage", None)
         if callable(validator):
             validator(stage_enum)
+        verify_stage_assignment(plugin, stage_enum)
 
         key = str(stage_enum)
-=======
-        key = str(stage_enum)
-        plugin_name = name or getattr(plugin, "name", plugin.__class__.__name__)
->>>>>>> pr-1448
         if key not in self._stage_plugins:
             self._stage_plugins[key] = OrderedDict()
         self._stage_plugins[key][plugin] = plugin_name
         if plugin not in self._names:
             self._names[plugin] = plugin_name
-<<<<<<< HEAD
         caps = self._capabilities.get(plugin)
         if caps is None:
             deps = list(getattr(plugin, "dependencies", []))
@@ -87,8 +69,6 @@ class PluginRegistry:
             for dep in required_resources:
                 if dep not in caps.required_resources:
                     caps.required_resources.append(dep)
-=======
->>>>>>> pr-1448
 
     def get_plugins_for_stage(self, stage: str | PipelineStage) -> List[Any]:
         key = str(PipelineStage.ensure(stage))

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -407,10 +407,6 @@ async def execute_pipeline(
             result = create_default_response("No response generated", state.pipeline_id)
         else:
             result = state.response
-<<<<<<< HEAD
-
-=======
->>>>>>> pr-1448
         elapsed_ms = (time.time() - _start) * 1000
         if metrics is not None:
             await metrics.record_custom_metric(
@@ -418,10 +414,6 @@ async def execute_pipeline(
                 metric_name="pipeline_duration_ms",
                 value=elapsed_ms,
             )
-<<<<<<< HEAD
-=======
-
->>>>>>> pr-1448
         state.stage_results.clear()
         return result
 

--- a/tests/test_plugins/test_plugin_registry_order.py
+++ b/tests/test_plugins/test_plugin_registry_order.py
@@ -6,7 +6,7 @@ from entity.pipeline.stages import PipelineStage
 
 
 class DummyPlugin(Plugin):
-    stages = [PipelineStage.THINK]
+    stages = [PipelineStage.THINK, PipelineStage.DO, PipelineStage.INPUT]
 
     async def _execute_impl(self, context):
         pass
@@ -39,3 +39,16 @@ async def test_list_plugins_uses_insertion_order():
     await registry.register_plugin_for_stage(c, PipelineStage.INPUT, "c")
 
     assert registry.list_plugins() == [a, b, c]
+
+
+@pytest.mark.asyncio
+async def test_get_plugin_name_preserves_registration_order():
+    registry = PluginRegistry()
+    a = DummyPlugin({})
+    b = DummyPlugin({})
+
+    await registry.register_plugin_for_stage(a, PipelineStage.THINK, "first")
+    await registry.register_plugin_for_stage(b, PipelineStage.THINK, "second")
+
+    names = [registry.get_plugin_name(p) for p in registry.list_plugins()]
+    assert names == ["first", "second"]


### PR DESCRIPTION
## Summary
- use an OrderedDict inside PluginRegistry
- clarify ordering guarantee in the plugin docs
- test registry order via get_plugin_name
- clean merge markers in runtime modules

## Testing
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_architecture/ -v` *(fails: DID NOT RAISE <class 'entity.pipeline.errors.InitializationError'>)*
- `poetry run pytest tests/test_resources/ -v`
- `poetry run mypy src` *(fails: Found 295 errors in 56 files)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config ???` *(failed: argument required)*


------
https://chatgpt.com/codex/tasks/task_e_6873e747effc83229ffdb1659ecf53bd