### PR TITLE
Fix PluginRegistry lookup

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added has_plugin method to PluginRegistry to fix workflow validation
 AGENT NOTE - 2025-08-04: Resolved lingering merge markers and restored notes
 AGENT NOTE - 2025-08-02: Resolved remaining merge conflict markers
 AGENT NOTE - 2025-08-01: Document example plugins with literalinclude

--- a/src/entity/core/registries.py
+++ b/src/entity/core/registries.py
@@ -88,6 +88,11 @@ class PluginRegistry:
     def list_plugins(self) -> List[Any]:
         return list(self._names.keys())
 
+    def has_plugin(self, name: str) -> bool:
+        """Return ``True`` if a plugin registered under ``name`` exists."""
+
+        return any(n == name for n in self._names.values())
+
     def get_capabilities(self, plugin: Any) -> PluginCapabilities | None:
         return self._capabilities.get(plugin)
 


### PR DESCRIPTION
## Summary
- ensure workflow validation doesn't fail by adding `has_plugin` method
- log the change

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml`
- `poetry run pytest tests/test_architecture/ -v`
- `poetry run pytest tests/test_plugins/ -v`
- `poetry run pytest tests/test_resources/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6873ed5af3708322bdfc6a4867112f02