### PR TITLE
Document pytest-asyncio dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,15 @@ poetry run python -m src.entity.core.registry_validator
 Execute the full test suite:
 
 ```bash
+poetry install --with dev  # includes pytest-asyncio
 pytest
 pytest tests/integration/ -v
 pytest tests/infrastructure/ -v
 pytest tests/performance/ -m benchmark
 ```
+
+`pytest-asyncio` must be installed; without it pytest reports
+`Unknown config option: asyncio_mode`.
 
 **Test requirements:**
 - Add tests for all new functionality

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Documented pytest-asyncio requirement for tests
 AGENT NOTE - 2025-07-13: Added has_plugin method to PluginRegistry to fix workflow validation
 AGENT NOTE - 2025-08-04: Resolved lingering merge markers and restored notes
 AGENT NOTE - 2025-08-02: Resolved remaining merge conflict markers


### PR DESCRIPTION
## Summary
- note pytest-asyncio requirement in docs
- log new agent note

## Testing
- `poetry run black src tests`
- `poetry run pytest -q` *(fails: ImportError: cannot import name 'Plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6873f08b8f4c8322a402ec6a09411efe