### PR TITLE
Fix optional dependency errors

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added ImportError guard for optional deps in __init__.py
 AGENT NOTE - 2025-07-13: Added has_plugin method to PluginRegistry to fix workflow validation
 AGENT NOTE - 2025-08-04: Resolved lingering merge markers and restored notes
 AGENT NOTE - 2025-08-02: Resolved remaining merge conflict markers

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -2,22 +2,39 @@
 
 from __future__ import annotations
 
-from .core.agent import Agent
-from .infrastructure import DuckDBInfrastructure
-from .resources import LLM, Memory, Storage
-from .resources.logging import LoggingResource
-from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
-from plugins.builtin.resources.ollama_llm import OllamaLLMResource
-from .plugins.prompts.basic_error_handler import BasicErrorHandler
-from .core.stages import PipelineStage
-from .core.plugins import PromptPlugin, ToolPlugin
-from .utils.setup_manager import Layer0SetupManager
-from entity.workflows.default import DefaultWorkflow
-from entity.core.registries import SystemRegistries
-from entity.core.runtime import AgentRuntime
-from entity.core.resources.container import ResourceContainer
-import inspect
 import asyncio
+import inspect
+
+
+def _handle_import_error(exc: ModuleNotFoundError) -> None:
+    """Re-raise missing optional dependency errors with guidance."""
+
+    missing = exc.name
+    mapping = {"yaml": "pyyaml", "dotenv": "python-dotenv", "httpx": "httpx"}
+    requirement = mapping.get(missing, missing)
+    raise ImportError(
+        f"Optional dependency '{requirement}' is required. "
+        f"Install it with `pip install {requirement}`."
+    ) from exc
+
+
+try:
+    from .core.agent import Agent
+    from .infrastructure import DuckDBInfrastructure
+    from .resources import LLM, Memory, Storage
+    from .resources.logging import LoggingResource
+    from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
+    from plugins.builtin.resources.ollama_llm import OllamaLLMResource
+    from .plugins.prompts.basic_error_handler import BasicErrorHandler
+    from .core.stages import PipelineStage
+    from .core.plugins import PromptPlugin, ToolPlugin
+    from .utils.setup_manager import Layer0SetupManager
+    from entity.workflows.default import DefaultWorkflow
+    from entity.core.registries import SystemRegistries
+    from entity.core.runtime import AgentRuntime
+    from entity.core.resources.container import ResourceContainer
+except ModuleNotFoundError as exc:  # pragma: no cover - missing optional deps
+    _handle_import_error(exc)
 
 
 def _create_default_agent() -> Agent:


### PR DESCRIPTION
## Summary
- guard optional imports in `src/entity/__init__.py`
- add project note

## Testing
- `poetry run ruff check --fix src tests` *(fails: 159 errors)*
- `poetry run mypy src` *(fails: found 297 errors)*
- `poetry run bandit -r src` *(fails: 58 issues)*
- `poetry run vulture src tests` *(fails: syntax errors in templates)*
- `poetry run unimport src tests` *(fails: invalid syntax in templates)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: Ollama not reachable)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: Ollama not reachable)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: requires --config)*
- `pytest tests/test_architecture/ -v` *(fails: ModuleNotFoundError: no module named 'entity')*
- `pytest tests/test_plugins/ -v` *(fails: ModuleNotFoundError: no module named 'entity')*
- `pytest tests/test_resources/ -v` *(fails: ModuleNotFoundError: no module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_6873f08871008322aad9919b6f8f9123