### PR TITLE
Add LlamaCpp infrastructure plugin

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-05: Added LlamaCppInfrastructure plugin for running local llama.cpp server
 AGENT NOTE - 2025-07-13: Added has_plugin method to PluginRegistry to fix workflow validation
 AGENT NOTE - 2025-08-04: Resolved lingering merge markers and restored notes
 AGENT NOTE - 2025-08-02: Resolved remaining merge conflict markers

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -6,3 +6,20 @@ same sequence in which they were added. Both `get_plugins_for_stage()` and
 `list_plugins()` return plugins in registration order, guaranteeing
 deterministic execution whenever multiple plugins share a stage.
 
+
+## LlamaCppInfrastructure
+
+The `LlamaCppInfrastructure` plugin runs a local [llama.cpp](https://github.com/ggerganov/llama.cpp) server. Configure the binary path and model file:
+
+```yaml
+infrastructure:
+  llm:
+    type: entity.infrastructure.llamacpp.LlamaCppInfrastructure
+    binary: /usr/local/bin/llama
+    model: /models/mistral-q4.bin
+    host: 127.0.0.1
+    port: 8080
+    args: ["--threads", "4"]
+```
+
+Register the plugin in your workflow or resource container like any other infrastructure plugin.

--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -3,6 +3,7 @@ from .duckdb import DuckDBInfrastructure
 from .docker import DockerInfrastructure
 from .opentofu import OpenTofuInfrastructure
 from .aws_standard import AWSStandardInfrastructure
+from .llamacpp import LlamaCppInfrastructure
 
 __all__ = [
     "PostgresInfrastructure",
@@ -10,4 +11,5 @@ __all__ = [
     "DockerInfrastructure",
     "OpenTofuInfrastructure",
     "AWSStandardInfrastructure",
+    "LlamaCppInfrastructure",
 ]

--- a/src/entity/infrastructure/llamacpp.py
+++ b/src/entity/infrastructure/llamacpp.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List
+
+import httpx
+
+from entity.core.plugins import InfrastructurePlugin
+
+
+class LlamaCppInfrastructure(InfrastructurePlugin):
+    """Run a local llama.cpp server."""
+
+    name = "llamacpp"
+    infrastructure_type = "llm_provider"
+    stages: List = []
+    dependencies: List[str] = []
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.binary = self.config.get("binary", "llama")
+        self.model = self.config.get("model")
+        self.host = self.config.get("host", "127.0.0.1")
+        self.port = int(self.config.get("port", 8000))
+        self.args = self.config.get("args", [])
+        self._proc: asyncio.subprocess.Process | None = None
+
+    async def initialize(self) -> None:
+        if self._proc is not None:
+            return
+        cmd = [
+            self.binary,
+            "--model",
+            self.model,
+            "--host",
+            self.host,
+            "--port",
+            str(self.port),
+            *self.args,
+        ]
+        self._proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+    async def validate_runtime(self) -> bool:
+        url = f"http://{self.host}:{self.port}/health"
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(url)
+            return resp.status_code == 200
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def shutdown(self) -> None:
+        if self._proc is None:
+            return
+        self._proc.terminate()
+        try:
+            await asyncio.wait_for(self._proc.wait(), timeout=5)
+        except asyncio.TimeoutError:  # pragma: no cover - best effort cleanup
+            self._proc.kill()
+        self._proc = None

--- a/tests/infrastructure/test_llamacpp.py
+++ b/tests/infrastructure/test_llamacpp.py
@@ -1,0 +1,72 @@
+import asyncio
+
+import pytest
+
+from entity.infrastructure.llamacpp import LlamaCppInfrastructure
+
+
+class FakeProcess:
+    def __init__(self):
+        self.terminated = False
+        self.waited = False
+        self.killed = False
+
+    def terminate(self):
+        self.terminated = True
+
+    async def wait(self):
+        self.waited = True
+        return 0
+
+    def kill(self):
+        self.killed = True
+
+
+@pytest.mark.asyncio
+async def test_initialize_and_shutdown(monkeypatch):
+    calls = {}
+
+    async def fake_exec(*args, **kwargs):
+        calls["args"] = list(args)
+        return FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    infra = LlamaCppInfrastructure(
+        {
+            "binary": "foo",
+            "model": "bar.bin",
+            "host": "0.0.0.0",
+            "port": 1234,
+            "args": ["--threads", "1"],
+        }
+    )
+    await infra.initialize()
+    proc = infra._proc
+    assert calls["args"][0] == "foo"
+    assert "--model" in calls["args"]
+    assert proc is not None
+
+    await infra.shutdown()
+    assert proc.terminated
+    assert proc.waited
+    assert infra._proc is None
+
+
+@pytest.mark.asyncio
+async def test_validate_runtime(monkeypatch):
+    class R:
+        def __init__(self, code):
+            self.status_code = code
+
+    async def fake_get(self, url):
+        return R(200)
+
+    monkeypatch.setattr("httpx.AsyncClient.get", fake_get, raising=False)
+    infra = LlamaCppInfrastructure({"model": "m"})
+    assert await infra.validate_runtime() is True
+
+    async def fake_get_bad(self, url):
+        raise RuntimeError
+
+    monkeypatch.setattr("httpx.AsyncClient.get", fake_get_bad, raising=False)
+    assert await infra.validate_runtime() is False


### PR DESCRIPTION
## Summary
- add `LlamaCppInfrastructure` to manage a local llama.cpp server
- export the plugin from `entity.infrastructure`
- document configuration example in `plugins.md`
- test process startup and runtime validation
- log note about the new plugin

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(failed: Command not found)*
- `poetry run unimport --remove-all src tests` *(failed: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml`
- `poetry run pytest tests/architecture -v`
- `poetry run pytest tests/plugins -v`
- `poetry run pytest tests/resources -v` *(failed: 1 failed, 6 passed)*
- `poetry run pytest tests/infrastructure/test_llamacpp.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6873f09ddcbc83228bdce2f4302a4e70