### PR TITLE
docs: add poe usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,9 @@ poetry install --with dev
 pip install -e ".[dev]"
 ```
 
+With dependencies installed you can run the included poe tasks:
+
+```bash
+poe test
+```
+

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Documented poe usage and PYTHONPATH for tasks
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ sphinxcontrib-mermaid = "^1.0.0"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.poe.env]
+PYTHONPATH = "src"
+
 [tool.poe.tasks]
 docs = { cmd = "sphinx-build -c docs/source docs/source docs/build/html" }
 docs_view = { cmd = "sphinx-autobuild -c docs/source docs/source docs/build/html" }


### PR DESCRIPTION
## Summary
- document how to run poe tasks
- set `PYTHONPATH` for poe tasks
- log note for future contributors

## Testing
- `poetry run poe test` *(fails: ModuleNotFoundError: entity.pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_6873f368e2308322ba46f796b74b87dc