### PR TITLE
Add llama.cpp infrastructure plugin

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-08-06: Revised LlamaCppInfrastructure runtime validation with timeout and status checks
+AGENT NOTE - 2025-08-05: Added LlamaCppInfrastructure plugin for launching local llama.cpp servers
 AGENT NOTE - 2025-07-13: Added has_plugin method to PluginRegistry to fix workflow validation
 AGENT NOTE - 2025-08-04: Resolved lingering merge markers and restored notes
 AGENT NOTE - 2025-08-02: Resolved remaining merge conflict markers

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -6,3 +6,21 @@ same sequence in which they were added. Both `get_plugins_for_stage()` and
 `list_plugins()` return plugins in registration order, guaranteeing
 deterministic execution whenever multiple plugins share a stage.
 
+## LlamaCppInfrastructure
+
+`LlamaCppInfrastructure` manages a local `llama.cpp` server used by
+`LLMResource` providers. The plugin launches the server binary and
+validates it via the `/health` endpoint.
+
+```yaml
+plugins:
+  infrastructure:
+    llama:
+      type: entity.infrastructure.llamacpp:LlamaCppInfrastructure
+      binary: ./server
+      model: phi3.Q4_K_M
+      host: 0.0.0.0
+      port: 8080
+      args: [--threads, 4]
+```
+

--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -3,6 +3,7 @@ from .duckdb import DuckDBInfrastructure
 from .docker import DockerInfrastructure
 from .opentofu import OpenTofuInfrastructure
 from .aws_standard import AWSStandardInfrastructure
+from .llamacpp import LlamaCppInfrastructure
 
 __all__ = [
     "PostgresInfrastructure",
@@ -10,4 +11,5 @@ __all__ = [
     "DockerInfrastructure",
     "OpenTofuInfrastructure",
     "AWSStandardInfrastructure",
+    "LlamaCppInfrastructure",
 ]

--- a/src/entity/infrastructure/llamacpp.py
+++ b/src/entity/infrastructure/llamacpp.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Sequence
+
+import httpx
+
+from entity.core.plugins import InfrastructurePlugin, ValidationResult
+
+
+class LlamaCppInfrastructure(InfrastructurePlugin):
+    """Launch a local llama.cpp server."""
+
+    name = "llamacpp"
+    infrastructure_type = "llm_provider"
+    resource_category = "infrastructure"
+    stages: list = []
+    dependencies: list[str] = []
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.binary = self.config.get("binary", "llama")
+        self.model = self.config.get("model", "")
+        self.host = self.config.get("host", "127.0.0.1")
+        self.port = int(self.config.get("port", 8000))
+        self.args: Sequence[str] = self.config.get("args", [])
+        self._process: asyncio.subprocess.Process | None = None
+
+    async def initialize(self) -> None:
+        if self._process is not None:
+            return
+        cmd = [
+            self.binary,
+            "--model",
+            self.model,
+            "--host",
+            self.host,
+            "--port",
+            str(self.port),
+            *self.args,
+        ]
+        self._process = await asyncio.create_subprocess_exec(*cmd)
+
+    async def validate_runtime(self) -> ValidationResult:
+        url = f"http://{self.host}:{self.port}/health"
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(url, timeout=5.0)
+                resp.raise_for_status()
+        except Exception as exc:  # noqa: BLE001
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()
+
+    async def shutdown(self) -> None:
+        if self._process is None:
+            return
+        self._process.terminate()
+        try:
+            await asyncio.wait_for(self._process.wait(), timeout=5)
+        except Exception:  # noqa: BLE001 - best effort cleanup
+            self._process.kill()
+        self._process = None

--- a/tests/infrastructure/test_llamacpp.py
+++ b/tests/infrastructure/test_llamacpp.py
@@ -1,0 +1,47 @@
+import asyncio
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from entity.infrastructure.llamacpp import LlamaCppInfrastructure
+
+
+@pytest.mark.asyncio
+async def test_validate_runtime_success(monkeypatch):
+    infra = LlamaCppInfrastructure({"host": "localhost", "port": 9999})
+
+    async def fake_get(self, url, timeout=5.0):
+        return SimpleNamespace(status_code=200, raise_for_status=lambda: None)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    result = await infra.validate_runtime()
+    assert result.success
+
+
+@pytest.mark.asyncio
+async def test_initialize_and_shutdown(monkeypatch):
+    calls = {}
+
+    class DummyProc:
+        def terminate(self):
+            calls["terminated"] = True
+
+        async def wait(self):
+            calls["waited"] = True
+
+    async def fake_exec(*_args, **_kwargs):
+        calls["started"] = True
+        return DummyProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    infra = LlamaCppInfrastructure({"binary": "dummy", "model": "foo"})
+    await infra.initialize()
+    assert calls.get("started")
+    assert infra._process is not None
+
+    await infra.shutdown()
+    assert calls.get("terminated")
+    assert calls.get("waited")
+    assert infra._process is None


### PR DESCRIPTION
## Summary
- add LlamaCppInfrastructure to manage llama.cpp servers
- document how to register the plugin in plugins.md
- validate runtime with HTTP status checks and timeout
- test process lifecycle and runtime validation
- log the update in agents.log

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 159 errors)*
- `poetry run mypy src` *(fails: 297 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(missing --config)*
- `pytest tests/test_architecture/ -v` *(ImportError)*
- `pytest tests/test_plugins/ -v` *(ImportError)*
- `pytest tests/test_resources/ -v` *(ImportError)*
- `pytest tests/infrastructure/test_llamacpp.py -v` *(ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6873eff45b188322ab5809ebdd02d504