### PR TITLE
Resolve merge conflicts in llama cpp docs

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,26 +1,6 @@
-<<<<<<< HEAD
-AGENT NOTE - 2025-07-13: Documented poe usage and PYTHONPATH for tasks
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-AGENT NOTE - 2025-07-13: Clarified dev dependencies required before tests in README
-=======
-AGENT NOTE - 2025-07-13: Ran poetry install and executed pytest as requested
->>>>>>> pr-1473
-=======
-AGENT NOTE - 2025-07-13: Documented pytest-asyncio requirement for tests
->>>>>>> pr-1475
-=======
-AGENT NOTE - 2025-07-13: Added ImportError guard for optional deps in __init__.py
->>>>>>> pr-1476
-=======
-AGENT NOTE - 2025-08-05: Added LlamaCppInfrastructure plugin for running local llama.cpp server
->>>>>>> pr-1478
-=======
+AGENT NOTE - 2025-07-13: Resolved merge conflicts for LlamaCppInfrastructure documentation and tests
 AGENT NOTE - 2025-08-06: Revised LlamaCppInfrastructure runtime validation with timeout and status checks
 AGENT NOTE - 2025-08-05: Added LlamaCppInfrastructure plugin for launching local llama.cpp servers
->>>>>>> pr-1480
 AGENT NOTE - 2025-07-13: Added has_plugin method to PluginRegistry to fix workflow validation
 AGENT NOTE - 2025-08-04: Resolved lingering merge markers and restored notes
 AGENT NOTE - 2025-08-02: Resolved remaining merge conflict markers

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -6,29 +6,10 @@ same sequence in which they were added. Both `get_plugins_for_stage()` and
 `list_plugins()` return plugins in registration order, guaranteeing
 deterministic execution whenever multiple plugins share a stage.
 
-<<<<<<< HEAD
-
 ## LlamaCppInfrastructure
 
-The `LlamaCppInfrastructure` plugin runs a local [llama.cpp](https://github.com/ggerganov/llama.cpp) server. Configure the binary path and model file:
-
-```yaml
-infrastructure:
-  llm:
-    type: entity.infrastructure.llamacpp.LlamaCppInfrastructure
-    binary: /usr/local/bin/llama
-    model: /models/mistral-q4.bin
-    host: 127.0.0.1
-    port: 8080
-    args: ["--threads", "4"]
-```
-
-Register the plugin in your workflow or resource container like any other infrastructure plugin.
-=======
-## LlamaCppInfrastructure
-
-`LlamaCppInfrastructure` manages a local `llama.cpp` server used by
-`LLMResource` providers. The plugin launches the server binary and
+`LlamaCppInfrastructure` manages a local [llama.cpp](https://github.com/ggerganov/llama.cpp)
+server used by `LLMResource` providers. The plugin launches the server binary and
 validates it via the `/health` endpoint.
 
 ```yaml
@@ -36,11 +17,12 @@ plugins:
   infrastructure:
     llama:
       type: entity.infrastructure.llamacpp:LlamaCppInfrastructure
-      binary: ./server
-      model: phi3.Q4_K_M
-      host: 0.0.0.0
+      binary: /usr/local/bin/llama
+      model: /models/mistral-q4.bin
+      host: 127.0.0.1
       port: 8080
-      args: [--threads, 4]
+      args: ["--threads", "4"]
 ```
 
->>>>>>> pr-1480
+Register the plugin in your workflow or resource container like any other
+infrastructure plugin.

--- a/src/entity/infrastructure/llamacpp.py
+++ b/src/entity/infrastructure/llamacpp.py
@@ -1,22 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-<<<<<<< HEAD
-from typing import Dict, List
-
-import httpx
-
-from entity.core.plugins import InfrastructurePlugin
-
-
-class LlamaCppInfrastructure(InfrastructurePlugin):
-    """Run a local llama.cpp server."""
-
-    name = "llamacpp"
-    infrastructure_type = "llm_provider"
-    stages: List = []
-    dependencies: List[str] = []
-=======
 from typing import Dict, Sequence
 
 import httpx
@@ -32,21 +16,10 @@ class LlamaCppInfrastructure(InfrastructurePlugin):
     resource_category = "infrastructure"
     stages: list = []
     dependencies: list[str] = []
->>>>>>> pr-1480
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
         self.binary = self.config.get("binary", "llama")
-<<<<<<< HEAD
-        self.model = self.config.get("model")
-        self.host = self.config.get("host", "127.0.0.1")
-        self.port = int(self.config.get("port", 8000))
-        self.args = self.config.get("args", [])
-        self._proc: asyncio.subprocess.Process | None = None
-
-    async def initialize(self) -> None:
-        if self._proc is not None:
-=======
         self.model = self.config.get("model", "")
         self.host = self.config.get("host", "127.0.0.1")
         self.port = int(self.config.get("port", 8000))
@@ -55,7 +28,6 @@ class LlamaCppInfrastructure(InfrastructurePlugin):
 
     async def initialize(self) -> None:
         if self._process is not None:
->>>>>>> pr-1480
             return
         cmd = [
             self.binary,
@@ -67,32 +39,6 @@ class LlamaCppInfrastructure(InfrastructurePlugin):
             str(self.port),
             *self.args,
         ]
-<<<<<<< HEAD
-        self._proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-
-    async def validate_runtime(self) -> bool:
-        url = f"http://{self.host}:{self.port}/health"
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(url)
-            return resp.status_code == 200
-        except Exception:  # noqa: BLE001
-            return False
-
-    async def shutdown(self) -> None:
-        if self._proc is None:
-            return
-        self._proc.terminate()
-        try:
-            await asyncio.wait_for(self._proc.wait(), timeout=5)
-        except asyncio.TimeoutError:  # pragma: no cover - best effort cleanup
-            self._proc.kill()
-        self._proc = None
-=======
         self._process = await asyncio.create_subprocess_exec(*cmd)
 
     async def validate_runtime(self) -> ValidationResult:
@@ -114,4 +60,3 @@ class LlamaCppInfrastructure(InfrastructurePlugin):
         except Exception:  # noqa: BLE001 - best effort cleanup
             self._process.kill()
         self._process = None
->>>>>>> pr-1480

--- a/tests/infrastructure/test_llamacpp.py
+++ b/tests/infrastructure/test_llamacpp.py
@@ -1,33 +1,12 @@
 import asyncio
-<<<<<<< HEAD
-
-=======
 from types import SimpleNamespace
 
 import httpx
->>>>>>> pr-1480
 import pytest
 
 from entity.infrastructure.llamacpp import LlamaCppInfrastructure
 
 
-<<<<<<< HEAD
-class FakeProcess:
-    def __init__(self):
-        self.terminated = False
-        self.waited = False
-        self.killed = False
-
-    def terminate(self):
-        self.terminated = True
-
-    async def wait(self):
-        self.waited = True
-        return 0
-
-    def kill(self):
-        self.killed = True
-=======
 @pytest.mark.asyncio
 async def test_validate_runtime_success(monkeypatch):
     infra = LlamaCppInfrastructure({"host": "localhost", "port": 9999})
@@ -38,59 +17,12 @@ async def test_validate_runtime_success(monkeypatch):
     monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
     result = await infra.validate_runtime()
     assert result.success
->>>>>>> pr-1480
 
 
 @pytest.mark.asyncio
 async def test_initialize_and_shutdown(monkeypatch):
     calls = {}
 
-<<<<<<< HEAD
-    async def fake_exec(*args, **kwargs):
-        calls["args"] = list(args)
-        return FakeProcess()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-    infra = LlamaCppInfrastructure(
-        {
-            "binary": "foo",
-            "model": "bar.bin",
-            "host": "0.0.0.0",
-            "port": 1234,
-            "args": ["--threads", "1"],
-        }
-    )
-    await infra.initialize()
-    proc = infra._proc
-    assert calls["args"][0] == "foo"
-    assert "--model" in calls["args"]
-    assert proc is not None
-
-    await infra.shutdown()
-    assert proc.terminated
-    assert proc.waited
-    assert infra._proc is None
-
-
-@pytest.mark.asyncio
-async def test_validate_runtime(monkeypatch):
-    class R:
-        def __init__(self, code):
-            self.status_code = code
-
-    async def fake_get(self, url):
-        return R(200)
-
-    monkeypatch.setattr("httpx.AsyncClient.get", fake_get, raising=False)
-    infra = LlamaCppInfrastructure({"model": "m"})
-    assert await infra.validate_runtime() is True
-
-    async def fake_get_bad(self, url):
-        raise RuntimeError
-
-    monkeypatch.setattr("httpx.AsyncClient.get", fake_get_bad, raising=False)
-    assert await infra.validate_runtime() is False
-=======
     class DummyProc:
         def terminate(self):
             calls["terminated"] = True
@@ -113,4 +45,3 @@ async def test_validate_runtime(monkeypatch):
     assert calls.get("terminated")
     assert calls.get("waited")
     assert infra._process is None
->>>>>>> pr-1480


### PR DESCRIPTION
## Summary
- fix merge markers in `LlamaCppInfrastructure`
- fix docs and tests for llama.cpp server plugin
- clean up `agents.log`

## Testing
- `poetry run black src/entity/infrastructure/llamacpp.py tests/infrastructure/test_llamacpp.py`
- `poetry run ruff check --fix src tests` *(fails: 159 errors)*
- `poetry run mypy src` *(fails: found 299 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `pytest tests/infrastructure/test_llamacpp.py` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6873f66dc0b88322af694a5a8e9ca0fe