### PR TITLE
Add YAML plugin order test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added YAML plugin ordering test and documentation
 AGENT NOTE - 2025-07-13: Resolved merge conflicts for LlamaCppInfrastructure documentation and tests
 AGENT NOTE - 2025-08-06: Revised LlamaCppInfrastructure runtime validation with timeout and status checks
 AGENT NOTE - 2025-08-05: Added LlamaCppInfrastructure plugin for launching local llama.cpp servers

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -6,6 +6,11 @@ same sequence in which they were added. Both `get_plugins_for_stage()` and
 `list_plugins()` return plugins in registration order, guaranteeing
 deterministic execution whenever multiple plugins share a stage.
 
+Plugins declared in a YAML configuration file maintain this ordering as well.
+The initializer reads entries sequentially and registers each plugin as it
+appears, so restarting the system with the same YAML file yields identical
+execution order.
+
 ## LlamaCppInfrastructure
 
 `LlamaCppInfrastructure` manages a local [llama.cpp](https://github.com/ggerganov/llama.cpp)

--- a/tests/plugins/test_execution_order.py
+++ b/tests/plugins/test_execution_order.py
@@ -1,0 +1,51 @@
+import yaml
+import pytest
+
+from entity.pipeline.initializer import SystemInitializer
+from entity.core.plugins import Plugin
+from entity.core.resources.container import ResourceContainer
+from entity.pipeline.stages import PipelineStage
+
+
+class FirstPlugin(Plugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        return "first"
+
+
+class SecondPlugin(Plugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context):
+        return "second"
+
+
+@pytest.mark.asyncio
+async def test_plugin_order_preserved(tmp_path, monkeypatch):
+    cfg = {
+        "plugins": {
+            "prompts": {
+                "first": {"type": f"{__name__}:FirstPlugin"},
+                "second": {"type": f"{__name__}:SecondPlugin"},
+            }
+        },
+        "workflow": {},
+    }
+    cfg_file = tmp_path / "init.yaml"
+    cfg_file.write_text(yaml.safe_dump(cfg))
+
+    async def _noop(self):
+        return None
+
+    monkeypatch.setattr(ResourceContainer, "build_all", _noop)
+    monkeypatch.setattr(
+        SystemInitializer, "_ensure_canonical_resources", lambda self, container: None
+    )
+
+    init = SystemInitializer.from_yaml(str(cfg_file))
+    registry, container, tool_registry, workflow = await init.initialize()
+
+    assert [p.__class__ for p in registry.list_plugins()] == [FirstPlugin, SecondPlugin]
+    stage_plugins = registry.get_plugins_for_stage(str(PipelineStage.THINK))
+    assert [p.__class__ for p in stage_plugins] == [FirstPlugin, SecondPlugin]


### PR DESCRIPTION
## Summary
- test plugin registry ordering from YAML config
- clarify YAML ordering guarantee in developer docs

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 159 errors)*
- `poetry run mypy src` *(fails: found 299 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `poetry run pytest tests/test_architecture/ -v` *(fails: 3 failed, 3 passed)*
- `poetry run pytest tests/test_plugins/ -v` *(fails: 3 failed, 9 passed)*
- `poetry run pytest tests/test_resources/ -v`
- `poetry run pytest` *(fails: 6 errors during collection)*
- `poetry run pytest tests/integration/ -v` *(fails: 7 failed, 2 passed)*
- `poetry run pytest tests/infrastructure/ -v`
- `poetry run pytest tests/performance/ -m benchmark` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f866095c8322b04f6e8b5f22b4d3