### PR TITLE
Fix test import paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Use this document when preparing changes or reviewing pull requests.
 - Create `AGENT NOTE:` comments for other agents.
 - Always use the Poetry environment for development.
 - Run `poetry install --with dev` before executing any quality checks or tests.
+- Run tests using `poetry run poe test` or related tasks to ensure `PYTHONPATH` is set.
 - Use the `agents.log` file to track changes and decisions made during development.
 - **DO NOT use the `agents.log` file for architectural decisions!** Architectural decisions must be documented in `ARCHITECTURE.md`.
 - 
@@ -312,9 +313,9 @@ poetry run entity-cli --config config/prod.yaml verify
 poetry run python -m src.entity.core.registry_validator
 
 # Test architectural boundaries
-pytest tests/test_architecture/ -v
-pytest tests/test_plugins/ -v
-pytest tests/test_resources/ -v
+poetry run poe test-architecture
+poetry run poe test-plugins
+poetry run poe test-resources
 ```
 
 ## Review Decision Tree

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-13: Use conftest to set PYTHONPATH and new poe test tasks
+AGENT NOTE - 2025-07-13: Added sys.path setup for tests to locate entity packages
 AGENT NOTE - 2025-07-13: Resolved merge conflicts for LlamaCppInfrastructure documentation and tests
 AGENT NOTE - 2025-08-06: Revised LlamaCppInfrastructure runtime validation with timeout and status checks
 AGENT NOTE - 2025-08-05: Added LlamaCppInfrastructure plugin for launching local llama.cpp servers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,9 @@ release = ["docs", "patch", "_publish"]
 test = { cmd = "pytest" }
 test-verbose = { cmd = "pytest -v" }
 test-coverage = { cmd = "pytest --cov=src --cov-report=html --cov-report=term-missing" }
+test-architecture = { cmd = "pytest tests/test_architecture/ -v" }
+test-plugins = { cmd = "pytest tests/test_plugins/ -v" }
+test-resources = { cmd = "pytest tests/test_resources/ -v" }
 setup-dev = { cmd = "poetry install --with dev" }
 [tool.poe.tasks.lint]
 sequence = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 from pathlib import Path
+import sys
 
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from entity.infrastructure import DuckDBInfrastructure
 from entity.resources import Memory

--- a/tests/plugins/harness.py
+++ b/tests/plugins/harness.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import sys
-import pathlib
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
 
 from entity.core.plugins import Plugin
 from cli.plugin_tool.utils import load_plugin

--- a/tests/plugins/test_harness.py
+++ b/tests/plugins/test_harness.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
 
 from tests.plugins.harness import run_plugin
 

--- a/tests/plugins/test_stage_assignment.py
+++ b/tests/plugins/test_stage_assignment.py
@@ -1,10 +1,5 @@
 import logging
-import pathlib
-import sys
-
 import pytest
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
 
 from entity.core.context import PluginContext
 from entity.core.plugins import Plugin, PromptPlugin

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -1,13 +1,9 @@
-import pathlib
-import sys
 from typing import Iterable
 
 import pytest
 
 from entity.workflows.base import Workflow
 from entity.pipeline.stages import PipelineStage
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
 
 from entity.cli import EntityCLI, CLIArgs
 

--- a/tests/test_decorator_plugin.py
+++ b/tests/test_decorator_plugin.py
@@ -1,8 +1,4 @@
-import pathlib
-import sys
 import pytest
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
 
 from entity.core import plugin_utils
 from entity.core.plugins import (

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,8 +1,3 @@
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
-
 from entity import Agent
 from entity.core import decorators
 from entity.core.stages import PipelineStage

--- a/tests/test_initializer_canonical_resources.py
+++ b/tests/test_initializer_canonical_resources.py
@@ -1,13 +1,8 @@
-import pathlib
-import sys
 import asyncio
 import pytest
 from entity.core.resources.container import ResourceContainer
 from entity.pipeline.errors import InitializationError
 from entity.resources.logging import LoggingResource
-
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
 
 from entity.pipeline.initializer import SystemInitializer
 

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -1,12 +1,6 @@
 import types
 import pytest
 
-import sys
-import pathlib
-
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
-
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
 from entity.core.stages import PipelineStage

--- a/tests/test_plugin_tool_analyze.py
+++ b/tests/test_plugin_tool_analyze.py
@@ -1,9 +1,4 @@
 import logging
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
-
 from cli.plugin_tool.main import PluginToolCLI, PluginToolArgs
 
 

--- a/tests/test_plugin_tool_test.py
+++ b/tests/test_plugin_tool_test.py
@@ -1,9 +1,4 @@
 import logging
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
-
 from cli.plugin_tool.main import PluginToolCLI, PluginToolArgs
 
 

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -1,5 +1,4 @@
 import logging
-
 from entity.pipeline import Plugin  # noqa: F401 - configure plugins
 
 from entity.core.plugin_utils import PluginAutoClassifier

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -1,8 +1,3 @@
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
-
 import pytest
 import yaml
 from entity.core.plugins import (

--- a/tests/test_response_control.py
+++ b/tests/test_response_control.py
@@ -1,8 +1,4 @@
 from datetime import datetime
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
 import pytest
 
 from entity.core.context import PluginContext


### PR DESCRIPTION
## Summary
- ensure pytest can find `entity` and `plugins` packages via `tests/conftest.py`
- run tests through new poe tasks that set `PYTHONPATH`
- update contributor instructions with the new workflow

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: E402 etc.)*
- `poetry run mypy src` *(fails: Found 299 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport -r src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: Ollama not reachable)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: Ollama not reachable)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing `--config`)*
- `poetry run poe test-architecture` *(fails: 3 failed, 3 passed)*
- `poetry run poe test-plugins` *(fails: 3 failed, 9 passed)*
- `poetry run poe test-resources`

------
https://chatgpt.com/codex/tasks/task_e_6873f83bb5008322ad72b608757876e2