### PR TITLE
Add example plugins to default workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ print(asyncio.run(agent.handle("Hello")))
 
 ## Example Plugins
 
-Check the `examples/plugins` directory for minimal plugins demonstrating the
+Check the `src/plugins/examples` directory for minimal plugins demonstrating the
 INPUT, PARSE, and REVIEW stages. Each shows how to interact with the
-`PluginContext` during execution. The rendered source is available in the
+`PluginContext` during execution. These plugins are registered in the
+`DefaultWorkflow` for quick experimentation. The rendered source is available in the
 [Plugin Examples](https://entity.readthedocs.io/en/latest/plugin_examples.html)
 documentation.
 

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow
 AGENT NOTE - 2025-07-13: Resolved merge conflicts for LlamaCppInfrastructure documentation and tests
 AGENT NOTE - 2025-08-06: Revised LlamaCppInfrastructure runtime validation with timeout and status checks
 AGENT NOTE - 2025-08-05: Added LlamaCppInfrastructure plugin for launching local llama.cpp servers

--- a/docs/source/plugin_examples.md
+++ b/docs/source/plugin_examples.md
@@ -1,6 +1,6 @@
 # Plugin Examples
 
-The `examples/plugins/` directory contains minimal plugins for each pipeline stage.
+The `src/plugins/examples/` directory contains minimal plugins for each pipeline stage.
 These demonstrate how to interact with the `PluginContext` and which methods
 are appropriate for different stages.
 
@@ -9,7 +9,7 @@ are appropriate for different stages.
 `InputLogger` runs during the **INPUT** stage and saves the raw user message for
 later steps.
 
-```{literalinclude} ../../examples/plugins/input_logger.py
+```{literalinclude} ../../src/plugins/examples/input_logger.py
 :language: python
 :caption: InputLogger
 ```
@@ -19,7 +19,7 @@ later steps.
 `MessageParser` executes in the **PARSE** stage and normalizes the user's
 message.
 
-```{literalinclude} ../../examples/plugins/message_parser.py
+```{literalinclude} ../../src/plugins/examples/message_parser.py
 :language: python
 :caption: MessageParser
 ```
@@ -29,7 +29,7 @@ message.
 `ResponseReviewer` runs in the **REVIEW** stage to modify the final response if
 needed.
 
-```{literalinclude} ../../examples/plugins/response_reviewer.py
+```{literalinclude} ../../src/plugins/examples/response_reviewer.py
 :language: python
 :caption: ResponseReviewer
 ```

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -26,6 +26,7 @@ try:
     from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
     from plugins.builtin.resources.ollama_llm import OllamaLLMResource
     from .plugins.prompts.basic_error_handler import BasicErrorHandler
+    from plugins.examples import InputLogger, MessageParser, ResponseReviewer
     from .core.stages import PipelineStage
     from .core.plugins import PromptPlugin, ToolPlugin
     from .utils.setup_manager import Layer0SetupManager
@@ -85,6 +86,9 @@ def _create_default_agent() -> Agent:
         plugins=builder.plugin_registry,
     )
     asyncio.run(builder.add_plugin(BasicErrorHandler({})))
+    asyncio.run(builder.add_plugin(InputLogger({})))
+    asyncio.run(builder.add_plugin(MessageParser({})))
+    asyncio.run(builder.add_plugin(ResponseReviewer({})))
     workflow = getattr(setup, "workflow", DefaultWorkflow())
     agent._runtime = AgentRuntime(caps, workflow=workflow)
     return agent

--- a/src/entity/workflows/default.py
+++ b/src/entity/workflows/default.py
@@ -13,8 +13,10 @@ class DefaultWorkflow(Workflow):
     """Simple INPUT -> THINK -> OUTPUT workflow."""
 
     stage_map = {
-        PipelineStage.INPUT: [],
+        PipelineStage.INPUT: ["input_logger"],
+        PipelineStage.PARSE: ["message_parser"],
         PipelineStage.THINK: [],
+        PipelineStage.REVIEW: ["response_reviewer"],
         PipelineStage.OUTPUT: [],
         PipelineStage.ERROR: ["basic_error_handler"],
     }

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,1 +1,6 @@
 """Entry point for plugin modules."""
+
+# Include example plugins for reference
+from . import examples  # noqa: F401
+
+__all__ = ["examples"]

--- a/src/plugins/examples/__init__.py
+++ b/src/plugins/examples/__init__.py
@@ -1,0 +1,7 @@
+"""Simple example plugins showing various stages."""
+
+from .input_logger import InputLogger
+from .message_parser import MessageParser
+from .response_reviewer import ResponseReviewer
+
+__all__ = ["InputLogger", "MessageParser", "ResponseReviewer"]

--- a/src/plugins/examples/input_logger.py
+++ b/src/plugins/examples/input_logger.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from entity.core.context import PluginContext
+from entity.core.plugins import InputAdapterPlugin
+from entity.pipeline.stages import PipelineStage
+
+
+class InputLogger(InputAdapterPlugin):
+    """Record the raw user message."""
+
+    name = "input_logger"
+
+    stages = [PipelineStage.INPUT]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        message = context.conversation()[-1].content if context.conversation() else ""
+        await context.think("raw_input", message)

--- a/src/plugins/examples/message_parser.py
+++ b/src/plugins/examples/message_parser.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from entity.core.context import PluginContext
+from entity.core.plugins import PromptPlugin
+from entity.pipeline.stages import PipelineStage
+
+
+class MessageParser(PromptPlugin):
+    """Normalize user input for later stages."""
+
+    name = "message_parser"
+
+    stages = [PipelineStage.PARSE]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        raw = context.conversation()[-1].content if context.conversation() else ""
+        await context.think("parsed_input", raw.strip().lower())

--- a/src/plugins/examples/response_reviewer.py
+++ b/src/plugins/examples/response_reviewer.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from entity.core.context import PluginContext
+from entity.core.plugins import PromptPlugin
+from entity.pipeline.stages import PipelineStage
+
+
+class ResponseReviewer(PromptPlugin):
+    """Sanitize the final response before delivery."""
+
+    name = "response_reviewer"
+
+    stages = [PipelineStage.REVIEW]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        if not context.has_response():
+            return
+        updated = context.response.replace("badword", "***")
+        context.update_response(lambda _old: updated)


### PR DESCRIPTION
## Summary
- add example plugins under `src/plugins/examples`
- register example plugins in the `DefaultWorkflow`
- expose example plugins through the `plugins` package
- document example plugins in the README and docs
- update agent registry note

## Testing
- `poetry run black src tests`
- `poetry run pytest` *(fails: ImportError: cannot import name 'Plugin' from 'entity.pipeline')*

------
https://chatgpt.com/codex/tasks/task_e_6873f8649b08832292825bdaee99e325