### PR TITLE
Fix pipeline __path__ setup

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Ensured pipeline package sets __path__ for plugin discovery
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow
 AGENT NOTE - 2025-07-13: Resolved merge conflicts for LlamaCppInfrastructure documentation and tests

--- a/src/entity/pipeline/__init__.py
+++ b/src/entity/pipeline/__init__.py
@@ -1,7 +1,13 @@
 """Pipeline component:   init  ."""
 
+from __future__ import annotations
+
+import pkgutil
+
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
+
+__path__ = pkgutil.extend_path(globals().get("__path__", []), __name__)
 
 from .exceptions import CircuitBreakerTripped
 from entity.core.circuit_breaker import CircuitBreaker, RetryPolicy


### PR DESCRIPTION
## Summary
- ensure `entity.pipeline` defines `__path__` for namespace packages
- record development note

## Testing
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: Ollama not reachable)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: Ollama not reachable)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `poetry run poe test-architecture` *(fails: tests failed)*
- `poetry run poe test-plugins` *(fails: tests failed)*
- `poetry run poe test-resources`
- `poetry run pytest tests/plugins/test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6873ffe70938832294d3a4fb1b2a58f6