### PR TITLE
Default vector store injection

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-10: Inject default DuckDBVectorStore and keep interfaces under entity.resources.interfaces
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -838,6 +838,14 @@ class SystemInitializer:
             container.register("database", DuckDBResource, {}, layer=2)
             registered.add("database")
 
+        if "vector_store" not in registered:
+            from entity.resources.interfaces.duckdb_vector_store import (
+                DuckDBVectorStore,
+            )
+
+            container.register("vector_store", DuckDBVectorStore, {}, layer=2)
+            registered.add("vector_store")
+
         required = {"memory", "llm", "storage"}
         missing = required - set(container._classes)
         if missing:

--- a/src/plugins/builtin/resources/__init__.py
+++ b/src/plugins/builtin/resources/__init__.py
@@ -3,11 +3,9 @@
 from .echo_llm import EchoLLMResource
 from .ollama_llm import OllamaLLMResource
 from .pg_vector_store import PgVectorStore
-from entity.resources.interfaces.duckdb_resource import DuckDBResource
 
 __all__ = [
     "EchoLLMResource",
     "OllamaLLMResource",
     "PgVectorStore",
-    "DuckDBResource",
 ]


### PR DESCRIPTION
## Summary
- add DuckDBVectorStore to `_ensure_canonical_resources`
- keep only Layer 3 resources in builtin exports
- note the change

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 160 errors)*
- `poetry run mypy src` *(fails: found 302 errors)*
- `poetry run bandit -r src` *(command not found)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run pytest tests/resources` *(fails: InitializationError: Resource 'logging, metrics_collector' failed)*

------
https://chatgpt.com/codex/tasks/task_e_687400fc32f8832292376ad508e22891