### PR TITLE
Add infrastructure_type attribute test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-10: Added infrastructure_type attribute test
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow

--- a/tests/infrastructure/test_infrastructure_attrs.py
+++ b/tests/infrastructure/test_infrastructure_attrs.py
@@ -1,0 +1,9 @@
+import pytest
+from entity import infrastructure as infra
+
+
+@pytest.mark.parametrize("name", infra.__all__)
+def test_infrastructure_has_type(name):
+    cls = getattr(infra, name)
+    assert isinstance(getattr(cls, "infrastructure_type", None), str)
+    assert cls.infrastructure_type


### PR DESCRIPTION
## Summary
- add a unit test checking all infrastructure plugins expose an `infrastructure_type` string
- document the addition in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: many errors)*
- `poetry run mypy src` *(fails: 302 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: syntax errors in template files)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator --config config/dev.yaml` *(fails: AttributeError)*
- `poetry run poe test-architecture` *(fails: 3 failing tests)*
- `poetry run poe test-plugins` *(fails: 3 failing tests)*
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687400fcb8e48322ab51ebaf5c4e184b