### PR TITLE
Enforce adapter stage resolution

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Enforced adapter stage resolution in StageResolver
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow


### PR DESCRIPTION
## Summary
- restrict StageResolver to INPUT/OUTPUT for adapter plugins
- warn and override invalid adapter stages
- test adapter stage enforcement
- log adapter stage enforcement change

## Testing
- `poetry run poe test-plugins` *(fails: Failed: DID NOT RAISE <class 'entity.core.plugins.base.ConfigurationError'>)*
- `poetry run poe test-architecture` *(fails: Failed: DID NOT RAISE <class 'entity.pipeline.errors.InitializationError'>)*
- `poetry run poe test-resources`

------
https://chatgpt.com/codex/tasks/task_e_6874010100ec8322b7df281845f899ca