### PR TITLE
Fix resource cycle detection

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Detect cycles in resource initialization order and add regression tests
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -638,6 +638,8 @@ class ResourceContainer:
             traverse(resource)
 
     def _resolve_order(self) -> List[str]:
+        """Return initialization order or raise if a cycle exists."""
+
         # Build dependency graph with edges from each dependency to its dependents
         graph_map: Dict[str, List[str]] = {name: [] for name in self._deps}
         for name, deps in self._deps.items():
@@ -652,6 +654,6 @@ class ResourceContainer:
             raise InitializationError(
                 ", ".join(sorted(graph_map.keys())),
                 "dependency graph",
-                str(exc),
+                exc.remediation,
                 kind="Resource",
             ) from exc

--- a/tests/resources/test_circular_dependencies.py
+++ b/tests/resources/test_circular_dependencies.py
@@ -1,0 +1,44 @@
+import pytest
+
+from entity.core.resources.container import ResourceContainer
+from entity.pipeline.errors import InitializationError
+from entity.resources.base import AgentResource
+
+
+def test_simple_dependency_cycle():
+    class ResA(AgentResource):
+        stages: list = []
+        dependencies = ["b"]
+
+    class ResB(AgentResource):
+        stages: list = []
+        dependencies = ["a"]
+
+    container = ResourceContainer()
+    container.register("a", ResA, {}, layer=4)
+    container.register("b", ResB, {}, layer=4)
+
+    with pytest.raises(InitializationError, match="Circular dependency detected"):
+        container._resolve_order()
+
+
+def test_longer_dependency_cycle():
+    class ResA(AgentResource):
+        stages: list = []
+        dependencies = ["b"]
+
+    class ResB(AgentResource):
+        stages: list = []
+        dependencies = ["c"]
+
+    class ResC(AgentResource):
+        stages: list = []
+        dependencies = ["a"]
+
+    container = ResourceContainer()
+    container.register("a", ResA, {}, layer=4)
+    container.register("b", ResB, {}, layer=4)
+    container.register("c", ResC, {}, layer=4)
+
+    with pytest.raises(InitializationError, match="Circular dependency detected"):
+        container._resolve_order()


### PR DESCRIPTION
## Summary
- detect cycles when resolving resource order
- test dependency cycle resolution in container
- log update

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: 160 errors)*
- `poetry run mypy src` *(fails: found 302 errors)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(failed: missing --config)*
- `poetry run poe test-architecture` *(fails: 3 failed, 3 passed)*
- `poetry run poe test-plugins` *(fails: 3 failed, 9 passed)*
- `poetry run poe test-resources`
- `poetry run pytest tests/resources/test_circular_dependencies.py -v`

------
https://chatgpt.com/codex/tasks/task_e_68740105253883229b3c133006c5308d