### PR TITLE
Add workflow composition helpers

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added workflow support and composition helpers
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow

--- a/src/entity/workflows/__init__.py
+++ b/src/entity/workflows/__init__.py
@@ -1,11 +1,14 @@
 """Workflow utilities."""
 
 from .base import Workflow
+from .compose import compose_workflows, merge_workflows
 from .builtin import ChainOfThoughtWorkflow, ReActWorkflow, StandardWorkflow
 from .default import DefaultWorkflow, default_workflow
 
 __all__ = [
     "Workflow",
+    "compose_workflows",
+    "merge_workflows",
     "StandardWorkflow",
     "ReActWorkflow",
     "ChainOfThoughtWorkflow",

--- a/src/entity/workflows/compose.py
+++ b/src/entity/workflows/compose.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Utilities for combining workflows."""
+
+
+from entity.pipeline.stages import PipelineStage
+
+from .base import Workflow
+
+__all__ = ["compose_workflows", "merge_workflows"]
+
+
+def compose_workflows(*workflows: Workflow) -> Workflow:
+    """Return a new workflow concatenating plugin lists per stage."""
+
+    mapping: dict[PipelineStage, list[str]] = {}
+    for wf in workflows:
+        for stage, plugins in wf.stages.items():
+            mapping.setdefault(stage, []).extend(list(plugins))
+    return Workflow(mapping)
+
+
+def merge_workflows(*workflows: Workflow) -> Workflow:
+    """Return a new workflow where later workflows override earlier ones."""
+
+    mapping: dict[PipelineStage, list[str]] = {}
+    for wf in workflows:
+        for stage, plugins in wf.stages.items():
+            mapping[stage] = list(plugins)
+    return Workflow(mapping)

--- a/tests/integration/test_workflow_compose.py
+++ b/tests/integration/test_workflow_compose.py
@@ -1,0 +1,54 @@
+import pytest
+
+from entity.core.agent import _AgentBuilder
+from entity.core.plugins import Plugin
+from entity.pipeline.stages import PipelineStage
+from entity.workflows.base import Workflow
+from entity.workflows.compose import compose_workflows
+
+
+class MarkerPlugin(Plugin):
+    stages = [PipelineStage.THINK]
+    executed = False
+
+    async def _execute_impl(self, context):
+        MarkerPlugin.executed = True
+
+
+class EchoPlugin(Plugin):
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context):
+        context.say("ok")
+
+
+class WF1(Workflow):
+    stage_map = {PipelineStage.THINK: ["MarkerPlugin"]}
+
+
+class WF2(Workflow):
+    stage_map = {PipelineStage.OUTPUT: ["EchoPlugin"]}
+
+
+@pytest.mark.asyncio
+async def test_compose_workflows_execute():
+    builder = _AgentBuilder()
+    await builder.add_plugin(MarkerPlugin({}))
+    await builder.add_plugin(EchoPlugin({}))
+
+    wf = compose_workflows(WF1(), WF2())
+    runtime = await builder.build_runtime(wf)
+    result = await runtime.handle("hi")
+
+    assert result == "ok"
+    assert MarkerPlugin.executed
+
+
+@pytest.mark.asyncio
+async def test_compose_validates_plugins():
+    builder = _AgentBuilder()
+    await builder.add_plugin(EchoPlugin({}))
+
+    wf = compose_workflows(WF1(), WF2())
+    with pytest.raises(KeyError):
+        await builder.build_runtime(wf)


### PR DESCRIPTION
## Summary
- add workflow parameter validation in Agent.build_runtime
- provide workflow composition helpers
- test workflow composition helpers
- log workflow helper addition

## Testing
- `poetry run ruff check --fix src/entity/core/agent.py src/entity/workflows/compose.py src/entity/workflows/__init__.py tests/integration/test_workflow_compose.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `poetry run poe test-architecture` *(fails: tests failed)*
- `poetry run poe test-plugins` *(fails: tests failed)*
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68740106383c8322842f851f4b6271b1