### PR TITLE
Add example tests for tool intent discovery

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added tool intent discovery tests
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow

--- a/tests/plugins/test_tool_intents.py
+++ b/tests/plugins/test_tool_intents.py
@@ -1,0 +1,34 @@
+import pytest
+
+from entity.core.registries import ToolRegistry
+from entity.core.plugins import ToolPlugin
+from entity.core.stages import PipelineStage
+
+
+class HelloTool(ToolPlugin):
+    stages = [PipelineStage.DO]
+    intents = ["greeting"]
+
+    async def execute_function(self, params):
+        return "hello"
+
+
+class EchoTool(ToolPlugin):
+    stages = [PipelineStage.DO]
+    intents = ["echo", "greeting"]
+
+    async def execute_function(self, params):
+        return params.get("text", "")
+
+
+@pytest.mark.asyncio
+async def test_discover_by_intent() -> None:
+    registry = ToolRegistry()
+    await registry.add("hello", HelloTool())
+    await registry.add("echo", EchoTool())
+
+    greeting_tools = [name for name, _ in registry.discover(intent="greeting")]
+    assert greeting_tools == ["hello", "echo"]
+
+    echo_tools = [name for name, _ in registry.discover(intent="echo")]
+    assert echo_tools == ["echo"]


### PR DESCRIPTION
## Summary
- add a note in `agents.log` about tool intent discovery tests
- demonstrate `ToolRegistry.discover()` capability matching with new tests

## Testing
- `poetry run ruff check --fix src tests` *(fails: E402 and other errors)*
- `poetry run mypy src` *(fails: found 302 errors)*
- `poetry run bandit -r src` *(reports multiple issues)*
- `poetry run vulture src tests` *(fails: Command not found)*
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: missing --config)*
- `poetry run poe test-architecture` *(fails: 3 failed, 3 passed)*
- `poetry run poe test-plugins` *(fails: 3 failed, 9 passed)*
- `poetry run poe test-resources` *(passes)*
- `poetry run poe test` *(fails: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687401089c888322862dacf6c146cdc1