### PR TITLE
Implement DuckDB vector store and minimal workflow

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Implemented DuckDBVectorStore setup and minimal workflow tests
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -26,11 +26,13 @@ try:
     from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
     from plugins.builtin.resources.ollama_llm import OllamaLLMResource
     from .plugins.prompts.basic_error_handler import BasicErrorHandler
-    from plugins.examples import InputLogger, MessageParser, ResponseReviewer
+    from plugins.examples import InputLogger
+    from user_plugins.prompts import ComplexPrompt
+    from user_plugins.responders import ComplexPromptResponder
     from .core.stages import PipelineStage
     from .core.plugins import PromptPlugin, ToolPlugin
     from .utils.setup_manager import Layer0SetupManager
-    from entity.workflows.default import DefaultWorkflow
+    from entity.workflows.minimal import minimal_workflow
     from entity.core.registries import SystemRegistries
     from entity.core.runtime import AgentRuntime
     from entity.core.resources.container import ResourceContainer
@@ -87,9 +89,9 @@ def _create_default_agent() -> Agent:
     )
     asyncio.run(builder.add_plugin(BasicErrorHandler({})))
     asyncio.run(builder.add_plugin(InputLogger({})))
-    asyncio.run(builder.add_plugin(MessageParser({})))
-    asyncio.run(builder.add_plugin(ResponseReviewer({})))
-    workflow = getattr(setup, "workflow", DefaultWorkflow())
+    asyncio.run(builder.add_plugin(ComplexPrompt({})))
+    asyncio.run(builder.add_plugin(ComplexPromptResponder({})))
+    workflow = getattr(setup, "workflow", minimal_workflow)
     agent._runtime = AgentRuntime(caps, workflow=workflow)
     return agent
 

--- a/src/entity/utils/setup_manager.py
+++ b/src/entity/utils/setup_manager.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError:  # pragma: no cover - environment may omit duckdb
     duckdb = None
 
 from .logging import get_logger
-from entity.workflows.default import default_workflow
+from entity.workflows.minimal import minimal_workflow
 from entity.workflows import Workflow
 
 
@@ -64,7 +64,7 @@ class Layer0SetupManager:
         self.model = model
         self.base_url = base_url.rstrip("/")
         self.logger = logger or get_logger(self.__class__.__name__)
-        self.workflow = workflow or default_workflow
+        self.workflow = workflow or minimal_workflow
 
     async def ensure_ollama(self) -> bool:
         """Return ``True`` when Ollama and the desired model are available."""

--- a/src/entity/workflows/__init__.py
+++ b/src/entity/workflows/__init__.py
@@ -3,6 +3,7 @@
 from .base import Workflow
 from .builtin import ChainOfThoughtWorkflow, ReActWorkflow, StandardWorkflow
 from .default import DefaultWorkflow, default_workflow
+from .minimal import MinimalWorkflow, minimal_workflow
 
 __all__ = [
     "Workflow",
@@ -11,4 +12,6 @@ __all__ = [
     "ChainOfThoughtWorkflow",
     "DefaultWorkflow",
     "default_workflow",
+    "MinimalWorkflow",
+    "minimal_workflow",
 ]

--- a/src/entity/workflows/minimal.py
+++ b/src/entity/workflows/minimal.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Minimal workflow mapping."""
+
+from entity.pipeline.stages import PipelineStage
+
+from .base import Workflow
+
+
+class MinimalWorkflow(Workflow):
+    """Basic INPUT -> THINK -> OUTPUT flow."""
+
+    stage_map = {
+        PipelineStage.INPUT: ["input_logger"],
+        PipelineStage.THINK: ["ComplexPrompt"],
+        PipelineStage.OUTPUT: ["ComplexPromptResponder"],
+        PipelineStage.ERROR: ["basic_error_handler"],
+    }
+
+
+minimal_workflow = MinimalWorkflow()
+
+__all__ = ["MinimalWorkflow", "minimal_workflow"]

--- a/tests/setup/test_minimal_startup.py
+++ b/tests/setup/test_minimal_startup.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock
+
+from entity import _create_default_agent
+from entity.utils.setup_manager import Layer0SetupManager
+from entity.pipeline.stages import PipelineStage
+
+
+def test_create_default_agent_brand_new_env(monkeypatch, tmp_path):
+    def fake_init(
+        self,
+        db_path="./agent_memory.duckdb",
+        files_dir="./agent_files",
+        model="llama3",
+        base_url="http://localhost:11434",
+        logger=None,
+        workflow=None,
+    ):
+        self.db_path = tmp_path / "memory.duckdb"
+        self.files_dir = tmp_path / "files"
+        self.model = model
+        self.base_url = base_url
+        self.logger = logger
+        self.workflow = workflow
+
+    async def fake_ensure(self):
+        return True
+
+    monkeypatch.setattr(Layer0SetupManager, "__init__", fake_init, raising=False)
+    monkeypatch.setattr(Layer0SetupManager, "ensure_ollama", fake_ensure, raising=False)
+    monkeypatch.setattr(Layer0SetupManager, "setup", AsyncMock())
+
+    agent = _create_default_agent()
+    resources = agent._runtime.capabilities.resources
+    assert resources.get("vector_store") is not None
+    assert resources.get("memory") is not None
+    assert resources.get("database") is not None
+    assert agent._runtime.workflow.stages.keys() == {
+        PipelineStage.INPUT,
+        PipelineStage.THINK,
+        PipelineStage.OUTPUT,
+        PipelineStage.ERROR,
+    }


### PR DESCRIPTION
## Summary
- wire up `DuckDBVectorStore` in the default agent
- create `MinimalWorkflow` for simple INPUT->THINK->OUTPUT flows
- set `Layer0SetupManager` to use `minimal_workflow`
- add a regression test for bootstrapping a fresh environment
- log agent note

## Testing
- `poetry run ruff check --fix src tests` *(fails: Found 163 errors)*
- `poetry run mypy src` *(fails: Found 302 errors in 60 files)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails due to template syntax errors)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: argument --config is required)*
- `poetry run poe test-architecture` *(fails: 3 failed tests)*
- `poetry run poe test-plugins` *(fails: 3 failed tests)*
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687401007ec08322adc4e3f1e59dce61