### PR TITLE
Persist pipeline thoughts across runs

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-10: Stage results persist across runs and temporary thoughts moved to PipelineState
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow

--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -81,15 +81,15 @@ class AdvancedContext:
 
     async def think_temp(self, key: str, value: Any) -> None:
         """Store a temporary thought only accessible via ``advanced``."""
-        self._parent._temporary_thoughts[key] = value
+        self._parent._state.temporary_thoughts[key] = value
 
     async def reflect_temp(self, key: str, default: Any | None = None) -> Any:
         """Retrieve a temporary thought stored via ``think_temp``."""
-        return self._parent._temporary_thoughts.get(key, default)
+        return self._parent._state.temporary_thoughts.get(key, default)
 
     async def clear_temp(self) -> None:
         """Remove all temporary thoughts stored via ``think_temp``."""
-        self._parent._temporary_thoughts.clear()
+        self._parent._state.temporary_thoughts.clear()
 
     # ------------------------------------------------------------------
     # Stage control helpers
@@ -118,7 +118,6 @@ class PluginContext:
         self._memory = self._resources.get("memory")
         self._plugin_name: str | None = None
         self._advanced = AdvancedContext(self)
-        self._temporary_thoughts: dict[str, Any] = {}
 
     # ------------------------------------------------------------------
     @property
@@ -288,11 +287,7 @@ class PluginContext:
         return self._state.stage_results.get(key, default)
 
     async def clear_thoughts(self) -> None:
-        """Remove all stored stage results.
-
-        This is invoked automatically at the end of a pipeline run so that
-        interim reasoning does not leak between user messages.
-        """
+        """Remove all stored stage results on the current state."""
         self._state.stage_results.clear()
 
     # ------------------------------------------------------------------

--- a/src/entity/core/state.py
+++ b/src/entity/core/state.py
@@ -31,6 +31,7 @@ class PipelineState:
     response: Any = None
     prompt: str = ""
     stage_results: Dict[str, Any] = field(default_factory=dict)
+    temporary_thoughts: Dict[str, Any] = field(default_factory=dict)
     max_stage_results: int | None = 100
     pending_tool_calls: List[ToolCall] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
@@ -55,6 +56,7 @@ class PipelineState:
             "response": self.response,
             "prompt": self.prompt,
             "stage_results": self.stage_results,
+            "temporary_thoughts": self.temporary_thoughts,
             "pending_tool_calls": [
                 {
                     "name": c.name,
@@ -92,6 +94,7 @@ class PipelineState:
         state.response = data.get("response")
         state.prompt = data.get("prompt", "")
         state.stage_results = data.get("stage_results", {})
+        state.temporary_thoughts = data.get("temporary_thoughts", {})
         state.pending_tool_calls = [
             ToolCall(
                 name=c["name"],

--- a/src/entity/core/state_utils.py
+++ b/src/entity/core/state_utils.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .state import ConversationEntry, PipelineState
+
+
+def _last_entry(state: PipelineState, role: str) -> Optional[ConversationEntry]:
+    for entry in reversed(state.conversation):
+        if entry.role == role:
+            return entry
+    return None
+
+
+def last_user_message(state: PipelineState) -> Optional[str]:
+    entry = _last_entry(state, "user")
+    return entry.content if entry else None
+
+
+def last_assistant_message(state: PipelineState) -> Optional[str]:
+    entry = _last_entry(state, "assistant")
+    return entry.content if entry else None
+
+
+def get_stage_result(state: PipelineState, key: str, default: Any | None = None) -> Any:
+    return state.stage_results.get(key, default)
+
+
+def get_temp_thought(state: PipelineState, key: str, default: Any | None = None) -> Any:
+    return state.temporary_thoughts.get(key, default)
+
+
+def clear_temp_thoughts(state: PipelineState) -> None:
+    state.temporary_thoughts.clear()

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -414,7 +414,6 @@ async def execute_pipeline(
                 metric_name="pipeline_duration_ms",
                 value=elapsed_ms,
             )
-        state.stage_results.clear()
         return result
 
 

--- a/tests/core/test_state_utils.py
+++ b/tests/core/test_state_utils.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+
+from entity.core.state import ConversationEntry, PipelineState
+from entity.core.state_utils import (
+    clear_temp_thoughts,
+    get_stage_result,
+    get_temp_thought,
+    last_assistant_message,
+    last_user_message,
+)
+
+
+def _make_state() -> PipelineState:
+    return PipelineState(
+        conversation=[
+            ConversationEntry("hi", "user", datetime.now()),
+            ConversationEntry("there", "assistant", datetime.now()),
+        ],
+        stage_results={"x": 1},
+        temporary_thoughts={"y": 2},
+    )
+
+
+def test_last_user_message() -> None:
+    state = _make_state()
+    assert last_user_message(state) == "hi"
+
+
+def test_last_assistant_message() -> None:
+    state = _make_state()
+    assert last_assistant_message(state) == "there"
+
+
+def test_stage_and_temp_access() -> None:
+    state = _make_state()
+    assert get_stage_result(state, "x") == 1
+    assert get_temp_thought(state, "y") == 2
+    clear_temp_thoughts(state)
+    assert get_temp_thought(state, "y") is None

--- a/tests/test_context_helpers.py
+++ b/tests/test_context_helpers.py
@@ -32,8 +32,10 @@ async def test_advanced_temp_helpers():
     ctx = make_context()
     await ctx.advanced.think_temp("y", 2)
     assert await ctx.advanced.reflect_temp("y") == 2
+    assert ctx._state.temporary_thoughts["y"] == 2
     await ctx.advanced.clear_temp()
     assert await ctx.advanced.reflect_temp("y") is None
+    assert ctx._state.temporary_thoughts == {}
 
 
 def test_get_resource_helpers():

--- a/tests/test_thought_persistence.py
+++ b/tests/test_thought_persistence.py
@@ -51,7 +51,7 @@ async def test_thoughts_accumulate_across_iterations() -> None:
 
 
 @pytest.mark.asyncio
-async def test_thoughts_reset_after_run() -> None:
+async def test_thoughts_persist_between_runs() -> None:
     plugins = PluginRegistry()
     await plugins.register_plugin_for_stage(Counter({}), PipelineStage.THINK)
     await plugins.register_plugin_for_stage(TerminateOnThree({}), PipelineStage.OUTPUT)
@@ -61,7 +61,7 @@ async def test_thoughts_reset_after_run() -> None:
         pipeline_id="pid",
     )
     await execute_pipeline("hi", regs, state=state, workflow=None, max_iterations=5)
-    assert state.stage_results == {}
+    assert state.stage_results["count"] == 3
 
     state.conversation.append(ConversationEntry("again", "user", datetime.now()))
     state.response = None
@@ -72,7 +72,7 @@ async def test_thoughts_reset_after_run() -> None:
     result = await execute_pipeline(
         "", regs, state=state, workflow=None, max_iterations=5
     )
-    assert result == "3"
+    assert result == "4"
     assert state.iteration == 3
 
 
@@ -90,4 +90,4 @@ async def test_preexisting_thoughts_available_at_start() -> None:
         "hi", regs, state=state, workflow=None, max_iterations=1
     )
     assert result == "bar"
-    assert state.stage_results == {}
+    assert state.stage_results == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- preserve stage results between pipeline runs
- store temporary thoughts on `PipelineState`
- expose helpers for inspecting pipeline state
- add tests for temporary thoughts and state utilities

## Testing
- `poetry run poe check` *(fails: lint errors)*
- `poetry run poe test` *(fails: module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68740103cd14832289cb2eedb387b4df