### PR TITLE
Add user_id propagation and isolation tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-08-21: Added user_id propagation in pipeline and multi-user tests
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -25,15 +25,10 @@ try:
     from .resources.logging import LoggingResource
     from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
     from plugins.builtin.resources.ollama_llm import OllamaLLMResource
-<<<<<<< HEAD
-    from .plugins.prompts.basic_error_handler import BasicErrorHandler
-    from plugins.examples import InputLogger
-    from user_plugins.prompts import ComplexPrompt
-    from user_plugins.responders import ComplexPromptResponder
-=======
     from plugins.builtin.basic_error_handler import BasicErrorHandler
     from plugins.examples import InputLogger, MessageParser, ResponseReviewer
->>>>>>> pr-1508
+    from user_plugins.prompts import ComplexPrompt
+    from user_plugins.responders import ComplexPromptResponder
     from .core.stages import PipelineStage
     from .core.plugins import PromptPlugin, ToolPlugin
     from .utils.setup_manager import Layer0SetupManager

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -132,7 +132,9 @@ async def execute_stage(
                 if stage == PipelineStage.OUTPUT and state.response is not None:
                     break
                 if state.pending_tool_calls:
-                    tool_results = await execute_pending_tools(state, registries)
+                    tool_results = await execute_pending_tools(
+                        state, registries, user_id=user_id
+                    )
                     for call in state.pending_tool_calls:
                         result = tool_results.get(call.result_key)
                         context.add_conversation_entry(

--- a/src/entity/pipeline/tools/execution.py
+++ b/src/entity/pipeline/tools/execution.py
@@ -11,7 +11,7 @@ from entity.core.registries import SystemRegistries
 
 
 async def execute_pending_tools(
-    state: PipelineState, registries: SystemRegistries
+    state: PipelineState, registries: SystemRegistries, *, user_id: str
 ) -> Dict[str, Any]:
     """Run queued tools respecting registry options."""
     results: Dict[str, Any] = {}
@@ -19,7 +19,7 @@ async def execute_pending_tools(
         return results
     tools = registries.tools
     sem = asyncio.Semaphore(tools.concurrency_limit)
-    context = PluginContext(state, registries)
+    context = PluginContext(state, registries, user_id=user_id)
 
     async def run_call(call: ToolCall) -> None:
         tool = tools.get(call.name)


### PR DESCRIPTION
## Summary
- propagate `user_id` through tool execution
- add multi-user isolation test
- document update in agents.log
- clean imports in `entity.__init__`

## Testing
- `poetry run pytest tests/integration/test_multi_user.py -q`
- `poetry run poe test` *(fails: ImportError: cannot import name 'Plugin' from 'entity.pipeline')*

------
https://chatgpt.com/codex/tasks/task_e_68740933c00483228339320dff9c8429