### PR TITLE
Implement layer validation checks

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Fixed merge markers in __init__
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -25,15 +25,10 @@ try:
     from .resources.logging import LoggingResource
     from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
     from plugins.builtin.resources.ollama_llm import OllamaLLMResource
-<<<<<<< HEAD
-    from .plugins.prompts.basic_error_handler import BasicErrorHandler
+    from plugins.builtin.basic_error_handler import BasicErrorHandler
     from plugins.examples import InputLogger
     from user_plugins.prompts import ComplexPrompt
     from user_plugins.responders import ComplexPromptResponder
-=======
-    from plugins.builtin.basic_error_handler import BasicErrorHandler
-    from plugins.examples import InputLogger, MessageParser, ResponseReviewer
->>>>>>> pr-1508
     from .core.stages import PipelineStage
     from .core.plugins import PromptPlugin, ToolPlugin
     from .utils.setup_manager import Layer0SetupManager

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -547,6 +547,29 @@ class ResourceContainer:
             if expected == 4 and not self._deps.get(name):
                 allowed_layers.add(3)
 
+            if layer == 1:
+                if self._deps.get(name):
+                    raise InitializationError(
+                        name,
+                        "layer validation",
+                        "Layer-1 plugins cannot have dependencies.",
+                        kind="Resource",
+                    )
+                if not getattr(cls, "infrastructure_type", ""):
+                    raise InitializationError(
+                        name,
+                        "layer validation",
+                        "Layer-1 plugins must define infrastructure_type.",
+                        kind="Resource",
+                    )
+            if layer == 2 and not getattr(cls, "infrastructure_dependencies", None):
+                raise InitializationError(
+                    name,
+                    "layer validation",
+                    "Layer-2 plugins must declare infrastructure_dependencies.",
+                    kind="Resource",
+                )
+
             if layer not in allowed_layers:
                 message = (
                     f"Provided layer {layer} for {cls.__name__} is invalid."


### PR DESCRIPTION
## Summary
- enforce plugin layer rules in `ResourceContainer`
- resolve merge markers in `__init__`
- log maintenance note

## Testing
- `poetry run pytest tests/architecture -v`
- `poetry run poe test-architecture` *(fails)*
- `poetry run poe test-plugins` *(fails)*
- `poetry run poe test-resources`

------
https://chatgpt.com/codex/tasks/task_e_687409317cc083228088e8dc53a91c24