### PR TITLE
Ensure default metrics and logging resources

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-10-05: Added default dependency injection and tests
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -303,6 +303,14 @@ class ResourceContainer:
 
             self.register("logging", LoggingResource, {}, layer=3)
 
+        if (
+            "metrics_collector" not in self._classes
+            and "metrics_collector" not in self._resources
+        ):
+            from entity.resources.metrics import MetricsCollectorResource
+
+            self.register("metrics_collector", MetricsCollectorResource, {}, layer=3)
+
         self._validate_layers()
         self._order = self._resolve_order()
         self._init_order = []

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -551,7 +551,6 @@ class SystemInitializer:
         }
 
         plugins_cfg = self.config.get("plugins", {})
-        add_metrics = "metrics_collector" in plugins_cfg.get("resources", {})
 
         for section in resource_sections:
             entries = plugins_cfg.get(section, {})
@@ -564,21 +563,20 @@ class SystemInitializer:
                     )
                 cls = import_plugin_class(cls_path)
                 deps = list(getattr(cls, "dependencies", []))
-                if not add_metrics and "metrics_collector" in deps:
-                    deps.remove("metrics_collector")
-                if "logging" not in deps and cls.__name__ != "LoggingResource":
-                    deps.append("logging")
                 from entity.core.plugins import InfrastructurePlugin
 
                 if issubclass(cls, InfrastructurePlugin):
                     deps = [
                         d for d in deps if d not in {"logging", "metrics_collector"}
                     ]
-                if add_metrics and (
-                    cls.__name__ != "MetricsCollectorResource"
-                    and "metrics_collector" not in deps
-                ):
-                    deps.append("metrics_collector")
+                else:
+                    if cls.__name__ != "LoggingResource" and "logging" not in deps:
+                        deps.append("logging")
+                    if (
+                        cls.__name__ != "MetricsCollectorResource"
+                        and "metrics_collector" not in deps
+                    ):
+                        deps.append("metrics_collector")
                 cls.dependencies = deps
                 registry.register_class(cls, config, name, layer, section)
                 dep_graph[name] = deps
@@ -593,11 +591,9 @@ class SystemInitializer:
                     )
                 cls = import_plugin_class(cls_path)
                 deps = list(getattr(cls, "dependencies", []))
-                if not add_metrics and "metrics_collector" in deps:
-                    deps.remove("metrics_collector")
-                if "logging" not in deps and cls.__name__ != "LoggingResource":
+                if cls.__name__ != "LoggingResource" and "logging" not in deps:
                     deps.append("logging")
-                if add_metrics and (
+                if (
                     cls.__name__ != "MetricsCollectorResource"
                     and "metrics_collector" not in deps
                 ):

--- a/tests/core/test_container_defaults.py
+++ b/tests/core/test_container_defaults.py
@@ -1,0 +1,42 @@
+import pytest
+
+from entity.core.resources.container import ResourceContainer
+from entity.resources.base import AgentResource
+from entity.core.plugins import InfrastructurePlugin
+
+
+class DummyDatabase(InfrastructurePlugin):
+    infrastructure_type = "database_backend"
+    stages: list = []
+    dependencies: list = []
+
+
+class DummyResource(AgentResource):
+    __module__ = "entity.resources.tests"
+    dependencies: list[str] = []
+    stages: list = []
+
+    def __init__(self, config=None):
+        super().__init__(config or {})
+        self.initialized = False
+
+    async def initialize(self) -> None:
+        self.initialized = True
+
+
+DummyDatabase.dependencies = []
+DummyResource.dependencies = []
+
+
+@pytest.mark.asyncio
+async def test_build_all_adds_defaults():
+    container = ResourceContainer()
+    container.register("database_backend", DummyDatabase, {}, layer=1)
+    container.register("dummy", DummyResource, {}, layer=3)
+
+    await container.build_all()
+
+    assert container.get("logging") is not None
+    assert container.get("metrics_collector") is not None
+
+    await container.shutdown_all()

--- a/tests/core/test_dependency_injection.py
+++ b/tests/core/test_dependency_injection.py
@@ -86,6 +86,12 @@ def _base_cfg_no_metrics() -> dict:
     return cfg
 
 
+def _base_cfg_no_logging() -> dict:
+    cfg = _base_cfg()
+    cfg["plugins"]["agent_resources"].pop("logging")
+    return cfg
+
+
 def test_adapter_dependencies_added():
     cfg = _base_cfg()
     cfg["plugins"]["adapters"] = {"dummy_adapter": {"type": f"{__name__}:DummyAdapter"}}
@@ -123,6 +129,22 @@ def test_dependencies_without_metrics():
     dep_graph: dict[str, list[str]] = {}
     init._register_plugins(registry, dep_graph)
 
-    assert "metrics_collector" not in DummyTool.dependencies
-    assert "metrics_collector" not in DummyAdapter.dependencies
-    assert "metrics_collector" not in DummyPrompt.dependencies
+    assert "metrics_collector" in DummyTool.dependencies
+    assert "metrics_collector" in DummyAdapter.dependencies
+    assert "metrics_collector" in DummyPrompt.dependencies
+
+
+def test_dependencies_without_logging():
+    cfg = _base_cfg_no_logging()
+    cfg["plugins"]["tools"] = {"dummy": {"type": f"{__name__}:DummyTool"}}
+    cfg["plugins"]["adapters"] = {"dummy_adapter": {"type": f"{__name__}:DummyAdapter"}}
+    cfg["plugins"]["prompts"] = {"dummy_prompt": {"type": f"{__name__}:DummyPrompt"}}
+
+    init = SystemInitializer(cfg)
+    registry = ClassRegistry()
+    dep_graph: dict[str, list[str]] = {}
+    init._register_plugins(registry, dep_graph)
+
+    assert "logging" in DummyTool.dependencies
+    assert "logging" in DummyAdapter.dependencies
+    assert "logging" in DummyPrompt.dependencies


### PR DESCRIPTION
## Summary
- inject `metrics_collector` and `logging` dependencies for every plugin
- register default `LoggingResource` and `MetricsCollectorResource` in resource container
- add tests for dependency injection when resources aren't configured

## Testing
- `poetry run poe test` *(fails: ImportError in tests due to syntax error)*
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `bandit -r src` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6874092f37308322ba85ac23a984272c