### PR TITLE
Fix stage data lifecycle

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-10-06: Clear stage results and temporary thoughts after each pipeline run
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-08-21: Added user_id propagation in pipeline and multi-user tests

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -424,6 +424,8 @@ async def execute_pipeline(
                 metric_name="pipeline_duration_ms",
                 value=elapsed_ms,
             )
+        state.stage_results.clear()
+        state.temporary_thoughts.clear()
         return result
 
 

--- a/tests/test_thought_persistence.py
+++ b/tests/test_thought_persistence.py
@@ -48,10 +48,12 @@ async def test_thoughts_accumulate_across_iterations() -> None:
     )
     assert result == "3"
     assert state.iteration == 3
+    assert state.stage_results == {}
+    assert state.temporary_thoughts == {}
 
 
 @pytest.mark.asyncio
-async def test_thoughts_persist_between_runs() -> None:
+async def test_thoughts_cleared_between_runs() -> None:
     plugins = PluginRegistry()
     await plugins.register_plugin_for_stage(Counter({}), PipelineStage.THINK)
     await plugins.register_plugin_for_stage(TerminateOnThree({}), PipelineStage.OUTPUT)
@@ -61,7 +63,7 @@ async def test_thoughts_persist_between_runs() -> None:
         pipeline_id="pid",
     )
     await execute_pipeline("hi", regs, state=state, workflow=None, max_iterations=5)
-    assert state.stage_results["count"] == 3
+    assert state.stage_results == {}
 
     state.conversation.append(ConversationEntry("again", "user", datetime.now()))
     state.response = None
@@ -72,8 +74,10 @@ async def test_thoughts_persist_between_runs() -> None:
     result = await execute_pipeline(
         "", regs, state=state, workflow=None, max_iterations=5
     )
-    assert result == "4"
+    assert result == "3"
     assert state.iteration == 3
+    assert state.stage_results == {}
+    assert state.temporary_thoughts == {}
 
 
 @pytest.mark.asyncio
@@ -90,4 +94,5 @@ async def test_preexisting_thoughts_available_at_start() -> None:
         "hi", regs, state=state, workflow=None, max_iterations=1
     )
     assert result == "bar"
-    assert state.stage_results == {"foo": "bar"}
+    assert state.stage_results == {}
+    assert state.temporary_thoughts == {}


### PR DESCRIPTION
## Summary
- clear stage results and temporary thoughts after pipeline execution
- test lifecycle of stage data across pipeline runs
- log note about stage data clearance

## Testing
- `poetry run poe test` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_687435c477248322b0554509bdb4d0d0