### PR TITLE
Update dependency handling for infrastructure plugins

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Modified dependency injection for infrastructure plugins
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-08-21: Added user_id propagation in pipeline and multi-user tests

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -42,9 +42,9 @@ class ToolExecutionError(Exception):
 class BasePlugin:
     """Lightweight plugin foundation.
 
-    All subclasses depend on ``metrics_collector`` and ``logging`` resources
-    by default so they can record metrics and emit logs without extra
-    configuration.
+    Non-infrastructure subclasses automatically depend on ``metrics_collector``
+    and ``logging`` so they can record metrics and emit logs without
+    additional configuration.
     """
 
     stages: List[PipelineStage]
@@ -52,8 +52,10 @@ class BasePlugin:
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        _ensure_metrics_dependency(cls)
-        _ensure_logging_dependency(cls)
+        is_infra = any(base.__name__ == "InfrastructurePlugin" for base in cls.mro())
+        if not is_infra:
+            _ensure_metrics_dependency(cls)
+            _ensure_logging_dependency(cls)
 
     def __init__(self, config: Dict[str, Any] | None = None) -> None:
         self.config = config or {}


### PR DESCRIPTION
## Summary
- only inject metrics/logging dependencies on non-infrastructure plugins
- keep infrastructure plugin definitions dependency-free

## Testing
- `poetry run black src/entity/core/plugins/base.py tests`
- `poetry run poe test` *(fails: ImportError in tests due to unresolved merge markers)*

------
https://chatgpt.com/codex/tasks/task_e_687435c109d08322ba8f3c2267607bc0