### PR TITLE
Add ResourceError base class

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-13: Added ResourceError class cleanup and docs
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-08-21: Added user_id propagation in pipeline and multi-user tests

--- a/src/entity/pipeline/errors.py
+++ b/src/entity/pipeline/errors.py
@@ -36,11 +36,8 @@ class PluginExecutionError(PipelineError):
 
 
 class ResourceError(PipelineError):
-<<<<<<< HEAD
-    """Base class for resource errors."""
+    """Raised when a resource encounters an operational failure."""
 
-=======
->>>>>>> pr-1520
     pass
 
 
@@ -58,8 +55,8 @@ class InitializationError(PipelineError):
         self.kind = kind
 
 
-class ResourceInitializationError(InitializationError):
-    """Raised when a resource dependency is missing."""
+class ResourceInitializationError(ResourceError, InitializationError):
+    """Raised when a required resource dependency is missing."""
 
     def __init__(self, remediation: str, name: str) -> None:
         super().__init__(name, "initialization", remediation, kind="Resource")


### PR DESCRIPTION
## Summary
- document ResourceError for resource exceptions
- derive ResourceInitializationError from ResourceError
- log update in `agents.log`

## Testing
- `poetry run black src/entity/pipeline/errors.py tests`
- `poetry run ruff check --fix src/entity/pipeline/errors.py tests`
- `poetry run mypy src/entity/pipeline/errors.py`
- `poetry run bandit -r src/entity/pipeline/errors.py`
- `poetry run vulture src/entity/pipeline/errors.py tests`
- `poetry run unimport --remove-all src/entity/pipeline/errors.py` *(fails: unrecognized arguments)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: SyntaxError in __init__.py)*
- `poetry run poe test` *(fails: Command not found)*
- `poetry run poe test-architecture` *(fails: Command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687435cd3dc48322a55fce98a6ba17d3