### PR TITLE
Cleanup merge markers

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,50 +1,16 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
+AGENT NOTE - 2025-07-13: Removed merge conflict markers in core modules
 AGENT NOTE - 2025-08-21: Added user_id propagation in pipeline and multi-user tests
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Added websocket broadcast logging, file rotation, and structured pipeline logs.
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Updated black exclude paths to include CLI and plugin templates
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Fixed merge markers in __init__
-<<<<<<< HEAD
 AGENT NOTE - 2025-08-10: Added plugin reconfiguration updates and tests
-<<<<<<< HEAD
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Implemented validation phases and circuit breaker integration
-=======
 AGENT NOTE - 2025-10-05: Added default dependency injection and tests
->>>>>>> pr-1518
-=======
 AGENT NOTE - 2025-07-13: Verified memory vector search and analytics
->>>>>>> pr-1512
-=======
 AGENT NOTE - 2025-07-13: Added stage override warnings and output restrictions tests
->>>>>>> pr-1510
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
 AGENT NOTE - 2025-07-13: Cleaned merge markers and fixed default agent imports
->>>>>>> pr-1521
-=======
 AGENT NOTE - 2025-07-13: Cleaned merge markers and executed quality checks
 AGENT NOTE - 2025-07-13: Implemented DuckDBVectorStore setup and minimal workflow tests
->>>>>>> pr-1520
 AGENT NOTE - 2025-07-13: Implemented DuckDBVectorStore setup and minimal workflow tests
 AGENT NOTE - 2025-07-13: pytest now works with the unified entity.cli.plugin_tool structure
 AGENT NOTE - 2025-07-13: Added pythonpath configuration for pytest
@@ -60,20 +26,15 @@ AGENT NOTE - 2025-08-10: Added infrastructure_type attribute test
 AGENT NOTE - 2025-08-10: Inject default DuckDBVectorStore and keep interfaces under entity.resources.interfaces
 AGENT NOTE - 2025-08-10: Stage results persist across runs and temporary thoughts moved to PipelineState
 AGENT NOTE - 2025-07-13: Moved BasicErrorHandler to builtin and added example plugin tests
-=======
 AGENT NOTE - 2025-07-13: Improved layer validation with cycle detection and dependency graph tooling
->>>>>>> pr-1509
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-07-13: Ensured pipeline package sets __path__ for plugin discovery
-=======
 AGENT NOTE - 2025-07-13: Cleaned merge markers and deduplicated entries
 AGENT NOTE - 2025-08-10: Moved plugin_tool under entity.cli and updated imports
 AGENT NOTE - 2025-08-10: Added infrastructure_type attribute test
 AGENT NOTE - 2025-08-10: Inject default DuckDBVectorStore and keep interfaces under entity.resources.interfaces
 AGENT NOTE - 2025-08-10: Stage results persist across runs and temporary thoughts moved to PipelineState
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
->>>>>>> pr-1516
-=======
 AGENT NOTE - 2025-07-13: Resolved merge conflicts in agents.log
 AGENT NOTE - 2025-07-13: Moved BasicErrorHandler to builtin and added example plugin tests
 AGENT NOTE - 2025-08-10: Stage results persist across runs and temporary thoughts moved to PipelineState
@@ -92,7 +53,6 @@ AGENT NOTE - 2025-08-10: Added infrastructure_type attribute test
 AGENT NOTE - 2025-08-10: Inject default DuckDBVectorStore and keep interfaces under entity.resources.interfaces
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-07-13: Ensured pipeline package sets __path__ for plugin discovery
->>>>>>> pr-1514
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow
 AGENT NOTE - 2025-08-06: Revised LlamaCppInfrastructure runtime validation with timeout and status checks

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import os
 
 
 def _handle_import_error(exc: ModuleNotFoundError) -> None:
@@ -25,52 +24,10 @@ try:
     from .resources import LLM, Memory, Storage
     from .resources.logging import LoggingResource
     from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
-<<<<<<< HEAD
-<<<<<<< HEAD
-    from plugins.builtin.resources.ollama_llm import OllamaLLMResource
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-    from plugins.builtin.basic_error_handler import BasicErrorHandler
-<<<<<<< HEAD
-    from plugins.examples import InputLogger, MessageParser, ResponseReviewer
-=======
-    from plugins.examples import InputLogger
-    from user_plugins.prompts import ComplexPrompt
-    from user_plugins.responders import ComplexPromptResponder
->>>>>>> pr-1521
-=======
-=======
->>>>>>> pr-1515
-    from .plugins.prompts.basic_error_handler import BasicErrorHandler
-    from plugins.examples import InputLogger
-    from user_plugins.prompts import ComplexPrompt
-    from user_plugins.responders import ComplexPromptResponder
-<<<<<<< HEAD
->>>>>>> pr-1520
-=======
->>>>>>> pr-1519
-=======
-    from plugins.builtin.basic_error_handler import BasicErrorHandler
-    from plugins.examples import InputLogger
-    from user_plugins.prompts import ComplexPrompt
-    from user_plugins.responders import ComplexPromptResponder
->>>>>>> pr-1517
-=======
->>>>>>> pr-1515
-=======
->>>>>>> pr-1513
-=======
-    from plugins.builtin.basic_error_handler import BasicErrorHandler
-    from plugins.examples import InputLogger, MessageParser, ResponseReviewer
-    from user_plugins.prompts import ComplexPrompt
-    from user_plugins.responders import ComplexPromptResponder
->>>>>>> pr-1511
     from .core.stages import PipelineStage
     from .core.plugins import PromptPlugin, ToolPlugin
     from .utils.setup_manager import Layer0SetupManager
-    from entity.workflows.default import DefaultWorkflow
+    from entity.workflows.minimal import minimal_workflow
     from entity.core.registries import SystemRegistries
     from entity.core.runtime import AgentRuntime
     from entity.core.resources.container import ResourceContainer
@@ -88,10 +45,6 @@ def _create_default_agent() -> Agent:
         pass
     agent = Agent()
     builder = agent.builder
-
-    from plugins.builtin.resources.ollama_llm import OllamaLLMResource
-    from plugins.builtin.basic_error_handler import BasicErrorHandler
-    from plugins.examples import InputLogger, MessageParser, ResponseReviewer
 
     db = DuckDBInfrastructure({"path": str(setup.db_path)})
     try:
@@ -138,18 +91,6 @@ def _create_default_agent() -> Agent:
         tools=builder.tool_registry,
         plugins=builder.plugin_registry,
     )
-<<<<<<< HEAD
-    asyncio.run(builder.add_plugin(BasicErrorHandler({})))
-    asyncio.run(builder.add_plugin(InputLogger({})))
-<<<<<<< HEAD
-    try:
-        from user_plugins.prompts import ComplexPrompt
-        from user_plugins.responders import ComplexPromptResponder
-
-        asyncio.run(builder.add_plugin(ComplexPrompt({})))
-        asyncio.run(builder.add_plugin(ComplexPromptResponder({})))
-    except Exception:  # noqa: BLE001 - optional plugins
-=======
     # Default plugins are optional and may not be available in all environments
     try:
         from plugins.builtin.basic_error_handler import BasicErrorHandler
@@ -162,179 +103,97 @@ def _create_default_agent() -> Agent:
         asyncio.run(builder.add_plugin(ComplexPrompt({})))
         asyncio.run(builder.add_plugin(ComplexPromptResponder({})))
     except Exception:  # noqa: BLE001 - plugins optional
->>>>>>> pr-1519
         pass
     workflow = getattr(setup, "workflow", minimal_workflow)
-=======
-    asyncio.run(builder.add_plugin(MessageParser({})))
-    asyncio.run(builder.add_plugin(ResponseReviewer({})))
-    workflow = getattr(setup, "workflow", DefaultWorkflow())
->>>>>>> pr-1513
     agent._runtime = AgentRuntime(caps, workflow=workflow)
     return agent
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-agent: Agent | None = None
-
-
-def _ensure_agent() -> Agent:
-    global agent
-    if agent is None:
-        agent = _create_default_agent()
-    return agent
-
-=======
 try:
     agent = _create_default_agent()
 except Exception:  # noqa: BLE001 - optional defaults
     agent = Agent()
->>>>>>> pr-1519
 
 # Expose decorator helpers bound to the default agent
+plugin = agent.plugin
 
 
-def plugin(func=None, **hints):
-    ag = _ensure_agent()
-    return ag.plugin(func, **hints)
-=======
-if os.environ.get("ENTITY_AUTO_INIT") == "1":
-    agent = _create_default_agent()
-
-    # Expose decorator helpers bound to the default agent
-    plugin = agent.plugin
->>>>>>> pr-1513
-
-    def input(func=None, **hints):
-        return agent.plugin(func, stage=PipelineStage.INPUT, **hints)
-
-<<<<<<< HEAD
 def input(func=None, **hints):
-    ag = _ensure_agent()
-    return ag.plugin(func, stage=PipelineStage.INPUT, **hints)
-=======
-    agent.input = input
+    return agent.plugin(func, stage=PipelineStage.INPUT, **hints)
 
-    def parse(func=None, **hints):
-        return agent.plugin(func, stage=PipelineStage.PARSE, **hints)
 
-    agent.parse = parse
->>>>>>> pr-1513
+agent.input = input
 
-    def prompt(func=None, **hints):
-        return agent.plugin(func, stage=PipelineStage.THINK, **hints)
 
-<<<<<<< HEAD
 def parse(func=None, **hints):
-    ag = _ensure_agent()
-    return ag.plugin(func, stage=PipelineStage.PARSE, **hints)
-=======
-    agent.prompt = prompt
+    return agent.plugin(func, stage=PipelineStage.PARSE, **hints)
 
-    def tool(func=None, **hints):
-        """Register ``func`` as a tool plugin or simple tool."""
 
-        def decorator(f):
-            params = list(inspect.signature(f).parameters)
-            if params and params[0] in {"ctx", "context"}:
-                return agent.plugin(f, stage=PipelineStage.DO, **hints)
->>>>>>> pr-1513
+agent.parse = parse
 
-            class _WrappedTool(ToolPlugin):
-                async def execute_function(self, params_dict):
-                    return await f(**params_dict)
 
-<<<<<<< HEAD
 def prompt(func=None, **hints):
-    ag = _ensure_agent()
-    return ag.plugin(func, stage=PipelineStage.THINK, **hints)
-=======
-            asyncio.run(agent.builder.tool_registry.add(f.__name__, _WrappedTool({})))
-            return f
+    return agent.plugin(func, stage=PipelineStage.THINK, **hints)
 
-        return decorator(func) if func else decorator
 
-    agent.tool = tool
->>>>>>> pr-1513
+agent.prompt = prompt
 
-    def review(func=None, **hints):
-        return agent.plugin(func, stage=PipelineStage.REVIEW, **hints)
 
-    agent.review = review
+def tool(func=None, **hints):
+    """Register ``func`` as a tool plugin or simple tool."""
 
-<<<<<<< HEAD
     def decorator(f):
-        ag = _ensure_agent()
         params = list(inspect.signature(f).parameters)
         if params and params[0] in {"ctx", "context"}:
-            return ag.plugin(f, stage=PipelineStage.DO, **hints)
-=======
-    def output(func=None, **hints):
-        return agent.plugin(func, stage=PipelineStage.OUTPUT, **hints)
->>>>>>> pr-1513
+            return agent.plugin(f, stage=PipelineStage.DO, **hints)
 
-    agent.output = output
+        class _WrappedTool(ToolPlugin):
+            async def execute_function(self, params_dict):
+                return await f(**params_dict)
 
-<<<<<<< HEAD
-        ag = _ensure_agent()
-        asyncio.run(ag.builder.tool_registry.add(f.__name__, _WrappedTool({})))
+        asyncio.run(agent.builder.tool_registry.add(f.__name__, _WrappedTool({})))
         return f
-=======
-    def prompt_plugin(func=None, **hints):
-        hints["plugin_class"] = PromptPlugin
-        return agent.plugin(func, **hints)
->>>>>>> pr-1513
 
-    agent.prompt_plugin = prompt_plugin
+    return decorator(func) if func else decorator
 
-    def tool_plugin(func=None, **hints):
-        hints["plugin_class"] = ToolPlugin
-        return agent.plugin(func, **hints)
 
-<<<<<<< HEAD
+agent.tool = tool
+
+
 def review(func=None, **hints):
-    ag = _ensure_agent()
-    return ag.plugin(func, stage=PipelineStage.REVIEW, **hints)
+    return agent.plugin(func, stage=PipelineStage.REVIEW, **hints)
+
+
+agent.review = review
 
 
 def output(func=None, **hints):
-    ag = _ensure_agent()
-    return ag.plugin(func, stage=PipelineStage.OUTPUT, **hints)
+    return agent.plugin(func, stage=PipelineStage.OUTPUT, **hints)
+
+
+agent.output = output
 
 
 def prompt_plugin(func=None, **hints):
     hints["plugin_class"] = PromptPlugin
-    ag = _ensure_agent()
-    return ag.plugin(func, **hints)
+    return agent.plugin(func, **hints)
+
+
+agent.prompt_plugin = prompt_plugin
 
 
 def tool_plugin(func=None, **hints):
     hints["plugin_class"] = ToolPlugin
-    ag = _ensure_agent()
-    return ag.plugin(func, **hints)
-=======
-    agent.tool_plugin = tool_plugin
->>>>>>> pr-1513
+    return agent.plugin(func, **hints)
+
+
+agent.tool_plugin = tool_plugin
 
 
 __all__ = [
     "core",
     "Agent",
     "agent",
-    "_create_default_agent",
-<<<<<<< HEAD
-    "plugin",
-    "input",
-    "parse",
-    "prompt",
-    "tool",
-    "review",
-    "output",
-    "prompt_plugin",
-    "tool_plugin",
-=======
->>>>>>> pr-1521
 ]
 
 

--- a/src/entity/pipeline/errors.py
+++ b/src/entity/pipeline/errors.py
@@ -36,11 +36,6 @@ class PluginExecutionError(PipelineError):
 
 
 class ResourceError(PipelineError):
-<<<<<<< HEAD
-    """Base class for resource errors."""
-
-=======
->>>>>>> pr-1520
     pass
 
 
@@ -61,7 +56,7 @@ class InitializationError(PipelineError):
 class ResourceInitializationError(InitializationError):
     """Raised when a resource dependency is missing."""
 
-    def __init__(self, remediation: str, name: str) -> None:
+    def __init__(self, remediation: str, name: str = "resource") -> None:
         super().__init__(name, "initialization", remediation, kind="Resource")
 
 
@@ -136,6 +131,7 @@ __all__ = [
     "ResourceError",
     "ResourceInitializationError",
     "InitializationError",
+    "ResourceInitializationError",
     "StageExecutionError",
     "ToolExecutionError",
     "ErrorResponse",


### PR DESCRIPTION
## Summary
- remove merge conflict markers from project files
- restore imports for default agent and pipeline errors
- document cleanup in agents.log

## Testing
- `poetry run pytest -q` *(fails: Module 'entity.pipeline' has no attribute '__path__')*

------
https://chatgpt.com/codex/tasks/task_e_687435c0af108322ada28630bdbc1a66