### PR TITLE
Fix lazy default agent initialization

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,50 +1,16 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
+AGENT NOTE - 2025-07-13: Cleaned merge conflicts and implemented lazy default agent
 AGENT NOTE - 2025-08-21: Added user_id propagation in pipeline and multi-user tests
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Added websocket broadcast logging, file rotation, and structured pipeline logs.
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Updated black exclude paths to include CLI and plugin templates
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Fixed merge markers in __init__
-<<<<<<< HEAD
 AGENT NOTE - 2025-08-10: Added plugin reconfiguration updates and tests
-<<<<<<< HEAD
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Implemented validation phases and circuit breaker integration
-=======
 AGENT NOTE - 2025-10-05: Added default dependency injection and tests
->>>>>>> pr-1518
-=======
 AGENT NOTE - 2025-07-13: Verified memory vector search and analytics
->>>>>>> pr-1512
-=======
 AGENT NOTE - 2025-07-13: Added stage override warnings and output restrictions tests
->>>>>>> pr-1510
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
 AGENT NOTE - 2025-07-13: Cleaned merge markers and fixed default agent imports
->>>>>>> pr-1521
-=======
 AGENT NOTE - 2025-07-13: Cleaned merge markers and executed quality checks
 AGENT NOTE - 2025-07-13: Implemented DuckDBVectorStore setup and minimal workflow tests
->>>>>>> pr-1520
 AGENT NOTE - 2025-07-13: Implemented DuckDBVectorStore setup and minimal workflow tests
 AGENT NOTE - 2025-07-13: pytest now works with the unified entity.cli.plugin_tool structure
 AGENT NOTE - 2025-07-13: Added pythonpath configuration for pytest
@@ -60,20 +26,15 @@ AGENT NOTE - 2025-08-10: Added infrastructure_type attribute test
 AGENT NOTE - 2025-08-10: Inject default DuckDBVectorStore and keep interfaces under entity.resources.interfaces
 AGENT NOTE - 2025-08-10: Stage results persist across runs and temporary thoughts moved to PipelineState
 AGENT NOTE - 2025-07-13: Moved BasicErrorHandler to builtin and added example plugin tests
-=======
 AGENT NOTE - 2025-07-13: Improved layer validation with cycle detection and dependency graph tooling
->>>>>>> pr-1509
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-07-13: Ensured pipeline package sets __path__ for plugin discovery
-=======
 AGENT NOTE - 2025-07-13: Cleaned merge markers and deduplicated entries
 AGENT NOTE - 2025-08-10: Moved plugin_tool under entity.cli and updated imports
 AGENT NOTE - 2025-08-10: Added infrastructure_type attribute test
 AGENT NOTE - 2025-08-10: Inject default DuckDBVectorStore and keep interfaces under entity.resources.interfaces
 AGENT NOTE - 2025-08-10: Stage results persist across runs and temporary thoughts moved to PipelineState
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
->>>>>>> pr-1516
-=======
 AGENT NOTE - 2025-07-13: Resolved merge conflicts in agents.log
 AGENT NOTE - 2025-07-13: Moved BasicErrorHandler to builtin and added example plugin tests
 AGENT NOTE - 2025-08-10: Stage results persist across runs and temporary thoughts moved to PipelineState
@@ -92,7 +53,6 @@ AGENT NOTE - 2025-08-10: Added infrastructure_type attribute test
 AGENT NOTE - 2025-08-10: Inject default DuckDBVectorStore and keep interfaces under entity.resources.interfaces
 AGENT NOTE - 2025-08-09: Documented examples package and exported key modules
 AGENT NOTE - 2025-07-13: Ensured pipeline package sets __path__ for plugin discovery
->>>>>>> pr-1514
 AGENT NOTE - 2025-08-08: Cleaned merge conflict markers in agents.log
 AGENT NOTE - 2025-08-07: Added example plugins and registered them in default workflow
 AGENT NOTE - 2025-08-06: Revised LlamaCppInfrastructure runtime validation with timeout and status checks

--- a/src/entity/pipeline/errors.py
+++ b/src/entity/pipeline/errors.py
@@ -36,11 +36,8 @@ class PluginExecutionError(PipelineError):
 
 
 class ResourceError(PipelineError):
-<<<<<<< HEAD
     """Base class for resource errors."""
 
-=======
->>>>>>> pr-1520
     pass
 
 


### PR DESCRIPTION
## Summary
- resolve merge conflicts and cleanup `__init__`
- implement lazy default agent creation and expose decorators
- clean up conflict markers in `agents.log`
- fix merge markers in `pipeline.errors`

## Testing
- `poetry run black src/entity/__init__.py src/entity/pipeline/errors.py`
- `poetry run pytest -q` *(fails: ImportError: cannot import name 'Plugin' from 'entity.pipeline')*

------
https://chatgpt.com/codex/tasks/task_e_687435c59ed08322923b5b98bcdec603