### PR TITLE
Ensure persistent helpers isolate user data

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Verified persistence functions prepend user_id for isolation
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Removed deprecated AgentBuilder from public interface
 <<<<<<< HEAD

--- a/tests/integration/test_multi_user.py
+++ b/tests/integration/test_multi_user.py
@@ -88,3 +88,25 @@ async def test_cross_user_access_denied(memory_db):
     hist = await memory_db.load_conversation("chat", user_id="bob")
     assert hist == []
     assert await memory_db.get("last", user_id="bob") is None
+
+
+@pytest.mark.asyncio
+async def test_persistent_storage_is_isolated(memory_db):
+    await memory_db.store_persistent("token", "A", user_id="alice")
+    await memory_db.store_persistent("token", "B", user_id="bob")
+
+    assert await memory_db.fetch_persistent("token", user_id="alice") == "A"
+    assert await memory_db.fetch_persistent("token", user_id="bob") == "B"
+
+
+@pytest.mark.asyncio
+async def test_batch_store_and_delete_scoped_by_user(memory_db):
+    await memory_db.batch_store({"a": 1, "b": 2}, user_id="alice")
+    await memory_db.batch_store({"a": 3}, user_id="bob")
+
+    await memory_db.delete_persistent("a", user_id="bob")
+
+    assert await memory_db.fetch_persistent("a", user_id="alice") == 1
+    assert await memory_db.fetch_persistent("b", user_id="alice") == 2
+    assert await memory_db.fetch_persistent("a", user_id="bob") is None
+    assert await memory_db.fetch_persistent("b", user_id="bob") is None


### PR DESCRIPTION
## Summary
- document that persistence functions use user_id namespacing
- expand multi-user tests with persistence checks

## Testing
- `poetry run pytest tests/integration/test_multi_user.py -vv` *(fails: SyntaxError in src/entity/__init__.py)*

------
https://chatgpt.com/codex/tasks/task_e_68744acdff78832298f1f2a9dbd0fde3