### PR TITLE
Add PluginContext misusage test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Verified stage context assignment and added tests for say guard
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Removed deprecated AgentBuilder from public interface
 <<<<<<< HEAD

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -41,6 +41,13 @@ class SkippedPlugin(Plugin):
         self.executed = True
 
 
+class SayWrongStagePlugin(Plugin):
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        context.say("nope")
+
+
 @pytest.mark.asyncio
 async def test_plugin_failure_triggers_error_stage():
     plugins = PluginRegistry()
@@ -80,3 +87,24 @@ async def test_stage_stops_after_failure():
     assert result == "error handled"
     assert error_plugin.called is True
     assert skipped.executed is False
+
+
+@pytest.mark.asyncio
+async def test_say_misuse_triggers_plugin_context_error():
+    plugins = PluginRegistry()
+    error_plugin = CaptureErrorPlugin()
+    await plugins.register_plugin_for_stage(
+        SayWrongStagePlugin({}), PipelineStage.THINK, "bad"
+    )
+    await plugins.register_plugin_for_stage(error_plugin, PipelineStage.ERROR, "err")
+
+    regs = SystemRegistries(resources={}, tools=ToolRegistry(), plugins=plugins)
+    state = PipelineState(
+        conversation=[ConversationEntry("hi", "user", datetime.now())],
+        pipeline_id="pid",
+    )
+    result = await execute_pipeline("hi", regs, state=state)
+    assert result == "error handled"
+    assert error_plugin.called is True
+    assert state.failure_info is not None
+    assert state.failure_info.error_type == "PluginContextError"


### PR DESCRIPTION
## Summary
- note stage context verification in `agents.log`
- add a failing stage plugin that calls `say` incorrectly
- validate that the pipeline captures a `PluginContextError`

## Testing
- `poetry run poe test` *(fails: SyntaxError in src/entity/__init__.py)*

------
https://chatgpt.com/codex/tasks/task_e_68744ac85e6c8322a408f9618b94bdf9