### PR TITLE
Fix plugin import references

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Switched tests to core plugin imports
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Removed deprecated AgentBuilder from public interface
 <<<<<<< HEAD

--- a/tests/test_plugin_analyzer.py
+++ b/tests/test_plugin_analyzer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from entity.pipeline import Plugin  # noqa: F401 - triggers plugin configuration
+from entity.core.plugins import Plugin  # noqa: F401 - triggers plugin configuration
 from entity.pipeline.initializer import SystemInitializer
 from entity.pipeline.errors import InitializationError
 

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -1,5 +1,5 @@
 import logging
-from entity.pipeline import Plugin  # noqa: F401 - configure plugins
+from entity.core.plugins import Plugin  # noqa: F401 - configure plugins
 
 from entity.core.plugin_utils import PluginAutoClassifier
 from entity.core.stages import PipelineStage


### PR DESCRIPTION
## Summary
- switch tests to import `Plugin` from `entity.core.plugins`
- record note about updated import guidance in `agents.log`

## Testing
- `poetry run pytest -k test_plugin_utils -q` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_68744ac2567883228ceea44befba948d