### PR TITLE
Implement decorators & multi-stage support

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Implemented plugin decorators and multi-stage support
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Removed deprecated AgentBuilder from public interface
 <<<<<<< HEAD

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -4,50 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-<<<<<<< HEAD
-
-
-def _handle_import_error(exc: ModuleNotFoundError) -> None:
-    """Re-raise missing optional dependency errors with guidance."""
-
-    missing = exc.name
-    mapping = {"yaml": "pyyaml", "dotenv": "python-dotenv", "httpx": "httpx"}
-    requirement = mapping.get(missing, missing)
-    raise ImportError(
-        f"Optional dependency '{requirement}' is required. "
-        f"Install it with `pip install {requirement}`."
-    ) from exc
-
-
-try:
-    from .core.agent import Agent
-    from .infrastructure import DuckDBInfrastructure
-    from .resources import LLM, Memory, Storage
-    from .resources.logging import LoggingResource
-    from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
-<<<<<<< HEAD
-=======
-    from plugins.builtin.resources.ollama_llm import OllamaLLMResource
-    from plugins.builtin.basic_error_handler import BasicErrorHandler
-    from plugins.examples import InputLogger, MessageParser, ResponseReviewer
->>>>>>> pr-1529
-    from .core.stages import PipelineStage
-    from .core.plugins import PromptPlugin, ToolPlugin
-    from .utils.setup_manager import Layer0SetupManager
-    from entity.workflows.minimal import minimal_workflow
-    from entity.core.registries import SystemRegistries
-    from entity.core.runtime import AgentRuntime
-    from entity.core.resources.container import ResourceContainer
-except ModuleNotFoundError as exc:  # pragma: no cover - missing optional deps
-    _handle_import_error(exc)
-=======
 import os
 from types import SimpleNamespace
 
 from .core.agent import Agent
 from .core.plugins import PromptPlugin, ToolPlugin
-from .core.resources.container import ResourceContainer
 from .core.registries import SystemRegistries
+from .core.resources.container import ResourceContainer
 from .core.runtime import AgentRuntime
 from .core.stages import PipelineStage
 from .infrastructure import DuckDBInfrastructure
@@ -61,7 +24,6 @@ from entity.workflows.minimal import minimal_workflow
 # ---------------------------------------------------------------------------
 # default agent creation
 # ---------------------------------------------------------------------------
->>>>>>> pr-1530
 
 
 def _create_default_agent() -> Agent:
@@ -77,9 +39,6 @@ def _create_default_agent() -> Agent:
     builder = agent.builder
 
     db = DuckDBInfrastructure({"path": str(setup.db_path)})
-<<<<<<< HEAD
-    llm_provider = OllamaLLMResource({"model": setup.model, "base_url": setup.base_url})
-=======
     llm_provider = None
     try:
         from plugins.builtin.resources.ollama_llm import OllamaLLMResource
@@ -90,14 +49,14 @@ def _create_default_agent() -> Agent:
     except Exception:  # noqa: BLE001 - optional dependency
         pass
 
->>>>>>> pr-1530
     llm = LLM({})
     vector_store = DuckDBVectorStore({})
     memory = Memory({})
     storage = Storage({})
     logging_res = LoggingResource({})
 
-    llm.provider = llm_provider
+    if llm_provider is not None:
+        llm.provider = llm_provider
     memory.database = db
     vector_store.database = db
     memory.vector_store = vector_store
@@ -112,7 +71,8 @@ def _create_default_agent() -> Agent:
 
         await resources.add("database", db)
         await resources.add("vector_store", vector_store)
-        await resources.add("llm_provider", llm_provider)
+        if llm_provider is not None:
+            await resources.add("llm_provider", llm_provider)
         await resources.add("llm", llm)
         await resources.add("memory", memory)
         await resources.add("storage", storage)
@@ -125,14 +85,8 @@ def _create_default_agent() -> Agent:
         tools=builder.tool_registry,
         plugins=builder.plugin_registry,
     )
-<<<<<<< HEAD
-<<<<<<< HEAD
-    # Default plugins are optional and may not be available in all environments
-    try:
-=======
 
     try:  # optional default plugins
->>>>>>> pr-1530
         from plugins.builtin.basic_error_handler import BasicErrorHandler
         from plugins.examples import InputLogger, MessageParser, ResponseReviewer
         from user_plugins.prompts import ComplexPrompt
@@ -144,47 +98,20 @@ def _create_default_agent() -> Agent:
         asyncio.run(builder.add_plugin(ResponseReviewer({})))
         asyncio.run(builder.add_plugin(ComplexPrompt({})))
         asyncio.run(builder.add_plugin(ComplexPromptResponder({})))
-<<<<<<< HEAD
-    except Exception:  # noqa: BLE001 - plugins optional
-=======
-    asyncio.run(builder.add_plugin(BasicErrorHandler({})))
-    asyncio.run(builder.add_plugin(InputLogger({})))
-    try:
-        from user_plugins.prompts import ComplexPrompt
-        from user_plugins.responders import ComplexPromptResponder
-
-        asyncio.run(builder.add_plugin(ComplexPrompt({})))
-        asyncio.run(builder.add_plugin(ComplexPromptResponder({})))
-    except Exception:  # noqa: BLE001 - optional plugins
->>>>>>> pr-1529
-        pass
-    workflow = getattr(setup, "workflow", minimal_workflow)
-=======
     except Exception:  # noqa: BLE001
         pass
 
     wf = getattr(setup, "workflow", None)
     workflow = wf if wf is not None else minimal_workflow
->>>>>>> pr-1530
     agent._runtime = AgentRuntime(caps, workflow=workflow)
     return agent
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-try:
-    agent = _create_default_agent()
-except Exception:  # noqa: BLE001 - optional defaults
-    agent = Agent()
-=======
-agent: Agent | None = None
-=======
 # ---------------------------------------------------------------------------
 # lazy global agent setup
 # ---------------------------------------------------------------------------
 
 _default_agent: Agent | None = None
->>>>>>> pr-1530
 
 
 def _ensure_agent() -> Agent:
@@ -193,58 +120,6 @@ def _ensure_agent() -> Agent:
         _default_agent = _create_default_agent()
     return _default_agent
 
-<<<<<<< HEAD
->>>>>>> pr-1529
-
-# Expose decorator helpers bound to the default agent
-plugin = agent.plugin
-
-
-<<<<<<< HEAD
-def input(func=None, **hints):
-    return agent.plugin(func, stage=PipelineStage.INPUT, **hints)
-
-
-agent.input = input
-
-
-def parse(func=None, **hints):
-    return agent.plugin(func, stage=PipelineStage.PARSE, **hints)
-
-
-agent.parse = parse
-
-
-def prompt(func=None, **hints):
-    return agent.plugin(func, stage=PipelineStage.THINK, **hints)
-
-
-agent.prompt = prompt
-
-
-def tool(func=None, **hints):
-    """Register ``func`` as a tool plugin or simple tool."""
-
-=======
-def plugin(func=None, **hints):
-    ag = _ensure_agent()
-    return ag.plugin(func, **hints)
-
-
-def input(func=None, **hints):
-    ag = _ensure_agent()
-    return ag.plugin(func, stage=PipelineStage.INPUT, **hints)
-
-
-def parse(func=None, **hints):
-    ag = _ensure_agent()
-    return ag.plugin(func, stage=PipelineStage.PARSE, **hints)
-
-
-def prompt(func=None, **hints):
-    ag = _ensure_agent()
-    return ag.plugin(func, stage=PipelineStage.THINK, **hints)
-=======
 
 class _LazyAgent(SimpleNamespace):
     def __getattr__(self, item):  # type: ignore[override]
@@ -280,67 +155,25 @@ def parse(func=None, **hints):
 
 def prompt(func=None, **hints):
     return plugin(func, stage=PipelineStage.THINK, **hints)
->>>>>>> pr-1530
 
 
 def tool(func=None, **hints):
     """Register ``func`` as a tool plugin or simple tool."""
 
-<<<<<<< HEAD
->>>>>>> pr-1529
-=======
->>>>>>> pr-1530
     def decorator(f):
+        ag = _ensure_agent()
         params = list(inspect.signature(f).parameters)
         if params and params[0] in {"ctx", "context"}:
-<<<<<<< HEAD
-<<<<<<< HEAD
-            return agent.plugin(f, stage=PipelineStage.DO, **hints)
-=======
             return ag.plugin(f, stage=PipelineStage.DO, **hints)
->>>>>>> pr-1529
-=======
-            return ag.plugin(f, stage=PipelineStage.DO, **hints)
->>>>>>> pr-1530
 
         class _WrappedTool(ToolPlugin):
             async def execute_function(self, params_dict):
                 return await f(**params_dict)
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        asyncio.run(agent.builder.tool_registry.add(f.__name__, _WrappedTool({})))
-        return f
-
-    return decorator(func) if func else decorator
-
-
-agent.tool = tool
-=======
-        ag = _ensure_agent()
-=======
->>>>>>> pr-1530
         asyncio.run(ag.builder.tool_registry.add(f.__name__, _WrappedTool({})))
         return f
 
     return decorator(func) if func else decorator
-<<<<<<< HEAD
->>>>>>> pr-1529
-
-
-def review(func=None, **hints):
-    return agent.plugin(func, stage=PipelineStage.REVIEW, **hints)
-
-
-agent.review = review
-
-
-def output(func=None, **hints):
-    return agent.plugin(func, stage=PipelineStage.OUTPUT, **hints)
-
-
-agent.output = output
-=======
 
 
 def review(func=None, **hints):
@@ -349,47 +182,22 @@ def review(func=None, **hints):
 
 def output(func=None, **hints):
     return plugin(func, stage=PipelineStage.OUTPUT, **hints)
->>>>>>> pr-1530
 
 
 def prompt_plugin(func=None, **hints):
     hints["plugin_class"] = PromptPlugin
-<<<<<<< HEAD
-    return agent.plugin(func, **hints)
-
-
-agent.prompt_plugin = prompt_plugin
-=======
     return plugin(func, **hints)
->>>>>>> pr-1530
 
 
 def tool_plugin(func=None, **hints):
     hints["plugin_class"] = ToolPlugin
-<<<<<<< HEAD
-<<<<<<< HEAD
-    return agent.plugin(func, **hints)
-
-
-agent.tool_plugin = tool_plugin
-=======
-    ag = _ensure_agent()
-    return ag.plugin(func, **hints)
->>>>>>> pr-1529
-=======
     return plugin(func, **hints)
->>>>>>> pr-1530
 
 
 __all__ = [
     "core",
     "Agent",
     "agent",
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> pr-1530
     "_create_default_agent",
     "plugin",
     "input",
@@ -400,10 +208,6 @@ __all__ = [
     "output",
     "prompt_plugin",
     "tool_plugin",
-<<<<<<< HEAD
->>>>>>> pr-1529
-=======
->>>>>>> pr-1530
 ]
 
 
@@ -412,4 +216,8 @@ def __getattr__(name: str):  # pragma: no cover - lazily loaded modules
         from . import core as _core
 
         return _core
+    if name == "AgentBuilder":
+        from .core.agent import _AgentBuilder
+
+        return _AgentBuilder
     raise AttributeError(name)

--- a/src/entity/pipeline/errors.py
+++ b/src/entity/pipeline/errors.py
@@ -36,21 +36,8 @@ class PluginExecutionError(PipelineError):
 
 
 class ResourceError(PipelineError):
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-    """Raised when a resource encounters an operational failure."""
-
-=======
->>>>>>> pr-1528
-=======
     """Base class for resource errors."""
 
->>>>>>> pr-1529
-=======
-    """Base class for resource errors."""
-
->>>>>>> pr-1530
     pass
 
 
@@ -68,10 +55,10 @@ class InitializationError(PipelineError):
         self.kind = kind
 
 
-class ResourceInitializationError(ResourceError, InitializationError):
-    """Raised when a required resource dependency is missing."""
+class ResourceInitializationError(InitializationError):
+    """Raised when a resource dependency is missing."""
 
-    def __init__(self, remediation: str, name: str = "resource") -> None:
+    def __init__(self, remediation: str, name: str) -> None:
         super().__init__(name, "initialization", remediation, kind="Resource")
 
 
@@ -146,7 +133,6 @@ __all__ = [
     "ResourceError",
     "ResourceInitializationError",
     "InitializationError",
-    "ResourceInitializationError",
     "StageExecutionError",
     "ToolExecutionError",
     "ErrorResponse",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 from pathlib import Path
+import os
 import sys
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+os.environ.setdefault("ENTITY_AUTO_INIT", "0")
 
 from entity.infrastructure import DuckDBInfrastructure
 from entity.resources import Memory

--- a/tests/plugins/test_global_decorators.py
+++ b/tests/plugins/test_global_decorators.py
@@ -1,0 +1,60 @@
+import os
+
+os.environ["ENTITY_AUTO_INIT"] = "0"
+
+import entity
+from entity.core.agent import Agent
+from entity.pipeline.stages import PipelineStage
+
+
+def _plugin_from(decorator, monkeypatch) -> entity.core.plugins.Plugin:
+    ag = Agent()
+    monkeypatch.setattr(entity, "_default_agent", ag, raising=False)
+
+    @decorator
+    async def dummy(context):
+        pass
+
+    return ag.builder._added_plugins[-1]
+
+
+def test_input_decorator(monkeypatch):
+    plugin = _plugin_from(entity.input, monkeypatch)
+    assert plugin.stages == [PipelineStage.INPUT]
+
+
+def test_parse_decorator(monkeypatch):
+    plugin = _plugin_from(entity.parse, monkeypatch)
+    assert plugin.stages == [PipelineStage.PARSE]
+
+
+def test_prompt_decorator(monkeypatch):
+    plugin = _plugin_from(entity.prompt, monkeypatch)
+    assert plugin.stages == [PipelineStage.THINK]
+
+
+def test_tool_decorator(monkeypatch):
+    plugin = _plugin_from(entity.tool, monkeypatch)
+    assert plugin.stages == [PipelineStage.DO]
+
+
+def test_review_decorator(monkeypatch):
+    plugin = _plugin_from(entity.review, monkeypatch)
+    assert plugin.stages == [PipelineStage.REVIEW]
+
+
+def test_output_decorator(monkeypatch):
+    plugin = _plugin_from(entity.output, monkeypatch)
+    assert plugin.stages == [PipelineStage.OUTPUT]
+
+
+def test_plugin_multi_stage(monkeypatch):
+    ag = Agent()
+    monkeypatch.setattr(entity, "_default_agent", ag, raising=False)
+
+    @entity.plugin(stages=[PipelineStage.INPUT, PipelineStage.PARSE])
+    async def dummy(context):
+        pass
+
+    plugin = ag.builder._added_plugins[-1]
+    assert plugin.stages == [PipelineStage.INPUT, PipelineStage.PARSE]


### PR DESCRIPTION
## Summary
- clean up root `entity` module and expose decorator helpers
- allow multi-stage registration with `agent.plugin(stages=[...])`
- fix pipeline errors module after merge
- add tests covering default-agent decorators
- ensure tests skip default initialization in `conftest`

## Testing
- `black src tests`
- `pytest tests/plugins/test_global_decorators.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68744ac6836c8322ac2de7f8211b6cb4