### PR TITLE
Update examples and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,14 @@ With dependencies installed you can run the included poe tasks:
 poe test
 ```
 
+## Multi-User Support
+
+Pass a unique `user_id` when calling `agent.chat()` or `agent.handle()` to keep
+conversation history and memory isolated per user.
+
+```python
+response = await agent.chat("Hi", user_id="alice")
+```
+
+See [multi_user](docs/source/multi_user.md) for additional patterns.
+

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Revised examples for zero-config, updated configs, and documented multi-user patterns
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Removed deprecated AgentBuilder from public interface
 <<<<<<< HEAD

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -16,7 +16,9 @@ breaker_settings:
     failure_threshold: 2
 
 plugins:
+  # Layer 1 - infrastructure primitives
   infrastructure: {}
+  # Layer 2 - resource interfaces built on infrastructure
   resources:
     database:
       type: entity.resources.interfaces.duckdb_resource:DuckDBResource
@@ -29,20 +31,19 @@ plugins:
     #     dimensions: 3
     metrics_collector:
       type: entity.resources.metrics:MetricsCollectorResource
-  # llm:
-  #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
-  #   provider: ollama
-  #   base_url: "${OLLAMA_BASE_URL}"
-  #   model: "${OLLAMA_MODEL}"
-  #   retries: 3
-  #   backoff: 1.0
+  # Layer 3 - canonical agent resources
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
       dependencies: [database, vector_store]
-    # filesystem:
-    #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
-    #   bucket: agent-files
+    llm:
+      type: entity.resources.llm:LLM
+      provider: echo
+    storage:
+      type: entity.resources.storage:Storage
+  # filesystem:
+  #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
+  #   bucket: agent-files
     #   region: us-east-1
     # storage:
     #   type: plugins.builtin.resources.storage_resource:StorageResource
@@ -63,6 +64,7 @@ plugins:
 #       type: plugins.builtin.resources.s3_filesystem:S3FileSystem
 #       bucket: agent-files
 #       region: us-east-1
+  # Layer 4 - user defined compositions
   custom_resources: {}
   tools:
     calculator:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -16,7 +16,9 @@ breaker_settings:
     failure_threshold: 2
 
 plugins:
+  # Layer 1 - infrastructure primitives
   infrastructure: {}
+  # Layer 2 - resource interfaces built on infrastructure
   resources:
     database:
       type: entity.resources.interfaces.duckdb_resource:DuckDBResource
@@ -29,21 +31,19 @@ plugins:
     #     dimensions: 3
     metrics_collector:
       type: entity.resources.metrics:MetricsCollectorResource
-    # llm:
-    #   type: plugins.builtin.resources.llm.unified:UnifiedLLMResource
-    #   provider: ollama
-    #   base_url: "${OLLAMA_BASE_URL}"
-    #   model: "${OLLAMA_MODEL}"
-    #   temperature: 0.7
-    #   retries: 5
-    #   backoff: 2.0
+  # Layer 3 - canonical agent resources
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
       dependencies: [database, vector_store]
-    # filesystem:
-    #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
-    #   bucket: agent-files
+    llm:
+      type: entity.resources.llm:LLM
+      provider: echo
+    storage:
+      type: entity.resources.storage:Storage
+  # filesystem:
+  #   type: plugins.builtin.resources.s3_filesystem:S3FileSystem
+  #   bucket: agent-files
     #   region: us-east-1
     # storage:
     #   type: plugins.builtin.resources.storage_resource:StorageResource
@@ -64,6 +64,7 @@ plugins:
 #       type: plugins.builtin.resources.s3_filesystem:S3FileSystem
 #       bucket: agent-files
 #       region: us-east-1
+  # Layer 4 - user defined compositions
   custom_resources: {}
   tools:
     calculator:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -12,6 +12,7 @@ logging
 configuration
 plugin_examples
 plugins
+multi_user
 ```
 
 The following pages cover core concepts and usage patterns.

--- a/docs/source/multi_user.md
+++ b/docs/source/multi_user.md
@@ -1,0 +1,18 @@
+# Multi-User Patterns
+
+The framework isolates conversation data by accepting a `user_id` parameter on every pipeline run.
+
+````python
+response = await agent.chat("Hi", user_id="alice")
+````
+
+All persistent keys and conversation IDs are automatically namespaced using this identifier:
+
+````python
+pipeline_id = f"{user_id}_{generate_pipeline_id()}"
+await memory.save_conversation(pipeline_id, history)
+````
+
+Plugins access the active user through `ctx.user_id` and store data via the canonical `Memory` resource. The memory implementation prefixes keys with the `user_id` to prevent leaks between users.
+
+Deploy a single agent for many users or separate deployments per organization as security requirements demand. This approach requires no extra configuration and works within the stateless worker model described in [Decision #29](../ARCHITECTURE.md#29-multi-user-support-user_id-parameter-pattern).

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Each subdirectory contains a small agent showcasing different features.
 
 - **kitchen_sink** – demonstrates a ReAct loop with tool usage.
-- **zero_config_agent** – uses `@agent.tool` and `@agent.output` decorators.
+- **default** – minimal zero-config agent using decorators.
 - **plugins** – minimal plugins for INPUT, PARSE, and REVIEW stages.
 
 Run any example with:

--- a/examples/basic_agent/main.py
+++ b/examples/basic_agent/main.py
@@ -1,70 +1,17 @@
-from __future__ import annotations
-
 import asyncio
-from typing import Any
-from pathlib import Path
-import sys
-
-base = Path(__file__).resolve().parents[2]
-sys.path.append(str(base / "src"))
-sys.path.append(str(base))
-# ruff: noqa: E402
-
-from entity.core.plugins import PromptPlugin
-from entity.core.context import PluginContext
-from entity.core.stages import PipelineStage
-from datetime import datetime
-
-from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
-from entity.core.resources.container import ResourceContainer
-from entity.infrastructure.duckdb import DuckDBInfrastructure
-from entity.resources.memory import Memory
-from entity.resources.logging import LoggingResource
-from entity.pipeline.pipeline import execute_pipeline, generate_pipeline_id
-from entity.pipeline.state import ConversationEntry, PipelineState
+from entity import agent
 
 
-class EchoPrompt(PromptPlugin):
-    """Return the last user message."""
-
-    stages = [PipelineStage.OUTPUT]
-
-    async def _execute_impl(self, context: PluginContext) -> None:
-        last_message = ""
-        for entry in reversed(context.conversation()):
-            if entry.role == "user":
-                last_message = entry.content
-                break
-        context.say(f"You said: {last_message}")
+@agent.output
+async def echo(ctx):
+    last = next(
+        (e.content for e in reversed(ctx.conversation()) if e.role == "user"), ""
+    )
+    ctx.say(f"You said: {last}")
 
 
 async def main() -> None:
-    plugins = PluginRegistry()
-    await plugins.register_plugin_for_stage(EchoPrompt(), PipelineStage.OUTPUT, "echo")
-
-    resources = ResourceContainer()
-    db = DuckDBInfrastructure({"path": "./agent.duckdb"})
-    memory = Memory(config={})
-    memory.database = db
-    await db.initialize()
-    await resources.add("database", db)
-    await resources.add("memory", memory)
-    resources.register("logging", LoggingResource, {}, layer=3)
-    await resources.build_all()
-    logger: LoggingResource = resources.get("logging")  # type: ignore[assignment]
-
-    caps = SystemRegistries(resources=resources, tools=ToolRegistry(), plugins=plugins)
-
-    state = PipelineState(
-        conversation=[
-            ConversationEntry(content="Hello", role="user", timestamp=datetime.now())
-        ],
-        pipeline_id=generate_pipeline_id(),
-    )
-    result: dict[str, Any] = await execute_pipeline("Hello", caps, state=state)
-    await logger.log(
-        "info", "pipeline finished", component="pipeline", pipeline_id=state.pipeline_id
-    )
+    result = await agent.handle("Hello")
     print(result)
 
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -7,5 +7,5 @@ emits the final response at the correct stage.
 Run it with:
 
 ```bash
-poetry run python examples/default_setup/main.py
+poetry run python examples/default/main.py
 ```

--- a/examples/default_setup/README.md
+++ b/examples/default_setup/README.md
@@ -1,9 +1,8 @@
 # Default Setup Agent
 
-This example uses the high level `Agent` API and the
-`@agent.tool` and `@agent.prompt` decorators to register plugins. The
-prompt is assigned to the `OUTPUT` stage so responses are emitted from
-the correct point in the pipeline.
+This example uses the global `agent` with the
+`@agent.tool` and `@agent.output` decorators. No configuration is
+required; the default resources are set up automatically.
 
 Run it with:
 

--- a/examples/default_setup/main.py
+++ b/examples/default_setup/main.py
@@ -1,9 +1,6 @@
 import asyncio
 
-from entity import Agent
-from entity.core.stages import PipelineStage
-
-agent = Agent()
+from entity import agent
 
 
 @agent.tool
@@ -11,7 +8,7 @@ async def add(a: int, b: int) -> int:
     return a + b
 
 
-@agent.prompt(stage=PipelineStage.OUTPUT)
+@agent.output
 async def responder(ctx):
     user = next((e.content for e in ctx.conversation() if e.role == "user"), "")
     result = await ctx.tool_use("add", a=2, b=2)

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -1,77 +1,18 @@
-from __future__ import annotations
-
 import asyncio
-from typing import Any
-from pathlib import Path
-import sys
-
-base = Path(__file__).resolve().parents[2]
-sys.path.append(str(base / "src"))
-sys.path.append(str(base))
-# ruff: noqa: E402
-
-from user_plugins.responders import ComplexPromptResponder
-from entity.core.plugins import PromptPlugin, ResourcePlugin
-from entity.core.context import PluginContext
+from entity import agent
 from entity.core.stages import PipelineStage
-from datetime import datetime
-
-from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
-from entity.core.resources.container import ResourceContainer
-from entity.infrastructure.duckdb import DuckDBInfrastructure
-from entity.resources.memory import Memory
-from entity.pipeline.pipeline import execute_pipeline, generate_pipeline_id
-from entity.pipeline.state import ConversationEntry, PipelineState
+from user_plugins.responders import ComplexPromptResponder
 
 
-class EchoLLMResource(ResourcePlugin):
-    """LLM resource that echoes the prompt."""
-
-    async def generate(self, prompt: str) -> Any:
-        return {"content": prompt}
-
-
-class ChainOfThoughtPrompt(PromptPlugin):
-    """Simple reasoning plugin."""
-
-    stages = [PipelineStage.THINK]
-
-    async def _execute_impl(self, context: PluginContext) -> None:
-        user = next((e.content for e in context.conversation() if e.role == "user"), "")
-        await context.think("complex_response", f"Problem breakdown: {user}")
+@agent.prompt(stage=PipelineStage.THINK)
+async def chain_of_thought(ctx):
+    user = next((e.content for e in ctx.conversation() if e.role == "user"), "")
+    await ctx.think("complex_response", f"Problem breakdown: {user}")
 
 
 async def main() -> None:
-    resources = ResourceContainer()
-    db = DuckDBInfrastructure({"path": "./agent.duckdb"})
-    memory = Memory(config={})
-    memory.database = db
-    await db.initialize()
-    await resources.add("database", db)
-    await resources.add("memory", memory)
-    await resources.add("llm", EchoLLMResource({}))
-
-    plugins = PluginRegistry()
-    await plugins.register_plugin_for_stage(
-        ChainOfThoughtPrompt({"max_steps": 1}), PipelineStage.THINK, "cot"
-    )
-    await plugins.register_plugin_for_stage(
-        ComplexPromptResponder({}), PipelineStage.OUTPUT, "final"
-    )
-
-    caps = SystemRegistries(resources=resources, tools=ToolRegistry(), plugins=plugins)
-
-    state = PipelineState(
-        conversation=[
-            ConversationEntry(
-                content="Explain the sky", role="user", timestamp=datetime.now()
-            )
-        ],
-        pipeline_id=generate_pipeline_id(),
-    )
-    result: dict[str, Any] = await execute_pipeline(
-        "Explain the sky", caps, state=state
-    )
+    await agent.add_plugin(ComplexPromptResponder({}))
+    result = await agent.handle("Explain the sky")
     print(result)
 
 


### PR DESCRIPTION
## Summary
- refactor example scripts to rely on the zero‑config `agent`
- show multi-user usage in README and new docs
- clarify resource layers in dev and prod configs

## Testing
- `poetry run black src tests` *(fails: cannot parse)*
- `poetry run ruff check --fix src tests` *(fails: syntax errors)*
- `poetry run mypy src` *(fails: invalid syntax)*
- `poetry run bandit -r src` *(command not found)*
- `poetry run vulture src tests` *(command not found)*
- `poetry run unimport --remove-all src tests` *(command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed to import package)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed to import package)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: invalid syntax)*
- `poetry run poe test-architecture` *(command not found)*
- `pytest -k ''` *(fails: invalid syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68744ad832ec8322a9c636bb06984c23