### PR TITLE
Implement WebSocket log streaming and metrics hooks

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Implemented WebSocket log streaming and metrics tracking hooks
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-13: Removed deprecated AgentBuilder from public interface
 <<<<<<< HEAD

--- a/src/entity/resources/logging.py
+++ b/src/entity/resources/logging.py
@@ -181,6 +181,10 @@ class LoggingResource(AgentResource):
         self.host_name = self.config.get("host_name", socket.gethostname())
         self.process_id = self.config.get("process_id", os.getpid())
 
+    def stream_endpoints(self) -> List[str]:
+        """Return active WebSocket URIs for log streaming."""
+        return [f"ws://{s.host}:{s.port}" for s in self._stream_outputs]
+
     @classmethod
     async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
         try:


### PR DESCRIPTION
## Summary
- log resource exposes `stream_endpoints` for WebSocket clients
- metrics collector provides context managers for plugin and resource tracking
- test capturing metrics during pipeline run with LLM usage
- document new note in `agents.log`

## Testing
- `poetry run black src/entity/resources/logging.py src/entity/resources/metrics.py tests/integration/test_full_pipeline.py`
- `poetry run ruff check --fix src/entity/resources/logging.py src/entity/resources/metrics.py tests/integration/test_full_pipeline.py`
- `poetry run mypy src/entity/resources/logging.py src/entity/resources/metrics.py tests/integration/test_full_pipeline.py`
- `poetry run bandit -r src/entity/resources/logging.py src/entity/resources/metrics.py tests/integration/test_full_pipeline.py`
- `poetry run vulture src/entity/resources/logging.py src/entity/resources/metrics.py tests/integration/test_full_pipeline.py`
- `poetry run unimport --remove-all src/entity/resources/logging.py src/entity/resources/metrics.py tests/integration/test_full_pipeline.py` *(failed: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: SyntaxError in __init__.py)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: SyntaxError in __init__.py)*
- `poetry run poe test-architecture` *(failed: SyntaxError in __init__.py)*
- `poetry run poe test-plugins` *(failed: SyntaxError in __init__.py)*
- `poetry run poe test-resources` *(failed: SyntaxError in __init__.py)*
- `poetry run poe test` *(failed: SyntaxError in __init__.py)*

------
https://chatgpt.com/codex/tasks/task_e_68744ad373c88322a141898fa9b98413