### PR TITLE
Fix THINK plugin template

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Clarified THINK stage to store results via context.think
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-14: Added tests for infrastructure deps, layer jumps, and say() stage enforcement
 <<<<<<< HEAD

--- a/src/entity/cli/templates/prompt.py
+++ b/src/entity/cli/templates/prompt.py
@@ -6,6 +6,10 @@ workflow mapping under the ``THINK`` stage:
 ```
 workflow = {PipelineStage.THINK: ["MyPromptPlugin"]}
 ```
+
+THINK-stage plugins collect intermediate results with :meth:`context.think`.
+An OUTPUT-stage plugin should later read those results and call
+:meth:`context.say` to generate the final response.
 """
 
 from entity.core.plugins import PromptPlugin
@@ -22,10 +26,10 @@ class CLASS_NAME(PromptPlugin):
     # List position controls execution order and SystemInitializer preserves it.
 
     async def _execute_impl(self, context):
-        if await context.reflect("answer") is not None:
-            context.say(await context.reflect("answer"))
+        cached_answer = await context.reflect("answer")
+        if cached_answer is not None:
+            await context.think("answer", cached_answer)
             return
 
         result = await context.tool_use("some_tool", query=context.message)
         await context.think("answer", result)
-        context.say(result)


### PR DESCRIPTION
## Summary
- document THINK stage usage clearly
- update prompt plugin template to store answers with `context.think`

## Testing
- `poetry run black src/entity/cli/templates/prompt.py`
- `poetry run ruff check --fix src/entity/cli/templates/prompt.py`
- `poetry run mypy src/entity/cli/templates/prompt.py`
- `poetry run bandit -r src/entity/cli/templates/prompt.py` *(fails: Command not found)*
- `poetry run vulture src/entity/cli/templates/prompt.py` *(fails: Command not found)*
- `poetry run unimport --remove-all src/entity/cli/templates/prompt.py` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture` *(fails: Command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68744def5eac8322b501ee4528edffe7