### PR TITLE
Refactor AgentServer API

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Refactored AgentServer to accept capability container
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-14: Added tests for infrastructure deps, layer jumps, and say() stage enforcement
 <<<<<<< HEAD

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -285,7 +285,10 @@ class EntityCLI:
                 agent.runtime.manager.state_logger = state_logger
             from plugins.builtin.adapters.server import AgentServer
 
-            server = AgentServer(agent.runtime)
+            server = AgentServer(
+                capabilities=agent.runtime.capabilities,
+                manager=agent.runtime.manager,
+            )
             try:
                 if cmd == "serve-websocket":
                     await server.serve_websocket()

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -696,7 +696,9 @@ class Agent:
         await self._ensure_runtime()
         from plugins.builtin.adapters.server import AgentServer
 
-        server = AgentServer(self.runtime)
+        server = AgentServer(
+            capabilities=self.runtime.capabilities, manager=self.runtime.manager
+        )
         await server.serve_http(**config)
 
     async def serve_websocket(self, **config: Any) -> None:
@@ -705,7 +707,9 @@ class Agent:
         await self._ensure_runtime()
         from plugins.builtin.adapters.server import AgentServer
 
-        server = AgentServer(self.runtime)
+        server = AgentServer(
+            capabilities=self.runtime.capabilities, manager=self.runtime.manager
+        )
         await server.serve_websocket(**config)
 
     async def serve_cli(self, **config: Any) -> None:
@@ -714,7 +718,9 @@ class Agent:
         await self._ensure_runtime()
         from plugins.builtin.adapters.server import AgentServer
 
-        server = AgentServer(self.runtime)
+        server = AgentServer(
+            capabilities=self.runtime.capabilities, manager=self.runtime.manager
+        )
         await server.serve_cli(**config)
 
 

--- a/src/plugins/builtin/adapters/server.py
+++ b/src/plugins/builtin/adapters/server.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from entity.core.agent import AgentRuntime
 
 from .cli import CLIAdapter
 from .http_adapter import HTTPAdapter
@@ -14,17 +13,18 @@ from .websocket import WebSocketAdapter
 class AgentServer:
     """Expose adapter-based serving helpers."""
 
-    def __init__(self, runtime: AgentRuntime) -> None:
-        self.runtime = runtime
+    def __init__(self, *, capabilities: Any, manager: Any | None = None) -> None:
+        self.capabilities = capabilities
+        self.manager = manager
 
     async def serve_http(self, **config: Any) -> None:
-        adapter = HTTPAdapter(self.runtime.manager, config)
-        await adapter.serve(self.runtime.capabilities)
+        adapter = HTTPAdapter(self.manager, config)
+        await adapter.serve(self.capabilities)
 
     async def serve_websocket(self, **config: Any) -> None:
-        adapter = WebSocketAdapter(self.runtime.manager, config)
-        await adapter.serve(self.runtime.capabilities)
+        adapter = WebSocketAdapter(self.manager, config)
+        await adapter.serve(self.capabilities)
 
     async def serve_cli(self, **config: Any) -> None:
-        adapter = CLIAdapter(self.runtime.manager, config)
-        await adapter.serve(self.runtime.capabilities)
+        adapter = CLIAdapter(self.manager, config)
+        await adapter.serve(self.capabilities)


### PR DESCRIPTION
## Summary
- accept capability container and manager for serving helpers
- adapt Agent methods and CLI to new AgentServer API
- log note about the refactor

## Testing
- `poe test` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_68744dee424483228d1b1887de1807fa