### PR TITLE
Fix error class hierarchy

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Cleaned conflict markers in errors and restored resource hierarchy
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-14: Refactored AgentServer to accept capability container
 <<<<<<< HEAD

--- a/src/entity/pipeline/errors.py
+++ b/src/entity/pipeline/errors.py
@@ -39,12 +39,6 @@ class PluginExecutionError(PipelineError):
 class ResourceError(PipelineError):
     """Base class for resource errors."""
 
-    pass
-
-=======
->>>>>>> pr-1536
-=======
->>>>>>> pr-1540
 
 class InitializationError(PipelineError):
     """Raised when a plugin or resource fails to initialize."""
@@ -60,10 +54,10 @@ class InitializationError(PipelineError):
         self.kind = kind
 
 
-class ResourceInitializationError(InitializationError):
-    """Raised when a resource dependency is missing."""
+class ResourceInitializationError(ResourceError, InitializationError):
+    """Raised when a required resource dependency is missing."""
 
-    def __init__(self, remediation: str, name: str) -> None:
+    def __init__(self, remediation: str, name: str = "resource") -> None:
         super().__init__(name, "initialization", remediation, kind="Resource")
 
 


### PR DESCRIPTION
## Summary
- clean `errors.py` merge leftovers
- restore `ResourceInitializationError` to extend `ResourceError`
- format with black
- add a development note

## Testing
- `poetry run pytest tests/test_error_handling.py` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_687450b7c4308322b69463f17cc9ad6c