### PR TITLE
Clean merge markers from agents.log

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,17 +1,13 @@
+AGENT NOTE - 2025-07-14: Removed merge conflict markers from agents.log
 AGENT NOTE - 2025-07-14: Cleaned merge markers in source and updated lazy init helpers
-<<<<<<< HEAD
 AGENT NOTE - 2025-10-07: Resolved multi_user test conflicts and preserved all test cases
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-14: Refactored AgentServer to accept capability container
-=======
 AGENT NOTE - 2025-07-14: Removed conflict markers in tests and __init__
->>>>>>> pr-1553
 AGENT NOTE - 2025-10-07: Cleaned merge markers and restored lazy initialization
 AGENT NOTE - 2025-07-14: Added tests for infrastructure deps, layer jumps, and say() stage enforcement
 AGENT NOTE - 2025-07-14: Implemented plugin decorators and multi-stage support
 AGENT NOTE - 2025-07-14: Extended layer validation and tests for layer boundaries
 AGENT NOTE - 2025-07-14: Switched tests to core plugin imports
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-14: Verified persistence functions prepend user_id for isolation
 AGENT NOTE - 2025-07-14: Verified stage context assignment and added tests for say guard
 AGENT NOTE - 2025-07-14: Updated plugin dependency handling
@@ -23,8 +19,6 @@ AGENT NOTE - 2025-07-13: Added BasicErrorHandler plugin for error handling in ze
 AGENT NOTE - 2025-07-13: Added DefaultWorkflow and zero-config setup
 AGENT NOTE - 2025-07-13: Removed deprecated AgentBuilder from public interface
 AGENT NOTE - 2025-07-13: Modified dependency injection for infrastructure plugins
-=======
->>>>>>> pr-1553
 AGENT NOTE - 2025-10-07: Implemented lazy agent initialization respecting ENV
 AGENT NOTE - 2025-10-07: Cleaned conflict markers in __init__ and agents.log
 AGENT NOTE - 2025-07-12: Added canonical resource classes and StandardResources dataclass
@@ -94,9 +88,6 @@ AGENT NOTE - 2025-07-13: Updated tests for Memory initialization
 AGENT NOTE - 2025-07-13: Verified memory vector search and analytics
 AGENT NOTE - 2025-07-13: Verified merge conflict cleanup and preserved all notes
 AGENT NOTE - 2025-07-13: pytest now works with the unified entity.cli.plugin_tool structure
-<<<<<<< HEAD
-=======
-AGENT NOTE - 2025-07-14: Unified builder and runtime inside Agent
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
@@ -130,6 +121,3 @@ AGENT NOTE - 2025-08-10: Moved plugin_tool under entity.cli and updated imports
 AGENT NOTE - 2025-08-10: Stage results persist across runs and temporary thoughts moved to PipelineState
 AGENT NOTE - 2025-08-21: Added user_id propagation in pipeline and multi-user tests
 AGENT NOTE - 2025-10-05: Added default dependency injection and tests
-AGENT NOTE - 2025-10-06: Clear stage results and temporary thoughts after each pipeline run
-AGENT NOTE - 2025-10-06: Removed merge markers from agents.log
->>>>>>> pr-1553


### PR DESCRIPTION
## Summary
- remove leftover merge markers from `agents.log`
- deduplicate log entries
- log the cleanup

## Testing
- `poetry run black . --exclude 'src/entity/pipeline/errors.py'`

------
https://chatgpt.com/codex/tasks/task_e_6874566767488322bd0db214ac10b726