### PR TITLE
Update docs on verbose test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ With dependencies installed you can run the included poe tasks:
 poe test
 ```
 
+For more detailed output use the verbose task:
+
+```bash
+poe test-verbose
+```
+
 ## Multi-User Support
 
 Pass a unique `user_id` when calling `agent.chat()` or `agent.handle()` to keep

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Documented verbose test command in README
 AGENT NOTE - 2025-07-14: Cleaned merge markers in source and updated lazy init helpers
 <<<<<<< HEAD
 AGENT NOTE - 2025-10-07: Resolved multi_user test conflicts and preserved all test cases


### PR DESCRIPTION
## Summary
- mention `poe test-verbose` in the test instructions
- log the update in `agents.log`

## Testing
- `poetry run black src tests` *(fails: cannot parse errors.py)*
- `poetry run poe test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874566960708322a1eda4740d84013a