### PR TITLE
Fix default workflow fallback

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py
 AGENT NOTE - 2025-07-14: Cleaned merge markers in source and updated lazy init helpers
 AGENT NOTE - 2025-10-07: Resolved multi_user test conflicts and preserved all test cases

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -118,7 +118,7 @@ def _create_default_agent() -> Agent:
     except Exception:  # noqa: BLE001
         pass
 
-    workflow = getattr(setup, "workflow", minimal_workflow)
+    workflow = getattr(setup, "workflow", None) or minimal_workflow
     agent._runtime = AgentRuntime(caps, workflow=workflow)
     return agent
 


### PR DESCRIPTION
## Summary
- fallback to minimal workflow when Layer0SetupManager.workflow is None
- log change

## Testing
- `poetry run pytest tests/setup/test_minimal_startup.py -q`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: entity.pipeline.reliability)*

------
https://chatgpt.com/codex/tasks/task_e_6874587413ec8322a2e0bdac453f9e2c