### PR TITLE
Update README on PYTHONPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ With dependencies installed you can run the included poe tasks:
 poe test
 ```
 
+If you prefer calling `pytest` directly, prepend `PYTHONPATH=src` so Python can
+locate the editable package:
+
+```bash
+PYTHONPATH=src pytest
+```
+
 ## Multi-User Support
 
 Pass a unique `user_id` when calling `agent.chat()` or `agent.handle()` to keep

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py
 AGENT NOTE - 2025-07-14: Cleaned merge markers in source and updated lazy init helpers


### PR DESCRIPTION
## Summary
- note how to run tests when calling pytest directly
- log test command info in `agents.log`

## Testing
- `poetry run poe test` *(fails: ModuleNotFoundError: entity.pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_68745c8efa448322841c00ff327c3280