### PR TITLE
Update agent auto-init

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-10-08: _ensure_agent initializes default agent with warning when auto init disabled
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py

--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -19,6 +19,9 @@ from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
 from .resources.logging import LoggingResource
 from .utils.setup_manager import Layer0SetupManager
 from entity.workflows.minimal import minimal_workflow
+from entity.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def _handle_import_error(exc: ModuleNotFoundError) -> None:
@@ -130,8 +133,8 @@ def _ensure_agent() -> Agent:
     global _default_agent
     if _default_agent is None:
         if os.environ.get("ENTITY_AUTO_INIT", "1") != "1":
-            raise RuntimeError(
-                "ENTITY_AUTO_INIT is disabled; call _create_default_agent() manually"
+            logger.warning(
+                "ENTITY_AUTO_INIT is disabled; initializing default agent anyway"
             )
         _default_agent = _create_default_agent()
     return _default_agent

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 
 from entity.pipeline.utils import StageResolver


### PR DESCRIPTION
## Summary
- log warning if ENTITY_AUTO_INIT is disabled
- ensure agent still initializes in all cases
- lint repo

## Testing
- `poetry run poe test` *(fails: Resource 'metrics_collector, logging, database' initialization errors)*

------
https://chatgpt.com/codex/tasks/task_e_68757e8a69dc832299db81a813c84649