### PR TITLE
Improve ToolRegistry intent filtering

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Improved ToolRegistry intent discovery logic
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -37,15 +37,20 @@ async def test_discover_tools_by_intent() -> None:
     await registry.add("multi", MultiTool())
 
     found = registry.discover(intent="calc")
-    assert len(found) == 1
-    assert found[0][0] == "alpha"
+    assert [name for name, _ in found] == ["alpha"]
     assert isinstance(found[0][1], AlphaTool)
 
     found_ci = registry.discover(intent="CALC")
-    assert len(found_ci) == 1
-    assert found_ci[0][0] == "alpha"
+    assert [name for name, _ in found_ci] == ["alpha"]
 
     found_text = registry.discover(intent="text")
-    assert len(found_text) == 2
-    names = {name for name, _ in found_text}
-    assert names == {"beta", "multi"}
+    assert {name for name, _ in found_text} == {"beta", "multi"}
+
+
+@pytest.mark.asyncio
+async def test_discover_when_only_multi_intent_tool_registered() -> None:
+    registry = ToolRegistry()
+    await registry.add("multi", MultiTool())
+
+    found = registry.discover(intent="calc")
+    assert [name for name, _ in found] == ["multi"]


### PR DESCRIPTION
## Summary
- refine ToolRegistry `discover` logic to prefer specialized tools
- test filtering rules with multi-intent tools
- note update in `agents.log`

## Testing
- `poetry run pytest tests/test_tool_registry.py -q`
- `poetry run pytest tests/plugins/test_tool_intents.py -q`
- `poetry run poe test` *(fails: InitializationError: Resource ...)*

------
https://chatgpt.com/codex/tasks/task_e_68757e86b478832290a8b24c3a409732