### PR TITLE
Fix load_conversation user-id prefix

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Updated load_conversation ID logic and added tests
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -113,7 +113,10 @@ class Memory(AgentResource):
     async def load_conversation(
         self, pipeline_id: str, *, user_id: str = "default"
     ) -> List[ConversationEntry]:
-        conversation_id = f"{user_id}_{pipeline_id}"
+        if user_id == "default":
+            conversation_id = pipeline_id
+        else:
+            conversation_id = f"{user_id}_{pipeline_id}"
         if self.database is None:
             return []
         async with self.database.connection() as conn:

--- a/tests/test_memory_basic.py
+++ b/tests/test_memory_basic.py
@@ -107,3 +107,19 @@ async def test_conversation_search_text(simple_memory: Memory) -> None:
     results = await simple_memory.conversation_search("new message", user_id="default")
     assert len(results) == 1
     assert results[0]["content"] == "new message"
+
+
+@pytest.mark.asyncio
+async def test_load_conversation_with_user_id(simple_memory: Memory) -> None:
+    entry = ConversationEntry("hi", "user", datetime.now())
+    await simple_memory.save_conversation("pipe", [entry], user_id="alice")
+    history = await simple_memory.load_conversation("pipe", user_id="alice")
+    assert history == [entry]
+
+
+@pytest.mark.asyncio
+async def test_load_conversation_preformatted_id(simple_memory: Memory) -> None:
+    entry = ConversationEntry("hello", "user", datetime.now())
+    await simple_memory.save_conversation("pipe", [entry], user_id="bob")
+    history = await simple_memory.load_conversation("bob_pipe")
+    assert history == [entry]


### PR DESCRIPTION
## Summary
- handle preformatted conversation ids in `Memory.load_conversation`
- cover new behaviour with unit tests
- log this change for other agents

## Testing
- `poetry run poe test` *(fails: InitializationError: Resource 'metrics_collector, logging...')*
- `poetry run pytest tests/test_memory_basic.py::test_load_conversation_with_user_id tests/test_memory_basic.py::test_load_conversation_preformatted_id -q`

------
https://chatgpt.com/codex/tasks/task_e_68757e84423883228819bf7d481cc127