### PR TITLE
Fix layer validation cycle check

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Simplified layer validation by removing duplicate dependency check
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -635,18 +635,6 @@ class ResourceContainer:
                         f"Resource depends on '{dep_name}' but it is not registered.",
                         kind="Resource",
                     )
-                dep_layer = self._layers[dep_name]
-                if layer - dep_layer != 1:
-                    raise InitializationError(
-                        f"{name}, {dep_name}",
-                        "layer validation",
-                        (
-                            f"Resource '{name}' (layer {layer}) depends on "
-                            f"'{dep_name}' (layer {dep_layer}) and violates layer rules "
-                            "(one-layer step)."
-                        ),
-                        kind="Resource",
-                    )
 
         visited: set[str] = set()
         stack: list[str] = []


### PR DESCRIPTION
## Summary
- simplify dependency validation in `ResourceContainer`
- keep layer step validation inside recursive traversal
- log note for future contributors

## Testing
- `poetry run poe test` *(fails: metrics collector etc.)*
- `poetry run pytest tests/resources/test_layer_validation.py::test_cycle_detection_error -vv`


------
https://chatgpt.com/codex/tasks/task_e_68757e7e34e883228adaa85a1cc0867e