### PR TITLE
Add dependencies attribute to infrastructure classes

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Added dependencies attribute to infrastructure classes
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py

--- a/src/entity/infrastructure/aws_standard.py
+++ b/src/entity/infrastructure/aws_standard.py
@@ -11,6 +11,7 @@ class AWSStandardInfrastructure(OpenTofuInfrastructure):
     name = "aws-standard"
     infrastructure_type = "cloud"
     provider = "aws"
+    dependencies: list = []
 
     def __init__(self, region: str = "us-east-1", config: Dict | None = None) -> None:
         super().__init__("aws", "standard", region, config)

--- a/src/entity/infrastructure/docker.py
+++ b/src/entity/infrastructure/docker.py
@@ -13,6 +13,7 @@ class DockerInfrastructure(InfrastructurePlugin):
     infrastructure_type = "container"
     resource_category = "infrastructure"
     stages: list = []
+    dependencies: list = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/entity/infrastructure/duckdb.py
+++ b/src/entity/infrastructure/duckdb.py
@@ -25,6 +25,7 @@ class DuckDBInfrastructure(InfrastructurePlugin):
     infrastructure_type = "database"
     resource_category = "database"
     stages: list = []
+    dependencies: list = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/entity/infrastructure/llamacpp.py
+++ b/src/entity/infrastructure/llamacpp.py
@@ -15,6 +15,7 @@ class LlamaCppInfrastructure(InfrastructurePlugin):
     infrastructure_type = "llm_provider"
     resource_category = "infrastructure"
     stages: list = []
+    dependencies: list = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/entity/infrastructure/opentofu.py
+++ b/src/entity/infrastructure/opentofu.py
@@ -12,6 +12,7 @@ class OpenTofuInfrastructure(InfrastructurePlugin):
     infrastructure_type = "cloud"
     resource_category = "infrastructure"
     stages: list = []
+    dependencies: list = []
 
     def __init__(
         self,

--- a/src/entity/infrastructure/postgres.py
+++ b/src/entity/infrastructure/postgres.py
@@ -28,6 +28,7 @@ class PostgresInfrastructure(InfrastructurePlugin):
     infrastructure_type = "database"
     resource_category = "database"
     stages: list = []
+    dependencies: list = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 
 from entity.pipeline.utils import StageResolver


### PR DESCRIPTION
## Summary
- declare `dependencies` on each infrastructure class
- clean unused import in stage precedence tests
- note infra change in agents log

## Testing
- `poetry run pytest tests/architecture/test_infrastructure_dependencies.py -q`
- `poetry run poe test-architecture` *(fails: Incorrect layer regex)*
- `poetry run poe test-plugins` *(fails: missing dependency regex)*
- `poetry run poe test-resources`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68757e7b9bcc832294113e821477e7c8