### PR TITLE
Avoid injecting observability deps into resource plugins

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Disabled observability injection for ResourcePlugin subclasses to avoid unexpected dependencies
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -38,6 +38,12 @@ def _ensure_logging_dependency(cls: type) -> None:
 def _inject_observability_dependencies(cls: type) -> None:
     """Ensure metrics and logging dependencies are present."""
 
+    if any(
+        base.__name__ in {"ResourcePlugin", "InfrastructurePlugin"}
+        for base in cls.mro()
+    ):
+        return
+
     _ensure_metrics_dependency(cls)
     _ensure_logging_dependency(cls)
 

--- a/tests/core/test_resource_plugin_observability.py
+++ b/tests/core/test_resource_plugin_observability.py
@@ -1,0 +1,14 @@
+from entity.core.plugins import ResourcePlugin
+
+
+class DummyResource(ResourcePlugin):
+    """Simple resource for observability injection test."""
+
+    stages: list = []
+    infrastructure_dependencies: list[str] = []
+    dependencies: list[str] = []
+
+
+def test_resource_plugin_has_no_observability_dependencies() -> None:
+    assert "logging" not in DummyResource.dependencies
+    assert "metrics_collector" not in DummyResource.dependencies


### PR DESCRIPTION
## Summary
- prevent `_inject_observability_dependencies` from altering dependencies of `ResourcePlugin` or `InfrastructurePlugin` descendants
- verify ResourcePlugin subclasses keep explicit dependency declarations
- log note about the change

## Testing
- `poetry run poe test` *(fails: InitializationError from metrics_collector dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68757e782e0c832288c578eaad6853ed