### PR TITLE
Fix layer validation for plugin canonical resources

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Allowed plugin canonical resources to be registered at layer 4
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -551,13 +551,16 @@ class ResourceContainer:
                 )
             )
 
-            allowed_layers = {expected}
-            if (
-                expected == 4
-                and not issubclass(cls, CanonicalResource)
-                and not self._deps.get(name)
-            ):
-                allowed_layers.add(3)
+            if is_plugin_canonical:
+                allowed_layers = {3, 4}
+            else:
+                allowed_layers = {expected}
+                if (
+                    expected == 4
+                    and not issubclass(cls, CanonicalResource)
+                    and not self._deps.get(name)
+                ):
+                    allowed_layers.add(3)
 
             if layer == 1:
                 if self._deps.get(name):


### PR DESCRIPTION
## Summary
- allow plugin canonical resources at layers 3 or 4
- log the change in `agents.log`

## Testing
- `poetry run poe test` *(fails: Resource 'metrics_collector, logging' layer validation)*
- `poetry run pytest tests/architecture/test_invalid_layer_jumps.py::test_layer_jump_violation -vv`

------
https://chatgpt.com/codex/tasks/task_e_68757e814d78832287967029118834e5