### PR TITLE
Fix observability deps for logging and metrics resources

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-10-14: Updated observability dependency injection for LoggingResource and MetricsCollectorResource
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -18,7 +18,8 @@ from ..stages import PipelineStage
 
 
 def _ensure_metrics_dependency(cls: type) -> None:
-    if cls.__name__ == "MetricsCollectorResource":
+    excluded = {"MetricsCollectorResource", "LoggingResource"}
+    if cls.__name__ in excluded:
         return
     deps = list(getattr(cls, "dependencies", []))
     if "metrics_collector" not in deps:
@@ -27,7 +28,8 @@ def _ensure_metrics_dependency(cls: type) -> None:
 
 
 def _ensure_logging_dependency(cls: type) -> None:
-    if cls.__name__ == "LoggingResource":
+    excluded = {"LoggingResource", "MetricsCollectorResource"}
+    if cls.__name__ in excluded:
         return
     deps = list(getattr(cls, "dependencies", []))
     if "logging" not in deps:


### PR DESCRIPTION
## Summary
- avoid injecting metrics_collector into LoggingResource
- avoid injecting logging into MetricsCollectorResource

## Testing
- `poetry run poe test` *(fails: InitializationError in many tests)*

------
https://chatgpt.com/codex/tasks/task_e_687581fa42f48322bafa6d8a674505a1