### PR TITLE
Remove obsolete metrics dependency

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Removed infrastructure_dependencies from MetricsCollectorResource
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/src/entity/resources/metrics.py
+++ b/src/entity/resources/metrics.py
@@ -43,7 +43,7 @@ class MetricsCollectorResource(AgentResource):
     """Simple in-memory metrics collector."""
 
     name = "metrics_collector"
-    infrastructure_dependencies = ["database_backend"]
+    infrastructure_dependencies: list[str] = []
 
     def __init__(self, config: Dict[str, Any] | None = None) -> None:
         super().__init__(config or {})


### PR DESCRIPTION
## Summary
- drop the `database_backend` requirement from `MetricsCollectorResource`
- log note about removing the unused dependency

## Testing
- `poetry run black src/entity/resources/metrics.py`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture` *(fails: 3 tests)*
- `poetry run poe test-plugins` *(fails: 1 test)*
- `poetry run poe test-resources`

------
https://chatgpt.com/codex/tasks/task_e_687581fbc6f88322b7a48ca5e172d110