### PR TITLE
Fix dict config in plugin tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Updated plugin config tests to use dictionaries
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/tests/plugins/test_stage_order_from_yaml.py
+++ b/tests/plugins/test_stage_order_from_yaml.py
@@ -32,11 +32,11 @@ class OtherThinkPlugin(Plugin):
 async def test_stage_order_from_yaml(tmp_path, monkeypatch):
     cfg = {
         "plugins": {
-            "prompts": [
-                {"type": f"{__name__}:ParsePlugin"},
-                {"type": f"{__name__}:ThinkPlugin"},
-                {"type": f"{__name__}:OtherThinkPlugin"},
-            ]
+            "prompts": {
+                "parse": {"type": f"{__name__}:ParsePlugin"},
+                "think": {"type": f"{__name__}:ThinkPlugin"},
+                "other": {"type": f"{__name__}:OtherThinkPlugin"},
+            }
         },
         "workflow": {},
     }


### PR DESCRIPTION
## Summary
- update `test_stage_order_from_yaml` to use dict config for prompt plugins
- add log note about plugin config dict update

## Testing
- `poetry run poe test` *(fails: Resource 'metrics_collector' errors etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687582ec430883228484fd1d664e7b27