### PR TITLE
Fix example imports by adding src path

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Added sys.path setup in tests and examples for direct execution
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/examples/basic_agent/main.py
+++ b/examples/basic_agent/main.py
@@ -1,4 +1,10 @@
 import asyncio
+import sys
+from pathlib import Path
+
+# Ensure this example can find the entity package when run directly
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
 from entity import agent
 
 

--- a/examples/default/main.py
+++ b/examples/default/main.py
@@ -1,4 +1,10 @@
 import asyncio
+import sys
+from pathlib import Path
+
+# Ensure this example can find the entity package when run directly
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
 from entity import agent
 
 

--- a/examples/default_setup/main.py
+++ b/examples/default_setup/main.py
@@ -1,4 +1,9 @@
 import asyncio
+import sys
+from pathlib import Path
+
+# Ensure this example can find the entity package when run directly
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 
 from entity import agent
 

--- a/examples/duckdb_memory_agent/main.py
+++ b/examples/duckdb_memory_agent/main.py
@@ -3,7 +3,14 @@ import json
 from datetime import datetime
 from typing import Any, List
 
+import sys
+from pathlib import Path
+
 import duckdb
+
+# Ensure this example can find the entity package when run directly
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
 from entity import agent
 from entity.core.plugins import PromptPlugin, ResourcePlugin
 from entity.core.context import PluginContext

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -1,4 +1,10 @@
 import asyncio
+import sys
+from pathlib import Path
+
+# Ensure this example can find the entity package when run directly
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
 from entity import agent
 from entity.core.stages import PipelineStage
 from user_plugins.responders import ComplexPromptResponder

--- a/examples/kitchen_sink/main.py
+++ b/examples/kitchen_sink/main.py
@@ -1,4 +1,10 @@
 import asyncio
+import sys
+from pathlib import Path
+
+# Ensure this example can find the entity package when run directly
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
 from entity import agent
 from entity.core.stages import PipelineStage
 from user_plugins.tools.calculator_tool import CalculatorTool

--- a/tests/test_examples_run.py
+++ b/tests/test_examples_run.py
@@ -1,5 +1,9 @@
 from importlib import import_module
 from pathlib import Path
+import sys
+
+# Add src path so example modules can import entity when run in isolation
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 
 import pytest
 


### PR DESCRIPTION
## Summary
- ensure example modules can find `entity` when run directly
- adjust tests to include `src` on `sys.path`
- log the change for future agents

## Testing
- `poetry install --with dev`
- `poetry run poe test` *(fails: Resource initialization errors)*

------
https://chatgpt.com/codex/tasks/task_e_687582efde608322aa8cbcc5497c70e6