### PR TITLE
Fix conversation history lookup

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Fixed conversation history user_id namespacing and updated tests
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -113,10 +113,7 @@ class Memory(AgentResource):
     async def load_conversation(
         self, pipeline_id: str, *, user_id: str = "default"
     ) -> List[ConversationEntry]:
-        if user_id == "default":
-            conversation_id = pipeline_id
-        else:
-            conversation_id = f"{user_id}_{pipeline_id}"
+        conversation_id = f"{user_id}_{pipeline_id}"
         if self.database is None:
             return []
         async with self.database.connection() as conn:

--- a/tests/test_memory_basic.py
+++ b/tests/test_memory_basic.py
@@ -121,5 +121,5 @@ async def test_load_conversation_with_user_id(simple_memory: Memory) -> None:
 async def test_load_conversation_preformatted_id(simple_memory: Memory) -> None:
     entry = ConversationEntry("hello", "user", datetime.now())
     await simple_memory.save_conversation("pipe", [entry], user_id="bob")
-    history = await simple_memory.load_conversation("bob_pipe")
+    history = await simple_memory.load_conversation("pipe", user_id="bob")
     assert history == [entry]

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -133,7 +133,7 @@ async def run_test() -> None:
     await mem2.initialize()
 
     assert await mem2.get("foo", user_id="default") == "bar"
-    history = await mem2.load_conversation("cid", user_id="default")
+    history = await mem2.load_conversation("cid")
     assert history == [entry]
 
 
@@ -167,7 +167,7 @@ def test_memory_persists_with_connection_pool() -> None:
         mem2.vector_store = None
         await mem2.initialize()
         assert await mem2.get("foo", user_id="default") == "bar"
-        history = await mem2.load_conversation("cid", user_id="default")
+        history = await mem2.load_conversation("cid")
         assert history == [entry]
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- ensure Memory.load_conversation always namespaces with the user id
- adjust plugin context memory tests for new default behaviour
- update memory basic test to use explicit user id
- add agent note

## Testing
- `poetry run pytest tests/test_plugin_context_memory.py::test_memory_roundtrip -q`
- `poetry run pytest tests/test_plugin_context_memory.py::test_memory_persists_between_instances -q`
- `poetry run pytest tests/test_memory_basic.py::test_load_conversation_preformatted_id -q`


------
https://chatgpt.com/codex/tasks/task_e_687582ed1fe88322ab0c922ff746eed9