### PR TITLE
Fix stage mismatch warnings

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Fixed stage mismatch warning logging and updated tests
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -517,7 +517,7 @@ class SystemInitializer:
 
         for cls, config in registry.all_plugin_classes():
             cfg_value = config.get("stages") or config.get("stage")
-            class_value = getattr(cls, "stages", None) or getattr(cls, "stage", None)
+            class_value = cls.__dict__.get("stage") or cls.__dict__.get("stages")
             if cfg_value is None or class_value is None:
                 continue
 
@@ -531,9 +531,13 @@ class SystemInitializer:
                     f"{cls.__name__} configured stages {cfg_stages} "
                     f"override class stages {class_stages}"
                 )
-                if self.strict_stages:
-                    raise InitializationError(cls.__name__, "stage validation", msg)
                 logger.warning(msg)
+                if self.strict_stages:
+                    raise InitializationError(
+                        cls.__name__,
+                        "stage validation",
+                        msg,
+                    )
 
     def _register_plugins(
         self, registry: ClassRegistry, dep_graph: Dict[str, List[str]]


### PR DESCRIPTION
## Summary
- ensure `_warn_stage_mismatches` always logs a warning
- raise `InitializationError` with `strict_stages=True`
- test logger warning with monkeypatch
- document the change in `agents.log`

## Testing
- `poetry run pytest tests/test_strict_stages.py`
- `poetry run poe test` *(fails: InitializationError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687582f58d3c8322ad61c5f5595ae7ae