### PR TITLE
Document CLI optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ poetry install --with dev
 # or
 pip install -e ".[dev]"
 ```
+Make sure the optional dependencies `pyyaml` and `python-dotenv` are available
+to avoid runtime import errors when the CLI loads YAML configurations.
 
 With dependencies installed you can run the included poe tasks:
 

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Documented pyyaml/python-dotenv requirements for CLI validation
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ pydantic = "^2.0.0"
 fastapi = "^0.110.0"
 uvicorn = { extras = ["standard"], version = "^0.30.0" }
 asyncpg = "^0.30.0"
-python-dotenv = "^1.1.1"
+python-dotenv = "^1.1.1"  # required for CLI
 aiosqlite = "^0.20.0"
 pgvector = "^0.4.1"
 httpx = "0.27.*"


### PR DESCRIPTION
## Summary
- note that `pyyaml` and `python-dotenv` are required by the CLI
- clarify optional dependency usage in `pyproject.toml`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml validate` *(fails: ImportError)*
- `poetry run entity-cli --config config/prod.yaml validate` *(fails: ImportError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture` *(fails: tests failed)*
- `poetry run poe test-plugins` *(fails: tests failed)*
- `poetry run poe test-resources`

------
https://chatgpt.com/codex/tasks/task_e_687582ee6fd88322a644ef35de9af621