### PR TITLE
Add typed dependencies to infrastructure classes

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: typed dependencies for infrastructure plugins
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/src/entity/infrastructure/aws_standard.py
+++ b/src/entity/infrastructure/aws_standard.py
@@ -11,7 +11,7 @@ class AWSStandardInfrastructure(OpenTofuInfrastructure):
     name = "aws-standard"
     infrastructure_type = "cloud"
     provider = "aws"
-    dependencies: list = []
+    dependencies: list[str] = []
 
     def __init__(self, region: str = "us-east-1", config: Dict | None = None) -> None:
         super().__init__("aws", "standard", region, config)

--- a/src/entity/infrastructure/docker.py
+++ b/src/entity/infrastructure/docker.py
@@ -13,7 +13,7 @@ class DockerInfrastructure(InfrastructurePlugin):
     infrastructure_type = "container"
     resource_category = "infrastructure"
     stages: list = []
-    dependencies: list = []
+    dependencies: list[str] = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/entity/infrastructure/duckdb.py
+++ b/src/entity/infrastructure/duckdb.py
@@ -25,7 +25,7 @@ class DuckDBInfrastructure(InfrastructurePlugin):
     infrastructure_type = "database"
     resource_category = "database"
     stages: list = []
-    dependencies: list = []
+    dependencies: list[str] = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/entity/infrastructure/llamacpp.py
+++ b/src/entity/infrastructure/llamacpp.py
@@ -15,7 +15,7 @@ class LlamaCppInfrastructure(InfrastructurePlugin):
     infrastructure_type = "llm_provider"
     resource_category = "infrastructure"
     stages: list = []
-    dependencies: list = []
+    dependencies: list[str] = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/entity/infrastructure/opentofu.py
+++ b/src/entity/infrastructure/opentofu.py
@@ -12,7 +12,7 @@ class OpenTofuInfrastructure(InfrastructurePlugin):
     infrastructure_type = "cloud"
     resource_category = "infrastructure"
     stages: list = []
-    dependencies: list = []
+    dependencies: list[str] = []
 
     def __init__(
         self,

--- a/src/entity/infrastructure/postgres.py
+++ b/src/entity/infrastructure/postgres.py
@@ -28,7 +28,7 @@ class PostgresInfrastructure(InfrastructurePlugin):
     infrastructure_type = "database"
     resource_category = "database"
     stages: list = []
-    dependencies: list = []
+    dependencies: list[str] = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})


### PR DESCRIPTION
## Summary
- annotate `dependencies` attribute on infrastructure classes with `list[str]`
- log typed dependency addition in `agents.log`

## Testing
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError: user_plugins.prompts.memory_retrieval)*
- `poetry run poe test-architecture` *(fails: Regex pattern did not match)*
- `poetry run poe test-plugins` *(fails: Regex pattern did not match)*
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: 52 failed, 208 passed)*


------
https://chatgpt.com/codex/tasks/task_e_687581fa28508322a4f70473a9cc9dbf