### PR TITLE
Fix imports in tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Updated test imports for reliability modules and StageResolver
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -3742,6 +3742,18 @@ docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxc
 test = ["aiohttp (>=3.10.5)", "flake8 (>=5.0,<6.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=23.0.0,<23.1.0)", "pycodestyle (>=2.9.0,<2.10.0)"]
 
 [[package]]
+name = "vulture"
+version = "2.14"
+description = "Find dead code"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "vulture-2.14-py2.py3-none-any.whl", hash = "sha256:d9a90dba89607489548a49d557f8bac8112bd25d3cbc8aeef23e860811bd5ed9"},
+    {file = "vulture-2.14.tar.gz", hash = "sha256:cb8277902a1138deeab796ec5bef7076a6e0248ca3607a3f3dee0b6d9e9b8415"},
+]
+
+[[package]]
 name = "watchfiles"
 version = "1.1.0"
 description = "Simple, modern and high performance file watching and code reload in python."
@@ -4173,4 +4185,4 @@ examples = ["grpcio", "grpcio-tools", "websockets"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "5d0c7696f82dc213a13b8e98020fcfe67e519972f13f39a548f878e65b6c7b41"
+content-hash = "f9caf3de5066bfe01421750311d4c80e0a8b830157ab47aeb09edaae05271076"

--- a/tests/setup/test_minimal_startup.py
+++ b/tests/setup/test_minimal_startup.py
@@ -1,6 +1,5 @@
 from unittest.mock import AsyncMock
 
-from entity import _create_default_agent
 from entity.utils.setup_manager import Layer0SetupManager
 from entity.pipeline.stages import PipelineStage
 
@@ -28,6 +27,8 @@ def test_create_default_agent_brand_new_env(monkeypatch, tmp_path):
     monkeypatch.setattr(Layer0SetupManager, "__init__", fake_init, raising=False)
     monkeypatch.setattr(Layer0SetupManager, "ensure_ollama", fake_ensure, raising=False)
     monkeypatch.setattr(Layer0SetupManager, "setup", AsyncMock())
+
+    from entity import _create_default_agent
 
     agent = _create_default_agent()
     resources = agent._runtime.capabilities.resources

--- a/tests/setup/test_zero_config.py
+++ b/tests/setup/test_zero_config.py
@@ -1,6 +1,5 @@
 from unittest.mock import AsyncMock
 
-from entity import _create_default_agent
 from entity.utils.setup_manager import Layer0SetupManager
 
 
@@ -22,6 +21,8 @@ def test_zero_config_initialization(monkeypatch, tmp_path):
 
     monkeypatch.setattr(Layer0SetupManager, "__init__", fake_init, raising=False)
     monkeypatch.setattr(Layer0SetupManager, "setup", AsyncMock())
+
+    from entity import _create_default_agent
 
     agent = _create_default_agent()
     res = agent._runtime.capabilities.resources

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from entity import Agent
+from entity.core.agent import Agent
 from entity.core import decorators
 from entity.core.plugins import Plugin
 from entity.core.stages import PipelineStage

--- a/tests/test_infrastructure_validate_runtime.py
+++ b/tests/test_infrastructure_validate_runtime.py
@@ -3,7 +3,7 @@ import pytest
 
 
 from entity.infrastructure import DuckDBInfrastructure, PostgresInfrastructure
-from entity.pipeline.reliability import CircuitBreaker
+from entity.core.circuit_breaker import CircuitBreaker
 
 
 @pytest.mark.asyncio

--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -1,14 +1,9 @@
-import importlib
 import logging
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path("src").resolve()))
-import entity.pipeline.utils as pipeline_utils
+from entity.pipeline import utils as pipeline_utils
 from entity.core.stages import PipelineStage
 from entity.core.plugins import Plugin, PromptPlugin
 
-StageResolver = importlib.reload(pipeline_utils).StageResolver
+StageResolver = pipeline_utils.StageResolver
 
 
 class AttrPrompt(Plugin):


### PR DESCRIPTION
## Summary
- fix reliability import paths
- switch to core Agent import for decorator tests
- import default agent within setup tests
- simplify stage precedence tests
- update lockfile
- add agent log note

## Testing
- `poetry run poe test` *(fails: InitializationError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_687556fa0e08832283e79685a822cb27