### PR TITLE
Update README testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ With dependencies installed you can run the included poe tasks:
 poe test
 ```
 
+For detailed output, use the verbose task:
+
+```bash
+poe test-verbose
+```
+
 If you prefer calling `pytest` directly, prepend `PYTHONPATH=src` so Python can
 locate the editable package:
 

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Added test-verbose command to README testing section
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py


### PR DESCRIPTION
## Summary
- add instructions for running verbose tests in README
- log note about updated testing instructions

## Testing
- `poetry run black src tests`
- `PYTHONPATH=src poetry run pytest` *(fails: 'asyncio' not found in markers)*

------
https://chatgpt.com/codex/tasks/task_e_687502417a0c83229f0d7453c87ad6ab