### PR TITLE
Fix merge markers in errors module

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Verified errors.py contains no merge markers and ensured ResourceError uses pass
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py


### PR DESCRIPTION
## Summary
- verify `errors.py` contains no leftover merge markers
- note verification in `agents.log`

## Testing
- `poetry install --with dev`
- `poetry run poe test-verbose` *(fails: ModuleNotFoundError: entity.pipeline.reliability)*

------
https://chatgpt.com/codex/tasks/task_e_6875023fc0188322ab56dfe2c2a062cb