### PR TITLE
Add stages to hot reload test plugins

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Added explicit stages to test plugins and fixed missing dependency regex
 AGENT NOTE - 2025-07-14: Updated layer validation message checks in tests
 AGENT NOTE - 2025-07-14: typed dependencies for infrastructure plugins
 AGENT NOTE - 2025-07-14: Ensured PostgreSQL tests create and drop temporary database

--- a/tests/plugins/test_hot_reload.py
+++ b/tests/plugins/test_hot_reload.py
@@ -86,6 +86,8 @@ async def test_update_rejects_type_change():
 
 
 class FailingRollbackPlugin(ConfigPlugin):
+    stages = [PipelineStage.THINK]
+
     async def rollback_config(self, version: int) -> None:
         raise RuntimeError("boom")
 

--- a/tests/test_plugins/test_initializer_validations.py
+++ b/tests/test_plugins/test_initializer_validations.py
@@ -61,7 +61,7 @@ async def test_missing_dependency_name(monkeypatch):
         SystemInitializer, "_ensure_canonical_resources", lambda self, container: None
     )
     init = SystemInitializer(cfg)
-    with pytest.raises(InitializationError, match="missing"):
+    with pytest.raises(InitializationError, match="Missing"):
         await init.initialize()
 
 


### PR DESCRIPTION
## Summary
- declare THINK stage for FailingRollbackPlugin
- adjust dependency validation test to match new error text
- log note about stage updates

## Testing
- `poetry run poe test-plugins`

------
https://chatgpt.com/codex/tasks/task_e_687587768ecc8322aeb2da3c3f9d910c