### PR TITLE
Fix default LLM provider layer

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -5,6 +5,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+AGENT NOTE - 2025-10-09: Corrected default LLM provider layer
 AGENT NOTE - 2025-10-08: _ensure_agent initializes default agent with warning when auto init disabled
 =======
 AGENT NOTE - 2025-07-14: Simplified layer validation by removing duplicate dependency check

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -327,7 +327,9 @@ class _AgentBuilder:
         if not container.has_plugin("llm_provider"):
             from plugins.builtin.resources.echo_llm import EchoLLMResource
 
-            container.register("llm_provider", EchoLLMResource, {}, layer=4)
+            # Echo LLM acts as the default interface resource.
+            # Register at layer 2 so canonical LLM can depend on it.
+            container.register("llm_provider", EchoLLMResource, {}, layer=2)
 
         if not container.has_plugin("llm"):
             from entity.resources.llm import LLM


### PR DESCRIPTION
## Summary
- correct default layer for EchoLLMResource so canonical LLM can depend on it
- log the update in `agents.log`

## Testing
- `poetry run poe test tests/integration/test_workflow_compose.py tests/test_agent_runtime.py tests/test_builder_logging_injection.py tests/test_plugin_tool_test.py tests/test_reload_runtime_validation.py tests/test_reload_unknown_plugin.py tests/workflow/test_workflow_features.py` *(fails: Resource 'metrics_collector, da...)*

------
https://chatgpt.com/codex/tasks/task_e_687582e9ed588322bcffced29302189c