### PR TITLE
Improve pipeline error recovery test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Verified pipeline recovery returns final output
 AGENT NOTE - 2025-07-14: Updated layer validation message checks in tests
 AGENT NOTE - 2025-07-14: typed dependencies for infrastructure plugins
 AGENT NOTE - 2025-07-14: Ensured PostgreSQL tests create and drop temporary database

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -140,6 +140,10 @@ async def test_error_handling_and_recovery(registries: SystemRegistries) -> None
     worker = PipelineWorker(registries)
     success = await worker.execute_pipeline("pipe", "ok", user_id="u1")
     assert success == "ok"
+    history = await registries.resources.get("memory").load_conversation(
+        "pipe", user_id="u1"
+    )
+    assert [e.content for e in history if e.role == "user"] == ["hi", "ok"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_strict_stages.py
+++ b/tests/test_strict_stages.py
@@ -1,4 +1,3 @@
-import logging
 import pytest
 
 from entity.pipeline.errors import InitializationError


### PR DESCRIPTION
## Summary
- ensure pipeline worker retains history after failure
- clean up unused import in strict stage tests
- record note about pipeline recovery

## Testing
- `poetry run pytest tests/integration/test_full_pipeline.py::test_error_handling_and_recovery -q`

------
https://chatgpt.com/codex/tasks/task_e_6875877ad69083229407376f877c748e