### PR TITLE
Move metrics collector resource to layer 4

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Moved MetricsCollectorResource to layer 4 and updated container defaults
 AGENT NOTE - 2025-07-14: Updated layer validation message checks in tests
 AGENT NOTE - 2025-07-14: typed dependencies for infrastructure plugins
 AGENT NOTE - 2025-07-14: Ensured PostgreSQL tests create and drop temporary database

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -42,7 +42,7 @@ initializer logs a warning and metrics are disabled.
 
 ```yaml
 plugins:
-  resources:
+  custom_resources:
     metrics_collector:
       type: entity.resources.metrics:MetricsCollectorResource
       retention_days: 90

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -309,7 +309,12 @@ class ResourceContainer:
         ):
             from entity.resources.metrics import MetricsCollectorResource
 
-            self.register("metrics_collector", MetricsCollectorResource, {}, layer=3)
+            self.register(
+                "metrics_collector",
+                MetricsCollectorResource,
+                {},
+                layer=4,
+            )
 
         self._validate_layers()
         self._order = self._resolve_order()

--- a/src/entity/resources/metrics.py
+++ b/src/entity/resources/metrics.py
@@ -43,6 +43,7 @@ class MetricsCollectorResource(AgentResource):
     """Simple in-memory metrics collector."""
 
     name = "metrics_collector"
+    resource_category = "observability"
     infrastructure_dependencies: list[str] = []
 
     def __init__(self, config: Dict[str, Any] | None = None) -> None:

--- a/tests/test_builder_logging_injection.py
+++ b/tests/test_builder_logging_injection.py
@@ -23,7 +23,12 @@ async def test_builder_assigns_logging():
     LoggingResource.dependencies = []
     MetricsCollectorResource.dependencies = []
     container.register("logging", LoggingResource, {}, layer=3)
-    container.register("metrics_collector", MetricsCollectorResource, {}, layer=3)
+    container.register(
+        "metrics_collector",
+        MetricsCollectorResource,
+        {},
+        layer=4,
+    )
     await builder.add_plugin(DummyPrompt({}))
     await builder.build_runtime()
     plugin = builder._added_plugins[0]


### PR DESCRIPTION
## Summary
- assign MetricsCollectorResource to the observability category
- register MetricsCollectorResource at layer 4 in the ResourceContainer
- update builder test and documentation snippets to reflect the new layer
- log a note about the change

## Testing
- `poetry run poe test-architecture` *(fails: Regex pattern did not match)*

------
https://chatgpt.com/codex/tasks/task_e_68758771d67c8322b7c1335f3556fbed