### PR TITLE
Ensure metrics collector dependency for resources

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Added metrics_collector dependencies for LLM and VectorStoreResource
 AGENT NOTE - 2025-07-14: Updated layer validation message checks in tests
 AGENT NOTE - 2025-07-14: typed dependencies for infrastructure plugins
 AGENT NOTE - 2025-07-14: Ensured PostgreSQL tests create and drop temporary database

--- a/src/entity/resources/interfaces/vector_store.py
+++ b/src/entity/resources/interfaces/vector_store.py
@@ -11,6 +11,7 @@ class VectorStoreResource(ResourcePlugin):
     """Abstract vector store interface."""
 
     infrastructure_dependencies = ["vector_store"]
+    dependencies = ["metrics_collector?"]
     resource_category = "database"
 
     def __init__(self, config: Dict | None = None) -> None:

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -17,7 +17,7 @@ class LLM(AgentResource):
     """Simple LLM wrapper."""
 
     name = "llm"
-    dependencies = ["llm_provider?"]
+    dependencies = ["llm_provider?", "metrics_collector?"]
     resource_category = "api"
 
     def __init__(self, config: Dict | None = None) -> None:


### PR DESCRIPTION
## Summary
- wire `metrics_collector` into canonical resource dependencies
- note the dependency update in `agents.log`

## Testing
- `poetry run poe test-resources`

------
https://chatgpt.com/codex/tasks/task_e_6875877de8b48322ad494ea9d6c8ee30