### PR TITLE
Fix postgres test fixture

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-14: Updated PostgreSQL test fixture to use DatabaseJanitor
+
 AGENT NOTE - 2025-07-14: Updated layer validation message checks in tests
 AGENT NOTE - 2025-07-14: typed dependencies for infrastructure plugins
 AGENT NOTE - 2025-07-14: Ensured PostgreSQL tests create and drop temporary database

--- a/tests/resources/test_pg_vector_store.py
+++ b/tests/resources/test_pg_vector_store.py
@@ -17,10 +17,21 @@ from plugins.builtin.resources.pg_vector_store import PgVectorStore
 @pytest.fixture()
 def prepared_postgres(postgresql_proc, request):
     """Ensure the test database exists and clean it up afterwards."""
-    postgresql_proc.createdb(postgresql_proc.dbname)
+    from pytest_postgresql.janitor import DatabaseJanitor
+
+    janitor = DatabaseJanitor(
+        user=postgresql_proc.user,
+        host=postgresql_proc.host,
+        port=postgresql_proc.port,
+        dbname=postgresql_proc.dbname,
+        template_dbname=postgresql_proc.template_dbname,
+        version=postgresql_proc.version,
+        password=postgresql_proc.password,
+    )
+    janitor.init()
 
     def drop_db():
-        postgresql_proc.dropdb(postgresql_proc.dbname)
+        janitor.drop()
 
     request.addfinalizer(drop_db)
     return postgresql_proc


### PR DESCRIPTION
## Summary
- fix Postgres tests by using `DatabaseJanitor`
- document fixture update in agents log

## Testing
- `poetry run pytest tests/resources/test_pg_vector_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6875877959b883229ba72e1f80bae8ed