### PR TITLE
Fix pipeline exports and CLI imports

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Fixed pipeline exports for SystemInitializer and CLI lazy schema import
 AGENT NOTE - 2025-07-14: Updated layer validation message checks in tests
 AGENT NOTE - 2025-07-14: typed dependencies for infrastructure plugins
 AGENT NOTE - 2025-07-14: Ensured PostgreSQL tests create and drop temporary database

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -23,7 +23,6 @@ from entity.pipeline.exceptions import CircuitBreakerTripped
 from entity.core.circuit_breaker import CircuitBreaker
 from entity.utils.logging import get_logger
 from entity.config.environment import load_config
-from docs.generate_config_docs import build_schema
 from importlib import import_module  # noqa: E402
 from entity.infrastructure import (
     DockerInfrastructure,
@@ -825,6 +824,7 @@ class EntityCLI:
 
     def _lint_config(self, files: list[str]) -> int:
         """Validate YAML files against the generated configuration schema."""
+        from docs.generate_config_docs import build_schema
 
         schema = build_schema()["EntityConfig"]
         validator = Draft7Validator(schema)

--- a/src/entity/pipeline/__init__.py
+++ b/src/entity/pipeline/__init__.py
@@ -64,6 +64,9 @@ __all__ = [
     "Workflow",
     "PipelineWorker",
     "execute_with_observability",
+    "pipeline",
+    "initializer",
+    "utils",
 ]
 
 
@@ -115,6 +118,9 @@ def __getattr__(name: str) -> Any:
         "update_plugin_configuration": "entity.pipeline.config.config_update",
         "StateLogger": "entity.core.state_logger",
         "LogReplayer": "entity.core.state_logger",
+        "pipeline": "entity.pipeline.pipeline",
+        "initializer": "entity.pipeline.initializer",
+        "utils": "entity.pipeline.utils",
         "ClassRegistry": "entity.pipeline.initializer",
         "SystemInitializer": "entity.pipeline.initializer",
         "initialization_cleanup_context": "entity.pipeline.initializer",


### PR DESCRIPTION
## Summary
- ensure pipeline submodule exports map correctly
- lazy-load build_schema in CLI to avoid side effects
- document import fixes in agents.log

## Testing
- `pytest tests/test_cli_validate_failures.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68758774d844832288f5a92d9727f0d6