### PR TITLE
Update DummyResource layers

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Updated DummyResource tests to register at layer 4 and clear metrics dependencies
 AGENT NOTE - 2025-07-14: Updated layer validation message checks in tests
 AGENT NOTE - 2025-07-14: typed dependencies for infrastructure plugins
 AGENT NOTE - 2025-07-14: Ensured PostgreSQL tests create and drop temporary database

--- a/tests/core/test_container_defaults.py
+++ b/tests/core/test_container_defaults.py
@@ -1,8 +1,10 @@
 import pytest
 
 from entity.core.resources.container import ResourceContainer
-from entity.resources.base import AgentResource
+from entity.core.plugins import AgentResource
 from entity.core.plugins import InfrastructurePlugin
+from entity.resources.logging import LoggingResource
+from entity.resources.metrics import MetricsCollectorResource
 
 
 class DummyDatabase(InfrastructurePlugin):
@@ -26,13 +28,15 @@ class DummyResource(AgentResource):
 
 DummyDatabase.dependencies = []
 DummyResource.dependencies = []
+LoggingResource.dependencies = []
+MetricsCollectorResource.dependencies = []
 
 
 @pytest.mark.asyncio
 async def test_build_all_adds_defaults():
     container = ResourceContainer()
     container.register("database_backend", DummyDatabase, {}, layer=1)
-    container.register("dummy", DummyResource, {}, layer=3)
+    container.register("dummy", DummyResource, {}, layer=4)
 
     await container.build_all()
 

--- a/tests/test_custom_resource_access.py
+++ b/tests/test_custom_resource_access.py
@@ -2,8 +2,9 @@ import types
 import pytest
 
 from entity.core.resources.container import ResourceContainer
-from entity.resources import AgentResource
+from entity.core.plugins import AgentResource
 from entity.resources.logging import LoggingResource
+from entity.resources.metrics import MetricsCollectorResource
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
 
@@ -14,13 +15,14 @@ class DummyResource(AgentResource):
 
 DummyResource.dependencies = []
 LoggingResource.dependencies = []
+MetricsCollectorResource.dependencies = []
 
 
 @pytest.mark.asyncio
 async def test_custom_resource_access():
     container = ResourceContainer()
     DummyResource.dependencies = []
-    container.register("chat_gpt", DummyResource, {}, layer=3)
+    container.register("chat_gpt", DummyResource, {}, layer=4)
 
     await container.build_all()
     dummy = container.get("chat_gpt")

--- a/tests/test_strict_stages.py
+++ b/tests/test_strict_stages.py
@@ -1,4 +1,3 @@
-import logging
 import pytest
 
 from entity.pipeline.errors import InitializationError


### PR DESCRIPTION
## Summary
- register DummyResource at layer 4
- clear observability dependencies for tests
- keep lint cleanups from ruff
- add agent log note

## Testing
- `pytest tests/core/test_container_defaults.py`

------
https://chatgpt.com/codex/tasks/task_e_68758777b31483229b2dfb4996d8ab36