### PR TITLE
Fix PG vector store initialization order

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Ensure vector store initializes before memory for PG tests
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/tests/resources/test_pg_vector_store.py
+++ b/tests/resources/test_pg_vector_store.py
@@ -69,8 +69,8 @@ async def test_embedding_roundtrip(prepared_postgres) -> None:
     mem = Memory({})
     mem.database = db
     mem.vector_store = store
-    await mem.initialize()
     await store.initialize()
+    await mem.initialize()
 
     await mem.add_embedding("hello world")
     await mem.add_embedding("goodbye world")
@@ -93,8 +93,8 @@ async def test_conversation_integration(prepared_postgres) -> None:
     mem = Memory({})
     mem.database = db
     mem.vector_store = store
-    await mem.initialize()
     await store.initialize()
+    await mem.initialize()
 
     await mem.add_conversation_entry(
         "conv",


### PR DESCRIPTION
## Summary
- update `tests/resources/test_pg_vector_store` to initialize the vector store before memory
- log note about new initialization order

## Testing
- `poetry run poe test` *(fails: Command not found: poe)*

------
https://chatgpt.com/codex/tasks/task_e_68758f740f60832298919417183a207e