### PR TITLE
Fix user scoping calls in full pipeline tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Updated multi-user tests to use user_id parameter for load_conversation
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -109,8 +109,12 @@ async def test_multi_user_isolation(registries: SystemRegistries) -> None:
         worker.execute_pipeline("pipe", "one", user_id="u1"),
         worker.execute_pipeline("pipe", "two", user_id="u2"),
     )
-    hist1 = await registries.resources.get("memory").load_conversation("u1_pipe")
-    hist2 = await registries.resources.get("memory").load_conversation("u2_pipe")
+    hist1 = await registries.resources.get("memory").load_conversation(
+        "pipe", user_id="u1"
+    )
+    hist2 = await registries.resources.get("memory").load_conversation(
+        "pipe", user_id="u2"
+    )
     assert [e.content for e in hist1 if e.role == "user"] == ["one"]
     assert [e.content for e in hist2 if e.role == "user"] == ["two"]
 


### PR DESCRIPTION
## Summary
- update `load_conversation` calls in test_full_pipeline to pass `user_id`
- log note about the change

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: ModuleNotFoundError: No module named 'entity')*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError: No module named 'user_plugins.prompts.memory_retrieval')*
- `poetry run poe test-architecture` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `poetry run pytest tests/integration/test_full_pipeline.py::test_multi_user_isolation -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68758f707c388322b649ad7393ae155c