### PR TITLE
Update example decorators

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Updated decorator usage in examples and tests
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/examples/default_setup/main.py
+++ b/examples/default_setup/main.py
@@ -1,19 +1,18 @@
-import asyncio
 import sys
 from pathlib import Path
 
 # Ensure this example can find the entity package when run directly
 sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 
-from entity import agent
+from entity import agent, output, tool
 
 
-@agent.tool
+@tool
 async def add(a: int, b: int) -> int:
     return a + b
 
 
-@agent.output
+@output
 async def responder(ctx):
     user = next((e.content for e in ctx.conversation() if e.role == "user"), "")
     result = await ctx.tool_use("add", a=2, b=2)
@@ -26,4 +25,6 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
+    import asyncio
+
     asyncio.run(main())

--- a/examples/kitchen_sink/main.py
+++ b/examples/kitchen_sink/main.py
@@ -1,17 +1,16 @@
-import asyncio
 import sys
 from pathlib import Path
 
 # Ensure this example can find the entity package when run directly
 sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 
-from entity import agent
+from entity import agent, prompt
 from entity.core.stages import PipelineStage
 from user_plugins.tools.calculator_tool import CalculatorTool
 from user_plugins.responders import ReactResponder
 
 
-@agent.prompt(stage=PipelineStage.THINK)
+@prompt
 async def react_prompt(ctx):
     question = next((e.content for e in ctx.conversation() if e.role == "user"), "")
     tool_result = await ctx.tool_use("calc", expression="2+2")
@@ -28,4 +27,6 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
+    import asyncio
+
     asyncio.run(main())

--- a/tests/test_examples_run.py
+++ b/tests/test_examples_run.py
@@ -35,11 +35,12 @@ def test_zero_config_example_runs(monkeypatch):
         pytest.skip("example runtime failed")
 
 
-@pytest.mark.asyncio
-async def test_kitchen_sink_example(monkeypatch):
+def test_kitchen_sink_example(monkeypatch):
     path = Path("examples/kitchen_sink/main.py")
     if not path.exists():
         pytest.skip("kitchen_sink example not present")
     mod = import_module("examples.kitchen_sink.main")
     assert hasattr(mod, "main")
-    await mod.main()
+    import asyncio
+
+    asyncio.run(mod.main())


### PR DESCRIPTION
## Summary
- import global decorators in examples
- adjust kitchen sink example
- tweak example tests
- note decorator changes in `agents.log`

## Testing
- `poetry run pytest tests/test_examples_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68758f7537208322b32c3b87f7afcad9