### PR TITLE
Update hot reload plugin stages

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Added stage overrides for hot reload plugins
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD


### PR DESCRIPTION
## Summary
- add THINK stage to `RejectPlugin`
- subclass `FailingRollbackPlugin` from `DepPlugin` and override stage
- log note about hot reload plugin changes

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError: user_plugins.prompts.memory_retrieval)*
- `poetry run poe test-architecture` *(fails: 3 tests failed)*
- `poetry run poe test-plugins`
- `poetry run poe test-resources`


------
https://chatgpt.com/codex/tasks/task_e_68758f71f7e48322949d992f607eb6f4