### PR TITLE
Allow MetricsCollectorResource at layer 4

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-10-06: Updated layer validation to allow MetricsCollectorResource at layer 4
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -307,6 +307,8 @@ class ResourceContainer:
             "metrics_collector" not in self._classes
             and "metrics_collector" not in self._resources
         ):
+            # The collector is a built-in canonical resource but is injected
+            # like a custom one, so we register it at layer 4 by default.
             from entity.resources.metrics import MetricsCollectorResource
 
             self.register(
@@ -518,7 +520,12 @@ class ResourceContainer:
         return True
 
     def _validate_layers(self) -> None:
-        """Ensure layer dependencies follow the 4-layer architecture."""
+        """Ensure layer dependencies follow the 4-layer architecture.
+
+        Built-in canonical resources normally run at layer 3. The
+        ``MetricsCollectorResource`` is an exception and may operate in
+        layer 4 so it can be injected automatically like custom resources.
+        """
 
         from entity.core.plugins import (
             InfrastructurePlugin,
@@ -566,6 +573,8 @@ class ResourceContainer:
                     and not self._deps.get(name)
                 ):
                     allowed_layers.add(3)
+            if cls.__name__ == "MetricsCollectorResource":
+                allowed_layers.add(4)
 
             if layer not in allowed_layers:
                 raise InitializationError(


### PR DESCRIPTION
## Summary
- permit MetricsCollectorResource to run at layer 4
- clarify auto-registration comment
- log update about layer rule change

## Testing
- `poetry install --with dev` *(fails: pyproject.toml changed since lock file)*
- `poetry run pytest -k ""` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68758f6d3a84832294b5c2c137e9e39d