### PR TITLE
Fix end-to-end pipeline test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-10-30: Fixed async stage results in end-to-end pipeline test ensuring ReverseThink runs and final output is olleh
 AGENT NOTE - 2025-10-06: Updated layer validation to allow MetricsCollectorResource at layer 4
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/tests/test_end_to_end_pipeline.py
+++ b/tests/test_end_to_end_pipeline.py
@@ -13,7 +13,7 @@ class InputCapture(Plugin):
     stages = [PipelineStage.INPUT]
 
     async def _execute_impl(self, context):
-        context.think("input", context.conversation()[-1].content)
+        await context.think("input", context.conversation()[-1].content)
 
 
 class ParseLower(Plugin):
@@ -21,7 +21,7 @@ class ParseLower(Plugin):
 
     async def _execute_impl(self, context):
         raw = await context.reflect("input")
-        context.think("parsed", raw.lower())
+        await context.think("parsed", raw.lower())
 
 
 class ReverseThink(Plugin):
@@ -29,14 +29,14 @@ class ReverseThink(Plugin):
 
     async def _execute_impl(self, context):
         parsed = await context.reflect("parsed")
-        context.think("thought", parsed[::-1])
+        await context.think("thought", parsed[::-1])
 
 
 class ReviewPass(Plugin):
     stages = [PipelineStage.REVIEW]
 
     async def _execute_impl(self, context):
-        context.think("reviewed", await context.reflect("thought"))
+        await context.think("reviewed", await context.reflect("thought"))
 
 
 class OutputFinal(Plugin):


### PR DESCRIPTION
## Summary
- ensure stage result helpers are awaited in `test_end_to_end_pipeline`
- note the fix in `agents.log`

## Testing
- `poetry run pytest tests/test_end_to_end_pipeline.py::test_end_to_end_flow -vv`

------
https://chatgpt.com/codex/tasks/task_e_6875953e01848322b0716e4a2227fa6f