### PR TITLE
Add vector extension setup for Postgres tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,4 +1,5 @@
 AGENT NOTE - 2025-10-06: Updated layer validation to allow MetricsCollectorResource at layer 4
+AGENT NOTE - 2025-10-06: Tests require 'CREATE EXTENSION IF NOT EXISTS vector' when preparing Postgres
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-14: Updated decorator usage in examples and tests


### PR DESCRIPTION
## Summary
- extend the `prepared_postgres` fixture so it creates the `vector` extension
- log this setup step in `agents.log`

## Testing
- `poetry run poe test` *(fails: InitializationError, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6875953cc1b08322abff603176ae8ded