### PR TITLE
Update metrics collector checks

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,5 @@
+AGENT NOTE - 2025-07-14: Updated dependency injection tests to expect "metrics_collector?"
+
 AGENT NOTE - 2025-10-06: Updated layer validation to allow MetricsCollectorResource at layer 4
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/tests/core/test_dependency_injection.py
+++ b/tests/core/test_dependency_injection.py
@@ -59,7 +59,7 @@ def test_tool_dependencies_added():
     dep_graph: dict[str, list[str]] = {}
     init._register_plugins(registry, dep_graph)
 
-    assert "metrics_collector" in DummyTool.dependencies
+    assert "metrics_collector?" in DummyTool.dependencies
     assert "logging" in DummyTool.dependencies
 
 
@@ -101,7 +101,7 @@ def test_adapter_dependencies_added():
     dep_graph: dict[str, list[str]] = {}
     init._register_plugins(registry, dep_graph)
 
-    assert "metrics_collector" in DummyAdapter.dependencies
+    assert "metrics_collector?" in DummyAdapter.dependencies
     assert "logging" in DummyAdapter.dependencies
 
 
@@ -114,7 +114,7 @@ def test_prompt_dependencies_added():
     dep_graph: dict[str, list[str]] = {}
     init._register_plugins(registry, dep_graph)
 
-    assert "metrics_collector" in DummyPrompt.dependencies
+    assert "metrics_collector?" in DummyPrompt.dependencies
     assert "logging" in DummyPrompt.dependencies
 
 
@@ -129,9 +129,9 @@ def test_dependencies_without_metrics():
     dep_graph: dict[str, list[str]] = {}
     init._register_plugins(registry, dep_graph)
 
-    assert "metrics_collector" in DummyTool.dependencies
-    assert "metrics_collector" in DummyAdapter.dependencies
-    assert "metrics_collector" in DummyPrompt.dependencies
+    assert "metrics_collector?" in DummyTool.dependencies
+    assert "metrics_collector?" in DummyAdapter.dependencies
+    assert "metrics_collector?" in DummyPrompt.dependencies
 
 
 def test_dependencies_without_logging():

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -17,7 +17,7 @@ class DummyPlugin(Plugin):
 
 @pytest.mark.asyncio
 async def test_plugin_dependencies_include_metrics():
-    assert "metrics_collector" in DummyPlugin.dependencies
+    assert "metrics_collector?" in DummyPlugin.dependencies
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expect `metrics_collector?` optional dependency in injection tests
- note optional metrics dependency in agents.log

## Testing
- `poetry run poe test` *(fails: Resource initialization errors)*

------
https://chatgpt.com/codex/tasks/task_e_687595395d588322a3d37a2a9e2f8904