### PR TITLE
Fix test resource layers

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-14: Updated test resource layers to comply with 4-layer architecture
 <<<<<<< HEAD
 AGENT NOTE - 2025-10-06: Updated layer validation to allow MetricsCollectorResource at layer 4
 <<<<<<< HEAD

--- a/tests/architecture/test_layer_boundaries.py
+++ b/tests/architecture/test_layer_boundaries.py
@@ -45,7 +45,7 @@ async def test_layer_boundary_violation() -> None:
     container = ResourceContainer()
     container.register("db", Infra, {}, layer=1)
     container.register("iface", Interface, {}, layer=2)
-    container.register("bad", BadResource, {}, layer=3)
+    container.register("bad", BadResource, {}, layer=4)
 
     with pytest.raises(InitializationError, match="one-layer step"):
         await container.build_all()

--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -99,7 +99,7 @@ def test_layer_violation():
     container = ResourceContainer()
     container.register("database_backend", DuckDBInfrastructure, {}, layer=1)
     container.register("infra", InfraPlugin, {}, layer=1)
-    container.register("bad", BadResource, {}, layer=3)
+    container.register("bad", BadResource, {}, layer=4)
 
     with pytest.raises(InitializationError, match="one-layer step"):
         asyncio.run(container.build_all())


### PR DESCRIPTION
## Summary
- set failing resource layers to the correct custom layer
- log reasoning in `agents.log`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -d src tests` *(fails: unrecognized arguments)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture` *(fails: Command not found)*
- `poetry run poe test` *(fails: Command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875953ac18483228475ab967f1b8cac