### PR TITLE
Add structured test tasks

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Added poe tasks for unit, integration, and e2e tests
 AGENT NOTE - 2025-07-14: Updated test resource layers to comply with 4-layer architecture
 AGENT NOTE - 2025-07-14: Awaited context.think in tests and audited for missing awaits
 AGENT NOTE - 2025-07-14: Updated dependency injection tests to expect "metrics_collector?"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ test-architecture = { cmd = "pytest tests/test_architecture/ -v", env = { PYTHON
 test-plugins = { cmd = "pytest tests/test_plugins/ -v", env = { PYTHONPATH = "src" } }
 test-resources = { cmd = "pytest tests/test_resources/ -v", env = { PYTHONPATH = "src" } }
 test-decorators = { cmd = "pytest tests/test_decorators.py -v", env = { PYTHONPATH = "src" } }
+unit = { cmd = "pytest tests/unit", env = { PYTHONPATH = "src" } }
+integration = { cmd = "pytest tests/integration", env = { PYTHONPATH = "src" } }
+e2e = { cmd = "pytest tests/e2e", env = { PYTHONPATH = "src" } }
 
 setup-dev = { cmd = "poetry install --with dev" }
 


### PR DESCRIPTION
## Summary
- expose unit, integration, and e2e test tasks in Poe config
- log update

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run black src tests`
- `PYTEST_ADDOPTS="-k nothing" poetry run poe test` *(failed: Command not found: poe)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: ModuleNotFoundError: No module named 'entity')*

------
https://chatgpt.com/codex/tasks/task_e_68759b7398b48322912811140ba1e0a1