### PR TITLE
Remove mocks from strict stages test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Partial cleanup of mock usage in strict stage test
 AGENT NOTE - 2025-07-14: Updated test resource layers to comply with 4-layer architecture
 AGENT NOTE - 2025-07-14: Awaited context.think in tests and audited for missing awaits
 AGENT NOTE - 2025-07-14: Updated dependency injection tests to expect "metrics_collector?"

--- a/tests/test_strict_stages.py
+++ b/tests/test_strict_stages.py
@@ -21,10 +21,11 @@ class MyPlugin(PromptPlugin):
         pass
 
 
-from unittest.mock import MagicMock
+import logging
+from entity.utils.logging import configure_logging
 
 
-def test_stage_mismatch_warning(monkeypatch):
+def test_stage_mismatch_warning(caplog):
     cfg = {
         "plugins": {
             "agent_resources": {
@@ -48,10 +49,10 @@ def test_stage_mismatch_warning(monkeypatch):
     registry = ClassRegistry()
     dep_graph: dict[str, list[str]] = {}
     init._register_plugins(registry, dep_graph)
-    mock = MagicMock()
-    monkeypatch.setattr(initializer, "logger", mock)
-    init._warn_stage_mismatches(registry)
-    mock.warning.assert_called()
+    configure_logging("WARNING")
+    with caplog.at_level(logging.WARNING, logger="entity.pipeline.initializer"):
+        init._warn_stage_mismatches(registry)
+    assert any("override class stages" in r.message for r in caplog.records)
 
 
 def test_stage_mismatch_strict():


### PR DESCRIPTION
## Summary
- refactor strict stages test to use real logging capture instead of MagicMock
- note the test change in agents.log

## Testing
- `poetry run pytest tests/test_strict_stages.py::test_stage_mismatch_warning -q` *(fails: Unknown config option asyncio_mode)*

------
https://chatgpt.com/codex/tasks/task_e_68759b71700483229b4eab8a9d77cdf9