### PR TITLE
Use monkeypatch fixture for DuckDB runtime test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-11-27: Patched DuckDB runtime test using monkeypatch to auto-restore connection method
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Verified removal of conflict markers and ran formatting/tests

--- a/tests/test_infrastructure_validate_runtime.py
+++ b/tests/test_infrastructure_validate_runtime.py
@@ -5,7 +5,7 @@ from entity.core.circuit_breaker import CircuitBreaker
 
 
 @pytest.mark.asyncio
-async def test_duckdb_runtime_breaker_opens():
+async def test_duckdb_runtime_breaker_opens(monkeypatch):
     db = DuckDBInfrastructure({"failure_threshold": 2})
     breaker = CircuitBreaker(failure_threshold=2)
 
@@ -20,7 +20,7 @@ async def test_duckdb_runtime_breaker_opens():
     async def bad_connection(self):
         yield BadConn()
 
-    DuckDBInfrastructure.connection = bad_connection
+    monkeypatch.setattr(DuckDBInfrastructure, "connection", bad_connection)
 
     res1 = await db.validate_runtime(breaker)
     assert not res1.success


### PR DESCRIPTION
## Summary
- patch `DuckDBInfrastructure.connection` using monkeypatch in runtime test
- document the change in `agents.log`

## Testing
- `poetry run poe test tests/test_infrastructure_validate_runtime.py::test_duckdb_runtime_breaker_opens`


------
https://chatgpt.com/codex/tasks/task_e_6875a0d0c8008322b3511285c9c8af05