### PR TITLE
Fix layer validation test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Updated dependency assertion for layer validation message
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Verified removal of conflict markers and ran formatting/tests

--- a/tests/test_resource_dependencies.py
+++ b/tests/test_resource_dependencies.py
@@ -29,5 +29,6 @@ def test_dependency_on_higher_layer_raises() -> None:
     container.register("higher", HigherResource, {}, layer=3)
     container.register("lower", LowerInterface, {}, layer=2)
 
-    with pytest.raises(InitializationError, match="dependency graph"):
+    # The container validates layer rules before checking dependency order.
+    with pytest.raises(InitializationError, match="layer validation"):
         asyncio.run(container.build_all())

--- a/tests/test_strict_stages.py
+++ b/tests/test_strict_stages.py
@@ -1,7 +1,6 @@
 import pytest
 
 from entity.pipeline.errors import InitializationError
-from entity.pipeline import initializer
 from entity.pipeline.initializer import ClassRegistry, SystemInitializer
 from entity.pipeline.stages import PipelineStage
 from entity.core.plugins import PromptPlugin


### PR DESCRIPTION
## Summary
- align test with new layer validation message
- document container's validation order
- clean unused import automatically via ruff
- log update in agents.log

## Testing
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: multiple tests and docker compose errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875a0d13bc08322be8e9a56ab6c8aff