### PR TITLE
Adjust logging order in strict stage test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Adjusted logging configuration order in strict stage tests
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Verified removal of conflict markers and ran formatting/tests

--- a/tests/test_strict_stages.py
+++ b/tests/test_strict_stages.py
@@ -46,10 +46,10 @@ def test_stage_mismatch_warning(caplog):
     }
 
     init = SystemInitializer(cfg)
+    configure_logging("WARNING")
     registry = ClassRegistry()
     dep_graph: dict[str, list[str]] = {}
     init._register_plugins(registry, dep_graph)
-    configure_logging("WARNING")
     with caplog.at_level(logging.WARNING, logger="entity.pipeline.initializer"):
         init._warn_stage_mismatches(registry)
     assert any("override class stages" in r.message for r in caplog.records)
@@ -76,6 +76,7 @@ def test_stage_mismatch_strict():
     }
 
     init = SystemInitializer(cfg, strict_stages=True)
+    configure_logging("WARNING")
     registry = ClassRegistry()
     dep_graph: dict[str, list[str]] = {}
     init._register_plugins(registry, dep_graph)


### PR DESCRIPTION
## Summary
- configure logging before registering plugins in `tests/test_strict_stages.py`
- note change in `agents.log`

## Testing
- `poetry run poe test` *(fails: 23 failed, 213 passed, 1 skipped, 2 warnings, 14 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875a0d50d04832297608b027af71a72