### PR TITLE
Fix prompt plugin base validation

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: registry validation ensures prompt plugins must subclass PromptPlugin
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Verified removal of conflict markers and ran formatting/tests

--- a/src/entity/core/registry_validator.py
+++ b/src/entity/core/registry_validator.py
@@ -112,8 +112,6 @@ class RegistryValidator:
                 f"Plugin '{name}' in '{section}' must inherit from AdapterPlugin"
             )
         if section == "prompts" and not issubclass(cls, PromptPlugin):
-            if issubclass(cls, Plugin):
-                return
             raise SystemError(
                 f"Plugin '{name}' in '{section}' must inherit from PromptPlugin"
             )


### PR DESCRIPTION
## Summary
- enforce `PromptPlugin` base class for all prompt plugins
- document the change in `agents.log`

## Testing
- `poetry run pytest tests/architecture/test_plugin_taxonomy.py::test_discovered_plugin_validation tests/test_registry_validator.py::test_validator_cycle_detection -q`

------
https://chatgpt.com/codex/tasks/task_e_6875a0caac188322bed2cf60f78de7aa