### PR TITLE
Async safe DB calls

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Wrapped DB operations with awaitable helper for memory resource
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Verified removal of conflict markers and ran formatting/tests


### PR DESCRIPTION
## Summary
- allow Memory to work with both sync and async DB drivers
- add helper `_execute` and use it for initialization, kv ops, and conversation search

## Testing
- `poetry run pytest tests/resources/test_pg_vector_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6875a0cda97083228087399d25812412