### PR TITLE
Fix llm interface dependencies

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Set llm interface infra deps empty
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Verified removal of conflict markers and ran formatting/tests

--- a/src/entity/resources/interfaces/llm.py
+++ b/src/entity/resources/interfaces/llm.py
@@ -11,7 +11,7 @@ class LLMResource(ResourcePlugin):
     """Base class for simple LLM resources."""
 
     name = "llm_provider"
-    infrastructure_dependencies = ["llm_provider"]
+    infrastructure_dependencies: list[str] = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})


### PR DESCRIPTION
## Summary
- let `LLMResource` avoid infrastructure deps
- note this change in `agents.log`

## Testing
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove src tests`

------
https://chatgpt.com/codex/tasks/task_e_6875a0cb8e7c832295b3184308ecd5d3