### PR TITLE
Fix merge markers in agents.log

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,8 +1,7 @@
+AGENT NOTE - 2025-07-15: Cleaned merge markers from agents.log
 AGENT NOTE - 2025-07-15: Set llm interface infra deps empty
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Resolved merge conflict markers and restored missing notes
 AGENT NOTE - 2025-10-31: Integration tests now use Dockerized Postgres and Ollama
-=======
 AGENT NOTE - 2025-07-15: Resolved merge conflicts in agents.log and removed duplicate entries
 AGENT NOTE - 2025-07-15: Wrapped DB operations with awaitable helper for memory resource
 AGENT NOTE - 2025-07-15: Excluded LoggingResource from metrics dependency
@@ -15,7 +14,6 @@ AGENT NOTE - 2025-07-15: Partial cleanup of mock usage in strict stage test
 AGENT NOTE - 2025-07-15: Added poe tasks for unit, integration, and e2e tests
 AGENT NOTE - 2025-10-31: Integration tests now use Dockerized Postgres and Ollama
 AGENT NOTE - 2025-07-15: Removed monkeypatch-based tests and added poe tasks for unit/integration/e2e
->>>>>>> pr-1633
 AGENT NOTE - 2025-07-14: Updated test resource layers to comply with 4-layer architecture
 AGENT NOTE - 2025-07-14: Awaited context.think in tests and audited for missing awaits
 AGENT NOTE - 2025-07-14: Updated dependency injection tests to expect "metrics_collector?"


### PR DESCRIPTION
## Summary
- remove leftover conflict markers in `agents.log`
- add cleanup note to the top of the file

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests` *(fails: F841 local variable assigned but never used)*
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError: user_plugins.prompts.memory_retrieval)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources` *(fails: test_initialize_without_database_raises)*

------
https://chatgpt.com/codex/tasks/task_e_6875a8f1514883228dbdfafc5eaa0afc