### PR TITLE
Fix Memory method scope

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-11-28: Moved Memory methods inside class and kept helper functions module-level
 AGENT NOTE - 2025-07-15: Set llm interface infra deps empty
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Resolved merge conflict markers and restored missing notes

--- a/src/entity/core/registry_validator.py
+++ b/src/entity/core/registry_validator.py
@@ -83,7 +83,6 @@ class RegistryValidator:
             InfrastructurePlugin,
             InputAdapterPlugin,
             OutputAdapterPlugin,
-            Plugin,
             PromptPlugin,
             ResourcePlugin,
             ToolPlugin,

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -41,20 +41,6 @@ class Memory(AgentResource):
         if callable(commit):
             commit()
 
-
-async def _execute(conn: Any, sql: str, params: Any | None = None) -> Any:
-    """Run a query and await the result when necessary."""
-    result = conn.execute(sql, params or [])
-    if inspect.isawaitable(result):
-        result = await result
-    return result
-
-
-async def _maybe_await(value: Any) -> Any:
-    if inspect.isawaitable(value):
-        return await value
-    return value
-
     async def initialize(self) -> None:
         if self.database is None:
             raise ResourceInitializationError(
@@ -379,3 +365,17 @@ async def _maybe_await(value: Any) -> Any:
     remember = store_persistent
     recall = fetch_persistent
     forget = delete_persistent
+
+
+async def _execute(conn: Any, sql: str, params: Any | None = None) -> Any:
+    """Run a query and await the result when necessary."""
+    result = conn.execute(sql, params or [])
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value


### PR DESCRIPTION
## Summary
- move all methods after `initialize` into the `Memory` class
- keep `_execute` and `_maybe_await` as module-level helpers
- run code formatters and type checkers

## Testing
- `poetry run poe test` *(fails: InitializationError, docker compose missing)*

------
https://chatgpt.com/codex/tasks/task_e_6875a8efe1588322be01a58def19c94d