### PR TITLE
Update testing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ poetry run python -m src.entity.core.registry_validator
 
 ### Running Tests
 
-Execute the full test suite:
+Running tests requires the development dependencies. Install them and execute the full suite:
 
 ```bash
 poetry install --with dev  # includes pytest-asyncio
@@ -67,6 +67,8 @@ pytest tests/integration/ -v
 pytest tests/infrastructure/ -v
 pytest tests/performance/ -m benchmark
 ```
+
+`pytest-docker` ships with the dev dependencies and exposes the `docker_ip` and `docker_services` fixtures used in integration tests.
 
 `pytest-asyncio` must be installed; without it pytest reports
 `Unknown config option: asyncio_mode`.

--- a/README.md
+++ b/README.md
@@ -52,16 +52,18 @@ documentation.
 
 ## Running Tests
 
-Before running the test suite, install the development extras. Without these
-dependencies the `entity` package fails to import and tests will crash.
+Running the tests requires the development dependencies. Install them with:
 
 ```bash
 poetry install --with dev
 # or
 pip install -e ".[dev]"
 ```
-Make sure the optional dependencies `pyyaml` and `python-dotenv` are available
-to avoid runtime import errors when the CLI loads YAML configurations.
+
+`pytest-docker` is included and supplies the `docker_ip` and `docker_services`
+fixtures used by the integration tests. Make sure the optional dependencies
+`pyyaml` and `python-dotenv` are available to avoid runtime import errors when
+the CLI loads YAML configurations.
 
 With dependencies installed you can run the included poe tasks:
 

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Documented dev dependency installation and pytest-docker fixtures in README and CONTRIBUTING
 <<<<<<< HEAD
 =======
 AGENT NOTE - 2025-11-28: Moved Memory methods inside class and kept helper functions module-level


### PR DESCRIPTION
## Summary
- document dev dependency installation for tests
- mention pytest-docker fixtures

## Testing
- `poetry run poe test` *(fails: Resource 'llm_provider' failed during layer validation)*

------
https://chatgpt.com/codex/tasks/task_e_6875af0ef7d88322abfcf33a5c74273c