### PR TITLE
Fix strict stage logging test

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Adjusted logging configuration order in strict stage tests
 <<<<<<< HEAD
 =======
 AGENT NOTE - 2025-11-28: Moved Memory methods inside class and kept helper functions module-level


### PR DESCRIPTION
## Summary
- configure logging once per module for strict stage tests
- reattach pytest log handler after initializer resets logging
- note logging order change

## Testing
- `poetry run pytest tests/test_strict_stages.py::test_stage_mismatch_warning -q`
- `poetry run poe test` *(fails: InitializationError for llm_provider)*

------
https://chatgpt.com/codex/tasks/task_e_6875af0b84d08322b85aea97a87721b1