### PR TITLE
Fix parameter expansion for execute

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Adjusted _execute to unpack parameters using *args
 <<<<<<< HEAD
 =======
 AGENT NOTE - 2025-11-28: Moved Memory methods inside class and kept helper functions module-level

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -369,7 +369,7 @@ class Memory(AgentResource):
 
 async def _execute(conn: Any, sql: str, params: Any | None = None) -> Any:
     """Run a query and await the result when necessary."""
-    result = conn.execute(sql, params or [])
+    result = conn.execute(sql, *(params or []))
     if inspect.isawaitable(result):
         result = await result
     return result


### PR DESCRIPTION
## Summary
- expand params in `_execute` so None becomes zero arguments
- log note about `_execute` change

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test` *(failed: multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875af04771c8322b8545d0253d21d36