### PR TITLE
Set default infra dependency for LLMResource

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: set LLMResource infrastructure deps to llm_provider
 <<<<<<< HEAD
 =======
 AGENT NOTE - 2025-11-28: Moved Memory methods inside class and kept helper functions module-level

--- a/src/entity/resources/interfaces/llm.py
+++ b/src/entity/resources/interfaces/llm.py
@@ -11,7 +11,7 @@ class LLMResource(ResourcePlugin):
     """Base class for simple LLM resources."""
 
     name = "llm_provider"
-    infrastructure_dependencies: list[str] = []
+    infrastructure_dependencies = ["llm_provider"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})


### PR DESCRIPTION
## Summary
- configure LLMResource infrastructure dependencies
- log note about the change

## Testing
- `poetry run black src/entity/resources/interfaces/llm.py`
- `poetry run ruff check --fix src/entity/resources/interfaces/llm.py`
- `poetry run mypy src/entity/resources/interfaces/llm.py`
- `poetry run bandit -r src/entity/resources/interfaces/llm.py`
- `poetry run vulture src/entity/resources/interfaces/llm.py`
- `poetry run unimport --check src/entity/resources/interfaces/llm.py`
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`


------
https://chatgpt.com/codex/tasks/task_e_6875af02eb788322ad4ff7e21cb1c762