### PR TITLE
Fix llm interface self dependency

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Removed self-dependency from LLMResource interface
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Adjusted logging configuration order in strict stage tests
 <<<<<<< HEAD

--- a/src/entity/resources/interfaces/llm.py
+++ b/src/entity/resources/interfaces/llm.py
@@ -11,7 +11,7 @@ class LLMResource(ResourcePlugin):
     """Base class for simple LLM resources."""
 
     name = "llm_provider"
-    infrastructure_dependencies = ["llm_provider"]
+    infrastructure_dependencies: list[str] = []
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})


### PR DESCRIPTION
## Summary
- remove self dependency from `LLMResource`
- document change in `agents.log`

## Testing
- `poetry run black src/entity/resources/interfaces/llm.py tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875b312c4a48322810d7476e953c62a