### PR TITLE
Document pytest-docker usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,8 @@ poetry run python -m src.entity.core.registry_validator
 
 ### Running Tests
 
-Running tests requires the development dependencies. Install them and execute the full suite:
+Before running any tests, install the development dependencies. `pytest-docker`
+is provided through the dev group and required for Docker-based fixtures. Run:
 
 ```bash
 poetry install --with dev  # includes pytest-asyncio

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ documentation.
 
 ## Running Tests
 
-Running the tests requires the development dependencies. Install them with:
+Before running any tests, install the development dependencies. `pytest-docker`
+is included in this group and required for Docker-based fixtures. Install with:
 
 ```bash
 poetry install --with dev

--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Documented pytest-docker dev dependency and added fixture skip logic
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Adjusted logging configuration order in strict stage tests
 <<<<<<< HEAD

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,16 @@ import asyncpg
 import psycopg
 import pytest
 
+REQUIRE_PYTEST_DOCKER = (
+    "pytest-docker is required for Docker-based fixtures. "
+    "Run 'poetry install --with dev' to install it."
+)
+
+
+def _require_docker():
+    pytest.importorskip("pytest_docker", reason=REQUIRE_PYTEST_DOCKER)
+
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 os.environ.setdefault("ENTITY_AUTO_INIT", "0")
 
@@ -70,6 +80,7 @@ def _clear_metrics_deps():
 @pytest.fixture(scope="session")
 def docker_compose_file(pytestconfig: pytest.Config) -> str:
     """Return path to the docker compose file."""
+    _require_docker()
     return str(Path(pytestconfig.rootpath) / "tests" / "docker-compose.yml")
 
 
@@ -89,6 +100,7 @@ def _postgres_ready(dsn: str) -> bool:
 @pytest.fixture(scope="session")
 def postgres_dsn(docker_ip: str, docker_services) -> str:
     """Start the Postgres container and return a DSN."""
+    _require_docker()
     docker_services.start("postgres")
     port = docker_services.port_for("postgres", 5432)
     dsn = f"postgresql://test:test@{docker_ip}:{port}/test_db"
@@ -120,6 +132,7 @@ class AsyncPGDatabase(DatabaseResource):
 @pytest.fixture(scope="session")
 async def pg_memory(postgres_dsn: str) -> Memory:
     """Memory resource backed by Postgres."""
+    _require_docker()
     db = AsyncPGDatabase(postgres_dsn)
     mem = Memory({})
     mem.database = db
@@ -136,6 +149,7 @@ async def pg_memory(postgres_dsn: str) -> Memory:
 @pytest.fixture(scope="session")
 def ollama_url(docker_ip: str, docker_services) -> str:
     """Start the Ollama container and return its base URL."""
+    _require_docker()
     docker_services.start("ollama")
     port = docker_services.port_for("ollama", 11434)
     url = f"http://{docker_ip}:{port}"


### PR DESCRIPTION
## Summary
- clarify how to install dev dependencies in contributor docs
- note pytest-docker requirement in README
- skip docker fixtures when pytest-docker isn't installed
- record notes in agents.log

## Testing
- `poetry install --with dev`
- `poetry run poe test` *(fails: Command docker compose ...)*

------
https://chatgpt.com/codex/tasks/task_e_6875b3f50a188322856e7351badb584a