### PR TITLE
Add py.typed to ensure type hint discovery

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Added py.typed to package for typing support
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Updated memory._execute to handle paramstyle fallback
 <<<<<<< HEAD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 package-mode = true
 
 packages = [{ include = "entity", from = "src" }]
+include = ["src/entity/py.typed"]
 
 [tool.poetry.scripts]
 entity-cli = "entity.cli.__main__:main"


### PR DESCRIPTION
## Summary
- add a `py.typed` marker inside the `entity` package
- package the marker via `pyproject.toml`
- log the change for other agents

## Testing
- `poetry run poe test` *(fails: Resource 'llm_provider' failed, docker compose errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875b6d10c4c83228dd1da2fec60cd12