### PR TITLE
Replace monkeypatch in runtime tests

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Implemented failing infrastructure plugin for tests
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Updated memory._execute to handle paramstyle fallback
 <<<<<<< HEAD

--- a/tests/infrastructure/__init__.py
+++ b/tests/infrastructure/__init__.py
@@ -1,0 +1,8 @@
+"""Infrastructure helpers used in tests."""
+
+from .failing_plugins import FailingDuckDBInfrastructure, FailingPostgresInfrastructure
+
+__all__ = [
+    "FailingDuckDBInfrastructure",
+    "FailingPostgresInfrastructure",
+]

--- a/tests/infrastructure/failing_plugins.py
+++ b/tests/infrastructure/failing_plugins.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from entity.infrastructure import DuckDBInfrastructure, PostgresInfrastructure
+
+
+class FailingDuckDBInfrastructure(DuckDBInfrastructure):
+    """DuckDB plugin that always fails during runtime validation."""
+
+    name = "failing_duckdb"
+
+    @asynccontextmanager
+    async def connection(self):  # type: ignore[override]
+        class BadConn:
+            def execute(self, _q):
+                raise RuntimeError("boom")
+
+            def close(self):
+                pass
+
+        yield BadConn()
+
+
+class FailingPostgresInfrastructure(PostgresInfrastructure):
+    """Postgres plugin that always fails during runtime validation."""
+
+    name = "failing_postgres"
+
+    @asynccontextmanager
+    async def connection(self):  # type: ignore[override]
+        class BadConn:
+            async def execute(self, *args, **kwargs):
+                raise RuntimeError("bad")
+
+        yield BadConn()

--- a/tests/test_infrastructure_validate_runtime.py
+++ b/tests/test_infrastructure_validate_runtime.py
@@ -1,26 +1,25 @@
-from contextlib import asynccontextmanager
 import pytest
-from entity.infrastructure import DuckDBInfrastructure, PostgresInfrastructure
+
 from entity.core.circuit_breaker import CircuitBreaker
+from entity.core.resources.container import ResourceContainer
+from tests.infrastructure import (
+    FailingDuckDBInfrastructure,
+    FailingPostgresInfrastructure,
+)
 
 
 @pytest.mark.asyncio
-async def test_duckdb_runtime_breaker_opens(monkeypatch):
-    db = DuckDBInfrastructure({"failure_threshold": 2})
+async def test_duckdb_runtime_breaker_opens():
+    container = ResourceContainer()
+    container.register(
+        "duckdb",
+        FailingDuckDBInfrastructure,
+        {"failure_threshold": 2},
+        layer=1,
+    )
+    await container.build_all()
+    db = container.get("duckdb")
     breaker = CircuitBreaker(failure_threshold=2)
-
-    class BadConn:
-        def execute(self, _q):
-            raise RuntimeError("boom")
-
-        def close(self):
-            pass
-
-    @asynccontextmanager
-    async def bad_connection(self):
-        yield BadConn()
-
-    monkeypatch.setattr(DuckDBInfrastructure, "connection", bad_connection)
 
     res1 = await db.validate_runtime(breaker)
     assert not res1.success
@@ -33,20 +32,21 @@ async def test_duckdb_runtime_breaker_opens(monkeypatch):
     assert not res3.success
     assert "circuit breaker open" in res3.message.lower()
 
+    await container.shutdown_all()
+
 
 @pytest.mark.asyncio
 async def test_postgres_runtime_breaker_opens():
-    pg = PostgresInfrastructure({"failure_threshold": 2})
+    container = ResourceContainer()
+    container.register(
+        "postgres",
+        FailingPostgresInfrastructure,
+        {"failure_threshold": 2},
+        layer=1,
+    )
+    await container.build_all()
+    pg = container.get("postgres")
     breaker = CircuitBreaker(failure_threshold=2)
-
-    class BadConn:
-        async def execute(self, *args, **kwargs):
-            raise RuntimeError("bad")
-
-    async def acquire():
-        return BadConn()
-
-    pg._pool.acquire = acquire
 
     res1 = await pg.validate_runtime(breaker)
     assert not res1.success
@@ -58,3 +58,5 @@ async def test_postgres_runtime_breaker_opens():
     res3 = await pg.validate_runtime(breaker)
     assert not res3.success
     assert "circuit breaker open" in res3.message.lower()
+
+    await container.shutdown_all()


### PR DESCRIPTION
## Summary
- implement failing infrastructure plugins for tests
- register failing infrastructure in runtime validation tests
- log note about failing plugin

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`


------
https://chatgpt.com/codex/tasks/task_e_6875b6cf81d083228b1e2adfb8f41615