### PR TITLE
Add echo llm backend infrastructure

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Added echo_llm_backend infrastructure and updated defaults
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Updated memory._execute to handle paramstyle fallback
 <<<<<<< HEAD

--- a/docs/source/config_reference.md
+++ b/docs/source/config_reference.md
@@ -58,7 +58,7 @@ Configuration model for the :class:`~entity.resources.llm.LLM`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| provider | str | 'default' |  |
+| provider | str | 'default' | defaults to an echo backend |
 
 ## LogOutputConfig
 

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -42,3 +42,17 @@ plugins:
 
 Register the plugin in your workflow or resource container like any other
 infrastructure plugin.
+
+## EchoLLMBackend
+
+`EchoLLMBackend` provides a dummy LLM server used by the default provider. It simply echoes input
+back to the caller and exposes the `"llm_backend"` infrastructure type.
+
+```yaml
+plugins:
+  infrastructure:
+    echo_llm_backend:
+      type: plugins.builtin.infrastructure.echo_llm_backend:EchoLLMBackend
+```
+
+No configuration options are required.

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -324,6 +324,11 @@ class _AgentBuilder:
 
             container.register("memory", Memory, {}, layer=3)
 
+        if not container.has_plugin("echo_llm_backend"):
+            from plugins.builtin.infrastructure.echo_llm_backend import EchoLLMBackend
+
+            container.register("echo_llm_backend", EchoLLMBackend, {}, layer=1)
+
         if not container.has_plugin("llm_provider"):
             from entity.resources.interfaces.echo_llm import EchoLLMResource
 

--- a/src/entity/resources/interfaces/echo_llm.py
+++ b/src/entity/resources/interfaces/echo_llm.py
@@ -10,7 +10,7 @@ from entity.resources.interfaces.llm import LLMResource
 class EchoLLMResource(LLMResource):
     """LLM that simply echoes the prompt."""
 
-    dependencies: list[str] = []
+    infrastructure_dependencies = ["echo_llm_backend"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/plugins/builtin/infrastructure/__init__.py
+++ b/src/plugins/builtin/infrastructure/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure implementations shipped with the framework."""
+
+from .echo_llm_backend import EchoLLMBackend
+
+__all__ = ["EchoLLMBackend"]

--- a/src/plugins/builtin/infrastructure/echo_llm_backend.py
+++ b/src/plugins/builtin/infrastructure/echo_llm_backend.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from entity.core.plugins import InfrastructurePlugin, ValidationResult
+
+
+class EchoLLMBackend(InfrastructurePlugin):
+    """Simple backend that echoes prompts."""
+
+    name = "echo_llm_backend"
+    infrastructure_type = "llm_backend"
+    resource_category = "llm"
+    stages: list = []
+    dependencies: list[str] = []
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+
+    async def generate(self, prompt: str) -> str:
+        return prompt
+
+    async def validate_runtime(self) -> ValidationResult:
+        return ValidationResult.success_result()

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -59,6 +59,8 @@ async def test_builder_registers_default_resources() -> None:
     assert runtime is not None
     assert builder.resource_registry.get("memory") is not None
     assert builder.resource_registry.get("llm") is not None
+    assert builder.resource_registry.get("llm_provider") is not None
+    assert builder.resource_registry.get("echo_llm_backend") is not None
     assert builder.resource_registry.get("storage") is not None
     mem = builder.resource_registry.get("memory")
     assert getattr(mem, "database", None) is not None


### PR DESCRIPTION
## Summary
- implement `EchoLLMBackend` infrastructure plugin
- register echo backend before default LLM provider
- connect `EchoLLMResource` to the echo backend
- document the new infrastructure and provider behaviour
- verify default resource registration in tests

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError: user_plugins.prompts.memory_retrieval)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test` *(failed: InitializationError and docker compose errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875b6cf82d4832282851a592d476bfb