### PR TITLE
Fix execute param handling

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,42 +1,5 @@
-<<<<<<< HEAD
-AGENT NOTE - 2025-07-15: Updated memory._execute to handle paramstyle fallback
-<<<<<<< HEAD
-AGENT NOTE - 2025-07-15: Updated cycle detection test for new error message
-=======
-AGENT NOTE - 2025-07-15: Removed self-dependency from LLMResource interface
->>>>>>> pr-1649
-=======
-AGENT NOTE - 2025-07-15: Documented pytest-docker dev dependency and added fixture skip logic
->>>>>>> pr-1651
-<<<<<<< HEAD
-AGENT NOTE - 2025-07-15: Adjusted logging configuration order in strict stage tests
-<<<<<<< HEAD
-AGENT NOTE - 2025-07-15: Adjusted _execute to unpack parameters using *args
-<<<<<<< HEAD
-AGENT NOTE - 2025-07-15: Adjusted _execute to unpack parameters using *args
-<<<<<<< HEAD
-AGENT NOTE - 2025-07-15: Updated validator tests for PromptPlugin requirement
-=======
-AGENT NOTE - 2025-07-15: Documented dev dependency installation and pytest-docker fixtures in README and CONTRIBUTING
->>>>>>> pr-1640
-=======
-AGENT NOTE - 2025-07-15: set LLMResource infrastructure deps to llm_provider
->>>>>>> pr-1646
-<<<<<<< HEAD
-=======
-=======
-AGENT NOTE - 2025-07-15: Cleaned conflict markers and sorted log chronologically
->>>>>>> pr-1644
-AGENT NOTE - 2025-11-28: Moved Memory methods inside class and kept helper functions module-level
-AGENT NOTE - 2025-11-28: Moved Memory methods inside class and kept helper functions module-level
-=======
-AGENT NOTE - 2025-07-15: Cleaned conflict markers and sorted log chronologically
-AGENT NOTE - 2025-11-28: Moved Memory methods inside class and kept helper functions module-level
-AGENT NOTE - 2025-11-28: Moved Memory methods inside class and kept helper functions module-level
->>>>>>> pr-1642
+AGENT NOTE - 2025-07-15: Updated memory._execute to handle empty params and cleaned log
 AGENT NOTE - 2025-11-27: Patched DuckDB runtime test using monkeypatch to auto-restore connection method
-AGENT NOTE - 2025-11-27: Patched DuckDB runtime test using monkeypatch to auto-restore connection method
-AGENT NOTE - 2025-10-31: Integration tests now use Dockerized Postgres and Ollama
 AGENT NOTE - 2025-10-31: Integration tests now use Dockerized Postgres and Ollama
 AGENT NOTE - 2025-10-30: Fixed async stage results in end-to-end pipeline test ensuring ReverseThink runs and final output is olleh
 AGENT NOTE - 2025-10-25: Updated Workflow schema and validation to match WorkflowSettings
@@ -88,10 +51,8 @@ AGENT NOTE - 2025-07-20: Updated load_env precedence and tests
 AGENT NOTE - 2025-07-18: Added integration pipeline tests covering workflows, multi-user isolation, error handling, and metrics
 AGENT NOTE - 2025-07-16: Revised built-in resource config validation and tests
 AGENT NOTE - 2025-07-15: Set llm interface infra deps empty
-AGENT NOTE - 2025-07-15: Set llm interface infra deps empty
 AGENT NOTE - 2025-07-15: Cleaned merge markers from agents.log
 AGENT NOTE - 2025-07-15: Updated CI to install dev dependencies via poetry
-AGENT NOTE - 2025-07-15: Set llm interface infra deps empty
 AGENT NOTE - 2025-07-15: Resolved merge conflict markers and restored missing notes
 AGENT NOTE - 2025-07-15: Resolved merge conflicts in agents.log and removed duplicate entries
 AGENT NOTE - 2025-07-15: Wrapped DB operations with awaitable helper for memory resource
@@ -103,16 +64,7 @@ AGENT NOTE - 2025-07-15: Verified removal of conflict markers and ran formatting
 AGENT NOTE - 2025-07-15: Partial cleanup of mock usage in strict stage test
 AGENT NOTE - 2025-07-15: Added poe tasks for unit, integration, and e2e tests
 AGENT NOTE - 2025-07-15: Removed monkeypatch-based tests and added poe tasks for unit/integration/e2e
-AGENT NOTE - 2025-07-15: Verified removal of conflict markers and ran formatting/tests
 AGENT NOTE - 2025-07-15: Verified stage order test markers removed and logged update
-AGENT NOTE - 2025-07-15: Added poe tasks for unit, integration, and e2e tests
-AGENT NOTE - 2025-07-15: Partial cleanup of mock usage in strict stage test
-AGENT NOTE - 2025-07-15: Removed monkeypatch-based tests and added poe tasks for unit/integration/e2e
-AGENT NOTE - 2025-07-15: Updated dependency assertion for layer validation message
-AGENT NOTE - 2025-07-15: Adjusted logging configuration order in strict stage tests
-AGENT NOTE - 2025-07-15: registry validation ensures prompt plugins must subclass PromptPlugin
-AGENT NOTE - 2025-07-15: Wrapped DB operations with awaitable helper for memory resource
-AGENT NOTE - 2025-07-15: Excluded LoggingResource from metrics dependency
 AGENT NOTE - 2025-07-14: Updated test resource layers to comply with 4-layer architecture
 AGENT NOTE - 2025-07-14: Awaited context.think in tests and audited for missing awaits
 AGENT NOTE - 2025-07-14: Updated dependency injection tests to expect "metrics_collector?"
@@ -141,7 +93,6 @@ AGENT NOTE - 2025-07-14: Ensured PostgreSQL tests create and drop temporary data
 AGENT NOTE - 2025-07-14: Updated plugin config tests to use dictionaries
 AGENT NOTE - 2025-07-14: Removed infrastructure_dependencies from MetricsCollectorResource
 AGENT NOTE - 2025-07-14: Added sys.path setup in tests and examples for direct execution
-AGENT NOTE - 2025-07-14: Ensured PostgreSQL tests create and drop temporary database
 AGENT NOTE - 2025-07-14: Revised layer validation order and cycle detection
 AGENT NOTE - 2025-07-14: Fixed conversation history user_id namespacing and updated tests
 AGENT NOTE - 2025-07-14: Fixed stage mismatch warning logging and updated tests
@@ -155,10 +106,7 @@ AGENT NOTE - 2025-07-14: Allowed plugin canonical resources to be registered at 
 AGENT NOTE - 2025-07-14: Removed merge conflict markers from agents.log
 AGENT NOTE - 2025-07-14: Verified errors.py contains no merge markers and ensured ResourceError uses pass
 AGENT NOTE - 2025-07-14: Added test-verbose command to README testing section
-AGENT NOTE - 2025-07-14: Added test-verbose command to README testing section
 AGENT NOTE - 2025-07-14: Updated test imports for reliability modules and StageResolver
-AGENT NOTE - 2025-07-14: Verified errors.py contains no merge markers and ensured ResourceError uses pass
-AGENT NOTE - 2025-07-14: Removed merge conflict markers from agents.log
 AGENT NOTE - 2025-07-14: Documented PYTHONPATH usage for pytest in README
 AGENT NOTE - 2025-07-14: Fixed workflow fallback in _create_default_agent
 AGENT NOTE - 2025-07-14: Removed merge markers from errors.py

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -397,7 +397,13 @@ async def _execute(conn: Any, sql: str, params: Any | None = None) -> Any:
     """Run a query against ``conn`` and await the result when necessary."""
     style = _detect_paramstyle(conn)
     sql = _convert_placeholders(sql, style)
-    result = conn.execute(sql, params or [])
+    if not params:
+        result = conn.execute(sql)
+    else:
+        try:
+            result = conn.execute(sql, *params)
+        except Exception:
+            result = conn.execute(sql, params)
     if inspect.isawaitable(result):
         result = await result
     return result


### PR DESCRIPTION
## Summary
- handle asyncpg-style execute calls in `_execute`
- clear merge markers from agents log

## Testing
- `poetry run pytest tests/test_memory_basic.py::test_set_get tests/test_memory_basic.py::test_remember_alias tests/test_memory_basic.py::test_batch_store tests/test_memory_basic.py::test_conversation_search_text tests/test_memory_basic.py::test_load_conversation_with_user_id tests/test_memory_basic.py::test_load_conversation_preformatted_id -q`
- `poetry run pytest tests/resources/test_memory.py -q`
- `poetry run pytest tests/test_cli_get_stats.py::test_cli_get_conversation_stats -q`
- `poetry run pytest tests/architecture/test_dependency_injection.py::test_memory_user_isolation -q`
- `poetry run pytest tests/test_plugin_context_memory.py::test_memory_roundtrip tests/test_plugin_context_memory.py::test_memory_persists_between_instances tests/test_plugin_context_memory.py::test_memory_persists_with_connection_pool -q`


------
https://chatgpt.com/codex/tasks/task_e_6875b6ca48a883229e81b1fcba380770