### PR TITLE
Remove unused import

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,3 +1,4 @@
+AGENT NOTE - 2025-07-15: Removed unused PipelineStage import from kitchen sink example
 <<<<<<< HEAD
 <<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Clarified pytest-docker and Docker requirements in README

--- a/examples/kitchen_sink/main.py
+++ b/examples/kitchen_sink/main.py
@@ -5,7 +5,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 
 from entity import agent, prompt
-from entity.core.stages import PipelineStage
 from user_plugins.tools.calculator_tool import CalculatorTool
 from user_plugins.responders import ReactResponder
 


### PR DESCRIPTION
## Summary
- clean up `examples/kitchen_sink/main.py` by removing an unused import
- log this change in `agents.log`

## Testing
- `poetry run black examples/kitchen_sink/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6875baf3fa4483228200bce10d282e20