### PR TITLE
Add pytest-docker note in testing guide

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -32,6 +32,7 @@ This project uses **Poetry + Pytest** with a focus on **realistic, integration-d
   * Ollama (for LLM reasoning)
   * FastAPI app (for API-based e2e)
 * Use [`docker-compose`](https://docs.docker.com/compose/) or [`pytest-docker`](https://pypi.org/project/pytest-docker/) for managed spinup
+* Install **`pytest-docker`** before running integration tests; without it pytest will fail with `fixture 'docker_ip' not found` errors.
 
 ---
 


### PR DESCRIPTION
## Summary
- emphasize that pytest-docker must be installed for integration tests
- warn about the `fixture 'docker_ip' not found` error when it's missing

## Testing
- `poetry install --with dev`
- `poetry run poe test` *(fails: docker compose errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875c19fbdc08322895da23e0cba6a5e