### PR TITLE
Fix conversation table creation

### DIFF
--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -54,8 +54,7 @@ class Memory(AgentResource):
             )
             await _execute(
                 conn,
-                f"CREATE TABLE IF NOT EXISTS {self._history_table} ("
-                "conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)",
+                f"CREATE TABLE IF NOT EXISTS {self._history_table} (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)",
             )
             self._maybe_commit(conn)
 


### PR DESCRIPTION
## Summary
- simplify SQL creation string for history table in `Memory.initialize`
- verify memory unit tests

## Testing
- `poetry run pytest tests/test_memory_basic.py tests/resources/test_memory.py tests/test_resources/test_memory_init.py tests/state/test_memory_serialization.py tests/state/test_memory_advanced.py tests/state/test_anthropomorphic_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6875c19da02c8322bf21e4a11df3111d