### PR TITLE
Fix ResourcePlugin dependencies

### DIFF
--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -280,6 +280,7 @@ class ResourcePlugin(Plugin):
     infrastructure_dependencies: List[str] = []
     resource_category: str = ""
     stages: List[PipelineStage] = []
+    dependencies: List[str] = []
 
     async def _on_initialize(self) -> None:
         async def _noop() -> None:
@@ -370,6 +371,8 @@ class ResourcePlugin(Plugin):
 
 class AgentResource(ResourcePlugin):
     """Layer 3 canonical or custom agent resource."""
+
+    dependencies: List[str] = []
 
 
 class ToolPlugin(Plugin):

--- a/src/entity/resources/base.py
+++ b/src/entity/resources/base.py
@@ -10,6 +10,8 @@ from ..core.plugins import ResourcePlugin
 class AgentResource(ResourcePlugin):
     """Layer 3 building block depending only on infrastructure resources."""
 
+    dependencies: list[str] = []
+
 
 from .llm import LLM
 from .memory import Memory


### PR DESCRIPTION
## Summary
- override inherited dependencies in `ResourcePlugin`
- give `AgentResource` classes explicit empty dependencies

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `unimport src tests`
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- ❌ `poetry run entity-cli --config config/dev.yaml verify` (failed to run)
- ❌ `poetry run entity-cli --config config/prod.yaml verify` (failed to run)
- ❌ `poetry run python -m src.entity.core.registry_validator` (failed to run)

------
https://chatgpt.com/codex/tasks/task_e_6875c199d3e083229fc760f729070f3a