### PR TITLE
Update vector store metrics injection

### DIFF
--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -233,6 +233,7 @@ class ResourceContainer:
     async def add(self, name: str, resource: Any) -> None:
         async with self._lock:
             self._resources[name] = resource
+            setattr(resource, "resource_container", self)
 
     async def add_from_config(self, name: str, cls: type, config: Dict) -> None:
         instance = self._create_instance(cls, config)

--- a/src/entity/resources/interfaces/vector_store.py
+++ b/src/entity/resources/interfaces/vector_store.py
@@ -11,7 +11,6 @@ class VectorStoreResource(ResourcePlugin):
     """Abstract vector store interface."""
 
     infrastructure_dependencies = ["vector_store"]
-    dependencies = ["metrics_collector?"]
     resource_category = "database"
 
     def __init__(self, config: Dict | None = None) -> None:
@@ -22,6 +21,10 @@ class VectorStoreResource(ResourcePlugin):
         pool_cfg = PoolConfig(**self.config.get("pool", {}))
         self._pool = ResourcePool(self._create_client, pool_cfg, "vector_store")
         metrics = getattr(self, "metrics_collector", None)
+        if metrics is None:
+            container = getattr(self, "resource_container", None)
+            if container is not None:
+                metrics = container.get("metrics_collector")
         if metrics is not None:
             self._pool.set_metrics_collector(metrics)
         await self._pool.initialize()

--- a/tests/test_vector_store_metrics.py
+++ b/tests/test_vector_store_metrics.py
@@ -1,0 +1,26 @@
+import pytest
+
+from entity.core.resources.container import ResourceContainer
+from entity.resources.metrics import MetricsCollectorResource
+from entity.resources.interfaces.vector_store import VectorStoreResource
+
+
+class DummyVector(VectorStoreResource):
+    async def add_embedding(self, text: str) -> None:
+        return None
+
+    async def query_similar(self, query: str, k: int = 5):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_injected_via_container():
+    container = ResourceContainer()
+    container.register("custom_store", DummyVector, {}, layer=2)
+    container.register("metrics_collector", MetricsCollectorResource, {}, layer=4)
+    await container.build_all()
+    vec: DummyVector = container.get("custom_store")
+    pool = vec.get_connection_pool()
+    assert getattr(pool, "_metrics", None) is not None
+
+    await container.shutdown_all()


### PR DESCRIPTION
## Summary
- update VectorStoreResource to fetch metrics from the container if available
- store the owning container on resources when added
- test that vector store pools receive metrics collectors

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests`
- `poetry run python -m entity.cli --config config/dev.yaml verify` *(fails: coroutine not awaited)*
- `poetry run python -m entity.cli --config config/prod.yaml verify` *(fails: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: multiple tests and docker-compose errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875c19c1a7c83229d3fa3c07b8d2c7a