### PR TITLE
Handle missing pytest-docker gracefully

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -32,7 +32,9 @@ This project uses **Poetry + Pytest** with a focus on **realistic, integration-d
   * Ollama (for LLM reasoning)
   * FastAPI app (for API-based e2e)
 * Use [`docker-compose`](https://docs.docker.com/compose/) or [`pytest-docker`](https://pypi.org/project/pytest-docker/) for managed spinup
-* Install **`pytest-docker`** before running integration tests; without it pytest will fail with `fixture 'docker_ip' not found` errors.
+* Install **`pytest-docker`** before running integration tests.
+  If it's missing, `tests/conftest.py` skips all Docker-based tests at import time
+  with a clear message: "pytest-docker is required for Docker-based fixtures. Run 'poetry install --with dev' to install it."
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,14 @@ REQUIRE_PYTEST_DOCKER = (
     "Run 'poetry install --with dev' to install it."
 )
 
+try:  # Skip entire module if pytest-docker isn't available
+    import pytest_docker as _  # noqa: F401
+except Exception:  # pragma: no cover - environment dependent
+    pytest.skip(REQUIRE_PYTEST_DOCKER, allow_module_level=True)
 
-def _require_docker():
+
+def _require_docker() -> None:
+    """Ensure pytest-docker is installed before using docker fixtures."""
     pytest.importorskip("pytest_docker", reason=REQUIRE_PYTEST_DOCKER)
 
 


### PR DESCRIPTION
## Summary
- skip docker-based fixtures when pytest-docker isn't installed
- clarify pytest-docker requirement in test docs

## Testing
- `poetry run poe test` *(fails: InitializationError and docker compose errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875c53da6708322a7c797678a885c60