### PR TITLE
Support asyncpg fetch in Memory

### DIFF
--- a/tests/resources/test_pg_vector_store.py
+++ b/tests/resources/test_pg_vector_store.py
@@ -141,3 +141,30 @@ async def test_asyncpg_paramstyle_insert(prepared_postgres) -> None:
     history = await mem.load_conversation("conv", user_id="u")
     assert len(history) == 1
     assert history[0].content == "asyncpg works"
+
+
+@pytest.mark.asyncio
+async def test_asyncpg_search_and_load(prepared_postgres) -> None:
+    if shutil.which("pg_ctl") is None:
+        pytest.skip("pg_ctl not installed")
+    dsn = (
+        f"postgresql://{prepared_postgres.user}:{prepared_postgres.password}@"
+        f"{prepared_postgres.host}:{prepared_postgres.port}/{prepared_postgres.dbname}"
+    )
+    db = AsyncPGDatabase(dsn)
+    mem = Memory({})
+    mem.database = db
+    await mem.initialize()
+
+    await mem.add_conversation_entry(
+        "conv",
+        ConversationEntry(content="search me", role="user", timestamp=datetime.now()),
+        user_id="u",
+    )
+
+    history = await mem.load_conversation("conv", user_id="u")
+    assert [h.content for h in history] == ["search me"]
+
+    results = await mem.conversation_search("search", user_id="u")
+    assert len(results) == 1
+    assert results[0]["content"] == "search me"


### PR DESCRIPTION
## Summary
- use `conn.fetch` when available for SELECT queries
- wrap fetched rows in cursor-like object
- add integration test for asyncpg search and load

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test` *(failed: 19 failed, 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875c53a7e1c832292c7f04849da980c