### PR TITLE
Remove metrics dependency from LLM

### DIFF
--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -17,7 +17,7 @@ class LLM(AgentResource):
     """Simple LLM wrapper."""
 
     name = "llm"
-    dependencies = ["llm_provider?", "metrics_collector?"]
+    dependencies = ["llm_provider?"]
     resource_category = "api"
 
     def __init__(self, config: Dict | None = None) -> None:


### PR DESCRIPTION
## Summary
- drop `metrics_collector?` from `LLM.dependencies`
- keep metrics wiring in `VectorStoreResource.initialize` and container `add_pool`

## Testing
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: Resource 'database, logging' etc.)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6875c69df8cc8322946d33b782a5baa9