### PR TITLE
Fix metrics collector layer

### DIFF
--- a/tests/test_vector_store_metrics.py
+++ b/tests/test_vector_store_metrics.py
@@ -3,9 +3,17 @@ import pytest
 from entity.core.resources.container import ResourceContainer
 from entity.resources.metrics import MetricsCollectorResource
 from entity.resources.interfaces.vector_store import VectorStoreResource
+from entity.core.plugins import InfrastructurePlugin
+
+
+class DummyVectorInfra(InfrastructurePlugin):
+    infrastructure_type = "vector_store"
+    resource_category = "database"
 
 
 class DummyVector(VectorStoreResource):
+    infrastructure_dependencies = ["vector_store"]
+
     async def add_embedding(self, text: str) -> None:
         return None
 
@@ -16,8 +24,9 @@ class DummyVector(VectorStoreResource):
 @pytest.mark.asyncio
 async def test_metrics_collector_injected_via_container():
     container = ResourceContainer()
+    container.register("vector_store", DummyVectorInfra, {}, layer=1)
     container.register("custom_store", DummyVector, {}, layer=2)
-    container.register("metrics_collector", MetricsCollectorResource, {}, layer=4)
+    container.register("metrics_collector", MetricsCollectorResource, {}, layer=3)
     await container.build_all()
     vec: DummyVector = container.get("custom_store")
     pool = vec.get_connection_pool()


### PR DESCRIPTION
## Summary
- register a dummy vector store infra so layer validation passes
- inject metrics collector at layer 3
- keep test verifying connection pool exposes metrics

## Testing
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run pytest tests/test_vector_store_metrics.py`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run mypy src`
- `poetry run ruff check --fix src tests`
- `poetry run black src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run unimport --remove-all src tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875c6a1df488322bafff79a1b68dec0