### PR TITLE
Document docker requirement for integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,10 @@ poetry run python -m src.entity.core.registry_validator
 
 ### Running Tests
 
-Before running any tests, install the development dependencies. `pytest-docker`
-is provided through the dev group and required for Docker-based fixtures. Run:
+Before running any tests, install the development dependencies. Integration
+tests spin up containers using Docker, so Docker **must** be installed.
+The `pytest-docker` plugin is provided through the dev group and manages these
+containers. Run:
 
 ```bash
 poetry install --with dev  # includes pytest-asyncio


### PR DESCRIPTION
## Summary
- note that Docker is required for integration tests

## Testing
- `poetry install --with dev`
- `poetry run poe test` *(fails: Resource initialization and docker compose errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875c6a4b4d083228955f8978e6eed3c