### PR TITLE
Resolve lingering merge conflicts

### DIFF
--- a/agents.log
+++ b/agents.log
@@ -1,10 +1,5 @@
-<<<<<<< HEAD
 AGENT NOTE - 2025-07-15: Removed unused PipelineStage import from kitchen sink example
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
 AGENT NOTE - 2025-07-15: Cleaned agents.log merge markers and ran quality checks
->>>>>>> pr-1659
 AGENT NOTE - 2025-07-15: Clarified pytest-docker and Docker requirements in README
 AGENT NOTE - 2025-07-15: Added optional llm_backend dependency to LLMResource
 AGENT NOTE - 2025-07-15: Added echo_llm_backend infrastructure and updated defaults

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -422,54 +422,18 @@ async def _execute(conn: Any, sql: str, params: Any | None = None) -> Any:
     """Run a query against ``conn`` and await the result when necessary."""
     style = _detect_paramstyle(conn)
     sql = _convert_placeholders(sql, style)
-<<<<<<< HEAD
+
+    asyncpg_like = hasattr(conn, "fetch")
     is_select = sql.lstrip().lower().startswith(("select", "with"))
 
-    if hasattr(conn, "fetch") and is_select:
+    if asyncpg_like and is_select:
         if params:
             rows = conn.fetch(sql, *params)
         else:
             rows = conn.fetch(sql)
         if inspect.isawaitable(rows):
             rows = await rows
-        description = []
-        if rows:
-            description = [(name,) for name in rows[0].keys()]
-
-        class _Cursor:
-            def __init__(self, rows: list[Any]):
-                self._rows = list(rows)
-                self.description = description
-                self._index = 0
-
-            def fetchall(self) -> list[Any]:
-                remaining = self._rows[self._index :]
-                self._index = len(self._rows)
-                return remaining
-
-            def fetchone(self) -> Any:
-                if self._index < len(self._rows):
-                    row = self._rows[self._index]
-                    self._index += 1
-                    return row
-                return None
-
-        return _Cursor(rows)
-=======
-
-    asyncpg_like = hasattr(conn, "fetch")
-    is_select = sql.lstrip().lower().startswith("select")
-
-    if asyncpg_like and is_select:
-        if not params:
-            rows = await conn.fetch(sql)
-        else:
-            try:
-                rows = await conn.fetch(sql, *params)
-            except Exception:
-                rows = await conn.fetch(sql, params)
         return _RowCursor(list(rows))
->>>>>>> pr-1672
 
     if not params:
         result = conn.execute(sql)

--- a/tests/resources/test_pg_vector_store.py
+++ b/tests/resources/test_pg_vector_store.py
@@ -144,11 +144,7 @@ async def test_asyncpg_paramstyle_insert(prepared_postgres) -> None:
 
 
 @pytest.mark.asyncio
-<<<<<<< HEAD
 async def test_asyncpg_search_and_load(prepared_postgres) -> None:
-=======
-async def test_asyncpg_conversation_statistics(prepared_postgres) -> None:
->>>>>>> pr-1672
     if shutil.which("pg_ctl") is None:
         pytest.skip("pg_ctl not installed")
     dsn = (
@@ -160,7 +156,6 @@ async def test_asyncpg_conversation_statistics(prepared_postgres) -> None:
     mem.database = db
     await mem.initialize()
 
-<<<<<<< HEAD
     await mem.add_conversation_entry(
         "conv",
         ConversationEntry(content="search me", role="user", timestamp=datetime.now()),
@@ -173,7 +168,21 @@ async def test_asyncpg_conversation_statistics(prepared_postgres) -> None:
     results = await mem.conversation_search("search", user_id="u")
     assert len(results) == 1
     assert results[0]["content"] == "search me"
-=======
+
+
+@pytest.mark.asyncio
+async def test_asyncpg_conversation_statistics(prepared_postgres) -> None:
+    if shutil.which("pg_ctl") is None:
+        pytest.skip("pg_ctl not installed")
+    dsn = (
+        f"postgresql://{prepared_postgres.user}:{prepared_postgres.password}@"
+        f"{prepared_postgres.host}:{prepared_postgres.port}/{prepared_postgres.dbname}"
+    )
+    db = AsyncPGDatabase(dsn)
+    mem = Memory({})
+    mem.database = db
+    await mem.initialize()
+
     now = datetime.now()
     await mem.add_conversation_entry(
         "c1", ConversationEntry("hi", "user", now), user_id="u"
@@ -207,4 +216,3 @@ async def test_asyncpg_save_and_load(prepared_postgres) -> None:
     await mem.save_conversation("conv", [entry], user_id="u")
     loaded = await mem.load_conversation("conv", user_id="u")
     assert loaded == [entry]
->>>>>>> pr-1672


### PR DESCRIPTION
## Summary
- clean up lingering merge markers
- unify `_execute` helpers in memory
- combine asyncpg memory tests

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --check src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: 15 failed, 226 passed, 1 skipped, 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875cc47493083229a69571744dc2433