### PR TITLE
Fix metrics collector layer in builder test

### DIFF
--- a/tests/test_builder_logging_injection.py
+++ b/tests/test_builder_logging_injection.py
@@ -27,7 +27,7 @@ async def test_builder_assigns_logging():
         "metrics_collector",
         MetricsCollectorResource,
         {},
-        layer=4,
+        layer=3,
     )
     await builder.add_plugin(DummyPrompt({}))
     await builder.build_runtime()


### PR DESCRIPTION
## Summary
- ensure metrics collector uses layer 3 during registration

## Testing
- `poetry run poe test` *(fails: 15 failed, 226 passed, 1 skipped, 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876d53099208322aada99c434ebc80f