### PR TITLE
Register DuckDB for test runtime

### DIFF
--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -2,8 +2,11 @@ import pytest
 
 from entity.core.agent import Agent
 from entity.core.plugins import Plugin
+from entity.infrastructure import DuckDBInfrastructure
 from entity.pipeline.stages import PipelineStage
 from entity.pipeline.workflow import Pipeline, Workflow
+from entity.resources.interfaces.duckdb_resource import DuckDBResource
+from entity.resources.interfaces.duckdb_vector_store import DuckDBVectorStore
 
 
 class ThoughtPlugin(Plugin):
@@ -24,7 +27,8 @@ class EchoPlugin(Plugin):
 
 @pytest.mark.asyncio
 async def test_builder_runtime_executes_workflow():
-    builder = Agent().builder
+    agent = Agent()
+    builder = agent.builder
     await builder.add_plugin(ThoughtPlugin({}))
     await builder.add_plugin(EchoPlugin({}))
     wf = Workflow(
@@ -34,6 +38,9 @@ async def test_builder_runtime_executes_workflow():
         }
     )
     pipeline = Pipeline(builder=builder, workflow=wf)
+    agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
+    agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     runtime = await pipeline.build_runtime()
     result = await runtime.handle("hello")
     assert result == "hello!"
@@ -48,14 +55,20 @@ async def test_agent_handle_runs_workflow():
         {PipelineStage.THINK: ["ThoughtPlugin"], PipelineStage.OUTPUT: ["EchoPlugin"]}
     )
     agent.pipeline = Pipeline(builder=agent.builder, workflow=wf)
+    agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
+    agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     result = await agent.handle("bye")
     assert result == "bye!"
 
 
 @pytest.mark.asyncio
 async def test_builder_registers_default_resources() -> None:
-    builder = Agent().builder
-    runtime = await builder.build_runtime()
+    agent = Agent()
+    agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
+    agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
+    runtime = await agent.build_runtime()
     assert runtime is not None
     assert builder.resource_registry.get("memory") is not None
     assert builder.resource_registry.get("llm") is not None

--- a/tests/test_plugin_lifecycle.py
+++ b/tests/test_plugin_lifecycle.py
@@ -3,6 +3,9 @@ import asyncio
 from entity.core.agent import Agent
 from entity.core.plugins import Plugin
 from entity.core.stages import PipelineStage
+from entity.infrastructure import DuckDBInfrastructure
+from entity.resources.interfaces.duckdb_resource import DuckDBResource
+from entity.resources.interfaces.duckdb_vector_store import DuckDBVectorStore
 
 
 class LifecyclePlugin(Plugin):
@@ -29,6 +32,9 @@ def test_plugin_lifecycle():
     ag = Agent()
     plugin = LifecyclePlugin({})
     asyncio.run(ag.builder.add_plugin(plugin))
+    ag.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
+    ag.register_resource("database", DuckDBResource, {}, layer=2)
+    ag.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     asyncio.run(ag.builder.build_runtime())
 
     asyncio.run(plugin.execute(object()))

--- a/tests/test_reload_runtime_validation.py
+++ b/tests/test_reload_runtime_validation.py
@@ -8,7 +8,10 @@ from entity.core.plugins import Plugin, ValidationResult
 from entity.core.stages import PipelineStage
 from entity.cli import EntityCLI
 from entity.core.registries import PluginRegistry
+from entity.infrastructure import DuckDBInfrastructure
 from entity.pipeline.config.config_update import update_plugin_configuration
+from entity.resources.interfaces.duckdb_resource import DuckDBResource
+from entity.resources.interfaces.duckdb_vector_store import DuckDBVectorStore
 
 
 class RuntimeCheckPlugin(Plugin):
@@ -61,6 +64,9 @@ async def test_reload_aborts_on_failed_runtime_validation(tmp_path):
     agent = Agent()
     plugin = RuntimeCheckPlugin({"valid": True})
     await agent.add_plugin(plugin)
+    agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
+    agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     await agent.build_runtime()
 
     # Ensure config updates do not call async validator
@@ -85,6 +91,9 @@ async def test_reload_successful_reconfiguration(tmp_path):
     agent = Agent()
     plugin = ReconfigPlugin({"value": 1})
     await agent.add_plugin(plugin)
+    agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
+    agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     await agent.build_runtime()
 
     ReconfigPlugin.validate_config = classmethod(
@@ -108,6 +117,9 @@ async def test_reload_failed_reconfiguration(tmp_path):
     agent = Agent()
     plugin = FailingReconfigPlugin({"value": 1})
     await agent.add_plugin(plugin)
+    agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
+    agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     await agent.build_runtime()
 
     FailingReconfigPlugin.validate_config = classmethod(

--- a/tests/test_reload_unknown_plugin.py
+++ b/tests/test_reload_unknown_plugin.py
@@ -6,6 +6,9 @@ from entity.core.agent import Agent
 from entity.core.plugins import Plugin, ValidationResult
 from entity.core.stages import PipelineStage
 from entity.cli import EntityCLI
+from entity.infrastructure import DuckDBInfrastructure
+from entity.resources.interfaces.duckdb_resource import DuckDBResource
+from entity.resources.interfaces.duckdb_vector_store import DuckDBVectorStore
 
 from .test_reload_runtime_validation import run_reload
 
@@ -27,6 +30,9 @@ async def test_reload_requires_restart_when_plugin_missing(tmp_path: Path) -> No
     agent = Agent()
     plugin = SimplePlugin({})
     await agent.add_plugin(plugin)
+    agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
+    agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     await agent.build_runtime()
 
     cli = EntityCLI.__new__(EntityCLI)

--- a/tests/workflow/test_workflow_features.py
+++ b/tests/workflow/test_workflow_features.py
@@ -2,8 +2,11 @@ import pytest
 
 from entity.core.agent import Agent
 from entity.core.plugins import Plugin
+from entity.infrastructure import DuckDBInfrastructure
 from entity.pipeline.stages import PipelineStage
 from entity.pipeline.workflow import Pipeline
+from entity.resources.interfaces.duckdb_resource import DuckDBResource
+from entity.resources.interfaces.duckdb_vector_store import DuckDBVectorStore
 from entity.workflows.base import Workflow
 
 
@@ -32,12 +35,16 @@ class ChildWF(BaseWF):
 
 @pytest.mark.asyncio
 async def test_conditional_stage_skip():
-    builder = Agent().builder
+    agent = Agent()
+    builder = agent.builder
     await builder.add_plugin(MarkerPlugin({}))
     await builder.add_plugin(EchoPlugin({}))
 
     wf = ChildWF(conditions={PipelineStage.THINK: lambda _state: False})
     pipeline = Pipeline(builder=builder, workflow=wf)
+    agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
+    agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     runtime = await pipeline.build_runtime()
     result = await runtime.handle("hi")
     assert result == "ok"


### PR DESCRIPTION
## Summary
- register DuckDB resources before building runtimes in several tests
- tweak CLI test helper to include resource setup

## Testing
- `poetry run black tests/integration/test_workflow_compose.py tests/test_agent_runtime.py tests/test_plugin_lifecycle.py tests/test_plugin_tool_test.py tests/test_reload_runtime_validation.py tests/test_reload_unknown_plugin.py tests/workflow/test_workflow_features.py`
- `poetry run poe test` *(fails: Command docker compose ...)*

------
https://chatgpt.com/codex/tasks/task_e_6876d52d1c508322ad387420ed65d051