### PR TITLE
Fix duckdb resource attribute naming

### DIFF
--- a/src/entity/resources/interfaces/duckdb_resource.py
+++ b/src/entity/resources/interfaces/duckdb_resource.py
@@ -15,20 +15,28 @@ class DuckDBResource(ResourcePlugin):  # type: ignore[misc]
 
     def __init__(self, config: Dict[str, Any] | None = None) -> None:
         super().__init__(config or {})
-        self.database: DuckDBInfrastructure | None = None
+        self.database_backend: DuckDBInfrastructure | None = None
 
     def get_connection_pool(self) -> ResourcePool:
-        if self.database is not None:
-            return self.database.get_connection_pool()
+        if self.database_backend is not None:
+            return self.database_backend.get_connection_pool()
         return ResourcePool(lambda: None, PoolConfig())
 
     @asynccontextmanager
     async def connection(self) -> AsyncIterator[Any]:
-        if self.database is None:
+        if self.database_backend is None:
             yield None
         else:
-            async with self.database.connection() as conn:
+            async with self.database_backend.connection() as conn:
                 yield conn
+
+    @property
+    def database(self) -> DuckDBInfrastructure | None:
+        return self.database_backend
+
+    @database.setter
+    def database(self, value: DuckDBInfrastructure | None) -> None:
+        self.database_backend = value
 
 
 __all__ = ["DuckDBResource"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ from contextlib import asynccontextmanager
 import asyncpg
 import psycopg
 import pytest
-import pytest_docker
 
 REQUIRE_PYTEST_DOCKER = (
     "pytest-docker is required for Docker-based fixtures. "


### PR DESCRIPTION
## Summary
- rename `database` attribute in DuckDBResource to `database_backend`
- add database property for backward compatibility
- fix lint in tests/conftest.py

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: 13 failed, 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876d8b9113c8322b646c812cc7deb87