### PR TITLE
Add Poethepoet dev tasks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: entity_dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  postgres_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,12 @@ patch = { cmd = "poetry version patch" }
 _publish = { cmd = "poetry publish --build" }
 release = ["docs", "patch", "_publish"]
 
+# Development helpers
+build-react = { cmd = "npm ci --prefix webapp && npm run build --prefix webapp" }
+start-db = { cmd = "docker compose up -d postgres" }
+open-app = { cmd = "python -m entity.utils.browser" }
+dev = ["build-react", "start-db", "open-app"]
+
 # ALL test tasks need the env variable
 test = { cmd = "pytest", env = { PYTHONPATH = "src" } }
 test-verbose = { cmd = "pytest -v", env = { PYTHONPATH = "src" } }

--- a/src/entity/utils/__init__.py
+++ b/src/entity/utils/__init__.py
@@ -1,0 +1,8 @@
+from .logging import configure_logging, get_logger
+from .browser import BrowserLauncher
+
+__all__ = [
+    "configure_logging",
+    "get_logger",
+    "BrowserLauncher",
+]

--- a/src/entity/utils/browser.py
+++ b/src/entity/utils/browser.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Simple utility for launching a URL in the default web browser."""
+
+from dataclasses import dataclass
+from time import sleep
+from webbrowser import open as open_browser
+
+
+@dataclass
+class BrowserLauncher:
+    """Open a web browser after an optional delay."""
+
+    url: str
+    delay: float = 3.0
+
+    def launch(self) -> None:
+        """Launch the configured URL."""
+        if self.delay:
+            sleep(self.delay)
+        open_browser(self.url)
+
+
+def main() -> None:
+    BrowserLauncher(url="http://localhost:3000").launch()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add docker-compose file for local Postgres
- create BrowserLauncher helper
- expose BrowserLauncher in utils package
- add dev tasks using Poethepoet to build React app, start Postgres and open the app

## Testing
- `poetry run black src/entity/utils/browser.py src/entity/utils/__init__.py`
- `poetry run ruff check --fix src/entity/utils/browser.py src/entity/utils/__init__.py`
- `poetry run mypy src/entity/utils/browser.py src/entity/utils/__init__.py`
- `poetry run bandit -r src/entity/utils/browser.py src/entity/utils/__init__.py`
- `poetry run vulture src/entity/utils/browser.py src/entity/utils/__init__.py`
- `poetry run poe test` *(fails: InitializationError and Docker compose errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876dc9b33c88322bebe03ef6c95cfd1