### PR TITLE
Allow same-layer deps for logging resources

### DIFF
--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -670,7 +670,11 @@ class ResourceContainer:
                     )
 
                 dep_layer = self._layers[dep_name]
-                if self._layers[node] - dep_layer != 1:
+                skip_check = self._layers[node] == dep_layer == 3 and dep_name in {
+                    "logging",
+                    "metrics_collector",
+                }
+                if not skip_check and self._layers[node] - dep_layer != 1:
                     raise InitializationError(
                         f"{node}, {dep_name}",
                         "layer validation",


### PR DESCRIPTION
## Summary
- permit layer-3 resources to depend on the `logging` or `metrics_collector` resources without triggering the one-layer step error
- keep all existing layer validations intact

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError: user_plugins.prompts.memory_retrieval)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`


------
https://chatgpt.com/codex/tasks/task_e_6876ddb080008322a9a906c85549bf1e