### PR TITLE
Avoid logging dep for interface resources

### DIFF
--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -588,7 +588,11 @@ class SystemInitializer:
                         d for d in deps if d not in {"logging", "metrics_collector"}
                     ]
                 else:
-                    if cls.__name__ != "LoggingResource" and "logging" not in deps:
+                    if (
+                        not is_interface
+                        and cls.__name__ != "LoggingResource"
+                        and "logging" not in deps
+                    ):
                         deps.append("logging")
                     if (
                         not is_interface


### PR DESCRIPTION
## Summary
- skip logging dependency for layer2 resource interfaces
- keep other dependency logic as-is

## Testing
- `poetry run poe test` *(fails: Resource 'memory, logging' failed during layer validation, docker compose errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876ddb03c3c8322a93d43f84bc401dd