### PR TITLE
Use .env variables for Docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ If you installed dependencies individually, install the plugin directly:
 pip install pytest-docker
 ```
 
+Before starting Docker, copy `.env.example` to `.env` and adjust the values for
+your local setup. The compose files read this file automatically.
+
 Start Docker and then run the poe task:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,12 @@ version: '3.8'
 services:
   postgres:
     image: postgres:16-alpine
+    env_file:
+      - .env
     environment:
-      POSTGRES_USER: dev
-      POSTGRES_PASSWORD: dev
-      POSTGRES_DB: entity_dev
+      POSTGRES_USER: ${DB_USERNAME:-dev}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-dev}
+      POSTGRES_DB: ${DB_NAME:-entity_dev}
     ports:
       - "5432:5432"
     volumes:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,10 +2,12 @@ version: '3.8'
 services:
   postgres:
     image: postgres:16-alpine
+    env_file:
+      - ../.env
     environment:
-      POSTGRES_USER: test
-      POSTGRES_PASSWORD: test
-      POSTGRES_DB: test_db
+      POSTGRES_USER: ${DB_USERNAME:-test}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-test}
+      POSTGRES_DB: ${DB_NAME:-test_db}
     ports:
       - "5432"
   ollama:


### PR DESCRIPTION
## Summary
- load environment variables from `.env` in all Docker compose files
- update README to mention copying `.env.example`

## Testing
- `poetry install --with dev`
- `poetry run poe test` *(fails: Command docker compose ...)*

------
https://chatgpt.com/codex/tasks/task_e_6876e1b906908322ac6d1a44d5aca33e