### PR TITLE
Persist temp thoughts via Memory

### DIFF
--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -114,6 +114,16 @@ async def execute_stage(
     *,
     user_id: str,
 ) -> None:
+    memory = registries.resources.get("memory") if registries.resources else None
+    if memory is not None:
+        state.conversation = await memory.load_conversation(
+            state.pipeline_id, user_id=user_id
+        )
+        state.temporary_thoughts = await memory.fetch_persistent(
+            f"{state.pipeline_id}_temp",
+            {},
+            user_id=user_id,
+        )
     state.current_stage = stage
     log_res = registries.resources.get("logging") if registries.resources else None
     stage_plugins = registries.plugins.get_plugins_for_stage(stage)
@@ -266,6 +276,17 @@ async def execute_stage(
         if state.failure_info and stage != PipelineStage.ERROR:
             await execute_stage(PipelineStage.ERROR, state, registries, user_id=user_id)
             state.last_completed_stage = PipelineStage.ERROR
+    if memory is not None:
+        await memory.save_conversation(
+            state.pipeline_id,
+            state.conversation,
+            user_id=user_id,
+        )
+        await memory.store_persistent(
+            f"{state.pipeline_id}_temp",
+            state.temporary_thoughts,
+            user_id=user_id,
+        )
     _elapsed = time.perf_counter() - _start
     # elapsed time could be logged here if needed
 

--- a/tests/test_plugin_context_advanced.py
+++ b/tests/test_plugin_context_advanced.py
@@ -27,13 +27,14 @@ def make_context(state=None):
     return PluginContext(state, DummyRegistries())
 
 
-def test_replace_conversation_history():
+@pytest.mark.asyncio
+async def test_replace_conversation_history():
     ctx = make_context()
     new_history = [
         ConversationEntry("hi", "user", datetime.now()),
         ConversationEntry("hello", "assistant", datetime.now()),
     ]
-    ctx.advanced.replace_conversation_history(new_history)
+    await ctx.advanced.replace_conversation_history(new_history)
 
     assert ctx.get_conversation_history() == new_history
 

--- a/user_plugins/prompts/pii_scrubber.py
+++ b/user_plugins/prompts/pii_scrubber.py
@@ -23,7 +23,7 @@ class PIIScrubberPrompt(PromptPlugin):
 
     async def _execute_impl(self, context: PluginContext) -> None:
         new_history = [self._scrub_entry(entry) for entry in context.conversation()]
-        context.advanced.replace_conversation_history(new_history)
+        await context.advanced.replace_conversation_history(new_history)
         if context.has_response():
             context.update_response(self._scrub_value)
 


### PR DESCRIPTION
## Summary
- refactor AdvancedContext temporary memory methods to use Memory
- persist temp thoughts between stages
- persist conversation updates and temps in PipelineWorker
- update PII scrubber and tests for async API

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(failed: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError)*
- `poetry run poe test-architecture` *(failed: docker not found)*
- `poetry run poe test-plugins` *(failed: docker not found)*
- `poetry run poe test-resources` *(failed: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876e5e35d688322af23a72f5e43d6f2