### PR TITLE
Refactor resource lifecycle for per-request instantiation

### DIFF
--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -59,13 +59,23 @@ class _AgentRuntime:
     async def run_pipeline(self, message: str, *, user_id: str | None = None) -> Any:
         from entity.pipeline.pipeline import Pipeline as ExecPipeline, execute_pipeline
 
+        container = (
+            self.capabilities.resources.clone()
+            if hasattr(self.capabilities.resources, "clone")
+            else self.capabilities.resources
+        )
+        regs = SystemRegistries(
+            resources=container,
+            tools=self.capabilities.tools,
+            plugins=self.capabilities.plugins,
+            validators=self.capabilities.validators,
+        )
+
         if self.workflow is None:
-            return await execute_pipeline(
-                message, self.capabilities, user_id=user_id, workflow=None
-            )
+            return await execute_pipeline(message, regs, user_id=user_id, workflow=None)
 
         pipeline = ExecPipeline(self.workflow)
-        return await pipeline.run_message(message, self.capabilities, user_id=user_id)
+        return await pipeline.run_message(message, regs, user_id=user_id)
 
     async def handle(
         self, message: str, *, user_id: str | None = None


### PR DESCRIPTION
## Summary
- create `ResourceContainer.clone` and add active flag
- build resources when entering the container context and discard on exit
- clone a container for each pipeline execution
- update PipelineWorker and Agent runtime to use cloned containers

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests` *(fails: unrecognized arguments)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture` *(fails: docker not found)*
- `poetry run poe test-plugins` *(fails: docker not found)*
- `poetry run poe test-resources` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876e5e6e64c832292f276667117ca24