### PR TITLE
Switch tests to Postgres memory

### DIFF
--- a/tests/architecture/test_dependency_injection.py
+++ b/tests/architecture/test_dependency_injection.py
@@ -1,30 +1,11 @@
-from contextlib import asynccontextmanager
-from datetime import datetime
-import sqlite3
-
 import pytest
+from datetime import datetime
 
-from entity.core.plugins import ValidationResult, InfrastructurePlugin, ResourcePlugin
+from tests.conftest import AsyncPGDatabase
+from entity.core.plugins import ValidationResult, ResourcePlugin
 from entity.resources.base import AgentResource
 from entity.resources import Memory
 from entity.core.state import ConversationEntry
-
-
-class SqliteDB(InfrastructurePlugin):
-    infrastructure_type = "database"
-    stages: list = []
-    dependencies: list = []
-
-    def __init__(self, config=None) -> None:
-        super().__init__(config or {})
-        self.conn = sqlite3.connect(":memory:")
-
-    def get_connection_pool(self):
-        return self.conn
-
-    @asynccontextmanager
-    async def connection(self):
-        yield self.conn
 
 
 class DBInterface(ResourcePlugin):
@@ -51,24 +32,29 @@ class DepResource(AgentResource):
 
 
 DBInterface.dependencies = []
-SqliteDB.dependencies = []
 DepResource.dependencies = ["db"]
 
 
 @pytest.mark.asyncio
-async def test_memory_user_isolation() -> None:
+async def test_memory_user_isolation(postgres_dsn: str) -> None:
+    db = AsyncPGDatabase(postgres_dsn)
     mem = Memory(config={})
-    mem.database = SqliteDB()
+    mem.database = db
     mem.vector_store = None
     await mem.initialize()
 
-    entry1 = ConversationEntry(content="one", role="user", timestamp=datetime.now())
-    entry2 = ConversationEntry(content="two", role="user", timestamp=datetime.now())
-    await mem.save_conversation("pipe", [entry1], user_id="u1")
-    await mem.save_conversation("pipe", [entry2], user_id="u2")
+    try:
+        entry1 = ConversationEntry(content="one", role="user", timestamp=datetime.now())
+        entry2 = ConversationEntry(content="two", role="user", timestamp=datetime.now())
+        await mem.save_conversation("pipe", [entry1], user_id="u1")
+        await mem.save_conversation("pipe", [entry2], user_id="u2")
 
-    hist1 = await mem.load_conversation("pipe", user_id="u1")
-    hist2 = await mem.load_conversation("pipe", user_id="u2")
+        hist1 = await mem.load_conversation("pipe", user_id="u1")
+        hist2 = await mem.load_conversation("pipe", user_id="u2")
 
-    assert [e.content for e in hist1] == ["one"]
-    assert [e.content for e in hist2] == ["two"]
+        assert [e.content for e in hist1] == ["one"]
+        assert [e.content for e in hist2] == ["two"]
+    finally:
+        async with db.connection() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._kv_table}")
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._history_table}")

--- a/tests/resources/test_memory.py
+++ b/tests/resources/test_memory.py
@@ -1,32 +1,11 @@
-import sqlite3
-from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 
+from tests.conftest import AsyncPGDatabase
 import pytest
 
 from entity.resources import Memory
-from entity.resources.interfaces.database import DatabaseResource
 from entity.resources.interfaces.vector_store import VectorStoreResource
 from entity.core.state import ConversationEntry
-
-
-class SqliteDB(DatabaseResource):
-    def __init__(self) -> None:
-        super().__init__({})
-        self.conn = sqlite3.connect(":memory:")
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
-        )
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
-        )
-
-    @asynccontextmanager
-    async def connection(self):
-        yield self.conn
-
-    def get_connection_pool(self):
-        return self.conn
 
 
 class DummyVector(VectorStoreResource):
@@ -42,12 +21,18 @@ class DummyVector(VectorStoreResource):
 
 
 @pytest.fixture()
-async def memory_with_vector() -> Memory:
+async def memory_with_vector(postgres_dsn: str) -> Memory:
+    db = AsyncPGDatabase(postgres_dsn)
     mem = Memory(config={})
-    mem.database = SqliteDB()
+    mem.database = db
     mem.vector_store = DummyVector()
     await mem.initialize()
-    yield mem
+    try:
+        yield mem
+    finally:
+        async with db.connection() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._kv_table}")
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._history_table}")
 
 
 @pytest.mark.asyncio

--- a/tests/state/test_anthropomorphic_api.py
+++ b/tests/state/test_anthropomorphic_api.py
@@ -1,31 +1,11 @@
-import sqlite3
-from contextlib import asynccontextmanager
 import types
+
 import pytest
 
+from tests.conftest import AsyncPGDatabase
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
 from entity.resources import Memory
-from entity.resources.interfaces.database import DatabaseResource
-
-
-class InMemoryDB(DatabaseResource):
-    def __init__(self) -> None:
-        super().__init__({})
-        self.conn = sqlite3.connect(":memory:")
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
-        )
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
-        )
-
-    @asynccontextmanager
-    async def connection(self):
-        yield self.conn
-
-    def get_connection_pool(self):
-        return self.conn
 
 
 class DummyRegistries:
@@ -35,13 +15,19 @@ class DummyRegistries:
 
 
 @pytest.fixture()
-async def context() -> PluginContext:
+async def context(postgres_dsn: str) -> PluginContext:
+    db = AsyncPGDatabase(postgres_dsn)
     mem = Memory(config={})
-    mem.database = InMemoryDB()
+    mem.database = db
     mem.vector_store = None
     await mem.initialize()
     regs = DummyRegistries(mem)
-    return PluginContext(PipelineState(conversation=[]), regs)
+    try:
+        yield PluginContext(PipelineState(conversation=[]), regs)
+    finally:
+        async with db.connection() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._kv_table}")
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._history_table}")
 
 
 @pytest.mark.asyncio

--- a/tests/state/test_memory_advanced.py
+++ b/tests/state/test_memory_advanced.py
@@ -1,29 +1,8 @@
-import sqlite3
-from contextlib import asynccontextmanager
 import pytest
 
+from tests.conftest import AsyncPGDatabase
 from entity.resources import Memory
-from entity.resources.interfaces.database import DatabaseResource
 from entity.resources.interfaces.vector_store import VectorStoreResource
-
-
-class InMemoryDB(DatabaseResource):
-    def __init__(self) -> None:
-        super().__init__({})
-        self.conn = sqlite3.connect(":memory:")
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
-        )
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
-        )
-
-    @asynccontextmanager
-    async def connection(self):
-        yield self.conn
-
-    def get_connection_pool(self):
-        return self.conn
 
 
 class DummyVector(VectorStoreResource):
@@ -39,12 +18,18 @@ class DummyVector(VectorStoreResource):
 
 
 @pytest.fixture()
-async def memory() -> Memory:
+async def memory(postgres_dsn: str) -> Memory:
+    db = AsyncPGDatabase(postgres_dsn)
     mem = Memory(config={})
-    mem.database = InMemoryDB()
+    mem.database = db
     mem.vector_store = DummyVector()
     await mem.initialize()
-    yield mem
+    try:
+        yield mem
+    finally:
+        async with db.connection() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._kv_table}")
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._history_table}")
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_basic.py
+++ b/tests/test_memory_basic.py
@@ -1,31 +1,11 @@
-import sqlite3
-from contextlib import asynccontextmanager
 from datetime import datetime
 
 import pytest
+
+from tests.conftest import AsyncPGDatabase
 from entity.resources import Memory
-from entity.resources.interfaces.database import DatabaseResource
 from entity.resources.interfaces.vector_store import VectorStoreResource
 from entity.core.state import ConversationEntry
-
-
-class SqliteDB(DatabaseResource):
-    def __init__(self) -> None:
-        super().__init__({})
-        self.conn = sqlite3.connect(":memory:")
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
-        )
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
-        )
-
-    @asynccontextmanager
-    async def connection(self):
-        yield self.conn
-
-    def get_connection_pool(self):
-        return self.conn
 
 
 class DummyVector(VectorStoreResource):
@@ -45,21 +25,33 @@ class DummyVector(VectorStoreResource):
 
 
 @pytest.fixture()
-async def simple_memory() -> Memory:
+async def simple_memory(postgres_dsn: str) -> Memory:
+    db = AsyncPGDatabase(postgres_dsn)
     mem = Memory(config={})
-    mem.database = SqliteDB()
+    mem.database = db
     mem.vector_store = None
     await mem.initialize()
-    yield mem
+    try:
+        yield mem
+    finally:
+        async with db.connection() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._kv_table}")
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._history_table}")
 
 
 @pytest.fixture()
-async def vector_memory() -> Memory:
+async def vector_memory(postgres_dsn: str) -> Memory:
+    db = AsyncPGDatabase(postgres_dsn)
     mem = Memory(config={})
-    mem.database = SqliteDB()
+    mem.database = db
     mem.vector_store = DummyVector(["hello world"])
     await mem.initialize()
-    yield mem
+    try:
+        yield mem
+    finally:
+        async with db.connection() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._kv_table}")
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._history_table}")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- use AsyncPGDatabase in memory tests instead of Sqlite
- drop old Sqlite helper classes
- ensure tables are removed after each test

## Testing
- `poetry run poe test` *(fails: Command docker compose -f "/workspace/entity/tests/docker-compose.yml" ...)*

------
https://chatgpt.com/codex/tasks/task_e_6877b6b78d2083228c3a9fa67bb85850