### PR TITLE
Swap DummyVector for real vector store in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", f"http://localhost:{OLLAMA_PORT}"
 # -- Core imports (must follow sys.path change)
 from entity.infrastructure import DuckDBInfrastructure
 from entity.resources import Memory, LLM
+from plugins.builtin.resources.pg_vector_store import PgVectorStore
 from entity.resources.interfaces.duckdb_resource import DuckDBResource
 from entity.resources.interfaces.database import DatabaseResource
 from entity.core.resources.container import ResourceContainer
@@ -140,6 +141,27 @@ async def pg_memory(postgres_dsn: str) -> Memory:
         async with db.connection() as conn:
             await conn.execute(f"DROP TABLE IF EXISTS {mem._kv_table}")
             await conn.execute(f"DROP TABLE IF EXISTS {mem._history_table}")
+
+
+@pytest.fixture(scope="session")
+async def pg_vector_memory(postgres_dsn: str) -> Memory:
+    """Memory backed by Postgres with a PgVectorStore."""
+    _require_docker()
+    db = AsyncPGDatabase(postgres_dsn)
+    store = PgVectorStore({"table": "test_embeddings"})
+    store.database = db
+    mem = Memory({})
+    mem.database = db
+    mem.vector_store = store
+    await store.initialize()
+    await mem.initialize()
+    try:
+        yield mem
+    finally:
+        async with db.connection() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._kv_table}")
+            await conn.execute(f"DROP TABLE IF EXISTS {mem._history_table}")
+            await conn.execute(f"DROP TABLE IF EXISTS {store._table}")
 
 
 @pytest.fixture(scope="session")

--- a/tests/resources/test_memory.py
+++ b/tests/resources/test_memory.py
@@ -1,53 +1,14 @@
-import sqlite3
-from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 
 import pytest
 
 from entity.resources import Memory
-from entity.resources.interfaces.database import DatabaseResource
-from entity.resources.interfaces.vector_store import VectorStoreResource
 from entity.core.state import ConversationEntry
 
 
-class SqliteDB(DatabaseResource):
-    def __init__(self) -> None:
-        super().__init__({})
-        self.conn = sqlite3.connect(":memory:")
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
-        )
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
-        )
-
-    @asynccontextmanager
-    async def connection(self):
-        yield self.conn
-
-    def get_connection_pool(self):
-        return self.conn
-
-
-class DummyVector(VectorStoreResource):
-    def __init__(self) -> None:
-        super().__init__({})
-        self.entries: list[str] = []
-
-    async def add_embedding(self, text: str) -> None:
-        self.entries.append(text)
-
-    async def query_similar(self, query: str, k: int = 5):
-        return [t for t in self.entries if query in t][:k]
-
-
 @pytest.fixture()
-async def memory_with_vector() -> Memory:
-    mem = Memory(config={})
-    mem.database = SqliteDB()
-    mem.vector_store = DummyVector()
-    await mem.initialize()
-    yield mem
+async def memory_with_vector(pg_vector_memory: Memory) -> Memory:
+    yield pg_vector_memory
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_get_stats.py
+++ b/tests/test_cli_get_stats.py
@@ -7,15 +7,11 @@ from entity.core.state import ConversationEntry
 from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
 from entity.core.resources.container import ResourceContainer
 from entity.resources import Memory
-from tests.resources.test_memory import SqliteDB, DummyVector
 
 
 @pytest.mark.asyncio
-async def test_cli_get_conversation_stats(capsys) -> None:
-    mem = Memory(config={})
-    mem.database = SqliteDB()
-    mem.vector_store = DummyVector()
-    await mem.initialize()
+async def test_cli_get_conversation_stats(capsys, pg_memory: Memory) -> None:
+    mem = pg_memory
     await mem.add_conversation_entry(
         "c1",
         ConversationEntry(content="hi", role="user", timestamp=datetime.now()),


### PR DESCRIPTION
## Summary
- add `pg_vector_memory` fixture using the Postgres container
- update memory tests to rely on the real PgVectorStore
- simplify advanced memory tests and CLI stats test

## Testing
- `poetry run poe test` *(fails: Command docker compose)*

------
https://chatgpt.com/codex/tasks/task_e_6877b6bc44348322b348b707e1c6f7ce