### PR TITLE
Refactor tests to use real resources

### DIFF
--- a/tests/state/test_anthropomorphic_api.py
+++ b/tests/state/test_anthropomorphic_api.py
@@ -6,41 +6,19 @@ import pytest
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
 from entity.resources import Memory
-from entity.resources.interfaces.database import DatabaseResource
-
-
-class InMemoryDB(DatabaseResource):
-    def __init__(self) -> None:
-        super().__init__({})
-        self.conn = sqlite3.connect(":memory:")
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS memory_kv (key TEXT PRIMARY KEY, value TEXT)"
-        )
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS conversation_history (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)"
-        )
-
-    @asynccontextmanager
-    async def connection(self):
-        yield self.conn
-
-    def get_connection_pool(self):
-        return self.conn
-
-
-class DummyRegistries:
-    def __init__(self, mem: Memory) -> None:
-        self.resources = {"memory": mem}
-        self.tools = types.SimpleNamespace()
+from entity.core.resources.container import ResourceContainer
+from entity.core.registries import SystemRegistries, ToolRegistry, PluginRegistry
 
 
 @pytest.fixture()
-async def context() -> PluginContext:
-    mem = Memory(config={})
-    mem.database = InMemoryDB()
-    mem.vector_store = None
-    await mem.initialize()
-    regs = DummyRegistries(mem)
+async def context(memory_db: Memory) -> PluginContext:
+    container = ResourceContainer()
+    await container.add("memory", memory_db)
+    regs = SystemRegistries(
+        resources=container,
+        tools=ToolRegistry(),
+        plugins=PluginRegistry(),
+    )
     return PluginContext(PipelineState(conversation=[]), regs)
 
 

--- a/tests/test_custom_resource_access.py
+++ b/tests/test_custom_resource_access.py
@@ -7,6 +7,7 @@ from entity.resources.logging import LoggingResource
 from entity.resources.metrics import MetricsCollectorResource
 from entity.core.context import PluginContext
 from entity.core.state import PipelineState
+from entity.core.registries import SystemRegistries, ToolRegistry, PluginRegistry
 
 
 class DummyResource(AgentResource):
@@ -27,8 +28,10 @@ async def test_custom_resource_access():
     await container.build_all()
     dummy = container.get("chat_gpt")
 
-    registries = types.SimpleNamespace(
-        resources=container, tools=types.SimpleNamespace()
+    registries = SystemRegistries(
+        resources=container,
+        tools=ToolRegistry(),
+        plugins=PluginRegistry(),
     )
     context = PluginContext(PipelineState(conversation=[]), registries)
 

--- a/tests/test_logging_integration.py
+++ b/tests/test_logging_integration.py
@@ -8,6 +8,8 @@ from entity.core.state import PipelineState
 from entity.core.plugins import Plugin, ResourcePlugin
 from entity.core.stages import PipelineStage
 from entity.resources.logging import LoggingResource
+from entity.core.resources.container import ResourceContainer
+from entity.core.registries import SystemRegistries, ToolRegistry, PluginRegistry
 
 
 class DummyPlugin(Plugin):
@@ -36,12 +38,13 @@ async def test_plugin_logging(tmp_path):
     )
     await logger.initialize()
     plugin = DummyPlugin({})
+    container = ResourceContainer()
+    await container.add("logging", logger)
     plugin.logging = logger
-    registries = types.SimpleNamespace(
-        resources=types.SimpleNamespace(get=lambda _n: None),
-        tools=types.SimpleNamespace(),
-        plugins=None,
-        validators=None,
+    registries = SystemRegistries(
+        resources=container,
+        tools=ToolRegistry(),
+        plugins=PluginRegistry(),
     )
     state = PipelineState(conversation=[], pipeline_id="123")
     context = PluginContext(state, registries)

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -6,6 +6,8 @@ from entity.core.state import PipelineState
 from entity.core.stages import PipelineStage
 from entity.core.plugins import Plugin
 from entity.resources.metrics import MetricsCollectorResource
+from entity.core.resources.container import ResourceContainer
+from entity.core.registries import SystemRegistries, ToolRegistry
 
 
 class DummyPlugin(Plugin):
@@ -25,12 +27,11 @@ async def test_plugin_metrics_success():
     metrics = MetricsCollectorResource({})
     await metrics.initialize()
     plugin = DummyPlugin({})
+    container = ResourceContainer()
+    await container.add("metrics_collector", metrics)
     plugin.metrics_collector = metrics
-    registries = types.SimpleNamespace(
-        resources=types.SimpleNamespace(get=lambda _n: None),
-        tools=types.SimpleNamespace(),
-        plugins=None,
-        validators=None,
+    registries = SystemRegistries(
+        resources=container, tools=ToolRegistry(), plugins=PluginRegistry()
     )
     state = PipelineState(conversation=[], pipeline_id="123")
     context = PluginContext(state, registries)
@@ -54,12 +55,11 @@ async def test_plugin_metrics_failure():
     metrics = MetricsCollectorResource({})
     await metrics.initialize()
     plugin = FailPlugin({})
+    container = ResourceContainer()
+    await container.add("metrics_collector", metrics)
     plugin.metrics_collector = metrics
-    registries = types.SimpleNamespace(
-        resources=types.SimpleNamespace(get=lambda _n: None),
-        tools=types.SimpleNamespace(),
-        plugins=None,
-        validators=None,
+    registries = SystemRegistries(
+        resources=container, tools=ToolRegistry(), plugins=PluginRegistry()
     )
     state = PipelineState(conversation=[], pipeline_id="123")
     context = PluginContext(state, registries)

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -1,134 +1,32 @@
-import types
 import asyncio
-import json
 from datetime import datetime
-from contextlib import asynccontextmanager
-
-from entity.core.context import PluginContext  # noqa: E402
-from entity.core.state import PipelineState, ConversationEntry  # noqa: E402
-from entity.resources import Memory  # noqa: E402
-from entity.resources.interfaces.database import DatabaseResource
-from entity.resources.interfaces.duckdb_resource import DuckDBResource
-from entity.infrastructure.duckdb import DuckDBInfrastructure
-from entity.pipeline.errors import ResourceInitializationError  # noqa: E402
-import pytest  # noqa: E402
+import pytest
+from entity.core.context import PluginContext
+from entity.core.state import PipelineState, ConversationEntry
+from entity.resources import Memory
+from entity.pipeline.errors import ResourceInitializationError
+from entity.core.resources.container import ResourceContainer
+from entity.core.registries import SystemRegistries, ToolRegistry, PluginRegistry
 
 
-class DummyConnection:
-    def __init__(self, store: dict) -> None:
-        self.store = store
-
-    class _Cursor:
-        def __init__(self, rows: list[tuple] | None = None) -> None:
-            self.rows = rows or []
-
-        def fetchone(self) -> tuple | None:
-            return self.rows[0] if self.rows else None
-
-        def fetchall(self) -> list[tuple]:
-            return self.rows
-
-    def execute(
-        self, query: str, params: tuple | None = None
-    ) -> "DummyConnection._Cursor":
-        params = params or ()
-        if query.startswith("DELETE FROM conversation_history"):
-            cid = params[0] if isinstance(params, tuple) else params
-            self.store.setdefault("history", {}).pop(cid, None)
-            return self._Cursor()
-        if query.startswith("INSERT INTO conversation_history"):
-            cid, role, content, metadata, ts = params
-            self.store.setdefault("history", {}).setdefault(cid, []).append(
-                (role, content, json.loads(metadata), ts)
-            )
-            return self._Cursor()
-        if query.startswith("DELETE FROM memory_kv"):
-            key = params[0] if isinstance(params, tuple) else params
-            self.store.setdefault("kv", {}).pop(key, None)
-            return self._Cursor()
-        if query.startswith("INSERT OR REPLACE INTO memory_kv") or query.startswith(
-            "INSERT INTO memory_kv"
-        ):
-            key, value = params
-            self.store.setdefault("kv", {})[key] = json.loads(value)
-            return self._Cursor()
-        if query.startswith("SELECT value FROM memory_kv"):
-            key = params[0] if isinstance(params, tuple) else params
-            value = self.store.get("kv", {}).get(key)
-            return self._Cursor([(json.dumps(value),)] if value is not None else [])
-        if query.startswith(
-            "SELECT role, content, metadata, timestamp FROM conversation_history"
-        ):
-            cid = params[0] if isinstance(params, tuple) else params
-            rows = self.store.get("history", {}).get(cid, [])
-            return self._Cursor([(r[0], r[1], json.dumps(r[2]), r[3]) for r in rows])
-        return self._Cursor()
-
-    async def fetch(self, query: str, params: tuple) -> list:
-        if query.startswith(
-            "SELECT role, content, metadata, timestamp FROM conversation_history"
-        ):
-            cid = params[0] if isinstance(params, tuple) else params
-            return [
-                (role, content, metadata, ts)
-                for role, content, metadata, ts in self.store.get("history", {}).get(
-                    cid, []
-                )
-            ]
-        if query.startswith("SELECT value FROM memory_kv"):
-            key = params[0] if isinstance(params, tuple) else params
-            if key in self.store.get("kv", {}):
-                return [(json.dumps(self.store["kv"][key]),)]
-        return []
+async def make_context(memory: Memory) -> PluginContext:
+    regs = SystemRegistries(
+        resources=ResourceContainer(),
+        tools=ToolRegistry(),
+        plugins=PluginRegistry(),
+    )
+    await regs.resources.add("memory", memory)
+    return PluginContext(PipelineState(conversation=[]), regs)
 
 
-class DummyDatabase(DatabaseResource):
-    def __init__(self) -> None:
-        super().__init__({})
-        self.data: dict = {"history": {}, "kv": {}}
-
-    @asynccontextmanager
-    async def connection(self):
-        yield DummyConnection(self.data)
-
-
-class DummyPool(DummyDatabase):
-    pass
-
-
-class DummyRegistries:
-    def __init__(self, mem: Memory) -> None:
-        self.resources = {"memory": mem}
-        self.tools = types.SimpleNamespace()
-
-
-async def make_context(tmp_path) -> PluginContext:
-    state = PipelineState(conversation=[])
-    backend = DuckDBInfrastructure({"path": str(tmp_path / "mem.duckdb")})
-    await backend.initialize()
-    db = DuckDBResource({})
-    db.database = backend
-    mem = Memory(config={})
-    mem.database = db
-    mem.vector_store = None
-    await mem.initialize()
-    regs = DummyRegistries(mem)
-    return PluginContext(state, regs)
-
-
-async def run_test() -> None:
-    db = DummyDatabase()
-
-    mem1 = Memory(config={})
-    mem1.database = db
-    mem1.vector_store = None
-    await mem1.initialize()
+async def run_test(memory: Memory) -> None:
+    mem1 = memory
     await mem1.set("foo", "bar", user_id="default")
     entry = ConversationEntry("hi", "user", datetime.now())
     await mem1.save_conversation("cid", [entry], user_id="default")
 
-    mem2 = Memory(config={})
-    mem2.database = db
+    mem2 = Memory({})
+    mem2.database = mem1.database
     mem2.vector_store = None
     await mem2.initialize()
 
@@ -138,43 +36,20 @@ async def run_test() -> None:
 
 
 @pytest.mark.asyncio
-async def test_memory_roundtrip(tmp_path) -> None:
-    ctx = await make_context(tmp_path)
+async def test_memory_roundtrip(memory_db: Memory) -> None:
+    ctx = await make_context(memory_db)
     await ctx.remember("foo", "bar")
     assert await ctx.recall("foo") == "bar"
 
-    await run_test()
+    await run_test(memory_db)
 
 
-def test_memory_persists_between_instances() -> None:
-    asyncio.run(run_test())
-
-
-def test_memory_persists_with_connection_pool() -> None:
-    async def run_test() -> None:
-        pool = DummyPool()
-
-        mem1 = Memory(config={})
-        mem1.database = pool
-        mem1.vector_store = None
-        await mem1.initialize()
-        await mem1.set("foo", "bar", user_id="default")
-        entry = ConversationEntry("hi", "user", datetime.now())
-        await mem1.save_conversation("cid", [entry], user_id="default")
-
-        mem2 = Memory(config={})
-        mem2.database = pool
-        mem2.vector_store = None
-        await mem2.initialize()
-        assert await mem2.get("foo", user_id="default") == "bar"
-        history = await mem2.load_conversation("cid")
-        assert history == [entry]
-
-    asyncio.run(run_test())
+def test_memory_persists_between_instances(memory_db: Memory) -> None:
+    asyncio.run(run_test(memory_db))
 
 
 @pytest.mark.asyncio
 async def test_initialize_without_database_raises_error() -> None:
-    mem = Memory(config={})
+    mem = Memory({})
     with pytest.raises(ResourceInitializationError):
         await mem.initialize()


### PR DESCRIPTION
## Summary
- add PostgreSQL-backed ResourceContainer fixture
- rely on real resources in worker tests
- use ResourceContainer in helper fixtures
- clean up custom registry shims

## Testing
- `poetry run poe test` *(fails: docker compose unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6877b6bf64008322807edbac4d5a60af