### PR TITLE
Update docs about Docker test requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ documentation.
 
 ## Running Tests
 
+The test suite depends on **Docker** and the **`pytest-docker`** plugin. Ensure
+the services are up before running the tests:
+
+```bash
+docker compose up -d
+poetry run poe test
+```
+
 `pytest-docker` is required for the integration fixtures and Docker must be
 running. The plugin comes with the development dependencies:
 
@@ -69,13 +77,6 @@ pip install pytest-docker
 
 Before starting Docker, copy `.env.example` to `.env` and adjust the values for
 your local setup. The compose files read this file automatically.
-
-Start Docker and then run the poe task:
-
-```bash
-docker compose up -d  # ensure services are running
-poetry run poe test
-```
 
 `pytest-docker` exposes the `docker_ip` and `docker_services` fixtures used by
 the integration tests. Make sure the optional dependencies `pyyaml` and

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -36,6 +36,13 @@ This project uses **Poetry + Pytest** with a focus on **realistic, integration-d
   If it's missing, `tests/conftest.py` skips all Docker-based tests at import time
   with a clear message: "pytest-docker is required for Docker-based fixtures. Run 'poetry install --with dev' to install it."
 
+Start the services and run the tests:
+
+```bash
+docker compose up -d
+poetry run poe test
+```
+
 ---
 
 ## 🧼 Test Philosophy


### PR DESCRIPTION
## Summary
- document that tests rely on Docker and pytest-docker
- add the same note in `tests/AGENTS.md`

## Testing
- `poetry run ruff check --fix src tests` *(fails: F841 unused variable regs)*
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture`
- `poetry run poe test-plugins` *(fails: 2 failed)*
- `poetry run poe test-resources`
- `poetry run poe test` *(fails: 15 failed, 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877b6c3c32c8322bd1cb532197c435c