### PR TITLE
Fix builder resource registration

### DIFF
--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -136,6 +136,9 @@ class _AgentBuilder:
     ) -> None:
         """Validate and register ``plugin`` for its resolved stages."""
 
+        # Ensure built-in resources exist for dependency validation
+        self._register_default_resources()
+
         if not hasattr(plugin, "_execute_impl") or not callable(
             getattr(plugin, "_execute_impl")
         ):


### PR DESCRIPTION
## Summary
- ensure default resources are registered before validating plugin dependencies

## Testing
- `poetry run pytest tests/test_builder_logging_injection.py` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c377f95c832281d95ccac376095f