### PR TITLE
Fix config validation for tool registry

### DIFF
--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -90,7 +90,7 @@ class ServerConfig(BaseModel):
 class ToolRegistryConfig(BaseModel):
     """Options controlling tool execution."""
 
-    concurrency_limit: int = 5
+    concurrency_limit: int = Field(ge=1, default=5)
 
 
 class CircuitBreakerConfig(BaseModel):


### PR DESCRIPTION
## Summary
- ensure `concurrency_limit` in `ToolRegistryConfig` is a positive integer

## Testing
- `poetry run pytest tests/test_config/test_invalid_configs.py -q` *(fails: docker compose not available)*

------
https://chatgpt.com/codex/tasks/task_e_6877c37e8ad88322a13f7ec2566ce838