### PR TITLE
Improve upgrade compatibility check

### DIFF
--- a/src/entity/core/compatibility.py
+++ b/src/entity/core/compatibility.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Simple version compatibility matrix."""
 
-from typing import Dict, List
+from typing import Dict, List, Set
 
 # Map current version -> list of supported upgrade targets
 COMPATIBILITY_MATRIX: Dict[str, List[str]] = {
@@ -16,8 +16,22 @@ def register_compatibility(current: str, targets: List[str]) -> None:
 
 
 def is_upgrade_supported(current: str, target: str) -> bool:
-    """Return ``True`` if ``current`` can upgrade to ``target``."""
-    return target in COMPATIBILITY_MATRIX.get(current, [])
+    """Return ``True`` if ``current`` can upgrade to ``target``.
+
+    Performs a breadth-first search across registered upgrade paths so that
+    indirect upgrades are also supported.
+    """
+    visited: Set[str] = set()
+    queue = [current]
+    while queue:
+        version = queue.pop(0)
+        if version == target:
+            return True
+        for nxt in COMPATIBILITY_MATRIX.get(version, []):
+            if nxt not in visited:
+                visited.add(nxt)
+                queue.append(nxt)
+    return False
 
 
 __all__ = ["COMPATIBILITY_MATRIX", "register_compatibility", "is_upgrade_supported"]

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -6,5 +6,7 @@ from entity.core.compatibility import (
 
 def test_upgrade_matrix() -> None:
     register_compatibility("0.0.1", ["0.0.2"])
+    register_compatibility("0.0.2", ["0.1.0"])
     assert is_upgrade_supported("0.0.1", "0.0.2")
+    assert is_upgrade_supported("0.0.1", "0.1.0")
     assert not is_upgrade_supported("0.0.1", "1.0.0")


### PR DESCRIPTION
## Summary
- add BFS search for upgrade path in `compatibility.py`
- extend compatibility test to check multi-step upgrades

## Testing
- `poetry run pytest tests/test_compatibility.py -q` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c37e07188322a9946df4d9c07766