### PR TITLE
Improve resource lifecycle metrics

### DIFF
--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -282,17 +282,21 @@ class ResourcePlugin(Plugin):
     stages: List[PipelineStage] = []
     dependencies: List[str] = []
 
-    async def _on_initialize(self) -> None:
-        async def _noop() -> None:
-            return None
+    async def initialize(self) -> None:
+        if self.is_initialized and not self.is_shutdown:
+            return
 
-        await self._track_operation(operation="initialize", func=_noop)
+        await self._track_operation(operation="initialize", func=self._on_initialize)
+        self.is_initialized = True
+        self.is_shutdown = False
 
-    async def _on_shutdown(self) -> None:
-        async def _noop() -> None:
-            return None
+    async def shutdown(self) -> None:
+        if self.is_shutdown:
+            return
 
-        await self._track_operation(operation="shutdown", func=_noop)
+        await self._track_operation(operation="shutdown", func=self._on_shutdown)
+        self.is_initialized = False
+        self.is_shutdown = True
 
     async def _track_operation(
         self,


### PR DESCRIPTION
## Summary
- track resource initialization and shutdown with metrics

## Testing
- `poetry run pytest tests/core/test_resource_plugin_observability.py -q` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c36359b48322af51ee40af8fbff4