### PR TITLE
Handle missing Docker in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,10 +44,13 @@ from plugins.builtin.resources.pg_vector_store import PgVectorStore
 from entity.resources.interfaces.duckdb_resource import DuckDBResource
 from entity.resources.interfaces.database import DatabaseResource
 from entity.core.resources.container import ResourceContainer
+import shutil
 
 
 def _require_docker():
     pytest.importorskip("pytest_docker", reason=REQUIRE_PYTEST_DOCKER)
+    if shutil.which("docker") is None:
+        pytest.skip("Docker binary not available", allow_module_level=True)
 
 
 def _socket_open(host: str, port: int) -> bool:

--- a/tests/resources/test_memory.py
+++ b/tests/resources/test_memory.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 
-from tests.conftest import AsyncPGDatabase
 import pytest
 
 from entity.resources import Memory

--- a/tests/state/test_anthropomorphic_api.py
+++ b/tests/state/test_anthropomorphic_api.py
@@ -1,5 +1,3 @@
-import types
-
 import pytest
 
 from entity.core.context import PluginContext

--- a/tests/test_cli_get_stats.py
+++ b/tests/test_cli_get_stats.py
@@ -1,7 +1,6 @@
 import pytest
 from datetime import datetime
 
-from tests.conftest import AsyncPGDatabase
 from entity.cli import EntityCLI
 from entity.core.agent import Agent, _AgentRuntime
 from entity.core.state import ConversationEntry

--- a/tests/test_custom_resource_access.py
+++ b/tests/test_custom_resource_access.py
@@ -1,4 +1,3 @@
-import types
 import pytest
 
 from entity.core.resources.container import ResourceContainer

--- a/tests/test_logging_integration.py
+++ b/tests/test_logging_integration.py
@@ -1,5 +1,4 @@
 import json
-import types
 
 import pytest
 

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -1,4 +1,3 @@
-import types
 import pytest
 
 from entity.core.context import PluginContext

--- a/tests/test_plugin_context_advanced.py
+++ b/tests/test_plugin_context_advanced.py
@@ -1,4 +1,3 @@
-import types
 from datetime import datetime
 import pytest
 


### PR DESCRIPTION
## Summary
- adjust docker requirement helper to skip when Docker is unavailable
- run ruff fix removing unused imports in tests

## Testing
- `poetry run pytest tests/architecture/test_plugin_taxonomy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c35ea5f083228322b048e5f12c8c