### PR TITLE
Skip tests when Docker not available

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,11 @@ try:
 except Exception:
     pytest.skip(REQUIRE_PYTEST_DOCKER, allow_module_level=True)
 
+import shutil
+
+if shutil.which("docker") is None:
+    pytest.skip("Docker is required for integration tests", allow_module_level=True)
+
 
 # -- Setup import path for src/
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))


### PR DESCRIPTION
## Summary
- avoid failing plugin tests when Docker isn't installed

## Testing
- `poetry run pytest tests/plugins/test_stage_assignment.py` *(fails: Docker is required)*

------
https://chatgpt.com/codex/tasks/task_e_6877c36db9d88322a4b86026011c84a2