### PR TITLE
Fix pg_memory fixture to require docker only when needed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,15 @@ def wait_for_port(host: str, port: int, timeout: float = 30.0):
 
 
 @pytest.fixture(autouse=True)
-async def _clear_pg_memory(pg_memory: Memory):
+async def _clear_pg_memory(request: pytest.FixtureRequest, pg_memory: Memory):
+    """Clear Postgres-backed memory only for tests that request it."""
+
+    if (
+        "pg_memory" not in request.fixturenames
+        and "pg_vector_memory" not in request.fixturenames
+    ):
+        return
+
     async with pg_memory.database.connection() as conn:
         await conn.execute(f"DELETE FROM {pg_memory._kv_table}")
         await conn.execute(f"DELETE FROM {pg_memory._history_table}")


### PR DESCRIPTION
## Summary
- update `_clear_pg_memory` fixture so tests without postgres don't require docker

## Testing
- `poetry run pytest tests/plugins/test_tool_intents.py -vv` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c3710d8083229051313cdcd95d61