### PR TITLE
Fix plugin shutdown guard

### DIFF
--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -189,7 +189,7 @@ class Plugin(BasePlugin):
     async def shutdown(self) -> None:
         """Release any resources held by the plugin."""
 
-        if self.is_shutdown:
+        if not self.is_initialized or self.is_shutdown:
             return
 
         await self._on_shutdown()


### PR DESCRIPTION
## Summary
- prevent shutdown from running before initialization

## Testing
- `poetry run pytest tests/plugins/test_lifecycle_state.py` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6877c36c858083228ad736f4a1ecac7e