### PR TITLE
Fix workflow composition stage mapping

### DIFF
--- a/src/entity/workflows/base.py
+++ b/src/entity/workflows/base.py
@@ -41,6 +41,7 @@ class Workflow(BaseModel):
             formatted = [str(p).format(**params) for p in plugins]
             self._assign_to(processed, stage, formatted)
         super().__init__(stages=processed)
+        object.__setattr__(self, "stage_map", processed)
         if registry is not None:
             self.validate_plugins(registry)
 

--- a/src/entity/workflows/compose.py
+++ b/src/entity/workflows/compose.py
@@ -17,7 +17,9 @@ def compose_workflows(*workflows: Workflow) -> Workflow:
     for wf in workflows:
         for stage, plugins in wf.stages.items():
             mapping.setdefault(stage, []).extend(list(plugins))
-    return Workflow(mapping)
+    wf_obj = Workflow(mapping)
+    wf_obj.stage_map = mapping
+    return wf_obj
 
 
 def merge_workflows(*workflows: Workflow) -> Workflow:
@@ -27,4 +29,6 @@ def merge_workflows(*workflows: Workflow) -> Workflow:
     for wf in workflows:
         for stage, plugins in wf.stages.items():
             mapping[stage] = list(plugins)
-    return Workflow(mapping)
+    wf_obj = Workflow(mapping)
+    wf_obj.stage_map = mapping
+    return wf_obj


### PR DESCRIPTION
## Summary
- ensure `Workflow` instances expose `stage_map` when built dynamically
- persist stage mappings in `compose_workflows` and `merge_workflows`

## Testing
- `poetry run ruff check --fix src/entity/workflows/base.py src/entity/workflows/compose.py`
- `poetry run mypy src/entity/workflows/base.py src/entity/workflows/compose.py`
- `poetry run bandit -r src/entity/workflows/base.py src/entity/workflows/compose.py`
- `poetry run vulture src/entity/workflows/base.py src/entity/workflows/compose.py`
- `poetry run unimport --remove-all src/entity/workflows/base.py src/entity/workflows/compose.py` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine not awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine not awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture` *(fails: Docker daemon not running)*
- `poetry run poe test-plugins` *(fails: Docker daemon not running)*
- `poetry run poe test-resources` *(fails: Docker daemon not running)*


------
https://chatgpt.com/codex/tasks/task_e_6877c3693cc08322998a5dad70de1e3d