### PR TITLE
Skip docker dependency for template tests

### DIFF
--- a/tests/infrastructure/conftest.py
+++ b/tests/infrastructure/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+# Override heavy fixtures from tests.conftest that require Docker
+
+
+@pytest.fixture(autouse=True)
+async def _clear_pg_memory():
+    # No-op fixture to avoid Docker dependencies in simple template tests
+    yield


### PR DESCRIPTION
## Summary
- avoid Docker dependencies when running template tests

## Testing
- `poetry run pytest tests/infrastructure/test_templates.py`

------
https://chatgpt.com/codex/tasks/task_e_6877c36643a8832289061a9cdc64c148