### PR TITLE
Handle missing Docker in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import sys
 import asyncio
 import socket
+import shutil
 from pathlib import Path
 from contextlib import asynccontextmanager
 
@@ -48,6 +49,8 @@ from entity.core.resources.container import ResourceContainer
 
 def _require_docker():
     pytest.importorskip("pytest_docker", reason=REQUIRE_PYTEST_DOCKER)
+    if shutil.which("docker") is None:
+        pytest.skip("Docker executable not found", allow_module_level=True)
 
 
 def _socket_open(host: str, port: int) -> bool:


### PR DESCRIPTION
## Summary
- ensure integration tests skip when Docker binary is missing

## Testing
- `poetry run pytest tests/infrastructure/test_infrastructure_attrs.py`


------
https://chatgpt.com/codex/tasks/task_e_6877c363dcfc832287924abbb744750b