### PR TITLE
Improve config extends path resolution

### DIFF
--- a/src/entity/config/environment.py
+++ b/src/entity/config/environment.py
@@ -78,9 +78,14 @@ def _load_with_extends(path: Path) -> dict[str, Any]:
     data = yaml.safe_load(path.read_text()) or {}
     parent = data.pop("extends", None)
     if parent:
+        parent = _interpolate(parent)
         parent_path = Path(parent)
+        if not parent_path.is_absolute():
+            candidate = path.parent / parent_path
+            parent_path = candidate if candidate.exists() else parent_path
         if not parent_path.exists():
-            parent_path = path.parent / f"{parent}.yaml"
+            alt = path.parent / f"{parent}.yaml"
+            parent_path = alt if alt.exists() else parent_path
         if parent_path.exists():
             base = _load_with_extends(parent_path)
             data = _merge(base, data)


### PR DESCRIPTION
## Summary
- allow environment variable interpolation in config `extends` paths

## Testing
- `poetry run pytest tests/config/test_loader.py -q` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c35f56f8832299c3ebfccf398fd1