### PR TITLE
Fix logging config validation

### DIFF
--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -159,6 +159,9 @@ class LogOutputConfig(BaseModel):
     max_size: int | None = None
     backup_count: int | None = None
 
+    class Config:
+        extra = "forbid"
+
 
 class LoggingConfig(BaseModel):
     """Settings controlling the :class:`LoggingResource`."""
@@ -166,6 +169,9 @@ class LoggingConfig(BaseModel):
     host_name: str = Field(default_factory=socket.gethostname)
     process_id: int = Field(default_factory=os.getpid)
     outputs: list[LogOutputConfig] = Field(default_factory=lambda: [LogOutputConfig()])
+
+    class Config:
+        extra = "forbid"
 
 
 class EntityConfig(BaseModel):


### PR DESCRIPTION
## Summary
- enforce `extra='forbid'` for `LoggingConfig` and `LogOutputConfig`
- update validation to reject unexpected keys

## Testing
- `poetry run pytest tests/test_builtin_resource_configs.py` *(fails: Docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_6877c37918ac8322bc30478c70dd2011