### PR TITLE
Improve plugin context error detail

### DIFF
--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -245,6 +245,7 @@ class PluginContext:
                 self.current_stage,
                 self.current_plugin or "unknown",
                 f"say may only be called in OUTPUT stage, not {self.current_stage}",
+                context=self._state.to_dict(),
             )
         self._state.response = content
         self.add_conversation_entry(


### PR DESCRIPTION
## Summary
- include pipeline state snapshot when a plugin misuses `context.say`

## Testing
- `poetry run pytest tests/integration/test_error_handling.py -q` *(fails: Docker is required for integration tests)*
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6877c3662830832295a7b7c70a7f54cc