### PR TITLE
Simplify docker test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,11 @@ documentation.
 
 ## Running Tests
 
-The test suite depends on **Docker** and the **`pytest-docker`** plugin. Ensure
-the services are up before running the tests:
+The test suite depends on **Docker** and the **`pytest-docker`** plugin. Use the
+provided Poe task to spin up services and run the tests:
 
 ```bash
-docker compose up -d
-poetry run poe test
+poetry run poe test-with-docker
 ```
 
 `pytest-docker` is required for the integration fixtures and Docker must be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,10 @@ unit = { cmd = "pytest tests/unit", env = { PYTHONPATH = "src" } }
 integration = { cmd = "pytest tests/integration", env = { PYTHONPATH = "src" } }
 e2e = { cmd = "pytest tests/e2e", env = { PYTHONPATH = "src" } }
 
+start-test-services = { cmd = "docker compose -f tests/docker-compose.yml up -d" }
+stop-test-services = { cmd = "docker compose -f tests/docker-compose.yml down -v" }
+test-with-docker = ["start-test-services", "test", "stop-test-services"]
+
 setup-dev = { cmd = "poetry install --with dev" }
 
 [tool.poe.tasks.lint]

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -36,11 +36,10 @@ This project uses **Poetry + Pytest** with a focus on **realistic, integration-d
   If it's missing, `tests/conftest.py` skips all Docker-based tests at import time
   with a clear message: "pytest-docker is required for Docker-based fixtures. Run 'poetry install --with dev' to install it."
 
-Start the services and run the tests:
+Start the services and run the tests in one step:
 
 ```bash
-docker compose up -d
-poetry run poe test
+poetry run poe test-with-docker
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add `test-with-docker` poe task
- recommend `poetry run poe test-with-docker` in docs
- update tests guide for new docker task

## Testing
- `poetry run black src tests`

------
https://chatgpt.com/codex/tasks/task_e_6877e417a89483229d829075be093594