### PR TITLE
Add test-with-docker shell wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ documentation.
 ## Running Tests
 
 The test suite depends on **Docker** and the **`pytest-docker`** plugin. Use the
-provided Poe task to spin up services and run the tests:
+provided Poe task to spin up services and run the tests. The task now runs a
+shell script that tears down containers even if the tests fail:
 
 ```bash
 poetry run poe test-with-docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ e2e = { cmd = "pytest tests/e2e", env = { PYTHONPATH = "src" } }
 
 start-test-services = { cmd = "docker compose -f tests/docker-compose.yml up -d" }
 stop-test-services = { cmd = "docker compose -f tests/docker-compose.yml down -v" }
-test-with-docker = ["start-test-services", "test", "stop-test-services"]
+test-with-docker = { cmd = "bash scripts/test_with_docker.sh" }
 
 setup-dev = { cmd = "poetry install --with dev" }
 

--- a/scripts/test_with_docker.sh
+++ b/scripts/test_with_docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose -f tests/docker-compose.yml up -d
+trap 'docker compose -f tests/docker-compose.yml down -v' EXIT
+
+PYTHONPATH=src pytest "$@"

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -36,7 +36,8 @@ This project uses **Poetry + Pytest** with a focus on **realistic, integration-d
   If it's missing, `tests/conftest.py` skips all Docker-based tests at import time
   with a clear message: "pytest-docker is required for Docker-based fixtures. Run 'poetry install --with dev' to install it."
 
-Start the services and run the tests in one step:
+Start the services and run the tests in one step. The Poe task now calls a
+shell script that shuts down containers on exit:
 
 ```bash
 poetry run poe test-with-docker


### PR DESCRIPTION
## Summary
- run pytest through a shell script that manages Docker
- call the script from the `test-with-docker` Poe task
- document the new behaviour in README and tests guidelines

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture` *(fails: Docker is required)*
- `poetry run poe test-plugins` *(fails: Docker is required)*
- `poetry run poe test-resources` *(fails: Docker is required)*
- `poetry run poe test` *(fails: Docker is required)*

------
https://chatgpt.com/codex/tasks/task_e_6877ecc4b04c832287ea5ebc61722968