### PR TITLE
Replace prints with logging in memory resource

### DIFF
--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List
 import inspect
 import json
+import logging
 
 from .base import AgentResource
 from .interfaces.database import DatabaseResource as DatabaseInterface
@@ -17,6 +18,8 @@ from entity.config.models import MemoryConfig
 from pydantic import ValidationError
 from ..core.state import ConversationEntry
 from entity.pipeline.errors import InitializationError, ResourceInitializationError
+
+logger = logging.getLogger(__name__)
 
 
 class Memory(AgentResource):
@@ -421,8 +424,8 @@ async def _execute(conn: Any, sql: str, params: Any | None = None) -> Any:
     style = _detect_paramstyle(conn)
     sql = _convert_placeholders(sql, style)
 
-    print(f"🧪 SQL: {sql}")
-    print(f"🧪 Params: {params}")
+    logger.debug("SQL: %s", sql)
+    logger.debug("Params: %s", params)
 
     asyncpg_like = hasattr(conn, "fetch")
     is_select = sql.lstrip().lower().startswith(("select", "with"))


### PR DESCRIPTION
## Summary
- use `logging.getLogger` in `memory.py`
- log SQL statements with `logger.debug`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: coroutine was never awaited)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: ModuleNotFoundError)*
- `poetry run poe test-architecture` *(fails: Docker is required for integration tests)*
- `poetry run poe test-plugins` *(fails: Docker is required for integration tests)*
- `poetry run poe test-resources` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_6877f1c280f48322b3fe8d6d70d54331