### PR TITLE
Update test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,18 @@ If you installed dependencies individually, install the plugin directly:
 pip install pytest-docker
 ```
 
+### Docker Requirement for Integration Tests
+
+Integration tests rely on containers defined in `tests/docker-compose.yml`.
+If Docker isn't running, `pytest-docker` automatically marks these tests as
+skipped so the rest of the suite can continue.
+
 Before starting Docker, copy `.env.example` to `.env` and adjust the values for
 your local setup. The compose files read this file automatically.
 
 ### Integration Tests & Docker
 
-Integration tests spin up containers defined in `tests/docker-compose.yml`. If
-Docker isn’t available, `pytest-docker` automatically skips these tests so the
-rest of the suite can still run.
+Integration tests spin up containers defined in `tests/docker-compose.yml`.
 
 `pytest-docker` exposes the `docker_ip` and `docker_services` fixtures used by
 the integration tests. Make sure the optional dependencies `pyyaml` and


### PR DESCRIPTION
## Summary
- clarify that integration tests depend on Docker and will skip when it's missing

## Testing
- `poetry run black src tests` *(fails: cannot parse memory.py)*
- `poetry run ruff check --fix src tests` *(fails: syntax errors in memory.py)*
- `poetry run mypy src` *(fails: invalid syntax in memory.py)*
- `poetry run bandit -r src`
- `poetry run vulture src tests` *(fails: invalid syntax in memory.py)*
- `poetry run unimport -r src tests` *(fails: invalid syntax in memory.py)*
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: invalid syntax in memory.py)*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: invalid syntax in memory.py)*
- `poetry run python -m src.entity.core.registry_validator` *(fails: invalid syntax in memory.py)*
- `poetry run poe test-architecture` *(tests skipped: Docker is required)*
- `poetry run poe test-plugins` *(tests skipped: Docker is required)*
- `poetry run poe test-resources` *(tests skipped: Docker is required)*
- `poetry run poe test` *(tests skipped: Docker is required)*

------
https://chatgpt.com/codex/tasks/task_e_6877f60889e48322a08b16e8659561b1