### PR TITLE
Add unimport to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ pytest-postgresql = "^7.0.2"
 pytest-docker = "^3.2.3"
 sphinxcontrib-mermaid = "^1.0.0"
 vulture = "^2.14"
+unimport = "^1.6"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- add `unimport` to the dev dependency list

## Testing
- `poetry run black . --check`
- `poetry install --with dev` *(fails: pyproject changed significantly)*
- `poetry lock` *(fails: version solving failed for unimport)*
- `poetry run bandit -r src/entity/resources/memory.py` *(fails: command not found)*
- `poetry run vulture src/entity/resources/memory.py` *(fails: command not found)*
- `poetry run unimport --remove-all src/entity/resources/memory.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877fbb250e08322b30801f04b219c96