### PR TITLE
Fix config validation, add memory retrieval prompt

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -35,10 +35,12 @@ plugins:
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
-      dependencies: [database, vector_store]
+      dependencies: [database]
     llm:
       type: entity.resources.llm:LLM
       provider: echo
+    logging:
+      type: entity.resources.logging:LoggingResource
     storage:
       type: entity.resources.storage:Storage
   # filesystem:
@@ -69,7 +71,7 @@ plugins:
   tools:
     calculator:
       type: user_plugins.tools.calculator_tool:CalculatorTool
-  adapters:
+  adapters: {}
     # http:
     #   type: plugins.builtin.adapters.http:HTTPAdapter
     #   stages: [parse, deliver]

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -35,10 +35,12 @@ plugins:
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
-      dependencies: [database, vector_store]
+      dependencies: [database]
     llm:
       type: entity.resources.llm:LLM
       provider: echo
+    logging:
+      type: entity.resources.logging:LoggingResource
     storage:
       type: entity.resources.storage:Storage
   # filesystem:
@@ -70,7 +72,7 @@ plugins:
     calculator:
       type: user_plugins.tools.calculator_tool:CalculatorTool
       precision: 10
-  adapters:
+  adapters: {}
     # http:
     #   type: plugins.builtin.adapters.http:HTTPAdapter
     #   stages: [parse, deliver]

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -27,14 +27,16 @@ plugins:
   agent_resources:
     memory:
       type: entity.resources.memory:Memory
-      dependencies: [database, vector_store]
+      dependencies: [database]
+    logging:
+      type: entity.resources.logging:LoggingResource
     # storage:
     #   type: plugins.builtin.resources.storage_resource:StorageResource
   custom_resources: {}
   tools:
     calculator:
       type: user_plugins.tools.calculator_tool:CalculatorTool
-  adapters:
+  adapters: {}
     # http:
     #   type: plugins.builtin.adapters.http:HTTPAdapter
     #   auth_tokens:

--- a/src/entity/cli/__init__.py
+++ b/src/entity/cli/__init__.py
@@ -69,6 +69,7 @@ class CLIArgs:
     user_id: Optional[str] = None
     message: Optional[str] = None
     files: Optional[list[str]] = None
+    strict_stages: bool = False
 
 
 class EntityCLI:
@@ -657,7 +658,7 @@ class EntityCLI:
             overlay = Path("config") / f"{env}.yaml"
         return load_config(config_path, overlay)
 
-    async def _verify_plugins(self, config_path: str) -> int:
+    def _verify_plugins(self, config_path: str) -> int:
         async def _run() -> int:
             from entity.pipeline import SystemInitializer
             import yaml

--- a/user_plugins/prompts/__init__.py
+++ b/user_plugins/prompts/__init__.py
@@ -4,6 +4,7 @@ from .chain_of_thought import ChainOfThoughtPrompt
 from .complex_prompt import ComplexPrompt
 from .conversation_history import ConversationHistory
 from .intent_classifier import IntentClassifierPrompt
+from .memory_retrieval import MemoryRetrievalPrompt
 from .pii_scrubber import PIIScrubberPrompt
 from .react_prompt import ReActPrompt
 
@@ -13,5 +14,6 @@ __all__ = [
     "ComplexPrompt",
     "ChainOfThoughtPrompt",
     "ConversationHistory",
+    "MemoryRetrievalPrompt",
     "PIIScrubberPrompt",
 ]

--- a/user_plugins/prompts/memory_retrieval.py
+++ b/user_plugins/prompts/memory_retrieval.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import List
+
+from entity.core.plugins import PromptPlugin
+from entity.core.context import PluginContext
+from entity.core.stages import PipelineStage
+from entity.resources.memory import Memory
+
+
+class MemoryRetrievalPrompt(PromptPlugin):
+    """Retrieve similar conversation snippets from ``Memory``."""
+
+    dependencies = ["memory"]
+    stages = [PipelineStage.THINK]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        memory: Memory | None = context.get_memory()
+        if memory is None:
+            return
+
+        last_user = next(
+            (
+                entry.content
+                for entry in reversed(context.conversation())
+                if entry.role == "user"
+            ),
+            "",
+        )
+
+        k = int(self.config.get("k", 3))
+        snippets: List[str] = await memory.search_similar(last_user, k)
+        max_length = int(self.config.get("max_context_length", 4000))
+        joined = "\n".join(snippets)[:max_length]
+        await context.think("retrieved_memory", joined)


### PR DESCRIPTION
## Summary
- fix `entity-cli` verify command
- add new MemoryRetrievalPrompt
- register prompt in user plugin package
- include logging resource in configs
- ensure adapter sections are valid dicts

## Testing
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`


------
https://chatgpt.com/codex/tasks/task_e_6877fbb29100832297e82f39ddf687ee