### PR TITLE
Fix Ollama port conflicts in tests

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     image: ollama/ollama
     privileged: true
     ports:
-      - "11434:11434"
+      - "11434"
     volumes:
       - ollama_data:/root/.ollama
     environment:


### PR DESCRIPTION
## Summary
- use Docker dynamic host port mapping for the Ollama service

## Testing
- `ruff check --fix src tests`
- `mypy src`
- `pytest tests/architecture/test_dependency_injection.py::test_memory_user_isolation -x` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_6877fe4409c48322bcaf8e9cf042c508