### PR TITLE
Fix async commit in memory resource

### DIFF
--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List
 import json
 import logging
+import inspect
 
 from .base import AgentResource
 from .interfaces.database import DatabaseResource as DatabaseInterface
@@ -36,11 +37,14 @@ class Memory(AgentResource):
         self._kv_table = self.config.get("kv_table", "memory_kv")
         self._history_table = self.config.get("history_table", "conversation_history")
 
-    def _maybe_commit(self, conn: Any) -> None:
+    async def _maybe_commit(self, conn: Any) -> None:
         """Commit writes when supported by the connection."""
         commit = getattr(conn, "commit", None)
-        if callable(commit):
-            commit()
+        if not callable(commit):
+            return
+        result = commit()
+        if inspect.isawaitable(result):
+            await result
 
     async def initialize(self) -> None:
         if self.database is None:
@@ -56,7 +60,7 @@ class Memory(AgentResource):
                 conn,
                 f"CREATE TABLE IF NOT EXISTS {self._history_table} (conversation_id TEXT, role TEXT, content TEXT, metadata TEXT, timestamp TEXT)",
             )
-            self._maybe_commit(conn)
+            await self._maybe_commit(conn)
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None
@@ -79,7 +83,7 @@ class Memory(AgentResource):
             return
         async with self.database.connection() as conn:
             await _execute(conn, f"DELETE FROM {self._kv_table}")
-            self._maybe_commit(conn)
+            await self._maybe_commit(conn)
 
     # ------------------------------------------------------------------
     # Conversation helpers
@@ -112,7 +116,7 @@ class Memory(AgentResource):
                         entry.timestamp.isoformat(),
                     ),
                 )
-            self._maybe_commit(conn)
+            await self._maybe_commit(conn)
 
     async def load_conversation(
         self, pipeline_id: str, *, user_id: str = "default"
@@ -212,7 +216,7 @@ class Memory(AgentResource):
                 sql = f"INSERT OR REPLACE INTO {self._kv_table} VALUES (?, ?)"
 
             await _execute(conn, sql, (namespaced_key, json.dumps(value)))
-            self._maybe_commit(conn)
+            await self._maybe_commit(conn)
 
     async def fetch_persistent(
         self, key: str, default: Any = None, *, user_id: str = "default"
@@ -241,7 +245,7 @@ class Memory(AgentResource):
                 f"DELETE FROM {self._kv_table} WHERE key = ?",
                 (namespaced_key,),
             )
-            self._maybe_commit(conn)
+            await self._maybe_commit(conn)
 
     async def add_conversation_entry(
         self, pipeline_id: str, entry: ConversationEntry, *, user_id: str = "default"
@@ -262,7 +266,7 @@ class Memory(AgentResource):
                     entry.timestamp.isoformat(),
                 ),
             )
-            self._maybe_commit(conn)
+            await self._maybe_commit(conn)
         if self.vector_store is not None:
             await self.vector_store.add_embedding(entry.content)
 


### PR DESCRIPTION
## Summary
- await async database commit operations in Memory
- run configuration verifications for dev and prod

## Testing
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`


------
https://chatgpt.com/codex/tasks/task_e_6877fe0861cc83229bcec697449857d3