### PR TITLE
Fix Postgres port clash in docker tests

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD:-dev}
       POSTGRES_DB: ${DB_NAME:-entity_dev}
     ports:
-      - "55432:5432"
+      - "0:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Summary
- free up Postgres port in test docker-compose by letting Docker choose the host port

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src` *(failed: Command not found)*
- `poetry run vulture src tests` *(failed: Command not found)*
- `poetry run unimport --remove-all src tests` *(failed: Command not found)*
- `poetry run entity-cli --config config/dev.yaml verify` *(failed: ModuleNotFoundError)*
- `poetry run entity-cli --config config/prod.yaml verify` *(failed: ModuleNotFoundError)*
- `poetry run python -m src.entity.core.registry_validator` *(failed: ModuleNotFoundError)*
- `poetry run pytest tests/test_architecture -q` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687800b24a8c832286098780db49d81e