### PR TITLE
Remove conflict markers in memory resource

### DIFF
--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -5,11 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
 import json
-<<<<<<< HEAD
-=======
-import logging
 import inspect
->>>>>>> pr-1739
 
 from .base import AgentResource
 from .interfaces.database import DatabaseResource as DatabaseInterface


### PR DESCRIPTION
## Summary
- fix leftover merge conflict markers in `Memory` resource

## Testing
- `poetry run poe test-with-docker -x` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878031e05c08322b5adc8639e32050d