### PR TITLE
Fix async fixture usage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,7 @@ async def _clear_pg_memory(request: pytest.FixtureRequest):
     ):
         yield
         return
-    pg_memory = await request.getfixturevalue("pg_memory")
+    pg_memory = request.getfixturevalue("pg_memory")
     async with pg_memory.database.connection() as conn:
         await conn.execute(f"DELETE FROM {pg_memory._kv_table}")
         await conn.execute(f"DELETE FROM {pg_memory._history_table}")


### PR DESCRIPTION
## Summary
- don't await `getfixturevalue` in `_clear_pg_memory`

## Testing
- `poetry run poe test-with-docker` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878073e895883228b30a4399f49f847