### PR TITLE
Fix compose workflow stage map

### DIFF
--- a/src/entity/workflows/compose.py
+++ b/src/entity/workflows/compose.py
@@ -18,7 +18,6 @@ def compose_workflows(*workflows: Workflow) -> Workflow:
         for stage, plugins in wf.stages.items():
             mapping.setdefault(stage, []).extend(list(plugins))
     wf_obj = Workflow(mapping)
-    wf_obj.stage_map = mapping
     return wf_obj
 
 
@@ -30,5 +29,4 @@ def merge_workflows(*workflows: Workflow) -> Workflow:
         for stage, plugins in wf.stages.items():
             mapping[stage] = list(plugins)
     wf_obj = Workflow(mapping)
-    wf_obj.stage_map = mapping
     return wf_obj


### PR DESCRIPTION
## Summary
- remove illegal assignment when composing workflows

## Testing
- `poetry run poe test-with-docker` *(fails: docker not found)*
- `poetry run poe test` *(skipped: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68780b764a148322aa7527424197b0fe