### PR TITLE
Enable pgvector in postgres containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ skipped so the rest of the suite can continue.
 Before starting Docker, copy `.env.example` to `.env` and adjust the values for
 your local setup. The compose files read this file automatically.
 
+The Postgres service uses the `pgvector/pgvector:pg16` image so the `vector`
+extension is available without additional setup.
+
 ### Integration Tests & Docker
 
 Integration tests spin up containers defined in `tests/docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     container_name: test-postgres
     env_file:
       - .env

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_USER: ${DB_USERNAME:-dev}
       POSTGRES_PASSWORD: ${DB_PASSWORD:-dev}


### PR DESCRIPTION
## Summary
- use pgvector image for the postgres service
- update docs explaining that the container ships with the extension

## Testing
- `poetry run black src tests`
- `bash scripts/test_with_docker.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68780e6a808083228bde185b01f136f7