### PR TITLE
Fix pgvector connection in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,7 @@ class AsyncPGDatabase(DatabaseResource):
 
         wait_for_port(host, port)
         conn = await asyncpg.connect(self._dsn)
+        await register_vector(conn)
         try:
             yield conn
         finally:


### PR DESCRIPTION
## Summary
- register vector extension on Postgres connections in tests

## Testing
- `poetry run poe test` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68781664aec4832295d3825035c019bf