### PR TITLE
Fix missing pgvector import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import subprocess
 import time
 from urllib.parse import urlparse
 import asyncpg
+from pgvector.asyncpg import register_vector
 import pytest
 from dotenv import load_dotenv
 


### PR DESCRIPTION
## Summary
- import `register_vector` in the tests' Postgres helpers

## Testing
- `poetry run pytest tests/architecture/test_dependency_injection.py::test_memory_user_isolation -vv` *(fails: Skipped: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_6878193a05148322ade5b8a38769fae1