### PR TITLE
Fix layer doc for resource registration

### DIFF
--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -281,7 +281,12 @@ class ResourceContainer:
     def register(
         self, name: str, cls: type, config: Dict, layer: int | None = None
     ) -> None:
-        """Register a resource class and its configuration."""
+        """Register a resource class and assign it to the proper layer.
+
+        When ``layer`` is ``None`` the container infers it from the class type
+        to preserve the one-layer-at-a-time rule enforced in
+        :meth:`_check_dependency_rules`.
+        """
 
         from entity.core.plugins import InfrastructurePlugin, ResourcePlugin
         from entity.resources.base import AgentResource as CanonicalResource


### PR DESCRIPTION
## Summary
- clarify layer inference in ResourceContainer.register

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run pytest tests/architecture/test_invalid_layer_jumps.py::test_layer_jump_violation -q` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68784b961a9083228bc9c25eda1c6d37