### PR TITLE
Fix pgvector initialization in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,7 @@ class AsyncPGDatabase(DatabaseResource):
 
         wait_for_port(host, port)
         conn = await asyncpg.connect(self._dsn)
+        await conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
         await register_vector(conn)
         try:
             yield conn


### PR DESCRIPTION
## Summary
- ensure `AsyncPGDatabase` creates the pgvector extension before registering the type

## Testing
- `poetry run poe test-architecture` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68784d9e2da08322863dfa35f9a739ef