### PR TITLE
Fix PluginConfig stage validator

### DIFF
--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -46,10 +46,12 @@ class PluginConfig(BaseModel):
 
     @validator("stages", pre=True)
     def _validate_stages(
-        cls, value: list[str | PipelineStage] | None
+        cls, value: list[str | PipelineStage] | str | PipelineStage | None
     ) -> list[PipelineStage]:
         if value is None:
             return []
+        if isinstance(value, (str, PipelineStage)):
+            value = [value]
         return [PipelineStage.ensure(v) for v in value]
 
 


### PR DESCRIPTION
## Summary
- tweak `_validate_stages` to accept single stage values

## Testing
- `poetry run pytest tests/config/test_models.py` *(fails: Docker is required for integration tests)*
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: unrecognized arguments)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run poe test-architecture` *(fails: Docker is required for integration tests)*
- `poetry run poe test-plugins` *(fails: Docker is required for integration tests)*
- `poetry run poe test-resources` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68784e99ad488322a110f036278f9e4c