### PR TITLE
Remove global docker skips

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,13 +25,13 @@ REQUIRE_PYTEST_DOCKER = (
 )
 
 try:
-    import pytest_docker as _  # noqa
+    import pytest_docker as _  # noqa: F401
+
+    PYTEST_DOCKER_AVAILABLE = True
 except Exception:
-    pytest.skip(REQUIRE_PYTEST_DOCKER, allow_module_level=True)
+    PYTEST_DOCKER_AVAILABLE = False
 
-
-if shutil.which("docker") is None:
-    pytest.skip("Docker is required for integration tests", allow_module_level=True)
+DOCKER_INSTALLED = shutil.which("docker") is not None
 
 
 # -- Setup import path for src/
@@ -51,21 +51,11 @@ from plugins.builtin.resources.pg_vector_store import PgVectorStore
 from entity.resources.interfaces.duckdb_resource import DuckDBResource
 from entity.resources.interfaces.database import DatabaseResource
 from entity.core.resources.container import ResourceContainer
-import shutil
-
-
-def _docker_available() -> bool:
-    return shutil.which("docker") is not None
 
 
 def _require_docker() -> bool:
-    """Return True if Docker is installed and running."""
-    try:
-        pytest.importorskip("pytest_docker", reason=REQUIRE_PYTEST_DOCKER)
-    except pytest.SkipTest:
-        return False
-
-    if shutil.which("docker") is None:
+    """Return True if Docker tooling is available and running."""
+    if not PYTEST_DOCKER_AVAILABLE or not DOCKER_INSTALLED:
         return False
 
     try:


### PR DESCRIPTION
## Summary
- guard Docker tests with flags instead of skipping at import
- return False early in _require_docker when Docker or pytest-docker is missing

## Testing
- `poetry run black tests/conftest.py --check`
- `poetry run ruff check --fix tests/conftest.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: unrecognized arguments)*
- `poetry run poe test` *(fails: 9 failed, 208 passed, 40 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68784e2a1a1c8322b10bb6e1ec8820b2