### PR TITLE
Add Docker prerequisite check

### DIFF
--- a/scripts/test_with_docker.sh
+++ b/scripts/test_with_docker.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+command -v docker >/dev/null 2>&1 || {
+	echo "Docker is required for integration tests" >&2
+	exit 1
+}
+
 docker compose -f tests/docker-compose.yml up -d
 trap 'docker compose -f tests/docker-compose.yml down -v' EXIT
 


### PR DESCRIPTION
## Summary
- check for Docker in `test_with_docker.sh`
- keep `set -euo pipefail` and format the script with `shfmt`

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: unrecognized arguments)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run poe test-architecture` *(fails: Docker is required for integration tests)*
- `poetry run poe test-plugins` *(fails: Docker is required for integration tests)*
- `poetry run poe test-resources` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68784e2c6504832295b9a8139ae51db3