### PR TITLE
Add layer boundary test task

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ shell script that tears down containers even if the tests fail:
 poetry run poe test-with-docker
 ```
 
+To run only the architecture boundary checks, use:
+
+```bash
+poetry run poe test-layer-boundaries
+```
+
 `pytest-docker` is required for the integration fixtures and Docker must be
 running. The plugin comes with the development dependencies:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ e2e = { cmd = "pytest tests/e2e", env = { PYTHONPATH = "src" } }
 start-test-services = { cmd = "docker compose -f tests/docker-compose.yml up -d" }
 stop-test-services = { cmd = "docker compose -f tests/docker-compose.yml down -v" }
 test-with-docker = { cmd = "bash scripts/test_with_docker.sh" }
+test-layer-boundaries = { cmd = "bash scripts/test_with_docker.sh tests/architecture/test_layer_boundaries.py" }
 
 setup-dev = { cmd = "poetry install --with dev" }
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -43,6 +43,12 @@ shell script that shuts down containers on exit:
 poetry run poe test-with-docker
 ```
 
+To check only the layer boundaries, run:
+
+```bash
+poetry run poe test-layer-boundaries
+```
+
 ---
 
 ## 🧼 Test Philosophy


### PR DESCRIPTION
## Summary
- add `test-layer-boundaries` to run architecture checks with Docker
- document the task in README and testing guide

## Testing
- `poetry run black src tests`
- `poetry run poe test-layer-boundaries` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c35cbf0083228a55043d7f612247