### PR TITLE
Resolve merge markers in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,12 +29,7 @@ try:
 except Exception:
     PYTEST_DOCKER_AVAILABLE = False
 
-<<<<<<< HEAD
-if shutil.which("docker") is None:
-    pytest.skip("Docker is required for integration tests", allow_module_level=True)
-=======
 DOCKER_INSTALLED = shutil.which("docker") is not None
->>>>>>> pr-1753
 
 # -- Path setup
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -54,16 +49,8 @@ from entity.core.resources.container import ResourceContainer
 
 
 def _require_docker() -> bool:
-<<<<<<< HEAD
-    try:
-        pytest.importorskip("pytest_docker", reason=REQUIRE_PYTEST_DOCKER)
-    except pytest.SkipTest:
-        return False
-    if shutil.which("docker") is None:
-=======
     """Return True if Docker tooling is available and running."""
     if not PYTEST_DOCKER_AVAILABLE or not DOCKER_INSTALLED:
->>>>>>> pr-1753
         return False
     try:
         subprocess.run(

--- a/tests/resources/test_pg_vector_store.py
+++ b/tests/resources/test_pg_vector_store.py
@@ -9,8 +9,6 @@ from entity.core.state import ConversationEntry
 from entity.resources.interfaces.database import DatabaseResource
 from plugins.builtin.resources.pg_vector_store import PgVectorStore
 
-from contextlib import asynccontextmanager
-
 
 @asynccontextmanager
 async def get_pg_connection(dsn):


### PR DESCRIPTION
## Summary
- remove merge conflict markers from `tests/conftest.py`
- drop a duplicate import in `test_pg_vector_store`

## Testing
- `poetry run ruff check src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_68791eb9ca588322aa8e3d2621dec2e5