### PR TITLE
Resolve merge conflict markers and fix plugin lifecycle test

### DIFF
--- a/tests/test_plugins/test_plugin_lifecycle.py
+++ b/tests/test_plugins/test_plugin_lifecycle.py
@@ -24,11 +24,13 @@ async def test_plugin_lifecycle_metrics():
     plugin = DummyPlugin({})
     metrics = MetricsCollectorResource()
     plugin.metrics_collector = metrics
+    await metrics.initialize()
     await plugin.initialize()
     assert plugin.is_initialized
     await plugin.shutdown()
     assert plugin.is_shutdown
-    assert metrics.get_resource_operations("dummy") == []
+    ops = await metrics.get_resource_operations()
+    assert ops == []
 
 
 @pytest.mark.asyncio
@@ -36,10 +38,11 @@ async def test_resource_plugin_lifecycle_metrics():
     resource = DummyResource({})
     metrics = MetricsCollectorResource()
     resource.metrics_collector = metrics
+    await metrics.initialize()
     await resource.initialize()
     assert resource.is_initialized
     await resource.shutdown()
     assert resource.is_shutdown
-    ops = [op for op in metrics.resource_operations if op.resource_name == "dummy"]
+    ops = await metrics.get_resource_operations()
     assert any(o.operation == "initialize" for o in ops)
     assert any(o.operation == "shutdown" for o in ops)


### PR DESCRIPTION
## Summary
- ensure plugin lifecycle metrics test uses async helpers
- verify plugin lifecycle metrics for resources

## Testing
- `poetry run poe test-plugins`
- `poetry run poe test-resources`


------
https://chatgpt.com/codex/tasks/task_e_687966ad0ed883229437507a71f1a539