### PR TITLE
Fix resource aliasing and plugin context tests

### DIFF
--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -41,6 +41,8 @@ class AdvancedContext:
                     user_id=self._parent.user_id,
                 )
             )
+        else:
+            self._parent._state.conversation = list(history)
 
     async def queue_tool_use(
         self,


### PR DESCRIPTION
## Summary
- implement resource aliasing in `ResourceContainer`
- update `PluginContext.replace_conversation_history` to handle missing memory
- modernize context advanced tests for asyncio

## Testing
- `poetry run pytest tests/test_plugin_context_advanced.py::test_replace_conversation_history -q`
- `poetry run pytest tests/test_plugin_context_advanced.py::test_update_response tests/test_plugin_context_advanced.py::test_queue_tool_use_via_property_and_wrapper -q`
- `poetry run pytest tests/test_pipeline_worker.py::test_conversation_id_generation -q`


------
https://chatgpt.com/codex/tasks/task_e_68796fdc57e483228a523e8db286042a