### PR TITLE
Convert pyproject metadata to [project]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,15 @@
-[tool.poetry]
+[project]
 name = "entity"
 version = "0.0.1"
 description = "Entity agentic system with PostgreSQL memory"
-authors = ["C. Thomas Brittain <cthomasbrittain@hotmail.com>"]
-license = "MIT"
+authors = [
+  { name = "C. Thomas Brittain", email = "cthomasbrittain@hotmail.com" },
+]
+license = { text = "MIT" }
 readme = "README.md"
+requires-python = ">=3.11"
+
+[tool.poetry]
 package-mode = true
 
 packages = [{ include = "entity", from = "src" }]


### PR DESCRIPTION
## Summary
- move top-level pyproject metadata from `[tool.poetry]` to `[project]`
- keep dependencies and script definitions untouched

## Testing
- `poetry run black . --check`
- `poetry run poe test` *(fails: FAILED tests/workflow/test_workflow_features.py::test_conditional_stage_skip)*

------
https://chatgpt.com/codex/tasks/task_e_687976a1e0288322a1ce37ff9f3971c5