### PR TITLE
Fix context manager arg lints

### DIFF
--- a/src/entity/core/resources/container.py
+++ b/src/entity/core/resources/container.py
@@ -190,7 +190,7 @@ class ResourcePool(Generic[T]):
         self._ctx_resource = await self.acquire()
         return self._ctx_resource
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
+    async def __aexit__(self, _exc_type, exc, _tb) -> None:
         if self._ctx_resource is not None:
             await self.release(self._ctx_resource)
             self._ctx_resource = None
@@ -288,7 +288,7 @@ class ResourceContainer:
             await self.build_all()
         return self
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
+    async def __aexit__(self, _exc_type, exc, _tb) -> None:
         await self.shutdown_all()
         self._resources.clear()
         self._init_order = []

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -372,7 +372,7 @@ class Memory(AgentResource):
 
 __all__ = [
     "Memory",
-    "remember",
-    "recall",
-    "forget",
+    "remember",  # noqa: F822
+    "recall",  # noqa: F822
+    "forget",  # noqa: F822
 ]


### PR DESCRIPTION
## Summary
- silence unused params in ResourcePool and ResourceContainer `__aexit__`
- ignore memory compatibility symbols from F822

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687976a4c07883228b03db3a3a866e0b