### PR TITLE
Mark performance test benchmark

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4307,4 +4307,4 @@ examples = ["grpcio", "grpcio-tools", "websockets"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "2acae945576b080142d10a7412c4467761db429a99870e0ae2ac9bdaf42bcca0"
+content-hash = "b4b305563580037c20a175abb9c9ab0017111936cc99527eeb497486767c55b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,8 @@ addopts = [
     "--strict-config",
     "--color=yes",
     "--durations=10",
+    "-m",
+    "not benchmark",
 ]
 asyncio_mode = "auto"
 

--- a/tests/test_end_to_end_pipeline.py
+++ b/tests/test_end_to_end_pipeline.py
@@ -64,7 +64,9 @@ async def test_end_to_end_flow(memory_db):
 
 
 @pytest.mark.asyncio
+@pytest.mark.benchmark
 async def test_pipeline_performance_under_load(memory_db):
+    """Benchmark pipeline throughput under concurrent load."""
     regs = types.SimpleNamespace(
         resources={"memory": memory_db},
         tools=types.SimpleNamespace(),


### PR DESCRIPTION
## Summary
- mark performance test with `pytest.mark.benchmark`
- skip benchmark tests by default in pytest config

## Testing
- `poetry run poe test` *(fails: tests/workflow/test_conditional_stage_skip)*
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests`


------
https://chatgpt.com/codex/tasks/task_e_68797a2dcd8c8322bd0b0b40f1bd879a