### PR TITLE
Implement Postgres infrastructure

### DIFF
--- a/src/entity/resources/interfaces/__init__.py
+++ b/src/entity/resources/interfaces/__init__.py
@@ -1,5 +1,6 @@
 from .database import DatabaseResource
 from .duckdb_resource import DuckDBResource
+from .postgres_resource import PostgresResource
 from .duckdb_vector_store import DuckDBVectorStore
 from .echo_llm import EchoLLMResource
 from .llm import LLMResource
@@ -11,6 +12,7 @@ __all__ = [
     "VectorStoreResource",
     "DuckDBVectorStore",
     "DuckDBResource",
+    "PostgresResource",
     "EchoLLMResource",
     "LLMResource",
     "StorageResource",

--- a/src/entity/resources/interfaces/postgres_resource.py
+++ b/src/entity/resources/interfaces/postgres_resource.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Dict
+
+from entity.infrastructure.postgres import PostgresInfrastructure
+from entity.core.resources.container import PoolConfig, ResourcePool
+from entity.core.plugins import ResourcePlugin
+
+
+class PostgresResource(ResourcePlugin):  # type: ignore[misc]
+    """Database interface over :class:`PostgresInfrastructure`."""
+
+    infrastructure_dependencies = ["database_backend"]
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        super().__init__(config or {})
+        self.database_backend: PostgresInfrastructure | None = None
+
+    def get_connection_pool(self) -> ResourcePool:
+        if self.database_backend is not None:
+            return self.database_backend.get_connection_pool()
+        return ResourcePool(lambda: None, PoolConfig())
+
+    @asynccontextmanager
+    async def connection(self) -> AsyncIterator[Any]:
+        if self.database_backend is None:
+            yield None
+        else:
+            async with self.database_backend.connection() as conn:
+                yield conn
+
+    @property
+    def database(self) -> PostgresInfrastructure | None:
+        return self.database_backend
+
+    @database.setter
+    def database(self, value: PostgresInfrastructure | None) -> None:
+        self.database_backend = value
+
+
+__all__ = ["PostgresResource"]


### PR DESCRIPTION
## Summary
- add async Postgres infrastructure
- add PostgresResource interface
- update interfaces exports
- adjust test fixture to use new Postgres backend

## Testing
- `poetry run pytest tests/test_pipeline_worker.py::test_conversation_id_generation -q`
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove-all src tests` *(fails: unrecognized arguments)*
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`


------
https://chatgpt.com/codex/tasks/task_e_6879851b8b3c83229288581d4cb38a0f