### PR TITLE
Add AsyncPG infrastructure and adjust Postgres fixtures

### DIFF
--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -4,6 +4,7 @@ from .docker import DockerInfrastructure
 from .opentofu import OpenTofuInfrastructure
 from .aws_standard import AWSStandardInfrastructure
 from .llamacpp import LlamaCppInfrastructure
+from .asyncpg import AsyncPGInfrastructure
 
 __all__ = [
     "PostgresInfrastructure",
@@ -12,4 +13,5 @@ __all__ = [
     "OpenTofuInfrastructure",
     "AWSStandardInfrastructure",
     "LlamaCppInfrastructure",
+    "AsyncPGInfrastructure",
 ]

--- a/src/entity/infrastructure/asyncpg.py
+++ b/src/entity/infrastructure/asyncpg.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, Dict, AsyncIterator
+
+import asyncpg
+
+from entity.core.plugins import InfrastructurePlugin, ValidationResult
+from entity.core.resources.container import PoolConfig, ResourcePool
+
+
+class AsyncPGInfrastructure(InfrastructurePlugin):
+    """PostgreSQL infrastructure using asyncpg."""
+
+    name = "asyncpg"
+    infrastructure_type = "database"
+    resource_category = "database"
+    stages: list = []
+    dependencies: list[str] = []
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.dsn: str = self.config.get("dsn", "")
+        pool_cfg = PoolConfig(**self.config.get("pool", {}))
+        self._pool = ResourcePool(self._create_conn, pool_cfg, "asyncpg")
+
+    async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    async def initialize(self) -> None:
+        metrics = getattr(self, "metrics_collector", None)
+        if metrics is not None:
+            self._pool.set_metrics_collector(metrics)
+        await self._pool.initialize()
+
+    async def _create_conn(self) -> asyncpg.Connection:
+        return await asyncpg.connect(self.dsn)
+
+    @asynccontextmanager
+    async def connection(self) -> AsyncIterator[asyncpg.Connection]:
+        async with self._pool as conn:
+            yield conn
+
+    def get_connection_pool(self) -> ResourcePool:
+        return self._pool
+
+    def get_pool(self) -> ResourcePool:
+        return self._pool
+
+    async def shutdown(self) -> None:
+        while not self._pool._pool.empty():
+            conn = await self._pool._pool.get()
+            await conn.close()
+
+    async def validate_runtime(self, breaker: Any | None = None) -> ValidationResult:
+        try:
+            async with self.connection() as conn:
+                await conn.execute("SELECT 1")
+            return ValidationResult.success_result()
+        except Exception as exc:  # noqa: BLE001
+            return ValidationResult.error_result(str(exc))
+
+
+__all__ = ["AsyncPGInfrastructure"]


### PR DESCRIPTION
## Summary
- implement `AsyncPGInfrastructure` for asyncpg connection pools
- expose it in the infrastructure package
- adapt test fixtures to register this infrastructure

## Testing
- `poetry run ruff check --fix src/entity/infrastructure/asyncpg.py src/entity/infrastructure/__init__.py tests/conftest.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run pytest tests/test_pipeline_worker.py -q`
- `poetry run poe test` *(fails: tests/workflow/test_workflow_features.py::test_conditional_stage_skip)*

------
https://chatgpt.com/codex/tasks/task_e_6879851b7a60832293232635fa92b30d