### PR TITLE
Resolve merge conflict in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,16 +40,11 @@ OLLAMA_PORT = int(os.getenv("OLLAMA_PORT", "11434"))
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama3:8b-instruct-q6_K")
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", f"http://localhost:{OLLAMA_PORT}")
 
-<<<<<<< HEAD
 from entity.infrastructure import DuckDBInfrastructure, AsyncPGInfrastructure
-=======
-from entity.infrastructure import DuckDBInfrastructure, PostgresInfrastructure
->>>>>>> pr-1770
 from entity.resources import Memory, LLM
 from plugins.builtin.resources.pg_vector_store import PgVectorStore
 from entity.resources.interfaces.duckdb_resource import DuckDBResource
 from entity.resources.interfaces.database import DatabaseResource
-from entity.resources.interfaces.postgres_resource import PostgresResource
 from entity.core.resources.container import ResourceContainer
 
 
@@ -282,7 +277,6 @@ async def pg_container(postgres_dsn: str) -> ResourceContainer:
         pytest.skip("Docker is required for Postgres-backed containers.")
     container = ResourceContainer()
     container.register(
-<<<<<<< HEAD
         "database_backend",
         AsyncPGInfrastructure,
         {"dsn": postgres_dsn},
@@ -294,11 +288,6 @@ async def pg_container(postgres_dsn: str) -> ResourceContainer:
         {"dsn": postgres_dsn},
         layer=2,
     )
-=======
-        "database_backend", PostgresInfrastructure, {"dsn": postgres_dsn}, layer=1
-    )
-    container.register("database", PostgresResource, {}, layer=2)
->>>>>>> pr-1770
     container.register("memory", Memory, {}, layer=3)
 
     await container.build_all()


### PR DESCRIPTION
## Summary
- remove leftover conflict markers in test fixtures
- default to `AsyncPGInfrastructure` in `tests/conftest.py`

## Testing
- `poetry run poe test` *(fails: OSError could not connect to postgres)*

------
https://chatgpt.com/codex/tasks/task_e_687a32daa0f88322949dec614dbf4be8