### PR TITLE
Fix failing postgres tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,10 @@ class AsyncPGDatabase(DatabaseResource):
         self._dsn = dsn
         self.database_backend = None
 
+    @classmethod
+    def from_config(cls, cfg: dict) -> "AsyncPGDatabase":
+        return cls(cfg["dsn"])
+
     @asynccontextmanager
     async def connection(self):
         backend = getattr(self, "database_backend", None)

--- a/tests/infrastructure/failing_plugins.py
+++ b/tests/infrastructure/failing_plugins.py
@@ -27,6 +27,10 @@ class FailingPostgresInfrastructure(PostgresInfrastructure):
 
     name = "failing_postgres"
 
+    async def initialize(self) -> None:  # type: ignore[override]
+        """Skip real connection setup."""
+        return None
+
     @asynccontextmanager
     async def connection(self):  # type: ignore[override]
         class BadConn:


### PR DESCRIPTION
## Summary
- ensure test pg database works with ResourceContainer
- avoid real postgres connection in FailingPostgresInfrastructure

## Testing
- `poetry run pytest tests/test_infrastructure_validate_runtime.py::test_postgres_runtime_breaker_opens tests/test_pipeline_worker.py::test_conversation_id_generation -q`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_687a376af320832289735ca7c9f70c6d