### PR TITLE
Refactor config validation helpers

### DIFF
--- a/src/entity/core/validation/__init__.py
+++ b/src/entity/core/validation/__init__.py
@@ -1,5 +1,6 @@
 from .input import PluginInputValidator, sanitize_text, validate_params
 from .plugin import verify_dependencies, verify_stage_assignment
+from .config import validate_model
 
 __all__ = [
     "PluginInputValidator",
@@ -7,4 +8,5 @@ __all__ = [
     "sanitize_text",
     "verify_stage_assignment",
     "verify_dependencies",
+    "validate_model",
 ]

--- a/src/entity/core/validation/config.py
+++ b/src/entity/core/validation/config.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Type
+
+from pydantic import BaseModel, ValidationError
+
+from entity.core.plugins import ValidationResult
+
+
+def validate_model(model: Type[BaseModel], data: Dict[str, Any]) -> ValidationResult:
+    """Parse ``data`` with ``model`` returning a :class:`ValidationResult`."""
+    try:
+        model.parse_obj(data)
+    except ValidationError as exc:  # pragma: no cover - error path
+        return ValidationResult.error_result(str(exc))
+    return ValidationResult.success_result()

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 from ..core.plugins import ValidationResult
 from entity.config.models import LLMConfig
-from pydantic import ValidationError
+from entity.core.validation import validate_model
 
 from ..core.resources.container import PoolConfig, ResourcePool
 from .base import AgentResource
@@ -57,11 +57,7 @@ class LLM(AgentResource):
 
     @classmethod
     async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
-        try:
-            LLMConfig.parse_obj(config)
-        except ValidationError as exc:
-            return ValidationResult.error_result(str(exc))
-        return ValidationResult.success_result()
+        return validate_model(LLMConfig, config)
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None

--- a/src/entity/resources/logging.py
+++ b/src/entity/resources/logging.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional
 
 from .base import AgentResource
 from entity.config.models import LoggingConfig
-from pydantic import ValidationError
+from entity.core.validation import validate_model
 from entity.core.plugins import ValidationResult
 
 
@@ -187,11 +187,7 @@ class LoggingResource(AgentResource):
 
     @classmethod
     async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
-        try:
-            LoggingConfig.parse_obj(config)
-        except ValidationError as exc:
-            return ValidationResult.error_result(str(exc))
-        return ValidationResult.success_result()
+        return validate_model(LoggingConfig, config)
 
     async def initialize(self) -> None:
         outputs_cfg = self.config.get("outputs", [{"type": "console"}])

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -15,8 +15,8 @@ from .interfaces.vector_store import (
 from .sql_utils import _execute, _maybe_await
 from ..core.plugins import ValidationResult
 from entity.config.models import MemoryConfig
-from pydantic import ValidationError
 from ..core.state import ConversationEntry
+from entity.core.validation import validate_model
 from entity.pipeline.errors import InitializationError, ResourceInitializationError
 
 
@@ -159,11 +159,7 @@ class Memory(AgentResource):
     async def validate_config(
         cls, config: Dict[str, Any]
     ) -> ValidationResult:  # noqa: D401
-        try:
-            MemoryConfig.parse_obj(config)
-        except ValidationError as exc:
-            return ValidationResult.error_result(str(exc))
-        return ValidationResult.success_result()
+        return validate_model(MemoryConfig, config)
 
     # ------------------------------------------------------------------
     # Advanced operations

--- a/src/entity/resources/storage.py
+++ b/src/entity/resources/storage.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 from ..core.plugins import ValidationResult
 from entity.config.models import StorageConfig
-from pydantic import ValidationError
+from entity.core.validation import validate_model
 
 
 from .base import AgentResource
@@ -24,11 +24,7 @@ class Storage(AgentResource):
 
     @classmethod
     async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
-        try:
-            StorageConfig.parse_obj(config)
-        except ValidationError as exc:
-            return ValidationResult.error_result(str(exc))
-        return ValidationResult.success_result()
+        return validate_model(StorageConfig, config)
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None


### PR DESCRIPTION
## Summary
- add `validate_model` helper for pydantic based config checks
- simplify resource validation using new helper

## Testing
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport src tests`
- `poetry run entity-cli --config config/dev.yaml verify`
- `poetry run entity-cli --config config/prod.yaml verify`
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run poe test` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_687a399172ec8322a16656eb2a11ca26