### PR TITLE
Add plugin lifecycle hooks and context cleanup

### DIFF
--- a/src/entity/core/context.py
+++ b/src/entity/core/context.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, cast
 
 from entity.core.state import ConversationEntry, PipelineState, ToolCall
-import warnings
 from entity.pipeline.errors import PluginContextError
 from entity.pipeline.stages import PipelineStage
 
@@ -298,24 +297,6 @@ class PluginContext:
         result = await tool.execute_function(params)
         return result
 
-    async def queue_tool_use(
-        self, name: str, *, result_key: str | None = None, **params: Any
-    ) -> str:
-        warnings.warn(
-            "PluginContext.queue_tool_use is deprecated; use context.advanced.queue_tool_use",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return await self.advanced.queue_tool_use(name, result_key=result_key, **params)
-
-    def discover_tools(self, **filters: Any) -> list[tuple[str, Any]]:
-        warnings.warn(
-            "PluginContext.discover_tools is deprecated; use context.advanced.discover_tools",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.advanced.discover_tools(**filters)
-
     # ------------------------------------------------------------------
     # Stage result helpers ("think"/"reflect")
     # ------------------------------------------------------------------
@@ -359,31 +340,9 @@ class PluginContext:
         if self._memory is not None:
             await self._memory.delete_persistent(key, user_id=self._user_id)
 
-    def set_metadata(self, key: str, value: Any) -> None:
-        warnings.warn(
-            "PluginContext.set_metadata is deprecated; use context.advanced.set_metadata",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.advanced.set_metadata(key, value)
-
-    def get_metadata(self, key: str, default: Any | None = None) -> Any:
-        warnings.warn(
-            "PluginContext.get_metadata is deprecated; use context.advanced.get_metadata",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.advanced.get_metadata(key, default)
+    # Backwards compatibility shims removed; use ``context.advanced`` directly.
 
     @property
     def failure_info(self) -> Any:
         """Return information about the most recent failure."""
         return self._state.failure_info
-
-    def set_response(self, value: Any) -> None:
-        warnings.warn(
-            "PluginContext.set_response is deprecated; use context.say",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.say(value)

--- a/src/entity/core/plugins/base.py
+++ b/src/entity/core/plugins/base.py
@@ -94,6 +94,7 @@ class BasePlugin:
             raise ValueError("invalid version")
         target = self._config_history[version - 1].copy()
         await self._handle_reconfiguration(self.config, target)
+        await self.on_reconfigure(self.config, target)
         self.config = target
         self.config_version = version
         self._config_history = self._config_history[:version]
@@ -106,6 +107,7 @@ class BasePlugin:
         for key, value in new_config.items():
             if old_config.get(key) != value and hasattr(self, key):
                 setattr(self, key, value)
+        await self.on_reconfigure(old_config, new_config)
 
     async def on_dependency_reconfigured(
         self, name: str, old_config: Dict[str, Any], new_config: Dict[str, Any]
@@ -183,6 +185,7 @@ class Plugin(BasePlugin):
             return
 
         await self._on_initialize()
+        await self.on_initialize()
         self.is_initialized = True
         self.is_shutdown = False
 
@@ -193,6 +196,7 @@ class Plugin(BasePlugin):
             return
 
         await self._on_shutdown()
+        await self.on_shutdown()
         self.is_initialized = False
         self.is_shutdown = True
 
@@ -202,6 +206,20 @@ class Plugin(BasePlugin):
 
     async def _on_shutdown(self) -> None:  # pragma: no cover - default hook
         """Hook executed once during :meth:`shutdown`."""
+        return None
+
+    async def on_initialize(self) -> None:  # pragma: no cover - default hook
+        """Hook executed after initialization completes."""
+        return None
+
+    async def on_shutdown(self) -> None:  # pragma: no cover - default hook
+        """Hook executed after shutdown completes."""
+        return None
+
+    async def on_reconfigure(
+        self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+    ) -> None:  # pragma: no cover - default hook
+        """Hook executed after configuration changes."""
         return None
 
     def validate_registration_stage(self, stage: PipelineStage) -> None:

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -73,3 +73,12 @@ class LLM(AgentResource):
             if not result.success:
                 return ValidationResult.error_result(f"provider: {result.message}")
         return ValidationResult.success_result()
+
+    async def health_check(self) -> bool:
+        """Return ``True`` when the provider is reachable."""
+        if self.provider is None:
+            return True
+        if hasattr(self.provider, "validate_runtime"):
+            result = await self.provider.validate_runtime()
+            return result.success
+        return True

--- a/src/entity/resources/logging.py
+++ b/src/entity/resources/logging.py
@@ -224,6 +224,16 @@ class LoggingResource(AgentResource):
         for stream in self._stream_outputs:
             await stream.stop()
 
+    async def health_check(self) -> bool:
+        """Return ``True`` if all log outputs are writable."""
+        try:
+            for out in self._outputs:
+                if isinstance(out, StructuredFileOutput):
+                    out._handle.flush()
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
     async def log(
         self,
         level: str,

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -62,6 +62,17 @@ class Memory(AgentResource):
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None
 
+    async def health_check(self) -> bool:
+        """Return ``True`` if the database connection is healthy."""
+        if self.database is None:
+            return True
+        try:
+            async with self.database.connection() as conn:
+                await _execute(conn, "SELECT 1")
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
     # ------------------------------------------------------------------
     # Key-value helpers
     # ------------------------------------------------------------------

--- a/src/entity/resources/storage.py
+++ b/src/entity/resources/storage.py
@@ -42,3 +42,11 @@ class Storage(AgentResource):
     async def validate_runtime(self) -> ValidationResult:
         """Check backend availability."""
         return ValidationResult.success_result()
+
+    async def health_check(self) -> bool:
+        """Simple check that storage dictionary is accessible."""
+        try:
+            _ = len(self._data)
+            return True
+        except Exception:  # noqa: BLE001
+            return False

--- a/tests/test_plugin_context_advanced.py
+++ b/tests/test_plugin_context_advanced.py
@@ -55,12 +55,12 @@ def test_update_response():
 
 
 @pytest.mark.asyncio
-async def test_queue_tool_use_via_property_and_wrapper():
+async def test_queue_tool_use():
     state = PipelineState(conversation=[])
     ctx = await make_context_async(state)
 
     key1 = await ctx.advanced.queue_tool_use("dummy", x=1)
-    key2 = await ctx.queue_tool_use("dummy", x=2)
+    key2 = await ctx.advanced.queue_tool_use("dummy", x=2)
 
     assert key1 == "dummy_0"
     assert key2 == "dummy_1"


### PR DESCRIPTION
## Summary
- introduce lifecycle event hooks in `BasePlugin`
- provide health checks for standard resources
- remove deprecated helpers from `PluginContext`
- update tests to use new context API

## Testing
- `poetry run poe test` *(fails: OSError: Connect call failed ('::1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_687a398c4f6083228fc9e20d70f28a23