### PR TITLE
Centralize test helpers

### DIFF
--- a/tests/architecture/test_stage_assignment.py
+++ b/tests/architecture/test_stage_assignment.py
@@ -6,6 +6,7 @@ from entity.core.stages import PipelineStage
 from entity.core.state import PipelineState
 from entity.pipeline.errors import PluginContextError
 from entity.pipeline.utils import resolve_stages
+from tests.utils import make_async_context
 
 
 class AttrPlugin(Plugin):
@@ -42,23 +43,9 @@ class SayDuringParse(PromptPlugin):
         context.say("oops")
 
 
-class DummyRegs:
-    def __init__(self) -> None:
-        self.resources = {}
-        self.tools = ToolRegistry()
-
-
-def make_context(stage: PipelineStage) -> PluginContext:
-    state = PipelineState(conversation=[])
-    ctx = PluginContext(state, DummyRegs())
-    ctx.set_current_stage(stage)
-    ctx.set_current_plugin("test")
-    return ctx
-
-
 @pytest.mark.asyncio
 async def test_say_only_allowed_for_output() -> None:
-    ctx = make_context(PipelineStage.PARSE)
+    ctx = await make_async_context(stage=PipelineStage.PARSE)
     plugin = SayDuringParse({})
     with pytest.raises(PluginContextError):
         await plugin.execute(ctx)

--- a/tests/plugins/test_stage_assignment.py
+++ b/tests/plugins/test_stage_assignment.py
@@ -13,6 +13,7 @@ from entity.core.state import PipelineState
 from entity.pipeline.errors import PluginContextError
 from entity.pipeline.stages import PipelineStage
 from entity.pipeline.utils import StageResolver
+from tests.utils import make_async_context
 
 
 class AttrPlugin(Plugin):
@@ -27,20 +28,6 @@ class SayDuringParse(PromptPlugin):
 
     async def _execute_impl(self, context: PluginContext) -> None:
         context.say("oops")
-
-
-class DummyRegs:
-    def __init__(self) -> None:
-        self.resources = {}
-        self.tools = ToolRegistry()
-
-
-def make_context(stage: PipelineStage) -> PluginContext:
-    state = PipelineState(conversation=[])
-    ctx = PluginContext(state, DummyRegs())
-    ctx.set_current_stage(stage)
-    ctx.set_current_plugin("test")
-    return ctx
 
 
 def test_config_overrides_class_stage(caplog: pytest.LogCaptureFixture) -> None:
@@ -72,7 +59,7 @@ def test_class_stage_used_without_config() -> None:
 
 @pytest.mark.asyncio
 async def test_say_only_allowed_for_output() -> None:
-    ctx = make_context(PipelineStage.PARSE)
+    ctx = await make_async_context(stage=PipelineStage.PARSE)
     plugin = SayDuringParse({})
     with pytest.raises(PluginContextError):
         await plugin.execute(ctx)

--- a/tests/test_context_helpers.py
+++ b/tests/test_context_helpers.py
@@ -1,22 +1,5 @@
-import types
 import pytest
-from entity.core.context import PluginContext
-from entity.core.state import PipelineState
-
-
-class DummyRegistries:
-    def __init__(self, resources):
-        self.resources = resources
-        self.tools = types.SimpleNamespace()
-
-
-def make_context(memory=None, storage=None, llm=None):
-    resources = {
-        "memory": memory,
-        "storage": storage or object(),
-        "llm": llm or object(),
-    }
-    return PluginContext(PipelineState(conversation=[]), DummyRegistries(resources))
+from tests.utils import make_context
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_context_memory.py
+++ b/tests/test_plugin_context_memory.py
@@ -1,22 +1,10 @@
 import asyncio
 from datetime import datetime
 import pytest
-from entity.core.context import PluginContext
-from entity.core.state import PipelineState, ConversationEntry
+from entity.core.state import ConversationEntry
 from entity.resources import Memory
 from entity.pipeline.errors import ResourceInitializationError
-from entity.core.resources.container import ResourceContainer
-from entity.core.registries import SystemRegistries, ToolRegistry, PluginRegistry
-
-
-async def make_context(memory: Memory) -> PluginContext:
-    regs = SystemRegistries(
-        resources=ResourceContainer(),
-        tools=ToolRegistry(),
-        plugins=PluginRegistry(),
-    )
-    await regs.resources.add("memory", memory)
-    return PluginContext(PipelineState(conversation=[]), regs)
+from tests.utils import make_async_context
 
 
 async def run_test(memory: Memory) -> None:
@@ -37,7 +25,7 @@ async def run_test(memory: Memory) -> None:
 
 @pytest.mark.asyncio
 async def test_memory_roundtrip(memory_db: Memory) -> None:
-    ctx = await make_context(memory_db)
+    ctx = await make_async_context(memory=memory_db)
     await ctx.remember("foo", "bar")
     assert await ctx.recall("foo") == "bar"
 

--- a/tests/test_response_control.py
+++ b/tests/test_response_control.py
@@ -14,24 +14,11 @@ from entity.pipeline.stages import PipelineStage
 from entity.pipeline.pipeline import execute_pipeline
 from entity.pipeline.errors import PluginContextError
 from entity.core.resources.container import ResourceContainer
-
-
-def make_context(stage: PipelineStage) -> PluginContext:
-    state = PipelineState(conversation=[])
-    container = ResourceContainer()
-    ctx = PluginContext(
-        state,
-        SystemRegistries(
-            resources=container, tools=ToolRegistry(), plugins=PluginRegistry()
-        ),
-    )
-    ctx.set_current_stage(stage)
-    ctx.set_current_plugin("test")
-    return ctx
+from tests.utils import make_context
 
 
 def test_say_only_output_stage() -> None:
-    ctx = make_context(PipelineStage.THINK)
+    ctx = make_context(stage=PipelineStage.THINK)
     with pytest.raises(PluginContextError):
         ctx.say("hi")
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,60 @@
+"""Utility helpers for tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from entity.core.context import PluginContext
+from entity.core.registries import PluginRegistry, SystemRegistries, ToolRegistry
+from entity.core.resources.container import ResourceContainer
+from entity.core.state import PipelineState
+from entity.pipeline.stages import PipelineStage
+
+
+async def make_async_context(
+    stage: PipelineStage = PipelineStage.THINK,
+    state: PipelineState | None = None,
+    *,
+    memory: Any | None = None,
+    storage: Any | None = None,
+    llm: Any | None = None,
+    tools: Mapping[str, Callable] | None = None,
+) -> PluginContext:
+    """Return a ready-to-use :class:`PluginContext`."""
+    if state is None:
+        state = PipelineState(conversation=[])
+
+    resources = ResourceContainer()
+    if memory is not None:
+        await resources.add("memory", memory)
+    if storage is not None:
+        await resources.add("storage", storage)
+    if llm is not None:
+        await resources.add("llm", llm)
+
+    tool_registry = ToolRegistry()
+    if tools:
+        for name, func in tools.items():
+            await tool_registry.add(name, func)
+
+    registries = SystemRegistries(
+        resources=resources,
+        tools=tool_registry,
+        plugins=PluginRegistry(),
+    )
+
+    ctx = PluginContext(state, registries)
+    ctx.set_current_stage(stage)
+    ctx.set_current_plugin("test")
+    return ctx
+
+
+def make_context(
+    stage: PipelineStage = PipelineStage.THINK,
+    state: PipelineState | None = None,
+    **kwargs: Any,
+) -> PluginContext:
+    """Synchronous wrapper for :func:`make_async_context`."""
+    return asyncio.run(make_async_context(stage, state, **kwargs))


### PR DESCRIPTION
## Summary
- add `tests/utils` with `make_async_context` and `make_context`
- update tests to use centralized helpers
- remove duplicated context helpers

## Testing
- `poetry run poe test` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_687a39a989688322960fb15dad00b4e4