### PR TITLE
Add defaults helper to configure agent

### DIFF
--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -17,7 +17,7 @@ from .infrastructure import DuckDBInfrastructure
 from .resources import LLM, Memory, Storage
 from .resources.interfaces.duckdb_vector_store import DuckDBVectorStore
 from .resources.logging import LoggingResource
-from .utils.setup_manager import Layer0SetupManager
+from .defaults import ensure_defaults
 from entity.workflows.minimal import minimal_workflow
 from entity.utils.logging import get_logger
 
@@ -50,11 +50,7 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
 def _create_default_agent() -> Agent:
     """Return a fully configured default :class:`Agent`."""
 
-    setup = Layer0SetupManager()
-    try:  # best effort environment preparation
-        asyncio.run(setup.setup())
-    except Exception:  # noqa: BLE001
-        pass
+    setup = ensure_defaults()
 
     agent = Agent()
     builder = agent.builder

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -27,6 +27,7 @@ from .registries import PluginRegistry, SystemRegistries, ToolRegistry
 from .resources.container import ResourceContainer
 from entity.workflows.base import Workflow
 from entity.workflows.discovery import discover_workflows, register_module_workflows
+from ..defaults import ensure_defaults
 
 from typing import TYPE_CHECKING
 
@@ -461,6 +462,8 @@ class Agent:
         pipeline: Pipeline | None = None,
         workflow: Workflow | None = None,
     ) -> None:
+        if config_path is None:
+            ensure_defaults()
         self.config_path = config_path
         self.pipeline = pipeline
         self.workflow = workflow

--- a/src/entity/defaults.py
+++ b/src/entity/defaults.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+
+from .utils.logging import get_logger
+from .utils.setup_manager import Layer0SetupManager
+
+logger = get_logger(__name__)
+
+_setup: Layer0SetupManager | None = None
+
+
+def ensure_defaults(**kwargs) -> Layer0SetupManager:
+    """Prepare local resources using :class:`Layer0SetupManager`."""
+    global _setup
+    if _setup is None:
+        _setup = Layer0SetupManager(**kwargs)
+        try:
+            asyncio.run(_setup.setup())
+        except Exception:  # noqa: BLE001 - best effort
+            logger.debug("Default setup failed", exc_info=True)
+    return _setup
+
+
+def ollama_available(
+    model: str = "llama3", base_url: str = "http://localhost:11434"
+) -> bool:
+    """Return ``True`` if Ollama is reachable and the model is present."""
+    manager = Layer0SetupManager(model=model, base_url=base_url)
+    try:
+        return asyncio.run(manager.ensure_ollama())
+    except Exception:  # noqa: BLE001 - optional runtime dependency
+        logger.debug("Ollama check failed", exc_info=True)
+        return False
+
+
+def _reset_defaults() -> None:  # pragma: no cover - testing helper
+    global _setup
+    _setup = None

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,25 @@
+import os
+from entity.defaults import ensure_defaults, ollama_available, _reset_defaults
+from entity.core.agent import Agent
+
+
+def test_ensure_defaults_creates_duckdb(tmp_path):
+    db = tmp_path / "db.duckdb"
+    files = tmp_path / "files"
+    _reset_defaults()
+    ensure_defaults(db_path=str(db), files_dir=str(files))
+    assert db.exists()
+    assert files.exists()
+
+
+def test_agent_auto_defaults(tmp_path):
+    prev = os.getcwd()
+    os.chdir(tmp_path)
+    _reset_defaults()
+    Agent()
+    assert (tmp_path / "agent_memory.duckdb").exists()
+    os.chdir(prev)
+
+
+def test_ollama_available_returns_bool():
+    assert isinstance(ollama_available(), bool)


### PR DESCRIPTION
## Summary
- add `entity.defaults` for automatic environment setup
- ensure defaults run when `Agent` is created
- reference helper in default agent creation
- check Ollama availability and provide tests

## Testing
- `poetry run poe test` *(fails: test_postgres_runtime_breaker_opens)*

------
https://chatgpt.com/codex/tasks/task_e_687a397ee1bc832281f649b687e83088