### PR TITLE
Fix stage utilities and tests

### DIFF
--- a/src/entity/pipeline/stages.py
+++ b/src/entity/pipeline/stages.py
@@ -1,36 +1,5 @@
-from __future__ import annotations
+"""Alias to the core :class:`PipelineStage` enumeration."""
 
-"""Enumeration of pipeline execution stages."""
-
-from enum import IntEnum
-
-
-class PipelineStage(IntEnum):
-    """Ordered pipeline stages."""
-
-    INPUT = 1
-    PARSE = 2
-    THINK = 3
-    DO = 4
-    REVIEW = 5
-    OUTPUT = 6
-    ERROR = 7
-
-    def __str__(self) -> str:
-        return self.name.lower()
-
-    @classmethod
-    def from_str(cls, value: str) -> "PipelineStage":
-        try:
-            return cls[value.upper()]
-        except KeyError as exc:  # pragma: no cover - defensive
-            raise ValueError(f"Unknown stage: {value}") from exc
-
-    @classmethod
-    def ensure(cls, value: "PipelineStage | str") -> "PipelineStage":
-        if isinstance(value, cls):
-            return value
-        return cls.from_str(str(value))
-
+from entity.core.stages import PipelineStage
 
 __all__ = ["PipelineStage"]


### PR DESCRIPTION
## Summary
- de-dupe PipelineStage enum by aliasing core version
- update StageResolver to correctly handle adapter subclasses
- add default logger when resolving stages

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687a432b318c8322820493584e88256f