### PR TITLE
Update stage precedence test

### DIFF
--- a/tests/test_stage_precedence.py
+++ b/tests/test_stage_precedence.py
@@ -90,8 +90,9 @@ def test_initializer_inherited_stage_not_explicit():
 def test_warning_for_stage_override(caplog):
     """Test if a warning is logged when a stage override occurs."""
     plugin = AttrPrompt({})
+    logger = logging.getLogger("stage-test")
     with caplog.at_level(logging.WARNING):
         StageResolver._resolve_plugin_stages(
-            AttrPrompt, {"stage": PipelineStage.REVIEW}, plugin
+            AttrPrompt, {"stage": PipelineStage.REVIEW}, plugin, logger=logger
         )
     assert any("configuration stages" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- confirm stage override warnings can be captured

## Testing
- `poetry run pytest tests/test_stage_precedence.py::test_warning_for_stage_override -q`

------
https://chatgpt.com/codex/tasks/task_e_687a553dd34c8322aa378e23c426afd0