### PR TITLE
Adjust adapter stage checks

### DIFF
--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -146,6 +146,7 @@ class ClassRegistry(StageResolver):
         stages, explicit = StageResolver._resolve_plugin_stages(
             cls, config, logger=logger
         )
+        stages = [PipelineStage.ensure(s) for s in stages]
         if not explicit:
             raise InitializationError(
                 name,


### PR DESCRIPTION
## Summary
- ensure logger is set when resolving plugin stages
- use direct subclass checks for Input and Output adapters
- normalize stage types inside initializer to avoid validation errors

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_687a553745048322a939e1b8eec60f80