### PR TITLE
Refactor stages to centralize PipelineStage enum

### DIFF
--- a/src/entity/core/stage_utils.py
+++ b/src/entity/core/stage_utils.py
@@ -23,7 +23,7 @@ class StageResolver:
         logger: Any | None = None,
     ) -> tuple[list[PipelineStage], bool]:
         """Return stages and whether they were explicit."""
-        logger = logger
+        logger = logger or getattr(_instance, "logger", None)
         cfg_value = config.get("stages") or config.get("stage")
         declared_value = getattr(plugin_class, "stages", None) or getattr(
             plugin_class, "stage", None
@@ -56,13 +56,11 @@ class StageResolver:
         else:
             stages = [PipelineStage.THINK]
 
-        if (
-            hasattr(plugin_class, "InputAdapterPlugin")
-            and any(
-                base.__name__ == "InputAdapterPlugin" for base in plugin_class.mro()[1:]
-            )
-            and stages != [PipelineStage.INPUT]
-        ):
+        from .plugins import InputAdapterPlugin, OutputAdapterPlugin
+
+        if issubclass(plugin_class, InputAdapterPlugin) and stages != [
+            PipelineStage.INPUT
+        ]:
             if logger is not None:
                 logger.warning(
                     "%s can only run in INPUT stage; ignoring configured %s",
@@ -71,14 +69,9 @@ class StageResolver:
                 )
             stages = [PipelineStage.INPUT]
 
-        if (
-            hasattr(plugin_class, "OutputAdapterPlugin")
-            and any(
-                base.__name__ == "OutputAdapterPlugin"
-                for base in plugin_class.mro()[1:]
-            )
-            and stages != [PipelineStage.OUTPUT]
-        ):
+        if issubclass(plugin_class, OutputAdapterPlugin) and stages != [
+            PipelineStage.OUTPUT
+        ]:
             if logger is not None:
                 logger.warning(
                     "%s can only run in OUTPUT stage; ignoring configured %s",

--- a/src/entity/core/stages.py
+++ b/src/entity/core/stages.py
@@ -1,36 +1,3 @@
-"""Stage enumeration for plugin execution."""
-
-from __future__ import annotations
-
-from enum import IntEnum
-
-
-class PipelineStage(IntEnum):
-    """Ordered pipeline stages."""
-
-    INPUT = 1
-    PARSE = 2
-    THINK = 3
-    DO = 4
-    REVIEW = 5
-    OUTPUT = 6
-    ERROR = 7
-
-    def __str__(self) -> str:
-        return self.name.lower()
-
-    @classmethod
-    def from_str(cls, value: str) -> "PipelineStage":
-        try:
-            return cls[value.upper()]
-        except KeyError as exc:  # pragma: no cover - defensive
-            raise ValueError(f"Unknown stage: {value}") from exc
-
-    @classmethod
-    def ensure(cls, value: "PipelineStage | str") -> "PipelineStage":
-        if isinstance(value, cls):
-            return value
-        return cls.from_str(str(value))
-
+from entity.pipeline.stages import PipelineStage
 
 __all__ = ["PipelineStage"]

--- a/src/entity/core/state.py
+++ b/src/entity/core/state.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from .stages import PipelineStage
+from entity.pipeline.stages import PipelineStage
 
 
 @dataclass

--- a/src/entity/pipeline/__init__.py
+++ b/src/entity/pipeline/__init__.py
@@ -9,13 +9,13 @@ from typing import TYPE_CHECKING, Any
 
 __path__ = pkgutil.extend_path(globals().get("__path__", []), __name__)
 
+from .stages import PipelineStage
 from .exceptions import CircuitBreakerTripped
 from entity.core.circuit_breaker import CircuitBreaker, RetryPolicy
 
 # Registry classes are no longer imported eagerly.
 # Access ``PluginRegistry`` and related classes via ``registry`` or
 # rely on this module's ``__getattr__`` for lazy loading.
-from .stages import PipelineStage
 
 # Expose plugin configuration API used by the pipeline package
 


### PR DESCRIPTION
## Summary
- re-export `PipelineStage` from `entity.pipeline` to simplify imports
- import `PipelineStage` directly in `state`
- reorder imports in pipeline `__init__`
- update `StageResolver` to infer logger from the plugin instance and to avoid eager imports

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687a5536a5408322a98700e3b4de440c