### PR TITLE
Fix PipelineStage import loop

### DIFF
--- a/src/entity/core/stages.py
+++ b/src/entity/core/stages.py
@@ -1,3 +1,5 @@
+"""Alias to :class:`~entity.pipeline.stages.PipelineStage`."""
+
 from entity.pipeline.stages import PipelineStage
 
 __all__ = ["PipelineStage"]

--- a/src/entity/pipeline/stages.py
+++ b/src/entity/pipeline/stages.py
@@ -1,5 +1,36 @@
-"""Alias to the core :class:`PipelineStage` enumeration."""
+"""Enumeration of pipeline execution stages."""
 
-from entity.core.stages import PipelineStage
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class PipelineStage(IntEnum):
+    """Ordered pipeline stages."""
+
+    INPUT = 1
+    PARSE = 2
+    THINK = 3
+    DO = 4
+    REVIEW = 5
+    OUTPUT = 6
+    ERROR = 7
+
+    def __str__(self) -> str:
+        return self.name.lower()
+
+    @classmethod
+    def from_str(cls, value: str) -> "PipelineStage":
+        try:
+            return cls[value.upper()]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Unknown stage: {value}") from exc
+
+    @classmethod
+    def ensure(cls, value: "PipelineStage | str") -> "PipelineStage":
+        if isinstance(value, cls):
+            return value
+        return cls.from_str(str(value))
+
 
 __all__ = ["PipelineStage"]


### PR DESCRIPTION
## Summary
- restore `PipelineStage` enum implementation
- keep `entity.core.stages` as a simple alias

## Testing
- `poetry run pytest tests/test_stage_precedence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687a72272f0883229b1dfb23fa057e25