### PR TITLE
Fix default resource paths and skip empty temp state

### DIFF
--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -268,11 +268,11 @@ class SystemInitializer:
         resources = self._config_model.plugins.resources
         if "database" not in resources:
             resources["database"] = PluginConfig(
-                type="entity.resources.interfaces.duckdb_resource:DuckDBResource"
+                type="entity.resources.database:DuckDBResource"
             )
             self.config.setdefault("plugins", {}).setdefault("resources", {})[
                 "database"
-            ] = {"type": "entity.resources.interfaces.duckdb_resource:DuckDBResource"}
+            ] = {"type": "entity.resources.database:DuckDBResource"}
         if "logging" not in resources:
             resources["logging"] = PluginConfig(
                 type="entity.resources.logging:LoggingResource"
@@ -858,15 +858,13 @@ class SystemInitializer:
             registered.add("database_backend")
 
         if "database" not in registered:
-            from entity.resources.interfaces.duckdb_resource import DuckDBResource
+            from entity.resources.database import DuckDBResource
 
             container.register("database", DuckDBResource, {}, layer=2)
             registered.add("database")
 
         if "vector_store" not in registered:
-            from entity.resources.interfaces.duckdb_vector_store import (
-                DuckDBVectorStore,
-            )
+            from entity.resources.duckdb_vector_store import DuckDBVectorStore
 
             container.register("vector_store", DuckDBVectorStore, {}, layer=2)
             registered.add("vector_store")

--- a/src/entity/pipeline/pipeline.py
+++ b/src/entity/pipeline/pipeline.py
@@ -283,11 +283,15 @@ async def execute_stage(
             state.conversation,
             user_id=user_id,
         )
-        await memory.store_persistent(
-            f"{state.pipeline_id}_temp",
-            state.temporary_thoughts,
-            user_id=user_id,
-        )
+        temp_key = f"{state.pipeline_id}_temp"
+        if state.temporary_thoughts:
+            await memory.store_persistent(
+                temp_key,
+                state.temporary_thoughts,
+                user_id=user_id,
+            )
+        else:
+            await memory.delete_persistent(temp_key, user_id=user_id)
     _elapsed = time.perf_counter() - _start
     # elapsed time could be logged here if needed
 

--- a/src/entity/worker/pipeline_worker.py
+++ b/src/entity/worker/pipeline_worker.py
@@ -55,9 +55,12 @@ class PipelineWorker:
             await memory.save_conversation(
                 pipeline_id, state.conversation, user_id=user_id
             )
-            await memory.store_persistent(
-                temp_key, state.temporary_thoughts, user_id=user_id
-            )
+            if state.temporary_thoughts:
+                await memory.store_persistent(
+                    temp_key, state.temporary_thoughts, user_id=user_id
+                )
+            else:
+                await memory.delete_persistent(temp_key, user_id=user_id)
             return result
 
         if hasattr(container, "__aenter__"):


### PR DESCRIPTION
## Summary
- fix DuckDB resource paths in initializer
- avoid persisting empty temporary thoughts
- drop unused temp keys after pipeline runs

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687a7e4f4f5c83228ed7216db6fd5304