### PR TITLE
Increase startup timeout for Postgres tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,7 @@ def postgres_dsn(docker_ip: str, docker_services) -> str:
     def check():
         return loop.run_until_complete(_can_connect(dsn))
 
-    docker_services.wait_until_responsive(timeout=30, pause=0.5, check=check)
+    docker_services.wait_until_responsive(timeout=60, pause=0.5, check=check)
     return dsn
 
 


### PR DESCRIPTION
## Summary
- extend docker wait timeout for Postgres startup so integration tests have more time

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad6ae97608322a3eb43524cf1cc77