### PR TITLE
Improve postgres_dsn failure logs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,14 @@ def postgres_dsn(docker_ip: str, docker_services) -> str:
     def check():
         return loop.run_until_complete(_can_connect(dsn))
 
-    docker_services.wait_until_responsive(timeout=60, pause=0.5, check=check)
+    try:
+        docker_services.wait_until_responsive(timeout=60, pause=0.5, check=check)
+    except Exception:
+        try:
+            print("\n❌ Postgres container logs:\n" + docker_services.logs("postgres"))
+        except Exception as log_error:
+            print(f"Failed to retrieve postgres logs: {log_error}")
+        raise
     return dsn
 
 


### PR DESCRIPTION
## Summary
- add log retrieval when Postgres fixture fails to start

## Testing
- `poetry run poe test-with-docker` *(fails: `docker compose` not available)*

------
https://chatgpt.com/codex/tasks/task_e_687adf1444dc8322894b55739693d20c