### PR TITLE
Resolve merge conflict in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,20 +102,16 @@ def postgres_dsn(docker_ip: str, docker_services) -> str:
     def check():
         return loop.run_until_complete(_can_connect(dsn))
 
-<<<<<<< HEAD
     try:
-        docker_services.wait_until_responsive(timeout=60, pause=0.5, check=check)
+        docker_services.wait_until_responsive(
+            timeout=POSTGRES_READY_TIMEOUT, pause=0.5, check=check
+        )
     except Exception:
         try:
             print("\n❌ Postgres container logs:\n" + docker_services.logs("postgres"))
         except Exception as log_error:
             print(f"Failed to retrieve postgres logs: {log_error}")
         raise
-=======
-    docker_services.wait_until_responsive(
-        timeout=POSTGRES_READY_TIMEOUT, pause=0.5, check=check
-    )
->>>>>>> pr-1803
     return dsn
 
 


### PR DESCRIPTION
## Summary
- resolve merge conflict in `tests/conftest.py`

## Testing
- `poetry run ruff check --fix tests/conftest.py`
- `poetry run black tests/conftest.py`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r tests/conftest.py`
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test-with-docker` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_687ae3c15c6083229829ae8ddd4b7925