### PR TITLE
Add example stories

### DIFF
--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -1,0 +1,28 @@
+# Example Stories
+
+Each example demonstrates a small aspect of the framework. These short stories explain what to expect when running them.
+
+## basic_agent
+This minimal agent echoes the most recent user message. It registers a single `@agent.output` function and prints the final response. Run it with:
+
+```bash
+poetry run python examples/basic_agent/main.py
+```
+
+## default
+`examples/default` shows the decorator-based API. A simple tool and output plugin are registered with `@agent.tool` and `@agent.output`. The agent calculates `2 + 2` and returns the result alongside the original message.
+
+## default_setup
+This variant uses the global `agent` instance. No configuration is required; the default resources are prepared automatically. It performs the same calculation as the `default` example.
+
+## duckdb_memory_agent
+This example introduces a custom `DuckDBMemory` resource. The agent increments a counter stored in a DuckDB database on each run and prints the current value.
+
+## full_workflow
+`examples/full_workflow` integrates multiple LLM providers with PostgreSQL, vector storage, logging, and metrics. It demonstrates how to register infrastructure resources and custom plugins for a complete workflow.
+
+## intermediate_agent
+This story chains a prompt plugin with a custom responder. The THINK stage collects a breakdown of the user's question. The responder outputs the final explanation.
+
+## kitchen_sink
+The kitchen sink agent executes a small ReAct loop. It calls the calculator tool, accumulates thoughts with `ctx.reflect()`, and replies with the final reasoning path.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -11,6 +11,7 @@ error_handling
 logging
 configuration
 plugin_examples
+examples
 plugins
 workflows
 multi_user

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,11 +1,14 @@
 # Example Agents
 
-Each subdirectory contains a small agent showcasing different features.
+Each subdirectory demonstrates a specific capability.
 
-- **kitchen_sink** – demonstrates a ReAct loop with tool usage.
-- **default** – minimal zero-config agent using decorators.
-- **plugins** – minimal plugins for INPUT, PARSE, and REVIEW stages.
-- **full_workflow** – multiple LLM providers with PostgreSQL and monitoring.
+- **basic_agent** – simplest echo example.
+- **default** – decorator-based workflow with one tool.
+- **default_setup** – global agent initialized automatically.
+- **duckdb_memory_agent** – custom memory backed by DuckDB.
+- **full_workflow** – multiple LLM providers with PostgreSQL and metrics.
+- **intermediate_agent** – chained prompt and responder plugins.
+- **kitchen_sink** – small ReAct loop using the calculator tool.
 
 Run any example with:
 

--- a/examples/basic_agent/README.md
+++ b/examples/basic_agent/README.md
@@ -1,0 +1,7 @@
+# Basic Agent
+
+This story is a bare-bones echo bot. The `@agent.output` function grabs the last user message and replies with it. Use it to confirm the framework is installed correctly.
+
+```bash
+poetry run python examples/basic_agent/main.py
+```

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -1,8 +1,8 @@
 # Default Setup Agent
 
-This example uses the default `agent` instance with the
-`@agent.tool` and `@agent.output` decorators. The output plugin
-emits the final response at the correct stage.
+This short story highlights the decorator API. The agent registers a small tool
+and an output plugin. When invoked it adds two numbers and replies with the
+result alongside the original user message.
 
 Run it with:
 

--- a/examples/default_setup/README.md
+++ b/examples/default_setup/README.md
@@ -1,8 +1,7 @@
 # Default Setup Agent
 
-This example uses the global `agent` with the
-`@agent.tool` and `@agent.output` decorators. No configuration is
-required; the default resources are set up automatically.
+This story mirrors the `default` example but shows that the global `agent`
+initializes its own resources. No configuration files are needed.
 
 Run it with:
 

--- a/examples/duckdb_memory_agent/README.md
+++ b/examples/duckdb_memory_agent/README.md
@@ -1,0 +1,7 @@
+# DuckDB Memory Agent
+
+This example defines a custom `DuckDBMemory` resource that persists key-value pairs and conversation history in a local DuckDB file. Each run increments a counter stored in the database.
+
+```bash
+poetry run python examples/duckdb_memory_agent/main.py
+```

--- a/examples/full_workflow/README.md
+++ b/examples/full_workflow/README.md
@@ -1,8 +1,8 @@
 # Full Workflow Example
 
-This example demonstrates how to combine multiple LLM providers with a PostgreSQL
-backend and pgvector. It also enables structured logging and metrics
-collection.
+This extended story wires together PostgreSQL, pgvector, and multiple LLM providers.
+It also enables structured logging and metrics collection to showcase a realistic
+production setup.
 
 ## Prerequisites
 

--- a/examples/full_workflow/main.py
+++ b/examples/full_workflow/main.py
@@ -7,8 +7,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 
 from entity.core.agent import Agent
-from entity.core.registries import SystemRegistries
-from entity.core.agent import AgentRuntime
 from entity.core.stages import PipelineStage
 from entity.resources.llm import LLM
 from entity.resources.memory import Memory

--- a/examples/intermediate_agent/README.md
+++ b/examples/intermediate_agent/README.md
@@ -1,0 +1,7 @@
+# Intermediate Agent
+
+The intermediate agent chains a prompt plugin with a custom responder from `user_plugins`. It stores a brief analysis during the THINK stage and outputs the final explanation in the OUTPUT stage.
+
+```bash
+poetry run python examples/intermediate_agent/main.py
+```

--- a/examples/kitchen_sink/README.md
+++ b/examples/kitchen_sink/README.md
@@ -1,8 +1,8 @@
 # Kitchen Sink Agent
 
-This example demonstrates a ReAct-style loop with the built-in calculator tool.
-The THINK stage stores analysis with `ctx.think()` and the OUTPUT stage
-returns it using `ctx.reflect()`.
+This story runs a small ReAct loop using the calculator tool. Thoughts are stored
+with `ctx.think()` and reviewed later with `ctx.reflect()` to produce the final
+answer.
 
 ```bash
 poetry run python examples/kitchen_sink/main.py


### PR DESCRIPTION
## Summary
- add `examples.md` to describe each example
- add READMEs for basic, intermediate, and DuckDB examples
- update example READMEs with concise stories
- link new page from docs index
- clean unused imports in `examples/full_workflow/main.py`

## Testing
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport -r src tests` *(reverted changes)*
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687b9d42ddd48322a014b2fc7e958915