### PR TITLE
Add infrastructure config validation

### DIFF
--- a/src/entity/config/models.py
+++ b/src/entity/config/models.py
@@ -166,6 +166,57 @@ class StorageConfig(BaseModel):
         extra = "forbid"
 
 
+class PostgresConfig(BaseModel):
+    """Configuration for :class:`~entity.infrastructure.postgres.PostgresInfrastructure`."""
+
+    dsn: str = ""
+    pool: Dict[str, int] = Field(default_factory=dict)
+
+    class Config:
+        extra = "allow"
+
+
+class AsyncPGConfig(BaseModel):
+    """Configuration for :class:`~entity.infrastructure.asyncpg.AsyncPGInfrastructure`."""
+
+    dsn: str = ""
+    pool: Dict[str, int] = Field(default_factory=dict)
+
+    class Config:
+        extra = "allow"
+
+
+class DuckDBConfig(BaseModel):
+    """Configuration for :class:`~entity.infrastructure.duckdb.DuckDBInfrastructure`."""
+
+    path: str = ":memory:"
+
+    class Config:
+        extra = "allow"
+
+
+class DockerConfig(BaseModel):
+    """Configuration for :class:`~entity.infrastructure.docker.DockerInfrastructure`."""
+
+    path: str = "."
+
+    class Config:
+        extra = "allow"
+
+
+class LlamaCppConfig(BaseModel):
+    """Configuration for :class:`~entity.infrastructure.llamacpp.LlamaCppInfrastructure`."""
+
+    binary: str = "llama"
+    model: str
+    host: str = "127.0.0.1"
+    port: int = 8000
+    args: list[str] = Field(default_factory=list)
+
+    class Config:
+        extra = "allow"
+
+
 class LogOutputConfig(BaseModel):
     """Configuration for a single logging output."""
 
@@ -255,6 +306,11 @@ __all__ = [
     "MemoryConfig",
     "LLMConfig",
     "StorageConfig",
+    "PostgresConfig",
+    "AsyncPGConfig",
+    "DuckDBConfig",
+    "DockerConfig",
+    "LlamaCppConfig",
     "LogOutputConfig",
     "LoggingConfig",
     "WorkflowSettings",

--- a/src/entity/infrastructure/asyncpg.py
+++ b/src/entity/infrastructure/asyncpg.py
@@ -7,6 +7,7 @@ import asyncpg
 
 from entity.core.plugins import InfrastructurePlugin, ValidationResult
 from entity.core.resources.container import PoolConfig, ResourcePool
+from entity.config.models import AsyncPGConfig
 
 
 class AsyncPGInfrastructure(InfrastructurePlugin):
@@ -23,6 +24,14 @@ class AsyncPGInfrastructure(InfrastructurePlugin):
         self.dsn: str = self.config.get("dsn", "")
         pool_cfg = PoolConfig(**self.config.get("pool", {}))
         self._pool = ResourcePool(self._create_conn, pool_cfg, "asyncpg")
+
+    @classmethod
+    async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        try:
+            AsyncPGConfig(**config)
+        except Exception as exc:  # noqa: BLE001
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None

--- a/src/entity/infrastructure/docker.py
+++ b/src/entity/infrastructure/docker.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from entity.core.plugins import InfrastructurePlugin
+from entity.core.plugins import InfrastructurePlugin, ValidationResult
+from entity.config.models import DockerConfig
 
 
 class DockerInfrastructure(InfrastructurePlugin):
@@ -19,6 +20,14 @@ class DockerInfrastructure(InfrastructurePlugin):
         super().__init__(config or {})
         self.path = Path(self.config.get("path", ".")).resolve()
         self.deployed = False
+
+    @classmethod
+    async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        try:
+            DockerConfig(**config)
+        except Exception as exc:  # noqa: BLE001
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()
 
     # ---------------------------------------------------------
     # helpers

--- a/src/entity/infrastructure/duckdb.py
+++ b/src/entity/infrastructure/duckdb.py
@@ -13,6 +13,7 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
 
 from entity.core.plugins import InfrastructurePlugin, ValidationResult
 from entity.core.resources.container import PoolConfig, ResourcePool
+from entity.config.models import DuckDBConfig
 
 
 class DuckDBInfrastructure(InfrastructurePlugin):
@@ -27,6 +28,14 @@ class DuckDBInfrastructure(InfrastructurePlugin):
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
         self.path: str = self.config.get("path", ":memory:")
+
+    @classmethod
+    async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        try:
+            DuckDBConfig(**config)
+        except Exception as exc:  # noqa: BLE001
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()
 
     async def _execute_impl(self, context: Any) -> None:  # pragma: no cover - stub
         return None

--- a/src/entity/infrastructure/llamacpp.py
+++ b/src/entity/infrastructure/llamacpp.py
@@ -6,6 +6,7 @@ from typing import Dict, Sequence
 import httpx
 
 from entity.core.plugins import InfrastructurePlugin, ValidationResult
+from entity.config.models import LlamaCppConfig
 
 
 class LlamaCppInfrastructure(InfrastructurePlugin):
@@ -25,6 +26,14 @@ class LlamaCppInfrastructure(InfrastructurePlugin):
         self.port = int(self.config.get("port", 8000))
         self.args: Sequence[str] = self.config.get("args", [])
         self._process: asyncio.subprocess.Process | None = None
+
+    @classmethod
+    async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        try:
+            LlamaCppConfig(**config)
+        except Exception as exc:  # noqa: BLE001
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()
 
     async def initialize(self) -> None:
         if self._process is not None:

--- a/src/entity/infrastructure/postgres.py
+++ b/src/entity/infrastructure/postgres.py
@@ -7,6 +7,7 @@ import asyncpg
 
 from entity.core.plugins import InfrastructurePlugin, ValidationResult
 from entity.core.resources.container import PoolConfig, ResourcePool
+from entity.config.models import PostgresConfig
 
 
 class PostgresInfrastructure(InfrastructurePlugin):
@@ -23,6 +24,14 @@ class PostgresInfrastructure(InfrastructurePlugin):
         self.dsn: str = self.config.get("dsn", "")
         pool_cfg = PoolConfig(**self.config.get("pool", {}))
         self._pool = ResourcePool(self._create_conn, pool_cfg, "postgres")
+
+    @classmethod
+    async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        try:
+            PostgresConfig(**config)
+        except Exception as exc:  # noqa: BLE001 - return validation error
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()
 
     async def _create_conn(self) -> asyncpg.Connection:
         return await asyncpg.connect(self.dsn)

--- a/tests/infrastructure/test_config_validation.py
+++ b/tests/infrastructure/test_config_validation.py
@@ -1,0 +1,41 @@
+import pytest
+
+from entity.infrastructure import (
+    PostgresInfrastructure,
+    AsyncPGInfrastructure,
+    DuckDBInfrastructure,
+    DockerInfrastructure,
+    LlamaCppInfrastructure,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cls,config",
+    [
+        (PostgresInfrastructure, {"dsn": "postgresql://user@localhost/db"}),
+        (AsyncPGInfrastructure, {"dsn": "postgresql://user@localhost/db"}),
+        (DuckDBInfrastructure, {"path": ":memory:"}),
+        (DockerInfrastructure, {"path": "."}),
+        (LlamaCppInfrastructure, {"model": "model.bin"}),
+    ],
+)
+async def test_validate_config_valid(cls, config):
+    result = await cls.validate_config(config)
+    assert result.success
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cls,config",
+    [
+        (PostgresInfrastructure, {"dsn": 1}),
+        (AsyncPGInfrastructure, {"dsn": 1}),
+        (DuckDBInfrastructure, {"path": 2}),
+        (DockerInfrastructure, {"path": 3}),
+        (LlamaCppInfrastructure, {"model": "x", "port": "bad"}),
+    ],
+)
+async def test_validate_config_invalid(cls, config):
+    result = await cls.validate_config(config)
+    assert not result.success


### PR DESCRIPTION
## Summary
- add Pydantic infrastructure config models
- allow extra fields for CircuitBreaker options
- implement validate_config for built-in infrastructures
- test config validation for infrastructures

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: Docker missing)*

------
https://chatgpt.com/codex/tasks/task_e_687bedb03c2c83228ba42593616fa787