### PR TITLE
Update docs for vector store layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ INPUT, PARSE, and REVIEW stages. Each shows how to interact with the
 [Plugin Examples](https://entity.readthedocs.io/en/latest/plugin_examples.html)
 documentation.
 
+## Infrastructure Plugins
+
+Register infrastructure plugins under the `database_backend` and `vector_store`
+keys when configuring resources.
+
+```yaml
+plugins:
+  infrastructure:
+    postgres_backend:
+      type: entity.infrastructure.asyncpg:AsyncPGInfrastructure
+      dsn: postgresql://user:pass@localhost:5432/agent
+  resources:
+    vector_store:
+      type: entity.resources.duckdb_vector_store:DuckDBVectorStore
+```
+
 ## Metrics & Performance
 
 Use the bundled `MetricsCollectorResource` to inspect plugin and resource activity.

--- a/docs/source/error_handling.md
+++ b/docs/source/error_handling.md
@@ -41,8 +41,9 @@ You can override defaults in your configuration:
 
 ```yaml
 plugins:
-  - db:
-      type: Postgres
+  infrastructure:
+    postgres_backend:
+      type: entity.infrastructure.asyncpg:AsyncPGInfrastructure
       failure_threshold: 5
       failure_reset_timeout: 120
       init_failure_threshold: 2

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -67,7 +67,7 @@ stats per plugin.
 ## DatabaseResource
 
 `DuckDBResource` provides a zero-config persistent database. It depends on the
-automatically created DuckDB infrastructure and is registered if omitted.
+automatically created `database_backend` infrastructure and is registered if omitted.
 
 ```yaml
 plugins:
@@ -75,4 +75,17 @@ plugins:
     database:
       type: entity.resources.database:DuckDBResource
       path: ./agent.duckdb
+```
+
+## VectorStoreResource
+
+`VectorStoreResource` adds semantic search using a pluggable vector store. The
+bundled `DuckDBVectorStore` registers at **layer 2** and relies on the same
+`database_backend` infrastructure.
+
+```yaml
+plugins:
+  resources:
+    vector_store:
+      type: entity.resources.duckdb_vector_store:DuckDBVectorStore
 ```

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -56,3 +56,16 @@ plugins:
 ```
 
 No configuration options are required.
+
+## AsyncPGInfrastructure
+
+`AsyncPGInfrastructure` connects to a PostgreSQL server and exposes a
+`database_backend` for resources.
+
+```yaml
+plugins:
+  infrastructure:
+    postgres_backend:
+      type: entity.infrastructure.asyncpg:AsyncPGInfrastructure
+      dsn: postgresql://user:pass@localhost:5432/agent
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,8 @@ Each subdirectory demonstrates a specific capability.
 - **default** – decorator-based workflow with one tool.
 - **default_setup** – global agent initialized automatically.
 - **duckdb_memory_agent** – custom memory backed by DuckDB.
-- **full_workflow** – multiple LLM providers with PostgreSQL and metrics.
+- **full_workflow** – multiple LLM providers with PostgreSQL, a vector store,
+  and metrics.
 - **intermediate_agent** – chained prompt and responder plugins.
 - **kitchen_sink** – small ReAct loop using the calculator tool.
 

--- a/examples/full_workflow/README.md
+++ b/examples/full_workflow/README.md
@@ -1,6 +1,7 @@
 # Full Workflow Example
 
-This extended story wires together PostgreSQL, pgvector, and multiple LLM providers.
+This extended story wires together PostgreSQL, a pgvector-based vector store,
+and multiple LLM providers.
 It also enables structured logging and metrics collection to showcase a realistic
 production setup.
 


### PR DESCRIPTION
## Summary
- clarify registration of `database_backend` infrastructure
- document `VectorStoreResource` as layer 2
- show `AsyncPGInfrastructure` usage
- note vector store in example READMEs

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_687bf4991c10832299b22c904463aef4