### PR TITLE
Introduce vector store infrastructure

### DIFF
--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -326,6 +326,13 @@ class _AgentBuilder:
 
             container.register("database", DuckDBResource, {}, layer=2)
 
+        if not container.has_plugin("vector_store_backend"):
+            from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
+
+            container.register(
+                "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+            )
+
         if not container.has_plugin("vector_store"):
             from entity.resources.duckdb_vector_store import DuckDBVectorStore
 

--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -3,6 +3,8 @@ from .duckdb import DuckDBInfrastructure
 from .docker import DockerInfrastructure
 from .llamacpp import LlamaCppInfrastructure
 from .asyncpg import AsyncPGInfrastructure
+from .vector_store import VectorStoreInfrastructure
+from .duckdb_vector import DuckDBVectorInfrastructure
 
 __all__ = [
     "PostgresInfrastructure",
@@ -10,4 +12,6 @@ __all__ = [
     "DockerInfrastructure",
     "LlamaCppInfrastructure",
     "AsyncPGInfrastructure",
+    "VectorStoreInfrastructure",
+    "DuckDBVectorInfrastructure",
 ]

--- a/src/entity/infrastructure/duckdb_vector.py
+++ b/src/entity/infrastructure/duckdb_vector.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, Dict, Iterator, List
+import math
+import importlib
+
+from entity.config.models import DuckDBConfig
+from entity.core.plugins import ValidationResult
+from entity.core.resources.container import PoolConfig, ResourcePool
+
+from .vector_store import VectorStoreInfrastructure
+
+try:
+    duckdb = importlib.import_module("duckdb")
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    duckdb = None
+
+
+class DuckDBVectorInfrastructure(VectorStoreInfrastructure):
+    """Vector store backend using DuckDB."""
+
+    name = "duckdb_vector_backend"
+    stages: list = []
+    dependencies: list[str] = []
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+        self.path: str = self.config.get("path", ":memory:")
+        self.table: str = self.config.get("table", "vector_mem")
+        self._pool = ResourcePool(
+            self._create_conn, PoolConfig(), "duckdb_vector_backend"
+        )
+
+    @classmethod
+    async def validate_config(cls, config: Dict[str, Any]) -> ValidationResult:
+        try:
+            DuckDBConfig(**config)
+        except Exception as exc:  # noqa: BLE001
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()
+
+    async def initialize(self) -> None:
+        if duckdb is None:
+            raise RuntimeError("duckdb package not installed")
+        await self._pool.initialize()
+        async with self.connection() as conn:
+            conn.execute(
+                f"CREATE TABLE IF NOT EXISTS {self.table} (text TEXT, embedding DOUBLE[])"
+            )
+            self._maybe_commit(conn)
+
+    def _create_conn(self) -> Any:
+        if duckdb is None:
+            raise RuntimeError("duckdb package not installed")
+        return duckdb.connect(self.path)
+
+    def get_connection_pool(self) -> ResourcePool:
+        return self._pool
+
+    def _maybe_commit(self, conn: Any) -> None:
+        commit = getattr(conn, "commit", None)
+        if callable(commit):
+            commit()
+
+    @asynccontextmanager
+    async def connection(self) -> Iterator[Any]:
+        conn = self._create_conn()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def _embed(self, text: str) -> List[float]:
+        return [float(ord(c)) for c in text][:256]
+
+    async def add_embedding(self, text: str) -> None:
+        async with self.connection() as conn:
+            emb = self._embed(text)
+            conn.execute(
+                f"INSERT INTO {self.table} VALUES (?, ?)",
+                (text, emb),
+            )
+            self._maybe_commit(conn)
+
+    async def query_similar(self, query: str, k: int = 5) -> List[str]:
+        async with self.connection() as conn:
+            rows = conn.execute(f"SELECT text, embedding FROM {self.table}").fetchall()
+        if not rows:
+            return []
+        qvec = self._embed(query)
+
+        def _distance(a: List[float], b: List[float]) -> float:
+            size = min(len(a), len(b))
+            if size == 0:
+                return float("inf")
+            dot = sum(a[i] * b[i] for i in range(size))
+            na = math.sqrt(sum(a[i] * a[i] for i in range(size)))
+            nb = math.sqrt(sum(b[i] * b[i] for i in range(size)))
+            return 1 - dot / (na * nb) if na and nb else float("inf")
+
+        scored = sorted(((t, _distance(qvec, e)) for t, e in rows), key=lambda x: x[1])
+        return [t for t, _ in scored[:k]]

--- a/src/entity/infrastructure/vector_store.py
+++ b/src/entity/infrastructure/vector_store.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, Dict, List, Iterator
+
+from entity.core.plugins import InfrastructurePlugin, ValidationResult
+from entity.core.resources.container import PoolConfig, ResourcePool
+
+
+class VectorStoreInfrastructure(InfrastructurePlugin):
+    """Base class for vector store backends."""
+
+    infrastructure_type = "vector_store"
+    resource_category = "database"
+    stages: list = []
+    dependencies: list[str] = []
+
+    def __init__(self, config: Dict | None = None) -> None:
+        super().__init__(config or {})
+
+    async def add_embedding(self, text: str) -> None:  # pragma: no cover - stub
+        return None
+
+    async def query_similar(
+        self, query: str, k: int = 5
+    ) -> List[str]:  # pragma: no cover - stub
+        return []
+
+    def get_connection_pool(self) -> ResourcePool:
+        return ResourcePool(lambda: None, PoolConfig())
+
+    @asynccontextmanager
+    async def connection(self) -> Iterator[Any]:  # pragma: no cover - stub
+        yield None
+
+    async def validate_runtime(self, breaker: Any | None = None) -> ValidationResult:
+        try:
+            await self.query_similar("ping", 1)
+        except Exception as exc:  # noqa: BLE001
+            return ValidationResult.error_result(str(exc))
+        return ValidationResult.success_result()

--- a/src/entity/pipeline/initializer.py
+++ b/src/entity/pipeline/initializer.py
@@ -863,6 +863,14 @@ class SystemInitializer:
             container.register("database", DuckDBResource, {}, layer=2)
             registered.add("database")
 
+        if "vector_store_backend" not in registered:
+            from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
+
+            container.register(
+                "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+            )
+            registered.add("vector_store_backend")
+
         if "vector_store" not in registered:
             from entity.resources.duckdb_vector_store import DuckDBVectorStore
 

--- a/tests/architecture/test_infrastructure_dependencies.py
+++ b/tests/architecture/test_infrastructure_dependencies.py
@@ -2,6 +2,8 @@ from entity.infrastructure.docker import DockerInfrastructure
 from entity.infrastructure.duckdb import DuckDBInfrastructure
 from entity.infrastructure.llamacpp import LlamaCppInfrastructure
 from entity.infrastructure.postgres import PostgresInfrastructure
+from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
+from entity.resources.duckdb_vector_store import DuckDBVectorStore
 
 
 def test_infrastructure_plugins_have_no_dependencies() -> None:
@@ -10,6 +12,7 @@ def test_infrastructure_plugins_have_no_dependencies() -> None:
         DuckDBInfrastructure,
         LlamaCppInfrastructure,
         PostgresInfrastructure,
+        DuckDBVectorInfrastructure,
     ]
     for cls in classes:
         assert (
@@ -18,3 +21,7 @@ def test_infrastructure_plugins_have_no_dependencies() -> None:
         assert (
             "dependencies" in cls.__dict__
         ), f"{cls.__name__} missing dependencies attribute"
+
+
+def test_vector_store_resource_requires_backend() -> None:
+    assert DuckDBVectorStore.infrastructure_dependencies == ["vector_store_backend"]

--- a/tests/integration/test_workflow_compose.py
+++ b/tests/integration/test_workflow_compose.py
@@ -6,6 +6,7 @@ from entity.infrastructure import DuckDBInfrastructure
 from entity.pipeline.stages import PipelineStage
 from entity.resources.database import DuckDBResource
 from entity.resources.duckdb_vector_store import DuckDBVectorStore
+from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
 from entity.workflows.base import Workflow
 from entity.workflows.compose import compose_workflows
 
@@ -44,6 +45,9 @@ async def test_compose_workflows_execute():
     wf = compose_workflows(WF1(), WF2())
     agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     runtime = await builder.build_runtime(wf)
     result = await runtime.handle("hi")
@@ -61,6 +65,9 @@ async def test_compose_validates_plugins():
     wf = compose_workflows(WF1(), WF2())
     agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     with pytest.raises(KeyError):
         await builder.build_runtime(wf)

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -7,6 +7,7 @@ from entity.pipeline.stages import PipelineStage
 from entity.pipeline.workflow import Pipeline, Workflow
 from entity.resources.database import DuckDBResource
 from entity.resources.duckdb_vector_store import DuckDBVectorStore
+from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
 
 
 class ThoughtPlugin(Plugin):
@@ -40,6 +41,9 @@ async def test_builder_runtime_executes_workflow():
     agent.pipeline = Pipeline(builder=builder, workflow=wf)
     agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     runtime = await agent.build_runtime()
     result = await runtime.handle("hello")
@@ -57,6 +61,9 @@ async def test_agent_handle_runs_workflow():
     agent.pipeline = Pipeline(builder=agent.builder, workflow=wf)
     agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     runtime = await agent.build_runtime()
     result = await runtime.handle("bye")
@@ -69,6 +76,9 @@ async def test_builder_registers_default_resources() -> None:
     builder = agent.builder
     agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     runtime = await agent.build_runtime()
     assert runtime is not None

--- a/tests/test_plugin_lifecycle.py
+++ b/tests/test_plugin_lifecycle.py
@@ -6,6 +6,7 @@ from entity.core.stages import PipelineStage
 from entity.infrastructure import DuckDBInfrastructure
 from entity.resources.database import DuckDBResource
 from entity.resources.duckdb_vector_store import DuckDBVectorStore
+from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
 
 
 class LifecyclePlugin(Plugin):
@@ -34,6 +35,9 @@ def test_plugin_lifecycle():
     asyncio.run(ag.builder.add_plugin(plugin))
     ag.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     ag.register_resource("database", DuckDBResource, {}, layer=2)
+    ag.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     ag.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     asyncio.run(ag.builder.build_runtime())
 

--- a/tests/test_plugin_tool_test.py
+++ b/tests/test_plugin_tool_test.py
@@ -5,6 +5,7 @@ from entity.core.plugins import ToolPlugin
 from entity.infrastructure import DuckDBInfrastructure
 from entity.resources.database import DuckDBResource
 from entity.resources.duckdb_vector_store import DuckDBVectorStore
+from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
 
 
 class _TestPluginToolCLI(PluginToolCLI):
@@ -32,6 +33,9 @@ class _TestPluginToolCLI(PluginToolCLI):
                 "database_backend", DuckDBInfrastructure, {}, layer=1
             )
             agent.register_resource("database", DuckDBResource, {}, layer=2)
+            agent.register_resource(
+                "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+            )
             agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
             wf = {stage: [plugin_cls.__name__] for stage in plugin_cls.stages}
             pipeline = PipelineWrapper(builder=agent.builder, workflow=wf)

--- a/tests/test_reload_runtime_validation.py
+++ b/tests/test_reload_runtime_validation.py
@@ -12,6 +12,7 @@ from entity.infrastructure import DuckDBInfrastructure
 from entity.pipeline.config.config_update import update_plugin_configuration
 from entity.resources.database import DuckDBResource
 from entity.resources.duckdb_vector_store import DuckDBVectorStore
+from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
 
 
 class RuntimeCheckPlugin(Plugin):
@@ -66,6 +67,9 @@ async def test_reload_aborts_on_failed_runtime_validation(tmp_path):
     await agent.add_plugin(plugin)
     agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     await agent.build_runtime()
 
@@ -93,6 +97,9 @@ async def test_reload_successful_reconfiguration(tmp_path):
     await agent.add_plugin(plugin)
     agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     await agent.build_runtime()
 
@@ -119,6 +126,9 @@ async def test_reload_failed_reconfiguration(tmp_path):
     await agent.add_plugin(plugin)
     agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     await agent.build_runtime()
 

--- a/tests/test_reload_unknown_plugin.py
+++ b/tests/test_reload_unknown_plugin.py
@@ -9,6 +9,7 @@ from entity.cli import EntityCLI
 from entity.infrastructure import DuckDBInfrastructure
 from entity.resources.database import DuckDBResource
 from entity.resources.duckdb_vector_store import DuckDBVectorStore
+from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
 
 from .test_reload_runtime_validation import run_reload
 
@@ -32,6 +33,9 @@ async def test_reload_requires_restart_when_plugin_missing(tmp_path: Path) -> No
     await agent.add_plugin(plugin)
     agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     await agent.build_runtime()
 

--- a/tests/workflow/test_workflow_features.py
+++ b/tests/workflow/test_workflow_features.py
@@ -7,6 +7,7 @@ from entity.pipeline.stages import PipelineStage
 from entity.pipeline.workflow import Pipeline
 from entity.resources.database import DuckDBResource
 from entity.resources.duckdb_vector_store import DuckDBVectorStore
+from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
 from entity.workflows.base import Workflow
 
 
@@ -45,6 +46,9 @@ async def test_conditional_stage_skip():
     pipeline = Pipeline(builder=builder, workflow=wf)
     agent.register_resource("database_backend", DuckDBInfrastructure, {}, layer=1)
     agent.register_resource("database", DuckDBResource, {}, layer=2)
+    agent.register_resource(
+        "vector_store_backend", DuckDBVectorInfrastructure, {}, layer=1
+    )
     agent.register_resource("vector_store", DuckDBVectorStore, {}, layer=2)
     runtime = await pipeline.build_runtime()
     result = await runtime.handle("hi")


### PR DESCRIPTION
## Summary
- create VectorStoreInfrastructure base class
- implement DuckDBVectorInfrastructure backend
- adapt DuckDBVectorStore to use vector store backend
- register vector store infrastructure by default
- update tests and architecture checks for new layer

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687bf497d82483228470c42bbd7c96a5