### PR TITLE
Align resource names with architecture

### DIFF
--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -18,7 +18,7 @@ class LLMResource(ResourcePlugin):
     """Base class for simple LLM resources."""
 
     name = "llm_provider"
-    infrastructure_dependencies: list[str] = ["llm_backend?"]
+    infrastructure_dependencies: list[str] = ["llm_provider?"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/entity/resources/storage.py
+++ b/src/entity/resources/storage.py
@@ -15,7 +15,7 @@ from .base import AgentResource
 class StorageResource(ResourcePlugin):
     """Abstract interface for key/value storage backends."""
 
-    infrastructure_dependencies = ["storage_backend"]
+    infrastructure_dependencies = ["file_system"]
     resource_category = "filesystem"
 
     def __init__(self, config: Dict | None = None) -> None:

--- a/src/plugins/builtin/infrastructure/echo_llm_backend.py
+++ b/src/plugins/builtin/infrastructure/echo_llm_backend.py
@@ -9,7 +9,7 @@ class EchoLLMBackend(InfrastructurePlugin):
     """Simple backend that echoes prompts."""
 
     name = "echo_llm_backend"
-    infrastructure_type = "llm_backend"
+    infrastructure_type = "llm_provider"
     resource_category = "llm"
     stages: list = []
     dependencies: list[str] = []


### PR DESCRIPTION
## Summary
- use `file_system` instead of `storage_backend`
- use `llm_provider` instead of `llm_backend`

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687bf498a4cc832289c927bf8c2e1195