### PR TITLE
Align resource dependencies with canonical names

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ documentation.
 
 ## Infrastructure Plugins
 
-Register infrastructure plugins under the `database_backend` and `vector_store`
+Register infrastructure plugins under the `database` and `vector_store`
 keys when configuring resources.
 
 ```yaml

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -67,7 +67,7 @@ stats per plugin.
 ## DatabaseResource
 
 `DuckDBResource` provides a zero-config persistent database. It depends on the
-automatically created `database_backend` infrastructure and is registered if omitted.
+automatically created `database` infrastructure and is registered if omitted.
 
 ```yaml
 plugins:
@@ -81,7 +81,7 @@ plugins:
 
 `VectorStoreResource` adds semantic search using a pluggable vector store. The
 bundled `DuckDBVectorStore` registers at **layer 2** and relies on the same
-`database_backend` infrastructure.
+`database` infrastructure.
 
 ```yaml
 plugins:

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -51,8 +51,8 @@ back to the caller and exposes the `"llm_backend"` infrastructure type.
 ```yaml
 plugins:
   infrastructure:
-    echo_llm_backend:
-      type: plugins.builtin.infrastructure.echo_llm_backend:EchoLLMBackend
+    echo_llm_provider:
+      type: plugins.builtin.infrastructure.echo_llm_provider:EchoLLMProvider
 ```
 
 No configuration options are required.
@@ -60,7 +60,7 @@ No configuration options are required.
 ## AsyncPGInfrastructure
 
 `AsyncPGInfrastructure` connects to a PostgreSQL server and exposes a
-`database_backend` for resources.
+`database` for resources.
 
 ```yaml
 plugins:

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -343,10 +343,10 @@ class _AgentBuilder:
 
             container.register("memory", Memory, {}, layer=3)
 
-        if not container.has_plugin("echo_llm_backend"):
-            from plugins.builtin.infrastructure.echo_llm_backend import EchoLLMBackend
+        if not container.has_plugin("echo_llm_provider"):
+            from plugins.builtin.infrastructure.echo_llm_provider import EchoLLMProvider
 
-            container.register("echo_llm_backend", EchoLLMBackend, {}, layer=1)
+            container.register("echo_llm_provider", EchoLLMProvider, {}, layer=1)
 
         if not container.has_plugin("llm_provider"):
             from entity.resources.llm import EchoLLMResource

--- a/src/entity/resources/database.py
+++ b/src/entity/resources/database.py
@@ -12,13 +12,13 @@ from entity.infrastructure.postgres import PostgresInfrastructure
 class DatabaseResource(ResourcePlugin):
     """Abstract database interface over a concrete backend."""
 
-    infrastructure_dependencies = ["database_backend"]
+    infrastructure_dependencies = ["database"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})
 
     def get_connection_pool(self) -> ResourcePool:
-        infrastructure = getattr(self, "database_backend", None)
+        infrastructure = getattr(self, "database", None)
         if infrastructure:
             return infrastructure.get_connection_pool()
         return ResourcePool(lambda: None, PoolConfig())
@@ -36,23 +36,23 @@ class DuckDBResource(DatabaseResource):  # type: ignore[misc]
 
     def __init__(self, config: Dict[str, Any] | None = None) -> None:
         super().__init__(config)
-        self.database_backend: DuckDBInfrastructure | None = None
+        self.database: DuckDBInfrastructure | None = None
 
     @asynccontextmanager
     async def connection(self) -> AsyncIterator[Any]:
-        if self.database_backend is None:
+        if self.database is None:
             yield None
         else:
-            async with self.database_backend.connection() as conn:
+            async with self.database.connection() as conn:
                 yield conn
 
     @property
     def database(self) -> DuckDBInfrastructure | None:
-        return self.database_backend
+        return self.database
 
     @database.setter
     def database(self, value: DuckDBInfrastructure | None) -> None:
-        self.database_backend = value
+        self.database = value
 
 
 class PostgresResource(DatabaseResource):  # type: ignore[misc]
@@ -60,23 +60,23 @@ class PostgresResource(DatabaseResource):  # type: ignore[misc]
 
     def __init__(self, config: Dict[str, Any] | None = None) -> None:
         super().__init__(config)
-        self.database_backend: PostgresInfrastructure | None = None
+        self.database: PostgresInfrastructure | None = None
 
     @asynccontextmanager
     async def connection(self) -> AsyncIterator[Any]:
-        if self.database_backend is None:
+        if self.database is None:
             yield None
         else:
-            async with self.database_backend.connection() as conn:
+            async with self.database.connection() as conn:
                 yield conn
 
     @property
     def database(self) -> PostgresInfrastructure | None:
-        return self.database_backend
+        return self.database
 
     @database.setter
     def database(self, value: PostgresInfrastructure | None) -> None:
-        self.database_backend = value
+        self.database = value
 
 
 __all__ = ["DatabaseResource", "DuckDBResource", "PostgresResource"]

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -49,7 +49,7 @@ class LLMResource(ResourcePlugin):
 class EchoLLMResource(LLMResource):
     """LLM that simply echoes the prompt."""
 
-    infrastructure_dependencies = ["echo_llm_backend"]
+    infrastructure_dependencies = ["echo_llm_provider"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/src/plugins/builtin/infrastructure/__init__.py
+++ b/src/plugins/builtin/infrastructure/__init__.py
@@ -1,5 +1,5 @@
 """Infrastructure implementations shipped with the framework."""
 
-from .echo_llm_backend import EchoLLMBackend
+from .echo_llm_provider import EchoLLMProvider
 
-__all__ = ["EchoLLMBackend"]
+__all__ = ["EchoLLMProvider"]

--- a/src/plugins/builtin/infrastructure/echo_llm_provider.py
+++ b/src/plugins/builtin/infrastructure/echo_llm_provider.py
@@ -5,10 +5,10 @@ from typing import Dict
 from entity.plugins.base import InfrastructurePlugin, ValidationResult
 
 
-class EchoLLMBackend(InfrastructurePlugin):
+class EchoLLMProvider(InfrastructurePlugin):
     """Simple backend that echoes prompts."""
 
-    name = "echo_llm_backend"
+    name = "echo_llm_provider"
     infrastructure_type = "llm_provider"
     resource_category = "llm"
     stages: list = []

--- a/src/plugins/builtin/resources/pg_vector_store.py
+++ b/src/plugins/builtin/resources/pg_vector_store.py
@@ -12,7 +12,7 @@ class PgVectorStore(VectorStoreResource):
     """Placeholder pgvector-based store."""
 
     name = "pg_vector_store"
-    infrastructure_dependencies = ["database_backend"]
+    infrastructure_dependencies = ["database"]
 
     def __init__(self, config: Dict | None = None) -> None:
         super().__init__(config or {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,7 @@ class AsyncPGDatabase(DatabaseResource):
     def __init__(self, dsn: str) -> None:
         super().__init__({})
         self._dsn = dsn
-        self.database_backend = None
+        self.database = None
 
     @classmethod
     def from_config(cls, cfg: dict) -> "AsyncPGDatabase":
@@ -127,7 +127,7 @@ class AsyncPGDatabase(DatabaseResource):
 
     @asynccontextmanager
     async def connection(self):
-        backend = getattr(self, "database_backend", None)
+        backend = getattr(self, "database", None)
         if backend is None:
             parsed = urlparse(self._dsn)
             wait_for_port(parsed.hostname, parsed.port)
@@ -145,7 +145,7 @@ class AsyncPGDatabase(DatabaseResource):
                 yield conn
 
     def get_connection_pool(self):
-        backend = getattr(self, "database_backend", None)
+        backend = getattr(self, "database", None)
         if backend is not None:
             return backend.get_connection_pool()
         return self._dsn

--- a/tests/core/test_container_defaults.py
+++ b/tests/core/test_container_defaults.py
@@ -8,7 +8,7 @@ from entity.resources.metrics import MetricsCollectorResource
 
 
 class DummyDatabase(InfrastructurePlugin):
-    infrastructure_type = "database_backend"
+    infrastructure_type = "database"
     stages: list = []
     dependencies: list = []
 

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -85,7 +85,7 @@ async def test_builder_registers_default_resources() -> None:
     assert builder.resource_registry.get("memory") is not None
     assert builder.resource_registry.get("llm") is not None
     assert builder.resource_registry.get("llm_provider") is not None
-    assert builder.resource_registry.get("echo_llm_backend") is not None
+    assert builder.resource_registry.get("echo_llm_provider") is not None
     assert builder.resource_registry.get("storage") is not None
     mem = builder.resource_registry.get("memory")
     assert getattr(mem, "database", None) is not None


### PR DESCRIPTION
## Summary
- switch DatabaseResource to depend on `database`
- rename echo LLM backend infrastructure to provider variant
- update default infrastructure docs
- refresh tests to use new names

## Testing
- `poetry run poe test-with-docker` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_687c0b1e24588322a463f831ff234238