### PR TITLE
Add vector store infrastructure base

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ documentation.
 
 ## Infrastructure Plugins
 
-Register infrastructure plugins under the `database_backend` and `vector_store`
-keys when configuring resources.
+Register infrastructure plugins under the `database_backend` and
+`vector_store_backend` keys when configuring resources.
 
 ```yaml
 plugins:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -80,8 +80,8 @@ plugins:
 ## VectorStoreResource
 
 `VectorStoreResource` adds semantic search using a pluggable vector store. The
-bundled `DuckDBVectorStore` registers at **layer 2** and relies on the same
-`database_backend` infrastructure.
+bundled `DuckDBVectorStore` registers at **layer 2** and relies on a dedicated
+`vector_store_backend` infrastructure.
 
 ```yaml
 plugins:

--- a/tests/architecture/test_infrastructure_dependencies.py
+++ b/tests/architecture/test_infrastructure_dependencies.py
@@ -4,6 +4,7 @@ from entity.infrastructure.llamacpp import LlamaCppInfrastructure
 from entity.infrastructure.postgres import PostgresInfrastructure
 from entity.infrastructure.duckdb_vector import DuckDBVectorInfrastructure
 from entity.resources.duckdb_vector_store import DuckDBVectorStore
+from entity.resources.vector_store import VectorStoreResource
 
 
 def test_infrastructure_plugins_have_no_dependencies() -> None:
@@ -25,3 +26,7 @@ def test_infrastructure_plugins_have_no_dependencies() -> None:
 
 def test_vector_store_resource_requires_backend() -> None:
     assert DuckDBVectorStore.infrastructure_dependencies == ["vector_store_backend"]
+
+
+def test_vector_store_interface_dependency() -> None:
+    assert VectorStoreResource.infrastructure_dependencies == ["vector_store"]


### PR DESCRIPTION
## Summary
- document dedicated `vector_store_backend` infrastructure
- expand architecture tests for vector stores

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687c0b1fb0e88322af316e6cce371f25