### PR TITLE
Switch plugin imports to public API

### DIFF
--- a/examples/duckdb_memory_agent/main.py
+++ b/examples/duckdb_memory_agent/main.py
@@ -12,7 +12,7 @@ import duckdb
 sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 
 from entity import agent
-from entity.core.plugins import PromptPlugin, ResourcePlugin
+from entity.plugins.base import PromptPlugin, ResourcePlugin
 from entity.core.context import PluginContext
 from entity.core.state import ConversationEntry
 from entity.core.stages import PipelineStage

--- a/examples/full_workflow/plugins.py
+++ b/examples/full_workflow/plugins.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from entity.core.context import PluginContext
-from entity.core.plugins import PromptPlugin
+from entity.plugins.base import PromptPlugin
 from entity.core.stages import PipelineStage
 
 

--- a/examples/plugins/input_logger.py
+++ b/examples/plugins/input_logger.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from entity.core.context import PluginContext
-from entity.core.plugins import InputAdapterPlugin
+from entity.plugins.base import InputAdapterPlugin
 from entity.core.stages import PipelineStage
 
 

--- a/examples/plugins/message_parser.py
+++ b/examples/plugins/message_parser.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from entity.core.context import PluginContext
-from entity.core.plugins import PromptPlugin
+from entity.plugins.base import PromptPlugin
 from entity.core.stages import PipelineStage
 
 

--- a/examples/plugins/response_reviewer.py
+++ b/examples/plugins/response_reviewer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from entity.core.context import PluginContext
-from entity.core.plugins import PromptPlugin
+from entity.plugins.base import PromptPlugin
 from entity.core.stages import PipelineStage
 
 

--- a/src/entity/infrastructure/duckdb_vector.py
+++ b/src/entity/infrastructure/duckdb_vector.py
@@ -6,7 +6,7 @@ import math
 import importlib
 
 from entity.config.models import DuckDBConfig
-from entity.core.plugins import ValidationResult
+from entity.plugins.base import ValidationResult
 from entity.core.resources.container import PoolConfig, ResourcePool
 
 from .vector_store import VectorStoreInfrastructure

--- a/src/entity/infrastructure/vector_store.py
+++ b/src/entity/infrastructure/vector_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Iterator
 
-from entity.core.plugins import InfrastructurePlugin, ValidationResult
+from entity.plugins.base import InfrastructurePlugin, ValidationResult
 from entity.core.resources.container import PoolConfig, ResourcePool
 
 


### PR DESCRIPTION
## Summary
- update built-in infrastructure to use `entity.plugins.base`
- update example plugins to use the public base module

## Testing
- `poetry run black src examples tests`
- `poetry install --with dev`
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_687c0b20918883229e4d6b0c9bd06769