### PR TITLE
Update docs for vector store backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ documentation.
 
 ## Infrastructure Plugins
 
-Register infrastructure plugins under the `database_backend` and `vector_store`
-keys when configuring resources.
+Register infrastructure plugins under the `database_backend` and
+`vector_store_backend` keys when configuring resources.
 
 ```yaml
 plugins:
@@ -61,6 +61,10 @@ plugins:
     postgres_backend:
       type: entity.infrastructure.asyncpg:AsyncPGInfrastructure
       dsn: postgresql://user:pass@localhost:5432/agent
+    vector_store_backend:
+      type: entity.infrastructure.duckdb_vector:DuckDBVectorInfrastructure
+      path: ./agent.duckdb
+      table: vector_mem
   resources:
     vector_store:
       type: entity.resources.duckdb_vector_store:DuckDBVectorStore

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -80,11 +80,14 @@ plugins:
 ## VectorStoreResource
 
 `VectorStoreResource` adds semantic search using a pluggable vector store. The
-bundled `DuckDBVectorStore` registers at **layer 2** and relies on the same
-`database_backend` infrastructure.
+bundled `DuckDBVectorStore` registers at **layer 2** and depends on the
+`vector_store_backend` infrastructure.
 
 ```yaml
 plugins:
+  infrastructure:
+    vector_store_backend:
+      type: entity.infrastructure.duckdb_vector:DuckDBVectorInfrastructure
   resources:
     vector_store:
       type: entity.resources.duckdb_vector_store:DuckDBVectorStore

--- a/docs/source/plugins.md
+++ b/docs/source/plugins.md
@@ -69,3 +69,17 @@ plugins:
       type: entity.infrastructure.asyncpg:AsyncPGInfrastructure
       dsn: postgresql://user:pass@localhost:5432/agent
 ```
+
+## DuckDBVectorInfrastructure
+
+`DuckDBVectorInfrastructure` is a lightweight vector-store backend. It
+registers under the `vector_store_backend` key at layer 1.
+
+```yaml
+plugins:
+  infrastructure:
+    vector_store_backend:
+      type: entity.infrastructure.duckdb_vector:DuckDBVectorInfrastructure
+      path: ./agent.duckdb
+      table: vector_mem
+```


### PR DESCRIPTION
## Summary
- document the new `vector_store_backend` infrastructure
- revise snippets in README and docs

## Testing
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_687c0b2482f083229d68af5be276dc3a