### PR TITLE
Resolve docs merge conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,9 @@ documentation.
 
 ## Infrastructure Plugins
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 Register infrastructure plugins under the `database_backend` and
-`vector_store_backend` keys when configuring resources.
-=======
-Register infrastructure plugins under the `database` and `vector_store`
-keys when configuring resources.
->>>>>>> pr-1816
-=======
-Register infrastructure plugins under the `database_backend` and
-`vector_store_backend` keys when configuring resources.
->>>>>>> pr-1820
+`vector_store_backend` keys when configuring resources. Earlier versions used
+the shorter `database` and `vector_store` keys.
 
 ```yaml
 plugins:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -80,18 +80,9 @@ plugins:
 ## VectorStoreResource
 
 `VectorStoreResource` adds semantic search using a pluggable vector store. The
-<<<<<<< HEAD
-<<<<<<< HEAD
-bundled `DuckDBVectorStore` registers at **layer 2** and relies on a dedicated
-`vector_store_backend` infrastructure.
-=======
-bundled `DuckDBVectorStore` registers at **layer 2** and relies on the same
-`database` infrastructure.
->>>>>>> pr-1816
-=======
-bundled `DuckDBVectorStore` registers at **layer 2** and depends on the
-`vector_store_backend` infrastructure.
->>>>>>> pr-1820
+bundled `DuckDBVectorStore` registers at **layer 2**. It typically depends on
+the `vector_store_backend` infrastructure, although earlier versions relied on
+the same `database` infrastructure.
 
 ```yaml
 plugins:


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in README and docs index
- clarify infrastructure plugin keys in README
- update vector store instructions in docs

## Testing
- `poetry run black src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --remove src tests`
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`
- `poetry run poe test-with-docker` *(fails: Docker is required)*

------
https://chatgpt.com/codex/tasks/task_e_687c37755d548322b47843efffeb8e4a