### PR TITLE
Use plugin_library in example workflows

### DIFF
--- a/examples/intermediate_agent/README.md
+++ b/examples/intermediate_agent/README.md
@@ -1,6 +1,6 @@
 # Intermediate Agent
 
-The intermediate agent chains a prompt plugin with a custom responder from `user_plugins`. It stores a brief analysis during the THINK stage and outputs the final explanation in the OUTPUT stage.
+The intermediate agent chains a prompt plugin with a custom responder from `plugin_library`. It stores a brief analysis during the THINK stage and outputs the final explanation in the OUTPUT stage.
 
 ```bash
 poetry run python examples/intermediate_agent/main.py

--- a/examples/intermediate_agent/main.py
+++ b/examples/intermediate_agent/main.py
@@ -7,7 +7,7 @@ sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 
 from entity import agent
 from entity.core.stages import PipelineStage
-from user_plugins.responders import ComplexPromptResponder
+from plugin_library.responders import ComplexPromptResponder
 
 
 @agent.prompt(stage=PipelineStage.THINK)

--- a/examples/kitchen_sink/main.py
+++ b/examples/kitchen_sink/main.py
@@ -5,8 +5,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
 
 from entity import agent, prompt
-from user_plugins.tools.calculator_tool import CalculatorTool
-from user_plugins.responders import ReactResponder
+from plugin_library.tools.calculator_tool import CalculatorTool
+from plugin_library.responders import ReactResponder
 
 
 @prompt

--- a/plugin_library/__init__.py
+++ b/plugin_library/__init__.py
@@ -1,0 +1,18 @@
+"""Alias to `user_plugins` for backward compatibility."""
+
+import importlib
+import sys
+
+_submodules = [
+    "prompts",
+    "responders",
+    "resources",
+    "tools",
+    "infrastructure",
+    "failure",
+]
+
+for _name in _submodules:
+    sys.modules[f"{__name__}.{_name}"] = importlib.import_module(
+        f"user_plugins.{_name}"
+    )

--- a/src/entity/workflows/examples.py
+++ b/src/entity/workflows/examples.py
@@ -14,7 +14,7 @@ class ChainOfThoughtWorkflow(Workflow):
 
     def __init__(
         self,
-        prompt: str = "user_plugins.prompts.chain_of_thought:ChainOfThoughtPrompt",
+        prompt: str = "plugin_library.prompts.chain_of_thought:ChainOfThoughtPrompt",
     ) -> None:
         super().__init__(prompt=prompt)
 
@@ -26,7 +26,7 @@ class ReActWorkflow(Workflow):
 
     def __init__(
         self,
-        prompt: str = "user_plugins.prompts.react_prompt:ReActPrompt",
+        prompt: str = "plugin_library.prompts.react_prompt:ReActPrompt",
     ) -> None:
         super().__init__(prompt=prompt)
 
@@ -38,7 +38,7 @@ class IntentClassificationWorkflow(Workflow):
 
     def __init__(
         self,
-        prompt: str = "user_plugins.prompts.intent_classifier:IntentClassifierPrompt",
+        prompt: str = "plugin_library.prompts.intent_classifier:IntentClassifierPrompt",
     ) -> None:
         super().__init__(prompt=prompt)
 

--- a/tests/test_kitchen_sink_example.py
+++ b/tests/test_kitchen_sink_example.py
@@ -1,7 +1,7 @@
 import pytest
 from entity import agent, prompt
-from user_plugins.tools.calculator_tool import CalculatorTool
-from user_plugins.responders import ReactResponder
+from plugin_library.tools.calculator_tool import CalculatorTool
+from plugin_library.responders import ReactResponder
 
 
 @prompt


### PR DESCRIPTION
## Summary
- add plugin_library package aliasing user_plugins
- update example workflows to use plugin_library imports
- adjust example scripts and docs
- fix tests importing example plugins

## Testing
- `poetry run pytest tests/test_example_plugins.py tests/test_kitchen_sink_example.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c3ee3193c8322b250075e5c8c3efe