### PR TITLE
Update plugin scaffold output dir

### DIFF
--- a/src/entity/cli/plugin_tool/main.py
+++ b/src/entity/cli/plugin_tool/main.py
@@ -77,7 +77,7 @@ class PluginToolCLI:
         scaffold.add_argument("--type", required=True, choices=list(PLUGIN_TYPES))
         scaffold.add_argument(
             "--out",
-            default="user_plugins",
+            default="plugin_library",
             help="Directory to create the project in",
         )
 


### PR DESCRIPTION
## Summary
- default plugin scaffold output folder to `plugin_library`
- run formatting and tests

## Testing
- `poetry run black src tests`
- `poetry run poe test` *(fails: InitializationError, RecursionError)*
- `poetry run poe test-with-docker` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_687c3edc6ca0832281d96043cd0633b8