### PR TITLE
Update CONTRIBUTING plugin directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,9 @@ This installs all required development dependencies including code quality tools
 - **`src/entity/config/`** - Configuration models and validation
 - **`src/entity/cli/`** - Developer CLI tools and utilities
 - **`src/entity/utils/`** - Shared utilities (logging, retries, etc.)
-- **`user_plugins/`** - Example plugins and local development plugins (not shipped with framework)
+- **`plugin_library/`** - Example plugins and local development plugins (not shipped with framework)
+  Use this folder as a starting point for your own plugins. Copy any sample plugin
+  and modify it to fit your needs.
 
 ### Test Organization
 Mirror the source structure in tests:
@@ -86,8 +88,8 @@ pytest tests/performance/ -m benchmark
 
 ### Plugin Location Rules
 - **Built-in plugins:** Add to `src/entity/plugins/` if the plugin ships with the framework
-- **Example/demo plugins:** Add to `user_plugins/` for examples, local development, or sharing
-- **Custom plugins:** Users develop in `user_plugins/` or their own repositories
+- **Example/demo plugins:** Add to `plugin_library/` for examples, local development, or sharing
+- **Custom plugins:** Users develop in `plugin_library/` or their own repositories
 
 ### Plugin Architecture Rules
 - **Import restrictions:** Plugins must NOT import core modules directly (enforces architectural boundaries)


### PR DESCRIPTION
## Summary
- update plugin docs to reference `plugin_library/`
- mention using sample plugins in this folder

## Testing
- `poetry run black CONTRIBUTING.md` *(fails: cannot parse file)*
- `poetry run poe test` *(fails: InitializationError + RecursionError)*
- `poetry run poe test-with-docker` *(fails: Docker is required)*

------
https://chatgpt.com/codex/tasks/task_e_687c3ee560588322ad351aebb67e932e