### PR TITLE
Fix merge conflict in plugin library

### DIFF
--- a/plugin_library/__init__.py
+++ b/plugin_library/__init__.py
@@ -1,8 +1,19 @@
-<<<<<<< HEAD
 """Alias to `user_plugins` for backward compatibility."""
 
-import importlib
+from importlib import import_module
 import sys
+
+_user_plugins = import_module("user_plugins")
+
+__all__ = getattr(_user_plugins, "__all__", [])
+__path__ = _user_plugins.__path__  # type: ignore[attr-defined]
+globals().update(
+    {
+        name: getattr(_user_plugins, name)
+        for name in dir(_user_plugins)
+        if not name.startswith("_")
+    }
+)
 
 _submodules = [
     "prompts",
@@ -14,23 +25,4 @@ _submodules = [
 ]
 
 for _name in _submodules:
-    sys.modules[f"{__name__}.{_name}"] = importlib.import_module(
-        f"user_plugins.{_name}"
-    )
-=======
-from importlib import import_module
-
-# Use user_plugins as the actual implementation
-_user_plugins = import_module("user_plugins")
-
-# Expose attributes and submodules
-__all__ = getattr(_user_plugins, "__all__", [])
-__path__ = _user_plugins.__path__  # type: ignore[attr-defined]
-globals().update(
-    {
-        name: getattr(_user_plugins, name)
-        for name in dir(_user_plugins)
-        if not name.startswith("_")
-    }
-)
->>>>>>> pr-1826
+    sys.modules[f"{__name__}.{_name}"] = import_module(f"user_plugins.{_name}")


### PR DESCRIPTION
## Summary
- resolve merge markers in `plugin_library/__init__.py`

## Testing
- `poetry run poe test` *(fails: AttributeError: 'NoneType' object has no attribute 'execute')*
- `poetry run poe test-with-docker` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_687c42ff1e4883228aaa9f88559c2be4