### PR TITLE
Add plugin library README reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This installs all required development dependencies including code quality tools
 - **`src/entity/config/`** - Configuration models and validation
 - **`src/entity/cli/`** - Developer CLI tools and utilities
 - **`src/entity/utils/`** - Shared utilities (logging, retries, etc.)
-- **`plugin_library/`** - Example plugins and local development plugins (not shipped with framework)
+- **`plugin_library/`** - Example plugins and local development plugins (not shipped with framework). See [plugin_library/README.md](plugin_library/README.md) for details.
   Use this folder as a starting point for your own plugins. Copy any sample plugin
   and modify it to fit your needs.
 
@@ -88,7 +88,7 @@ pytest tests/performance/ -m benchmark
 
 ### Plugin Location Rules
 - **Built-in plugins:** Add to `src/entity/plugins/` if the plugin ships with the framework
-- **Example/demo plugins:** Add to `plugin_library/` for examples, local development, or sharing
+- **Example/demo plugins:** Add to `plugin_library/` for examples, local development, or sharing. See [plugin_library/README.md](plugin_library/README.md) for details.
 - **Custom plugins:** Users develop in `plugin_library/` or their own repositories
 
 ### Plugin Architecture Rules

--- a/plugin_library/README.md
+++ b/plugin_library/README.md
@@ -1,3 +1,5 @@
 # Community Plugin Examples
 
-This folder contains example plugins used for demonstrations and local development. They show how to build tools, responders and resources using the framework. These plugins are not shipped with the core library.
+This directory hosts example plugins for demonstration and local development.
+They showcase how to build tools, responders, and resources with the framework.
+These plugins are not shipped with the core library.


### PR DESCRIPTION
## Summary
- clarify `plugin_library/` purpose
- link from CONTRIBUTING to plugin library README

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687c4c5640788322bc7a29ba4078f95e