### PR TITLE
Fix error formatter behavior

### DIFF
--- a/plugin_library/failure/error_formatter.py
+++ b/plugin_library/failure/error_formatter.py
@@ -24,4 +24,4 @@ class ErrorFormatter(FailurePlugin):
             }
         elif hasattr(failure_msg, "to_dict"):
             failure_msg = failure_msg.to_dict()
-        await context.say(failure_msg)
+        await context.think("failure_response", failure_msg)


### PR DESCRIPTION
## Summary
- avoid sending messages in the failure formatter

## Testing
- `poetry run poe test-with-docker` *(fails: Docker is required for integration tests)*
- `poetry run ruff check --fix src tests`
- `poetry run mypy src`
- `poetry run bandit -r src`
- `poetry run vulture src tests`
- `poetry run unimport --check src tests`
- `poetry run entity-cli --config config/dev.yaml verify` *(fails: invalid choice 'verify')*
- `poetry run entity-cli --config config/prod.yaml verify` *(fails: invalid choice 'verify')*
- `poetry run python -m src.entity.core.registry_validator`
- `poetry run poe test-architecture`
- `poetry run poe test-plugins`
- `poetry run poe test-resources`

------
https://chatgpt.com/codex/tasks/task_e_687c5316a3088322bbfd8f9f36b9e9f6