### PR TITLE
Add failure responder to default workflows

### DIFF
--- a/src/entity/workflows/builtin.py
+++ b/src/entity/workflows/builtin.py
@@ -14,6 +14,7 @@ class StandardWorkflow(Workflow):
         PipelineStage.PARSE: ["conversation_history"],
         PipelineStage.THINK: ["complex_prompt"],
         PipelineStage.REVIEW: ["pii_scrubber"],
+        PipelineStage.OUTPUT: ["failure_responder"],
         PipelineStage.ERROR: ["default_responder"],
     }
 
@@ -24,6 +25,7 @@ class ReActWorkflow(Workflow):
     stage_map = {
         PipelineStage.THINK: ["react"],
         PipelineStage.REVIEW: ["pii_scrubber"],
+        PipelineStage.OUTPUT: ["failure_responder"],
         PipelineStage.ERROR: ["default_responder"],
     }
 
@@ -34,5 +36,6 @@ class ChainOfThoughtWorkflow(Workflow):
     stage_map = {
         PipelineStage.THINK: ["chain_of_thought"],
         PipelineStage.REVIEW: ["pii_scrubber"],
+        PipelineStage.OUTPUT: ["failure_responder"],
         PipelineStage.ERROR: ["default_responder"],
     }

--- a/src/entity/workflows/default.py
+++ b/src/entity/workflows/default.py
@@ -17,7 +17,7 @@ class DefaultWorkflow(Workflow):
         PipelineStage.PARSE: ["message_parser"],
         PipelineStage.THINK: [],
         PipelineStage.REVIEW: ["response_reviewer"],
-        PipelineStage.OUTPUT: [],
+        PipelineStage.OUTPUT: ["failure_responder"],
         PipelineStage.ERROR: ["basic_error_handler"],
     }
 

--- a/src/entity/workflows/examples.py
+++ b/src/entity/workflows/examples.py
@@ -10,7 +10,10 @@ from . import Workflow
 class ChainOfThoughtWorkflow(Workflow):
     """Reason through problems step by step."""
 
-    stage_map = {PipelineStage.THINK: ["{prompt}"]}
+    stage_map = {
+        PipelineStage.THINK: ["{prompt}"],
+        PipelineStage.OUTPUT: ["failure_responder"],
+    }
 
     def __init__(
         self,
@@ -22,7 +25,10 @@ class ChainOfThoughtWorkflow(Workflow):
 class ReActWorkflow(Workflow):
     """Iteratively reason and act using tools."""
 
-    stage_map = {PipelineStage.THINK: ["{prompt}"]}
+    stage_map = {
+        PipelineStage.THINK: ["{prompt}"],
+        PipelineStage.OUTPUT: ["failure_responder"],
+    }
 
     def __init__(
         self,
@@ -34,7 +40,10 @@ class ReActWorkflow(Workflow):
 class IntentClassificationWorkflow(Workflow):
     """Classify the user's intent with a single prompt."""
 
-    stage_map = {PipelineStage.THINK: ["{prompt}"]}
+    stage_map = {
+        PipelineStage.THINK: ["{prompt}"],
+        PipelineStage.OUTPUT: ["failure_responder"],
+    }
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- ensure default workflows provide a failure responder plugin
- update builtin and example workflows so the OUTPUT stage includes `failure_responder`

## Testing
- `poetry run poe test`
- `bash scripts/test_with_docker.sh` *(fails: Docker is required)*

------
https://chatgpt.com/codex/tasks/task_e_687c53180a1883228edd0ecee66104e1