### PR TITLE
Add FailureResponder plugin

### DIFF
--- a/plugin_library/responders/__init__.py
+++ b/plugin_library/responders/__init__.py
@@ -1,7 +1,9 @@
 from .react_responder import ReactResponder
 from .complex_prompt_responder import ComplexPromptResponder
+from .failure_responder import FailureResponder
 
 __all__ = [
     "ReactResponder",
     "ComplexPromptResponder",
+    "FailureResponder",
 ]

--- a/plugin_library/responders/failure_responder.py
+++ b/plugin_library/responders/failure_responder.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from entity.plugins.base import PromptPlugin
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from entity.core.context import PluginContext
+
+from entity.core.stages import PipelineStage
+
+
+class FailureResponder(PromptPlugin):
+    """Emit a final failure message when available."""
+
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        failure = await context.reflect("failure_response")
+        if failure is None:
+            return
+        if hasattr(failure, "to_dict"):
+            failure = failure.to_dict()
+        await context.say(failure)


### PR DESCRIPTION
## Summary
- add FailureResponder plugin for final error messages
- export FailureResponder from responders package

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687c5316dbc48322acf00ebb55399587