### PR TITLE
Add BasicErrorResponder plugin

### DIFF
--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -108,11 +108,13 @@ def _create_default_agent() -> Agent:
 
     try:  # optional default plugins
         from plugins.builtin.basic_error_handler import BasicErrorHandler
+        from plugins.builtin.basic_error_responder import BasicErrorResponder
         from plugins.examples import InputLogger, MessageParser, ResponseReviewer
         from plugin_library.prompts import ComplexPrompt
         from plugin_library.responders import ComplexPromptResponder
 
         asyncio.run(builder.add_plugin(BasicErrorHandler({})))
+        asyncio.run(builder.add_plugin(BasicErrorResponder({})))
         asyncio.run(builder.add_plugin(InputLogger({})))
         asyncio.run(builder.add_plugin(MessageParser({})))
         asyncio.run(builder.add_plugin(ResponseReviewer({})))

--- a/src/entity/workflows/default.py
+++ b/src/entity/workflows/default.py
@@ -17,7 +17,7 @@ class DefaultWorkflow(Workflow):
         PipelineStage.PARSE: ["message_parser"],
         PipelineStage.THINK: [],
         PipelineStage.REVIEW: ["response_reviewer"],
-        PipelineStage.OUTPUT: ["failure_responder"],
+        PipelineStage.OUTPUT: ["failure_responder", "basic_error_responder"],
         PipelineStage.ERROR: ["basic_error_handler"],
     }
 

--- a/src/entity/workflows/minimal.py
+++ b/src/entity/workflows/minimal.py
@@ -13,7 +13,7 @@ class MinimalWorkflow(Workflow):
     stage_map = {
         PipelineStage.INPUT: ["input_logger"],
         PipelineStage.THINK: ["ComplexPrompt"],
-        PipelineStage.OUTPUT: ["ComplexPromptResponder"],
+        PipelineStage.OUTPUT: ["ComplexPromptResponder", "basic_error_responder"],
         PipelineStage.ERROR: ["basic_error_handler"],
     }
 

--- a/src/plugins/builtin/__init__.py
+++ b/src/plugins/builtin/__init__.py
@@ -1,5 +1,6 @@
 """Built-in plugins distributed with Entity."""
 
 from .basic_error_handler import BasicErrorHandler
+from .basic_error_responder import BasicErrorResponder
 
-__all__ = ["BasicErrorHandler"]
+__all__ = ["BasicErrorHandler", "BasicErrorResponder"]

--- a/src/plugins/builtin/basic_error_handler.py
+++ b/src/plugins/builtin/basic_error_handler.py
@@ -56,4 +56,4 @@ class BasicErrorHandler(FailurePlugin):
                 "type": "plugin_error",
             }
 
-        context._state.response = message
+        await context.think("failure_response", message)

--- a/src/plugins/builtin/basic_error_responder.py
+++ b/src/plugins/builtin/basic_error_responder.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+from entity.core.context import PluginContext
+from entity.plugins.base import PromptPlugin
+from entity.pipeline.stages import PipelineStage
+
+
+class BasicErrorResponder(PromptPlugin):
+    """Emit a formatted message for recorded failures."""
+
+    name = "basic_error_responder"
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context: PluginContext) -> Any:
+        info = context.failure_info
+        if info is None:
+            message = {
+                "error": "System error occurred",
+                "message": "An unexpected error prevented processing your request.",
+                "error_id": context.pipeline_id,
+                "type": "static_fallback",
+            }
+        else:
+            message = {
+                "error": info.error_message,
+                "message": "Unable to process request",
+                "error_id": context.pipeline_id,
+                "plugin": info.plugin_name,
+                "stage": info.stage,
+                "type": "plugin_error",
+            }
+        await context.say(message)


### PR DESCRIPTION
## Summary
- build a BasicErrorResponder OUTPUT plugin
- capture failure responses with `context.think` in BasicErrorHandler
- export BasicErrorResponder
- wire the responder into workflows and the default agent

## Testing
- `poetry run poe test-with-docker` *(fails: Docker is required)*

------
https://chatgpt.com/codex/tasks/task_e_687c5719296483228fb518939389432d