### PR TITLE
Add failure responder tests

### DIFF
--- a/plugin_library/failure/error_formatter.py
+++ b/plugin_library/failure/error_formatter.py
@@ -24,4 +24,4 @@ class ErrorFormatter(FailurePlugin):
             }
         elif hasattr(failure_msg, "to_dict"):
             failure_msg = failure_msg.to_dict()
-        await context.say(failure_msg)
+        await context.think("failure_response", failure_msg)

--- a/plugin_library/responders/__init__.py
+++ b/plugin_library/responders/__init__.py
@@ -1,7 +1,9 @@
 from .react_responder import ReactResponder
 from .complex_prompt_responder import ComplexPromptResponder
+from .failure_responder import FailureResponder
 
 __all__ = [
     "ReactResponder",
     "ComplexPromptResponder",
+    "FailureResponder",
 ]

--- a/plugin_library/responders/failure_responder.py
+++ b/plugin_library/responders/failure_responder.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
+from entity.core.context import PluginContext
+from entity.plugins.base import PromptPlugin
+from entity.core.stages import PipelineStage
+
+
+class FailureResponder(PromptPlugin):
+    """Respond with the formatted failure message."""
+
+    stages = [PipelineStage.OUTPUT]
+
+    async def _execute_impl(self, context: PluginContext) -> None:
+        message: Any = await context.reflect("failure_response")
+        if message is not None:
+            if hasattr(message, "to_dict"):
+                message = message.to_dict()
+            context.say(message)

--- a/tests/plugins/test_failure_responder.py
+++ b/tests/plugins/test_failure_responder.py
@@ -1,0 +1,27 @@
+import pytest
+
+from entity.pipeline.errors import PluginContextError
+from entity.core.stages import PipelineStage
+from plugin_library.failure import ErrorFormatter
+from plugin_library.responders import FailureResponder
+from tests.utils import make_async_context
+
+
+@pytest.mark.asyncio
+async def test_say_disallowed_in_error_stage() -> None:
+    ctx = await make_async_context(stage=PipelineStage.ERROR)
+    with pytest.raises(PluginContextError):
+        ctx.say("nope")
+
+
+@pytest.mark.asyncio
+async def test_formatter_and_responder_flow() -> None:
+    state_ctx = await make_async_context(stage=PipelineStage.ERROR)
+    await state_ctx.think("failure_response", {"error": "boom"})
+    formatter = ErrorFormatter({})
+    responder = FailureResponder({})
+    await formatter.execute(state_ctx)
+    # switch to OUTPUT stage for responder
+    state_ctx.set_current_stage(PipelineStage.OUTPUT)
+    await responder.execute(state_ctx)
+    assert state_ctx._state.response == {"error": "boom"}


### PR DESCRIPTION
## Summary
- add FailureResponder plugin and export it
- update ErrorFormatter to store the failure response
- test failure responder and context.say misuse

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687c531994cc8322912ab79c4c5fe50c