### PR TITLE
Enable constructor-based resource injection

### DIFF
--- a/plugin_library/tools/calculator_tool.py
+++ b/plugin_library/tools/calculator_tool.py
@@ -80,6 +80,9 @@ class CalculatorTool(ToolPlugin):
     intents = ["math"]
     _evaluator = SafeEvaluator()
 
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        super().__init__(config or {})
+
     class Params(BaseModel):
         expression: str
 

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -65,9 +65,11 @@ class LLM(AgentResource):
     dependencies = ["llm_provider?"]
     resource_category = "api"
 
-    def __init__(self, config: Dict | None = None) -> None:
+    def __init__(
+        self, config: Dict | None = None, llm_provider: LLMResource | None = None
+    ) -> None:
         super().__init__(config or {})
-        self.provider: LLMResource | None = None
+        self.provider = llm_provider
         self._pool: ResourcePool[LLMResource] | None = None
 
     async def initialize(self) -> None:

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -25,10 +25,15 @@ class Memory(AgentResource):
     dependencies = ["database", "vector_store?"]
     resource_category = "database"
 
-    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+    def __init__(
+        self,
+        config: Dict[str, Any] | None = None,
+        database: DatabaseInterface | None = None,
+        vector_store: VectorStoreInterface | None = None,
+    ) -> None:
         super().__init__(config or {})
-        self.database: DatabaseInterface | None = None
-        self.vector_store: VectorStoreInterface | None = None
+        self.database = database
+        self.vector_store = vector_store
         self._kv_table = self.config.get("kv_table", "memory_kv")
         self._history_table = self.config.get("history_table", "conversation_history")
 

--- a/tests/architecture/test_dependency_injection.py
+++ b/tests/architecture/test_dependency_injection.py
@@ -13,18 +13,18 @@ class DBInterface(ResourcePlugin):
     stages: list = []
     dependencies: list = []
 
-    def __init__(self, config=None) -> None:
+    def __init__(self, config=None, database=None) -> None:
         super().__init__(config or {})
-        self.database = None
+        self.database = database
 
 
 class DepResource(AgentResource):
     dependencies = ["db"]
     stages: list = []
 
-    def __init__(self, config=None) -> None:
+    def __init__(self, config=None, db=None) -> None:
         super().__init__(config or {})
-        self.db = None
+        self.db = db
 
     @classmethod
     async def validate_dependencies(cls, registry):

--- a/tests/plugins/test_hot_reload.py
+++ b/tests/plugins/test_hot_reload.py
@@ -25,8 +25,9 @@ class DepPlugin(Plugin):
     stages = [PipelineStage.THINK]
     dependencies = ["cfg"]
 
-    def __init__(self, cfg=None):
-        super().__init__(cfg or {})
+    def __init__(self, config=None, cfg=None):
+        super().__init__(config or {})
+        self.cfg = cfg
         self.seen = None
 
     async def _execute_impl(self, context):
@@ -90,8 +91,8 @@ async def test_update_rejects_type_change():
 class FailingRollbackPlugin(DepPlugin):
     stages = [PipelineStage.THINK]
 
-    def __init__(self, config=None):
-        super().__init__(config or {})
+    def __init__(self, config=None, cfg=None):
+        super().__init__(config, cfg=cfg)
         self.value = self.config.get("value", 0)
 
     async def _execute_impl(self, context):

--- a/tests/resources/test_lifecycle.py
+++ b/tests/resources/test_lifecycle.py
@@ -33,10 +33,10 @@ class Interface(ResourcePlugin):
     stages: list = []
     dependencies: list = []
 
-    def __init__(self, config=None) -> None:
+    def __init__(self, config=None, infra: Infra | None = None) -> None:
         super().__init__(config or {})
         self.initialized = False
-        self.infra: Infra | None = None
+        self.infra = infra
 
     async def initialize(self) -> None:
         events.append("init:iface")
@@ -48,9 +48,9 @@ class FailingResource(AgentResource):
     dependencies = ["iface"]
     stages: list = []
 
-    def __init__(self, config=None) -> None:
+    def __init__(self, config=None, iface: Interface | None = None) -> None:
         super().__init__(config or {})
-        self.iface: Interface | None = None
+        self.iface = iface
         self.healthy = True
 
     async def initialize(self) -> None:

--- a/tests/test_registry_validator.py
+++ b/tests/test_registry_validator.py
@@ -29,7 +29,7 @@ class B(Plugin):
     stages = [PipelineStage.THINK]
     dependencies = ["a"]
 
-    def __init__(self, a: A, config=None):
+    def __init__(self, a: A | None = None, config=None):
         super().__init__(config or {})
         self.a = a
 
@@ -45,7 +45,7 @@ class C(Plugin):
     dependencies = ["missing"]
 
     def __init__(
-        self, missing, config=None
+        self, missing=None, config=None
     ):  # pragma: no cover - constructed in validator
         super().__init__(config or {})
 
@@ -60,7 +60,9 @@ class D(Plugin):
     stages = [PipelineStage.PARSE]
     dependencies = ["e"]
 
-    def __init__(self, e, config=None):  # pragma: no cover - constructed in validator
+    def __init__(
+        self, e=None, config=None
+    ):  # pragma: no cover - constructed in validator
         super().__init__(config or {})
 
     async def _execute_impl(self, context):
@@ -74,7 +76,9 @@ class E(Plugin):
     stages = [PipelineStage.DO]
     dependencies = ["d"]
 
-    def __init__(self, d, config=None):  # pragma: no cover - constructed in validator
+    def __init__(
+        self, d=None, config=None
+    ):  # pragma: no cover - constructed in validator
         super().__init__(config or {})
 
     async def _execute_impl(self, context):
@@ -153,7 +157,7 @@ class ComplexPrompt(Plugin):
     dependencies = ["memory"]
 
     def __init__(
-        self, memory, config=None
+        self, memory=None, config=None
     ):  # pragma: no cover - constructed in validator
         super().__init__(config or {})
         self.memory = memory

--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -30,9 +30,9 @@ class InterfacePlugin(ResourcePlugin):
     stages: list = []
     dependencies: list = []
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, infra: InfraPlugin | None = None):
         super().__init__(config or {})
-        self.infra: InfraPlugin | None = None
+        self.infra = infra
         self.initialized = False
 
     async def initialize(self) -> None:
@@ -44,9 +44,9 @@ class CustomResource(AgentResource):
     dependencies = ["iface"]
     stages: list = []
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, iface: InterfacePlugin | None = None):
         super().__init__(config or {})
-        self.iface: InterfacePlugin | None = None
+        self.iface = iface
         self.initialized = False
         self.closed = False
 


### PR DESCRIPTION
## Summary
- inject dependencies during resource construction
- pass dependency parameters to built-in resources like `Memory`, `LLM`, and `CalculatorTool`
- update tests to accept dependency parameters

## Testing
- `poetry run poe test-with-docker` *(fails: Docker is required for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_687d24eea80c8322a277eb1ccc84b60e