### PR TITLE
Add infrastructure and resource layers

### DIFF
--- a/src/entity/infrastructure/duckdb_infra.py
+++ b/src/entity/infrastructure/duckdb_infra.py
@@ -1,0 +1,14 @@
+class DuckDBInfrastructure:
+    """Layer 1 infrastructure for managing a DuckDB database file."""
+
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+        self._connection = None
+
+    def connect(self):
+        """Return an open DuckDB connection."""
+        import duckdb
+
+        if self._connection is None:
+            self._connection = duckdb.connect(self.file_path)
+        return self._connection

--- a/src/entity/infrastructure/ollama_infra.py
+++ b/src/entity/infrastructure/ollama_infra.py
@@ -1,0 +1,20 @@
+import httpx
+
+
+class OllamaInfrastructure:
+    """Layer 1 infrastructure for communicating with an Ollama server."""
+
+    def __init__(self, base_url: str, model: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    async def generate(self, prompt: str) -> str:
+        """Send a prompt to Ollama and return the generated text."""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/api/generate",
+                json={"model": self.model, "prompt": prompt},
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("response", "")

--- a/src/entity/infrastructure/s3_infra.py
+++ b/src/entity/infrastructure/s3_infra.py
@@ -1,0 +1,17 @@
+import aioboto3
+
+
+class S3Infrastructure:
+    """Layer 1 infrastructure for interacting with an S3 bucket."""
+
+    def __init__(self, bucket: str) -> None:
+        self.bucket = bucket
+        self._session: aioboto3.Session | None = None
+
+    def session(self) -> aioboto3.Session:
+        if self._session is None:
+            self._session = aioboto3.Session()
+        return self._session
+
+    def client(self):
+        return self.session().client("s3")

--- a/src/entity/resources/database.py
+++ b/src/entity/resources/database.py
@@ -1,0 +1,12 @@
+from ..infrastructure.duckdb_infra import DuckDBInfrastructure
+
+
+class DatabaseResource:
+    """Layer 2 resource providing database access."""
+
+    def __init__(self, infrastructure: DuckDBInfrastructure) -> None:
+        self.infrastructure = infrastructure
+
+    def execute(self, query: str, *params):
+        conn = self.infrastructure.connect()
+        return conn.execute(query, params)

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -1,0 +1,11 @@
+from ..infrastructure.ollama_infra import OllamaInfrastructure
+
+
+class LLMResource:
+    """Layer 2 resource that wraps an Ollama LLM."""
+
+    def __init__(self, infrastructure: OllamaInfrastructure) -> None:
+        self.infrastructure = infrastructure
+
+    async def generate(self, prompt: str) -> str:
+        return await self.infrastructure.generate(prompt)

--- a/src/entity/resources/storage.py
+++ b/src/entity/resources/storage.py
@@ -1,0 +1,14 @@
+from ..infrastructure.s3_infra import S3Infrastructure
+
+
+class StorageResource:
+    """Layer 2 resource for S3-based file storage."""
+
+    def __init__(self, infrastructure: S3Infrastructure) -> None:
+        self.infrastructure = infrastructure
+
+    async def upload_text(self, key: str, data: str) -> None:
+        async with self.infrastructure.client() as client:
+            await client.put_object(
+                Bucket=self.infrastructure.bucket, Key=key, Body=data
+            )

--- a/src/entity/resources/vector_store.py
+++ b/src/entity/resources/vector_store.py
@@ -1,0 +1,16 @@
+from ..infrastructure.duckdb_infra import DuckDBInfrastructure
+
+
+class VectorStoreResource:
+    """Layer 2 resource for storing and searching vectors."""
+
+    def __init__(self, infrastructure: DuckDBInfrastructure) -> None:
+        self.infrastructure = infrastructure
+
+    def add_vector(self, table: str, vector):
+        conn = self.infrastructure.connect()
+        conn.execute(f"INSERT INTO {table} VALUES (?)", (vector,))
+
+    def query(self, query: str):
+        conn = self.infrastructure.connect()
+        return conn.execute(query)


### PR DESCRIPTION
## Summary
- add DuckDB, Ollama, and S3 infrastructure classes
- expose database, vector store, LLM, and storage resources
- keep Layer 2 resources dependent only on Layer 1 modules

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687fb5efdc108322bbc7a52d8586cc5b