### PR TITLE
Add canonical resource wrappers

### DIFF
--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -1,0 +1,21 @@
+"""Public resource interfaces and canonical wrappers."""
+
+from .database import DatabaseResource
+from .vector_store import VectorStoreResource
+from .llm import LLMResource
+from .storage import StorageResource
+from .exceptions import ResourceInitializationError
+from .memory import Memory
+from .llm_wrapper import LLM
+from .storage_wrapper import Storage
+
+__all__ = [
+    "DatabaseResource",
+    "VectorStoreResource",
+    "LLMResource",
+    "StorageResource",
+    "ResourceInitializationError",
+    "Memory",
+    "LLM",
+    "Storage",
+]

--- a/src/entity/resources/exceptions.py
+++ b/src/entity/resources/exceptions.py
@@ -1,0 +1,2 @@
+class ResourceInitializationError(Exception):
+    """Raised when a canonical resource is missing required dependencies."""

--- a/src/entity/resources/llm_wrapper.py
+++ b/src/entity/resources/llm_wrapper.py
@@ -1,0 +1,14 @@
+from .llm import LLMResource
+from .exceptions import ResourceInitializationError
+
+
+class LLM:
+    """Layer 3 wrapper around an LLM resource."""
+
+    def __init__(self, resource: LLMResource | None) -> None:
+        if resource is None:
+            raise ResourceInitializationError("LLMResource is required")
+        self.resource = resource
+
+    async def generate(self, prompt: str) -> str:
+        return await self.resource.generate(prompt)

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -1,0 +1,28 @@
+from .database import DatabaseResource
+from .vector_store import VectorStoreResource
+from .exceptions import ResourceInitializationError
+
+
+class Memory:
+    """Layer 3 resource that exposes persistent memory capabilities."""
+
+    def __init__(
+        self,
+        database: DatabaseResource | None,
+        vector_store: VectorStoreResource | None,
+    ) -> None:
+        if database is None or vector_store is None:
+            raise ResourceInitializationError(
+                "DatabaseResource and VectorStoreResource are required"
+            )
+        self.database = database
+        self.vector_store = vector_store
+
+    def execute(self, query: str, *params):
+        return self.database.execute(query, *params)
+
+    def add_vector(self, table: str, vector):
+        self.vector_store.add_vector(table, vector)
+
+    def query(self, query: str):
+        return self.vector_store.query(query)

--- a/src/entity/resources/storage_wrapper.py
+++ b/src/entity/resources/storage_wrapper.py
@@ -1,0 +1,14 @@
+from .storage import StorageResource
+from .exceptions import ResourceInitializationError
+
+
+class Storage:
+    """Layer 3 wrapper around a storage resource."""
+
+    def __init__(self, resource: StorageResource | None) -> None:
+        if resource is None:
+            raise ResourceInitializationError("StorageResource is required")
+        self.resource = resource
+
+    async def upload_text(self, key: str, data: str) -> None:
+        await self.resource.upload_text(key, data)


### PR DESCRIPTION
## Summary
- implement canonical Layer 3 resource wrappers: `Memory`, `LLM`, and `Storage`
- provide `ResourceInitializationError` and export all new classes
- update resource `__init__` with public exports

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687fb79741b4832283ba04cdcf98a88a