### PR TITLE
Implement layer-0 defaults

### DIFF
--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -1,9 +1,20 @@
+from ..defaults import load_defaults
+from ..plugins.defaults import default_workflow
+
+
 class Agent:
     def __init__(self, resources=None, workflow=None, infrastructure=None):
-        self.resources = resources or {}
+        self.resources = resources or load_defaults()
         self.workflow = workflow
         self.infrastructure = infrastructure
 
     async def chat(self, message, user_id="default"):
-        """Echo the given message back in a response dict."""
-        return {"response": message}
+        """Process the message through the configured workflow."""
+
+        steps = self.workflow or default_workflow()
+        result = message
+        for plugin_cls in steps:
+            plugin = plugin_cls(self.resources)
+            result = await plugin.run(result, user_id)
+
+        return {"response": result}

--- a/src/entity/defaults.py
+++ b/src/entity/defaults.py
@@ -1,0 +1,37 @@
+"""Convenience constructors for Layer 0 defaults."""
+
+from __future__ import annotations
+
+from .infrastructure.duckdb_infra import DuckDBInfrastructure
+from .infrastructure.ollama_infra import OllamaInfrastructure
+from .infrastructure.local_storage_infra import LocalStorageInfrastructure
+from .resources import (
+    DatabaseResource,
+    VectorStoreResource,
+    LLMResource,
+    Memory,
+    LLM,
+    LocalStorageResource,
+    Storage,
+)
+
+
+# Default infrastructure instances
+DUCKDB = DuckDBInfrastructure("./agent_memory.duckdb")
+OLLAMA = OllamaInfrastructure("http://localhost:11434", "llama3.2:3b")
+LOCAL_STORAGE = LocalStorageInfrastructure("./agent_files")
+
+
+def load_defaults() -> dict[str, object]:
+    """Return canonical Layer-3 resources configured with default infrastructure."""
+
+    db_resource = DatabaseResource(DUCKDB)
+    vector_resource = VectorStoreResource(DUCKDB)
+    llm_resource = LLMResource(OLLAMA)
+    storage_resource = LocalStorageResource(LOCAL_STORAGE)
+
+    return {
+        "memory": Memory(db_resource, vector_resource),
+        "llm": LLM(llm_resource),
+        "storage": Storage(storage_resource),
+    }

--- a/src/entity/infrastructure/local_storage_infra.py
+++ b/src/entity/infrastructure/local_storage_infra.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+class LocalStorageInfrastructure:
+    """Layer 1 infrastructure for storing files on the local filesystem."""
+
+    def __init__(self, base_path: str) -> None:
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def resolve_path(self, key: str) -> Path:
+        return self.base_path / key

--- a/src/entity/plugins/base.py
+++ b/src/entity/plugins/base.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+
+class Plugin:
+    """Minimal plugin interface used in tests."""
+
+    def __init__(self, resources: dict[str, object]):
+        self.resources = resources
+
+    async def run(self, message: str, user_id: str) -> str:
+        return message

--- a/src/entity/plugins/defaults/__init__.py
+++ b/src/entity/plugins/defaults/__init__.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from ..base import Plugin
+
+
+class InputPlugin(Plugin):
+    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+        """Return input unchanged."""
+        return message
+
+
+class ParsePlugin(Plugin):
+    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+        """Return message unchanged."""
+        return message
+
+
+class ThinkPlugin(Plugin):
+    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+        """Return message unchanged."""
+        return message
+
+
+class DoPlugin(Plugin):
+    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+        """Return message unchanged."""
+        return message
+
+
+class ReviewPlugin(Plugin):
+    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+        """Return message unchanged."""
+        return message
+
+
+class OutputPlugin(Plugin):
+    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+        """Return final response."""
+        return message
+
+
+def default_workflow() -> list[type[Plugin]]:
+    """Return the built-in workflow with one plugin per stage."""
+
+    return [
+        InputPlugin,
+        ParsePlugin,
+        ThinkPlugin,
+        DoPlugin,
+        ReviewPlugin,
+        OutputPlugin,
+    ]

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -4,6 +4,7 @@ from .database import DatabaseResource
 from .vector_store import VectorStoreResource
 from .llm import LLMResource
 from .storage import StorageResource
+from .local_storage import LocalStorageResource
 from .exceptions import ResourceInitializationError
 from .memory import Memory
 from .llm_wrapper import LLM
@@ -14,6 +15,7 @@ __all__ = [
     "VectorStoreResource",
     "LLMResource",
     "StorageResource",
+    "LocalStorageResource",
     "ResourceInitializationError",
     "Memory",
     "LLM",

--- a/src/entity/resources/local_storage.py
+++ b/src/entity/resources/local_storage.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from ..infrastructure.local_storage_infra import LocalStorageInfrastructure
+
+
+class LocalStorageResource:
+    """Layer 2 resource for local file storage."""
+
+    def __init__(self, infrastructure: LocalStorageInfrastructure) -> None:
+        self.infrastructure = infrastructure
+
+    async def upload_text(self, key: str, data: str) -> None:
+        path = self.infrastructure.resolve_path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(path.write_text, data)

--- a/src/entity/resources/storage_wrapper.py
+++ b/src/entity/resources/storage_wrapper.py
@@ -1,11 +1,12 @@
 from .storage import StorageResource
+from .local_storage import LocalStorageResource
 from .exceptions import ResourceInitializationError
 
 
 class Storage:
     """Layer 3 wrapper around a storage resource."""
 
-    def __init__(self, resource: StorageResource | None) -> None:
+    def __init__(self, resource: StorageResource | LocalStorageResource | None) -> None:
         if resource is None:
             raise ResourceInitializationError("StorageResource is required")
         self.resource = resource


### PR DESCRIPTION
## Summary
- add new local storage infrastructure and resource
- provide `load_defaults()` with default DuckDB, Ollama and local file storage
- execute default workflow when no workflow defined
- implement simple plugin set for each stage

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687fb90bbff88322bdae38ea9651aae8