### PR TITLE
Implement plugin execution wrapper

### DIFF
--- a/src/entity/plugins/base.py
+++ b/src/entity/plugins/base.py
@@ -1,11 +1,44 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
+from typing import Any
 
-class Plugin:
-    """Minimal plugin interface used in tests."""
 
-    def __init__(self, resources: dict[str, object]):
+class Plugin(ABC):
+    """Base class for all plugins."""
+
+    stage: str | None = None
+    dependencies: list[str] = []
+
+    def __init__(self, resources: dict[str, Any]):
         self.resources = resources
 
-    async def run(self, message: str, user_id: str) -> str:
-        return message
+    async def execute(self, context: Any) -> Any:
+        """Validate and run the plugin implementation."""
+        self._enforce_stage(context)
+        self._validate_dependencies()
+        try:
+            return await self._execute_impl(context)
+        except Exception:  # pragma: no cover - simple example
+            # In real system we'd log the error and propagate.
+            raise
+
+    def _enforce_stage(self, context: Any) -> None:
+        expected = self.stage
+        current = getattr(context, "current_stage", None)
+        if expected and current != expected:
+            raise RuntimeError(
+                f"{self.__class__.__name__} cannot run in stage '{current}'"
+            )
+
+    def _validate_dependencies(self) -> None:
+        missing = [dep for dep in self.dependencies if dep not in self.resources]
+        if missing:
+            raise RuntimeError(
+                f"Missing dependencies for {self.__class__.__name__}: {', '.join(missing)}"
+            )
+
+    @abstractmethod
+    async def _execute_impl(self, context: Any) -> Any:
+        """Plugin-specific execution logic."""
+        raise NotImplementedError

--- a/src/entity/plugins/defaults/__init__.py
+++ b/src/entity/plugins/defaults/__init__.py
@@ -4,39 +4,39 @@ from ..base import Plugin
 
 
 class InputPlugin(Plugin):
-    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+    async def _execute_impl(self, context) -> str:  # noqa: D401
         """Return input unchanged."""
-        return message
+        return context.message or ""
 
 
 class ParsePlugin(Plugin):
-    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+    async def _execute_impl(self, context) -> str:  # noqa: D401
         """Return message unchanged."""
-        return message
+        return context.message or ""
 
 
 class ThinkPlugin(Plugin):
-    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+    async def _execute_impl(self, context) -> str:  # noqa: D401
         """Return message unchanged."""
-        return message
+        return context.message or ""
 
 
 class DoPlugin(Plugin):
-    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+    async def _execute_impl(self, context) -> str:  # noqa: D401
         """Return message unchanged."""
-        return message
+        return context.message or ""
 
 
 class ReviewPlugin(Plugin):
-    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+    async def _execute_impl(self, context) -> str:  # noqa: D401
         """Return message unchanged."""
-        return message
+        return context.message or ""
 
 
 class OutputPlugin(Plugin):
-    async def run(self, message: str, user_id: str) -> str:  # noqa: D401
+    async def _execute_impl(self, context) -> str:  # noqa: D401
         """Return final response."""
-        return message
+        return context.message or ""
 
 
 def default_workflow() -> list[type[Plugin]]:


### PR DESCRIPTION
## Summary
- create a real `Plugin` ABC with execution wrapper and validations
- ensure `WorkflowExecutor` invokes plugins via the new `execute` method
- adapt built-in plugins to use `_execute_impl`

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687fc2415f44832287c993842793810f