### PR TITLE
Add plugin base subclasses

### DIFF
--- a/src/entity/plugins/__init__.py
+++ b/src/entity/plugins/__init__.py
@@ -1,0 +1,15 @@
+"""Public plugin interfaces and helpers."""
+
+from .base import Plugin
+from .prompt import PromptPlugin
+from .tool import ToolPlugin
+from .input_adapter import InputAdapterPlugin
+from .output_adapter import OutputAdapterPlugin
+
+__all__ = [
+    "Plugin",
+    "PromptPlugin",
+    "ToolPlugin",
+    "InputAdapterPlugin",
+    "OutputAdapterPlugin",
+]

--- a/src/entity/plugins/input_adapter.py
+++ b/src/entity/plugins/input_adapter.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .base import Plugin
+from ..workflow.executor import WorkflowExecutor
+
+
+class InputAdapterPlugin(Plugin):
+    """Convert external input into workflow messages."""
+
+    supported_stages = [WorkflowExecutor.INPUT]
+
+    def _enforce_stage(self, context: Any) -> None:  # noqa: D401
+        """Ensure plugin executes only in supported stages."""
+        super()._enforce_stage(context)
+        current = getattr(context, "current_stage", None)
+        if current not in self.supported_stages:
+            raise RuntimeError(
+                f"{self.__class__.__name__} cannot run in stage '{current}'"
+            )

--- a/src/entity/plugins/output_adapter.py
+++ b/src/entity/plugins/output_adapter.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .base import Plugin
+from ..workflow.executor import WorkflowExecutor
+
+
+class OutputAdapterPlugin(Plugin):
+    """Convert workflow responses into external representations."""
+
+    supported_stages = [WorkflowExecutor.OUTPUT]
+
+    def _enforce_stage(self, context: Any) -> None:  # noqa: D401
+        """Ensure plugin executes only in supported stages."""
+        super()._enforce_stage(context)
+        current = getattr(context, "current_stage", None)
+        if current not in self.supported_stages:
+            raise RuntimeError(
+                f"{self.__class__.__name__} cannot run in stage '{current}'"
+            )

--- a/src/entity/plugins/prompt.py
+++ b/src/entity/plugins/prompt.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .base import Plugin
+from ..workflow.executor import WorkflowExecutor
+
+
+class PromptPlugin(Plugin):
+    """LLM-driven reasoning or validation plugin."""
+
+    supported_stages = [WorkflowExecutor.THINK, WorkflowExecutor.REVIEW]
+    dependencies: list[str] = ["llm"]
+
+    def _enforce_stage(self, context: Any) -> None:  # noqa: D401
+        """Ensure plugin executes only in supported stages."""
+        super()._enforce_stage(context)
+        current = getattr(context, "current_stage", None)
+        if current not in self.supported_stages:
+            raise RuntimeError(
+                f"{self.__class__.__name__} cannot run in stage '{current}'"
+            )

--- a/src/entity/plugins/tool.py
+++ b/src/entity/plugins/tool.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .base import Plugin
+from ..workflow.executor import WorkflowExecutor
+
+
+class ToolPlugin(Plugin):
+    """Plugin type for executing external actions."""
+
+    supported_stages = [WorkflowExecutor.DO]
+    dependencies: list[str] = []
+
+    def _enforce_stage(self, context: Any) -> None:  # noqa: D401
+        """Ensure plugin executes only in supported stages."""
+        super()._enforce_stage(context)
+        current = getattr(context, "current_stage", None)
+        if current not in self.supported_stages:
+            raise RuntimeError(
+                f"{self.__class__.__name__} cannot run in stage '{current}'"
+            )


### PR DESCRIPTION
## Summary
- add prompt, tool, input, and output plugin types
- expose new plugin types via `entity.plugins`

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_687fcd3e15788322ab811658c518c2c6