### PR TITLE
Add enforcement for workflow output termination

### DIFF
--- a/src/entity/workflow/executor.py
+++ b/src/entity/workflow/executor.py
@@ -12,7 +12,10 @@ class WorkflowContext:
         self.message: str | None = None
 
     def say(self, message: str) -> None:
-        """Store the final response and mark workflow as complete."""
+        """Store the final response only during the OUTPUT stage."""
+
+        if self.current_stage != WorkflowExecutor.OUTPUT:
+            raise RuntimeError("context.say() only allowed in OUTPUT stage")
 
         self._response = message
 


### PR DESCRIPTION
## Summary
- restrict `context.say()` so it can only be invoked during the `OUTPUT` stage
- keep stage loop unchanged for plugin ordering and termination logic

## Testing
- `poetry run black src tests`
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_687fd2f5a47083229e255a083a3c3be3