### PR TITLE
Implement Plugin execution wrapper

### DIFF
--- a/src/entity/plugins/input_adapter.py
+++ b/src/entity/plugins/input_adapter.py
@@ -10,12 +10,3 @@ class InputAdapterPlugin(Plugin):
     """Convert external input into workflow messages."""
 
     supported_stages = [WorkflowExecutor.INPUT]
-
-    def _enforce_stage(self, context: Any) -> None:  # noqa: D401
-        """Ensure plugin executes only in supported stages."""
-        super()._enforce_stage(context)
-        current = getattr(context, "current_stage", None)
-        if current not in self.supported_stages:
-            raise RuntimeError(
-                f"{self.__class__.__name__} cannot run in stage '{current}'"
-            )

--- a/src/entity/plugins/output_adapter.py
+++ b/src/entity/plugins/output_adapter.py
@@ -10,12 +10,3 @@ class OutputAdapterPlugin(Plugin):
     """Convert workflow responses into external representations."""
 
     supported_stages = [WorkflowExecutor.OUTPUT]
-
-    def _enforce_stage(self, context: Any) -> None:  # noqa: D401
-        """Ensure plugin executes only in supported stages."""
-        super()._enforce_stage(context)
-        current = getattr(context, "current_stage", None)
-        if current not in self.supported_stages:
-            raise RuntimeError(
-                f"{self.__class__.__name__} cannot run in stage '{current}'"
-            )

--- a/src/entity/plugins/prompt.py
+++ b/src/entity/plugins/prompt.py
@@ -11,12 +11,3 @@ class PromptPlugin(Plugin):
 
     supported_stages = [WorkflowExecutor.THINK, WorkflowExecutor.REVIEW]
     dependencies: list[str] = ["llm"]
-
-    def _enforce_stage(self, context: Any) -> None:  # noqa: D401
-        """Ensure plugin executes only in supported stages."""
-        super()._enforce_stage(context)
-        current = getattr(context, "current_stage", None)
-        if current not in self.supported_stages:
-            raise RuntimeError(
-                f"{self.__class__.__name__} cannot run in stage '{current}'"
-            )

--- a/src/entity/plugins/tool.py
+++ b/src/entity/plugins/tool.py
@@ -11,12 +11,3 @@ class ToolPlugin(Plugin):
 
     supported_stages = [WorkflowExecutor.DO]
     dependencies: list[str] = []
-
-    def _enforce_stage(self, context: Any) -> None:  # noqa: D401
-        """Ensure plugin executes only in supported stages."""
-        super()._enforce_stage(context)
-        current = getattr(context, "current_stage", None)
-        if current not in self.supported_stages:
-            raise RuntimeError(
-                f"{self.__class__.__name__} cannot run in stage '{current}'"
-            )

--- a/src/entity/workflow/executor.py
+++ b/src/entity/workflow/executor.py
@@ -60,11 +60,7 @@ class WorkflowExecutor:
 
                 self.context.current_stage = stage
                 self.context.message = result
-                if hasattr(plugin, "execute"):
-                    result = await plugin.execute(self.context)
-                else:
-                    # Fallback for legacy plugins
-                    result = await plugin.run(result, user_id)
+                result = await plugin.execute(self.context)
 
                 if stage == self.OUTPUT and self.context.response is not None:
                     return self.context.response


### PR DESCRIPTION
## Summary
- create a reusable Plugin base class
- simplify specialized plugin classes
- call plugins using the new execution method

## Testing
- `poetry run black src tests`
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_68801bb83e148322bc9e3ead5d94c523