### PR TITLE
Add plugin context with user namespacing

### DIFF
--- a/src/entity/plugins/context.py
+++ b/src/entity/plugins/context.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..workflow.executor import WorkflowContext
+
+
+class PluginContext(WorkflowContext):
+    """Extended context exposing memory and resources."""
+
+    def __init__(self, resources: Dict[str, Any], user_id: str) -> None:
+        super().__init__()
+        self._resources = resources
+        self.user_id = user_id
+        self._memory: Dict[str, Any] = {}
+        self._conversation: List[str] = []
+
+    async def remember(self, key: str, value: Any) -> None:
+        """Persist value namespaced by ``user_id``."""
+        namespaced = f"{self.user_id}:{key}"
+        self._memory[namespaced] = value
+
+    async def recall(self, key: str, default: Any | None = None) -> Any:
+        """Retrieve stored value for ``key`` or ``default``."""
+        namespaced = f"{self.user_id}:{key}"
+        return self._memory.get(namespaced, default)
+
+    def say(self, message: str) -> None:  # type: ignore[override]
+        super().say(message)
+        self._conversation.append(message)
+
+    def listen(self) -> str | None:
+        """Return the last user message."""
+        return self.message
+
+    def conversation(self) -> List[str]:
+        """Return conversation history including outputs."""
+        history = list(self._conversation)
+        if self.message:
+            history.insert(0, self.message)
+        return history
+
+    def get_resource(self, name: str) -> Any:
+        """Return a resource by name."""
+        return self._resources.get(name)

--- a/src/entity/workflow/executor.py
+++ b/src/entity/workflow/executor.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
+from ..plugins.context import PluginContext
+
 
 class WorkflowContext:
     """Simple context passed to plugins during execution."""
@@ -46,26 +48,26 @@ class WorkflowExecutor:
         self.workflow = {
             stage: list(plugins) for stage, plugins in (workflow or {}).items()
         }
-        self.context = WorkflowContext()
 
     async def run(self, message: str, user_id: str = "default") -> str:
         """Execute configured plugins in order until an OUTPUT plugin calls ``say``."""
 
+        context = PluginContext(self.resources, user_id)
         result = message
         for stage in self._ORDER:
             for plugin_cls in self.workflow.get(stage, []):
                 plugin = plugin_cls(self.resources)
                 if hasattr(plugin, "context"):
-                    plugin.context = self.context
+                    plugin.context = context
 
-                self.context.current_stage = stage
-                self.context.message = result
+                context.current_stage = stage
+                context.message = result
                 if hasattr(plugin, "execute"):
-                    result = await plugin.execute(self.context)
+                    result = await plugin.execute(context)
                 else:
                     # Fallback for legacy plugins
                     result = await plugin.run(result, user_id)
 
-                if stage == self.OUTPUT and self.context.response is not None:
-                    return self.context.response
+                if stage == self.OUTPUT and context.response is not None:
+                    return context.response
         return result


### PR DESCRIPTION
## Summary
- introduce `PluginContext` for plugins
- namespace memory by user id
- allow plugins to access resources directly
- use `PluginContext` in workflow executor

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6880391777bc8322af853e7cef054728