### PR TITLE
Implement workflow configuration parsing

### DIFF
--- a/src/entity/plugins/context.py
+++ b/src/entity/plugins/context.py
@@ -2,7 +2,29 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from ..workflow.executor import WorkflowContext
+
+class WorkflowContext:
+    """Simple context passed to plugins during execution."""
+
+    def __init__(self) -> None:
+        self._response: str | None = None
+        self.current_stage: str | None = None
+        self.message: str | None = None
+
+    def say(self, message: str) -> None:
+        """Store the final response only during the OUTPUT stage."""
+
+        from ..workflow.executor import WorkflowExecutor
+
+        if self.current_stage != WorkflowExecutor.OUTPUT:
+            raise RuntimeError("context.say() only allowed in OUTPUT stage")
+
+        self._response = message
+
+    @property
+    def response(self) -> str | None:  # noqa: D401
+        """Return the response set by :py:meth:`say`."""
+        return self._response
 
 
 class PluginContext(WorkflowContext):

--- a/src/entity/workflow/__init__.py
+++ b/src/entity/workflow/__init__.py
@@ -1,3 +1,11 @@
-from .executor import WorkflowExecutor
+from importlib import import_module
 
-__all__ = ["WorkflowExecutor"]
+__all__ = ["Workflow", "WorkflowExecutor"]
+
+
+def __getattr__(name: str):
+    if name == "WorkflowExecutor":
+        return import_module(".executor", __name__).WorkflowExecutor
+    if name == "Workflow":
+        return import_module(".workflow", __name__).Workflow
+    raise AttributeError(name)

--- a/src/entity/workflow/executor.py
+++ b/src/entity/workflow/executor.py
@@ -5,28 +5,6 @@ from typing import Any, Iterable
 from ..plugins.context import PluginContext
 
 
-class WorkflowContext:
-    """Simple context passed to plugins during execution."""
-
-    def __init__(self) -> None:
-        self._response: str | None = None
-        self.current_stage: str | None = None
-        self.message: str | None = None
-
-    def say(self, message: str) -> None:
-        """Store the final response only during the OUTPUT stage."""
-
-        if self.current_stage != WorkflowExecutor.OUTPUT:
-            raise RuntimeError("context.say() only allowed in OUTPUT stage")
-
-        self._response = message
-
-    @property
-    def response(self) -> str | None:  # noqa: D401
-        """Return the response set by :py:meth:`say`."""
-        return self._response
-
-
 class WorkflowExecutor:
     """Run plugins through the standard workflow stages."""
 

--- a/src/entity/workflow/workflow.py
+++ b/src/entity/workflow/workflow.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib import import_module
+from typing import Dict, Iterable, List, Type
+
+import yaml
+
+from ..plugins.base import Plugin
+from .executor import WorkflowExecutor
+
+
+class WorkflowConfigError(Exception):
+    """Raised when the workflow configuration is invalid."""
+
+
+def _import_string(path: str) -> Type[Plugin]:
+    module_path, _, class_name = path.rpartition(".")
+    if not module_path:
+        raise WorkflowConfigError(f"Invalid plugin path: {path}")
+    module = import_module(module_path)
+    try:
+        plugin_cls = getattr(module, class_name)
+    except AttributeError as exc:
+        raise WorkflowConfigError(f"Plugin '{path}' not found") from exc
+    if not issubclass(plugin_cls, Plugin):
+        raise WorkflowConfigError(f"{path} is not a Plugin")
+    return plugin_cls
+
+
+@dataclass
+class Workflow:
+    """Mapping of workflow stages to plugin classes."""
+
+    steps: Dict[str, List[Type[Plugin]]] = field(default_factory=dict)
+
+    def plugins_for(self, stage: str) -> List[Type[Plugin]]:
+        """Return plugins configured for ``stage``."""
+        return self.steps.get(stage, [])
+
+    @classmethod
+    def from_dict(cls, config: Dict[str, Iterable[str | Type[Plugin]]]) -> "Workflow":
+        """Build a workflow from a stage-to-plugins mapping."""
+
+        steps: Dict[str, List[Type[Plugin]]] = {}
+        for stage, plugins in config.items():
+            if stage not in WorkflowExecutor._ORDER:
+                raise WorkflowConfigError(f"Unknown stage: {stage}")
+
+            steps[stage] = []
+            for plugin in plugins:
+                plugin_cls = (
+                    _import_string(plugin) if isinstance(plugin, str) else plugin
+                )
+                _validate_plugin_stage(plugin_cls, stage)
+                steps[stage].append(plugin_cls)
+        return cls(steps)
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "Workflow":
+        """Load a workflow configuration from a YAML file."""
+
+        with open(path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        if not isinstance(data, dict):
+            raise WorkflowConfigError("Workflow configuration must be a mapping")
+        return cls.from_dict(data)
+
+
+def _validate_plugin_stage(plugin_cls: Type[Plugin], stage: str) -> None:
+    """Ensure ``plugin_cls`` supports ``stage``."""
+
+    supported = getattr(plugin_cls, "supported_stages", None)
+    explicit = getattr(plugin_cls, "stage", None)
+
+    if supported and stage not in supported:
+        raise WorkflowConfigError(
+            f"{plugin_cls.__name__} does not support stage '{stage}'"
+        )
+    if explicit and explicit != stage:
+        raise WorkflowConfigError(
+            f"{plugin_cls.__name__} expects stage '{explicit}', not '{stage}'"
+        )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from entity.workflow.workflow import Workflow, WorkflowConfigError
+from entity.workflow.executor import WorkflowExecutor
+
+
+class DummyPlugin:
+    stage = WorkflowExecutor.THINK
+
+    async def _execute_impl(self, context):
+        return "ok"
+
+
+class MultiStagePlugin:
+    supported_stages = [WorkflowExecutor.PARSE, WorkflowExecutor.REVIEW]
+
+    async def _execute_impl(self, context):
+        return "ok"
+
+
+def test_from_dict_loads_plugins():
+    wf = Workflow.from_dict({"think": [DummyPlugin]})
+    assert wf.plugins_for("think") == [DummyPlugin]
+
+
+def test_validation_rejects_invalid_stage():
+    with pytest.raises(WorkflowConfigError):
+        Workflow.from_dict({"do": [DummyPlugin]})
+
+
+def test_validation_uses_supported_stages():
+    with pytest.raises(WorkflowConfigError):
+        Workflow.from_dict({"think": [MultiStagePlugin]})


### PR DESCRIPTION
## Summary
- add `Workflow` class to manage per-stage plugins
- allow loading workflow config from dict or YAML
- validate plugin compatibility with assigned stages
- expose workflow internals lazily to avoid circular imports
- move `WorkflowContext` to plugin context module
- cover workflow parsing and validation with unit tests

## Testing
- `poetry run black src tests`
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_68803d61c2488322b040b7d0225dda13