### PR TITLE
Add config validation and workflow error handling

### DIFF
--- a/src/entity/config/__init__.py
+++ b/src/entity/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration utilities."""
+
+from .validation import validate_config, validate_workflow
+
+__all__ = ["validate_config", "validate_workflow"]

--- a/src/entity/config/validation.py
+++ b/src/entity/config/validation.py
@@ -1,0 +1,49 @@
+"""Configuration validation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from ..workflow.workflow import Workflow, WorkflowConfigError
+from ..workflow.executor import WorkflowExecutor
+
+REQUIRED_KEYS = {"resources", "workflow"}
+
+
+def validate_config(path: str | Path) -> Dict[str, Any]:
+    """Load and validate a YAML configuration file."""
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except yaml.YAMLError as exc:  # pragma: no cover - simple parse error
+        raise ValueError(f"Invalid YAML syntax in {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError("Configuration must be a mapping")
+
+    missing = REQUIRED_KEYS - data.keys()
+    if missing:
+        raise ValueError(f"Missing required keys: {', '.join(sorted(missing))}")
+
+    return data
+
+
+def validate_workflow(workflow: Workflow) -> None:
+    """Validate plugin stages for a ``Workflow``."""
+    for stage, plugins in workflow.steps.items():
+        if stage not in WorkflowExecutor._STAGES:
+            raise WorkflowConfigError(f"Unknown stage: {stage}")
+        for plugin_cls in plugins:
+            supported = getattr(plugin_cls, "supported_stages", None)
+            explicit = getattr(plugin_cls, "stage", None)
+            if supported and stage not in supported:
+                raise WorkflowConfigError(
+                    f"{plugin_cls.__name__} does not support stage '{stage}'"
+                )
+            if explicit and explicit != stage:
+                raise WorkflowConfigError(
+                    f"{plugin_cls.__name__} expects stage '{explicit}', not '{stage}'"
+                )

--- a/src/entity/workflow/workflow.py
+++ b/src/entity/workflow/workflow.py
@@ -44,7 +44,7 @@ class Workflow:
 
         steps: Dict[str, List[Type[Plugin]]] = {}
         for stage, plugins in config.items():
-            if stage not in WorkflowExecutor._ORDER:
+            if stage not in WorkflowExecutor._STAGES:
                 raise WorkflowConfigError(f"Unknown stage: {stage}")
 
             steps[stage] = []

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,50 @@
+import pytest
+
+from entity.config.validation import validate_config, validate_workflow
+from entity.workflow.workflow import Workflow, WorkflowConfigError
+from entity.workflow.executor import WorkflowExecutor
+
+
+class DummyPlugin:
+    stage = WorkflowExecutor.THINK
+
+    async def _execute_impl(self, context):
+        return "ok"
+
+
+class MultiStagePlugin:
+    supported_stages = [WorkflowExecutor.PARSE]
+
+    async def _execute_impl(self, context):
+        return "ok"
+
+
+def test_validate_config_success(tmp_path):
+    cfg = tmp_path / "conf.yml"
+    cfg.write_text("resources: {}\nworkflow: {}")
+    data = validate_config(cfg)
+    assert data == {"resources": {}, "workflow": {}}
+
+
+def test_validate_config_missing(tmp_path):
+    cfg = tmp_path / "bad.yml"
+    cfg.write_text("workflow: {}")
+    with pytest.raises(ValueError):
+        validate_config(cfg)
+
+
+def test_validate_workflow_pass():
+    wf = Workflow(steps={"think": [DummyPlugin]})
+    validate_workflow(wf)
+
+
+def test_validate_workflow_fail_stage():
+    wf = Workflow(steps={"unknown": [DummyPlugin]})
+    with pytest.raises(WorkflowConfigError):
+        validate_workflow(wf)
+
+
+def test_validate_workflow_fail_plugin():
+    wf = Workflow(steps={"think": [MultiStagePlugin]})
+    with pytest.raises(WorkflowConfigError):
+        validate_workflow(wf)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+from entity.plugins.base import Plugin
+
 from entity.workflow.workflow import Workflow, WorkflowConfigError
 from entity.workflow.executor import WorkflowExecutor
 
@@ -33,3 +35,32 @@ def test_validation_rejects_invalid_stage():
 def test_validation_uses_supported_stages():
     with pytest.raises(WorkflowConfigError):
         Workflow.from_dict({"think": [MultiStagePlugin]})
+
+
+class FailingPlugin(Plugin):
+    stage = WorkflowExecutor.THINK
+
+    async def _execute_impl(self, context):
+        raise RuntimeError("boom")
+
+
+called = []
+
+
+class ErrorPlugin(Plugin):
+    stage = WorkflowExecutor.ERROR
+
+    async def _execute_impl(self, context):
+        called.append(context.message)
+
+
+@pytest.mark.asyncio
+async def test_error_hook_runs_on_failure():
+    wf = {
+        WorkflowExecutor.THINK: [FailingPlugin],
+        WorkflowExecutor.ERROR: [ErrorPlugin],
+    }
+    executor = WorkflowExecutor({}, wf)
+    with pytest.raises(RuntimeError):
+        await executor.run("hello")
+    assert called == ["boom"]


### PR DESCRIPTION
## Summary
- create `config` package with validation helpers
- add error stage handling in `WorkflowExecutor`
- allow `_STAGES` when parsing workflow configs
- validate workflows explicitly
- test new validation logic and error hooks

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68803fbf5f5c8322ac36e658540bb080