### PR TITLE
Add example workflow plugins

### DIFF
--- a/examples/basic_workflow.yaml
+++ b/examples/basic_workflow.yaml
@@ -1,0 +1,12 @@
+input:
+  - entity.plugins.examples.input_reader.InputReader
+parse:
+  - entity.plugins.examples.keyword_extractor.KeywordExtractor
+think:
+  - entity.plugins.examples.reason_generator.ReasonGenerator
+do:
+  - entity.plugins.examples.calculator.Calculator
+review:
+  - entity.plugins.examples.static_reviewer.StaticReviewer
+output:
+  - entity.plugins.examples.output_formatter.OutputFormatter

--- a/src/entity/plugins/examples/calculator.py
+++ b/src/entity/plugins/examples/calculator.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import ast
+import operator
+from ..tool import ToolPlugin
+from ...workflow.executor import WorkflowExecutor
+
+
+_ALLOWED_OPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: operator.pow,
+    ast.USub: operator.neg,
+}
+
+
+def _eval(node):
+    if isinstance(node, ast.Num):  # type: ignore[attr-defined]
+        return node.n
+    if isinstance(node, ast.BinOp):
+        left = _eval(node.left)
+        right = _eval(node.right)
+        op_type = type(node.op)
+        if op_type in _ALLOWED_OPS:
+            return _ALLOWED_OPS[op_type](left, right)
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _ALLOWED_OPS:
+        return _ALLOWED_OPS[type(node.op)](_eval(node.operand))
+    raise ValueError("Unsupported expression")
+
+
+class Calculator(ToolPlugin):
+    """Evaluate a simple arithmetic expression."""
+
+    supported_stages = [WorkflowExecutor.DO]
+
+    async def _execute_impl(self, context) -> str:  # noqa: D401
+        expr = context.message or "0"
+        tree = ast.parse(expr, mode="eval")
+        result = _eval(tree.body)
+        return str(result)

--- a/src/entity/plugins/examples/input_reader.py
+++ b/src/entity/plugins/examples/input_reader.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from ..input_adapter import InputAdapterPlugin
+
+
+class InputReader(InputAdapterPlugin):
+    """Simple INPUT stage plugin that passes the prompt through."""
+
+    async def _execute_impl(self, context) -> str:  # noqa: D401
+        """Return the incoming message unchanged."""
+        return context.message or ""

--- a/src/entity/plugins/examples/keyword_extractor.py
+++ b/src/entity/plugins/examples/keyword_extractor.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import re
+from ..base import Plugin
+from ...workflow.executor import WorkflowExecutor
+
+
+class KeywordExtractor(Plugin):
+    """Extract lowercase keywords from the prompt and store them."""
+
+    stage = WorkflowExecutor.PARSE
+
+    async def _execute_impl(self, context) -> str:  # noqa: D401
+        """Persist keywords and return the original message."""
+        text = context.message or ""
+        keywords = list(dict.fromkeys(re.findall(r"\w+", text.lower())))
+        await context.remember("keywords", keywords)
+        return text

--- a/src/entity/plugins/examples/output_formatter.py
+++ b/src/entity/plugins/examples/output_formatter.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from ..output_adapter import OutputAdapterPlugin
+
+
+class OutputFormatter(OutputAdapterPlugin):
+    """Return the final result to the user."""
+
+    async def _execute_impl(self, context) -> str:  # noqa: D401
+        message = context.message or ""
+        context.say(f"Result: {message}")
+        return message

--- a/src/entity/plugins/examples/reason_generator.py
+++ b/src/entity/plugins/examples/reason_generator.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from ..prompt import PromptPlugin
+from ...workflow.executor import WorkflowExecutor
+
+
+class ReasonGenerator(PromptPlugin):
+    """Generate reasoning about the extracted keywords."""
+
+    supported_stages = [WorkflowExecutor.THINK]
+
+    async def _execute_impl(self, context) -> str:  # noqa: D401
+        keywords = await context.recall("keywords", [])
+        llm = context.get_resource("llm")
+        prompt = f"Reason about: {', '.join(keywords)}"
+        reasoning = (
+            await llm.generate(prompt)
+            if llm is not None
+            else f"Reason: {', '.join(keywords)}"
+        )
+        await context.remember("reasoning", reasoning)
+        return context.message or ""

--- a/src/entity/plugins/examples/static_reviewer.py
+++ b/src/entity/plugins/examples/static_reviewer.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from ..base import Plugin
+from ...workflow.executor import WorkflowExecutor
+
+
+class StaticReviewer(Plugin):
+    """Pass-through REVIEW stage plugin."""
+
+    stage = WorkflowExecutor.REVIEW
+
+    async def _execute_impl(self, context) -> str:  # noqa: D401
+        return context.message or ""

--- a/tests/test_examples_workflow.py
+++ b/tests/test_examples_workflow.py
@@ -1,0 +1,20 @@
+import asyncio
+
+import pytest
+
+from entity.workflow import Workflow, WorkflowExecutor
+
+
+class DummyLLM:
+    async def generate(self, prompt: str) -> str:  # pragma: no cover - example
+        return "dummy reasoning"
+
+
+@pytest.mark.asyncio
+async def test_basic_example_workflow():
+    wf = Workflow.from_yaml("examples/basic_workflow.yaml")
+    resources = {"llm": DummyLLM()}
+    executor = WorkflowExecutor(resources, wf.steps)
+
+    result = await executor.run("2 + 2", user_id="test")
+    assert result == "Result: 4"


### PR DESCRIPTION
## Summary
- add example plugins for each workflow stage
- register them in `examples/basic_workflow.yaml`
- test that the example workflow runs end-to-end

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68804244b7b08322848d23133e3c937e