### PR TITLE
Add example memory sharing and test user isolation

### DIFF
--- a/src/entity/plugins/context.py
+++ b/src/entity/plugins/context.py
@@ -30,11 +30,16 @@ class WorkflowContext:
 class PluginContext(WorkflowContext):
     """Extended context exposing memory and resources."""
 
-    def __init__(self, resources: Dict[str, Any], user_id: str) -> None:
+    def __init__(
+        self,
+        resources: Dict[str, Any],
+        user_id: str,
+        memory: Dict[str, Any] | None = None,
+    ) -> None:
         super().__init__()
         self._resources = resources
         self.user_id = user_id
-        self._memory: Dict[str, Any] = {}
+        self._memory: Dict[str, Any] = memory if memory is not None else {}
         self._conversation: List[str] = []
 
     async def remember(self, key: str, value: Any) -> None:

--- a/src/entity/plugins/examples/input_reader.py
+++ b/src/entity/plugins/examples/input_reader.py
@@ -7,5 +7,7 @@ class InputReader(InputAdapterPlugin):
     """Simple INPUT stage plugin that passes the prompt through."""
 
     async def _execute_impl(self, context) -> str:  # noqa: D401
-        """Return the incoming message unchanged."""
-        return context.message or ""
+        """Store and return the incoming message."""
+        message = context.message or ""
+        await context.remember("input", message)
+        return message

--- a/src/entity/plugins/examples/keyword_extractor.py
+++ b/src/entity/plugins/examples/keyword_extractor.py
@@ -12,7 +12,7 @@ class KeywordExtractor(Plugin):
 
     async def _execute_impl(self, context) -> str:  # noqa: D401
         """Persist keywords and return the original message."""
-        text = context.message or ""
+        text = await context.recall("input", context.message or "")
         keywords = list(dict.fromkeys(re.findall(r"\w+", text.lower())))
         await context.remember("keywords", keywords)
         return text

--- a/src/entity/plugins/examples/output_formatter.py
+++ b/src/entity/plugins/examples/output_formatter.py
@@ -8,5 +8,7 @@ class OutputFormatter(OutputAdapterPlugin):
 
     async def _execute_impl(self, context) -> str:  # noqa: D401
         message = context.message or ""
+        reasoning = await context.recall("reasoning", "")
         context.say(f"Result: {message}")
+        await context.remember("last_reasoning", reasoning)
         return message

--- a/tests/test_memory_isolation.py
+++ b/tests/test_memory_isolation.py
@@ -1,0 +1,18 @@
+import asyncio
+import pytest
+
+from entity.plugins.context import PluginContext
+
+
+@pytest.mark.asyncio
+async def test_remember_isolated_by_user_id():
+    shared = {}
+    ctx_a = PluginContext({}, user_id="a", memory=shared)
+    ctx_b = PluginContext({}, user_id="b", memory=shared)
+
+    await ctx_a.remember("val", 1)
+    await ctx_b.remember("val", 2)
+
+    assert await ctx_a.recall("val") == 1
+    assert await ctx_b.recall("val") == 2
+    assert shared == {"a:val": 1, "b:val": 2}


### PR DESCRIPTION
## Summary
- allow PluginContext to accept an external memory store
- remember input text in example plugins and recall it later
- add test covering per-user isolation of remembered values

## Testing
- `poetry run black src tests`
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_688044289f1883229f2855ba10eab6bb