### PR TITLE
Add queued tool execution

### DIFF
--- a/src/entity/tools/dummy.py
+++ b/src/entity/tools/dummy.py
@@ -1,0 +1,6 @@
+"""Simple example tool used in tests."""
+
+
+async def echo(text: str) -> str:
+    """Return the provided text in upper case."""
+    return text.upper()

--- a/src/entity/workflow/executor.py
+++ b/src/entity/workflow/executor.py
@@ -52,8 +52,10 @@ class WorkflowExecutor:
                     await self._handle_error(context, exc, user_id)
                     raise
 
-                if stage == self.OUTPUT and context.response is not None:
-                    return context.response
+            await context.run_tool_queue()
+
+            if stage == self.OUTPUT and context.response is not None:
+                return context.response
         return result
 
     async def _handle_error(

--- a/tests/test_tool_execution.py
+++ b/tests/test_tool_execution.py
@@ -1,0 +1,49 @@
+import pytest
+
+from entity.workflow import Workflow, WorkflowExecutor
+from entity.plugins.base import Plugin
+from entity.plugins.context import PluginContext
+
+
+async def dummy_tool(text: str, results=None):
+    if results is not None:
+        results.append(text)
+    return text.upper()
+
+
+class ImmediatePlugin(Plugin):
+    stage = WorkflowExecutor.THINK
+
+    async def _execute_impl(self, context: PluginContext) -> str:
+        return await context.tool_use("dummy", text=context.message)
+
+
+class QueuePlugin(Plugin):
+    stage = WorkflowExecutor.THINK
+
+    async def _execute_impl(self, context: PluginContext) -> str:
+        context.queue_tool_use(
+            "dummy", text=context.message, results=context.get_resource("results")
+        )
+        return "queued"
+
+
+@pytest.mark.asyncio
+async def test_tool_use_immediate():
+    wf = Workflow(steps={WorkflowExecutor.THINK: [ImmediatePlugin]})
+    resources = {"tools": {"dummy": dummy_tool}}
+    executor = WorkflowExecutor(resources, wf.steps)
+
+    result = await executor.run("hello")
+    assert result == "HELLO"
+
+
+@pytest.mark.asyncio
+async def test_tool_use_queued():
+    results = []
+    wf = Workflow(steps={WorkflowExecutor.THINK: [QueuePlugin]})
+    resources = {"tools": {"dummy": dummy_tool}, "results": results}
+    executor = WorkflowExecutor(resources, wf.steps)
+
+    await executor.run("hi")
+    assert results == ["hi"]


### PR DESCRIPTION
## Summary
- extend `PluginContext` with `tool_use`, `queue_tool_use` and `run_tool_queue`
- allow `WorkflowExecutor` to run queued tools after each stage
- provide example tool `tools.dummy.echo`
- test immediate and queued tool execution

## Testing
- `poetry run black src tests`
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_6880473733dc8322a8648ed8ca00a820