### PR TITLE
Add tool registry and selector plugin

### DIFF
--- a/src/entity/plugins/context.py
+++ b/src/entity/plugins/context.py
@@ -93,3 +93,9 @@ class PluginContext(WorkflowContext):
         while self._tool_queue:
             name, kwargs = self._tool_queue.pop(0)
             await self.tool_use(name, **kwargs)
+
+    def discover_tools(self, **filters: Any):
+        """Return registered tools filtered by ``filters``."""
+        from ..tools.registry import discover_tools
+
+        return discover_tools(**filters)

--- a/src/entity/plugins/smart_selector.py
+++ b/src/entity/plugins/smart_selector.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from .prompt import PromptPlugin
+from ..tools.registry import ToolInfo
+from ..workflow.executor import WorkflowExecutor
+
+
+class SmartToolSelectorPlugin(PromptPlugin):
+    """Select and execute the most relevant tool."""
+
+    stage = WorkflowExecutor.THINK
+    dependencies: list[str] = []
+
+    def _rank_tools_by_relevance(
+        self, tools: Iterable[ToolInfo], message: str | None
+    ) -> ToolInfo | None:
+        text = (message or "").lower()
+        for tool in tools:
+            if tool.name.lower() in text:
+                return tool
+        return next(iter(tools), None)
+
+    async def _execute_impl(self, context) -> Any:  # noqa: D401
+        available = context.discover_tools()
+        best = self._rank_tools_by_relevance(available, context.message)
+        if best is None:
+            return context.message or ""
+        result = await context.tool_use(best.name)
+        await context.remember("selected_tool", best.name)
+        return result

--- a/src/entity/tools/__init__.py
+++ b/src/entity/tools/__init__.py
@@ -1,0 +1,3 @@
+from .registry import discover_tools, register_tool, ToolInfo, clear_registry
+
+__all__ = ["discover_tools", "register_tool", "ToolInfo", "clear_registry"]

--- a/src/entity/tools/registry.py
+++ b/src/entity/tools/registry.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+
+@dataclass
+class ToolInfo:
+    """Metadata about a registered tool."""
+
+    name: str
+    func: Callable[..., Any]
+    category: Optional[str] = None
+    description: Optional[str] = None
+
+
+_REGISTRY: Dict[str, ToolInfo] = {}
+
+
+def register_tool(
+    func: Callable[..., Any],
+    name: Optional[str] = None,
+    *,
+    category: Optional[str] = None,
+    description: Optional[str] = None,
+) -> None:
+    """Register ``func`` under ``name`` with optional metadata."""
+    tool_name = name or func.__name__
+    _REGISTRY[tool_name] = ToolInfo(tool_name, func, category, description)
+
+
+def discover_tools(category: Optional[str] = None) -> List[ToolInfo]:
+    """Return tools filtered by ``category`` if provided."""
+    if category is None:
+        return list(_REGISTRY.values())
+    return [tool for tool in _REGISTRY.values() if tool.category == category]
+
+
+def clear_registry() -> None:
+    """Remove all registered tools (mainly for tests)."""
+    _REGISTRY.clear()
+
+
+__all__ = ["register_tool", "discover_tools", "ToolInfo", "clear_registry"]

--- a/tests/test_tool_selection.py
+++ b/tests/test_tool_selection.py
@@ -1,0 +1,40 @@
+import pytest
+
+from entity.plugins.context import PluginContext
+from entity.plugins.smart_selector import SmartToolSelectorPlugin
+from entity.tools.registry import clear_registry, register_tool
+from entity.workflow import Workflow, WorkflowExecutor
+
+
+async def tool_a():
+    return "A"
+
+
+async def tool_b():
+    return "B"
+
+
+@pytest.mark.asyncio
+async def test_discover_tools_filtered():
+    clear_registry()
+    register_tool(tool_a, name="a", category="letters")
+    register_tool(tool_b, name="b", category="symbols")
+    ctx = PluginContext({}, user_id="t")
+    tools = ctx.discover_tools(category="letters")
+    assert [t.name for t in tools] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_smart_selector_picks_correct_tool():
+    clear_registry()
+    register_tool(tool_a, name="a")
+    register_tool(tool_b, name="b")
+    wf = Workflow(steps={WorkflowExecutor.THINK: [SmartToolSelectorPlugin]})
+    resources = {"tools": {"a": tool_a, "b": tool_b}}
+    executor = WorkflowExecutor(resources, wf.steps)
+
+    result_a = await executor.run("run a")
+    assert result_a == "A"
+
+    result_b = await executor.run("use b")
+    assert result_b == "B"


### PR DESCRIPTION
## Summary
- add a simple tool registry with registration & discovery
- export registry from `entity.tools`
- extend `PluginContext` with a new `discover_tools()` helper
- implement `SmartToolSelectorPlugin` to pick tools at runtime
- test dynamic tool discovery and selection

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_688075c3e4a4832290888fdc4bab66fb