### PR TITLE
Implement CLI adapter

### DIFF
--- a/src/entity/cli/__main__.py
+++ b/src/entity/cli/__main__.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+
+from ..core.agent import Agent
+from ..plugins.defaults import (
+    ParsePlugin,
+    ThinkPlugin,
+    DoPlugin,
+    ReviewPlugin,
+)
+from .ent_cli_adapter import EntCLIAdapter
+
+
+async def _run() -> None:
+    workflow = [
+        EntCLIAdapter,
+        ParsePlugin,
+        ThinkPlugin,
+        DoPlugin,
+        ReviewPlugin,
+        EntCLIAdapter,
+    ]
+    agent = Agent(workflow=workflow)
+    await agent.chat("")
+
+
+def main() -> None:
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/src/entity/cli/ent_cli_adapter.py
+++ b/src/entity/cli/ent_cli_adapter.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from ..plugins.input_adapter import InputAdapterPlugin
+from ..plugins.output_adapter import OutputAdapterPlugin
+from ..workflow.executor import WorkflowExecutor
+from ..plugins.context import PluginContext
+
+
+class EntCLIAdapter(InputAdapterPlugin, OutputAdapterPlugin):
+    """Simple CLI adapter using stdin and stdout."""
+
+    supported_stages = [WorkflowExecutor.INPUT, WorkflowExecutor.OUTPUT]
+
+    async def _execute_impl(self, context: PluginContext) -> str:
+        if context.current_stage == WorkflowExecutor.INPUT:
+            message = sys.stdin.readline().rstrip("\n")
+            await context.remember("cli_input", message)
+            return message
+        if context.current_stage == WorkflowExecutor.OUTPUT:
+            output = context.message or ""
+            print(output)
+            context.say(output)
+            return output
+        return context.message or ""

--- a/src/entity/plugins/defaults/__init__.py
+++ b/src/entity/plugins/defaults/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ..base import Plugin
+from ...cli.ent_cli_adapter import EntCLIAdapter
 
 
 class InputPlugin(Plugin):
@@ -43,10 +44,10 @@ def default_workflow() -> list[type[Plugin]]:
     """Return the built-in workflow with one plugin per stage."""
 
     return [
-        InputPlugin,
+        EntCLIAdapter,
         ParsePlugin,
         ThinkPlugin,
         DoPlugin,
         ReviewPlugin,
-        OutputPlugin,
+        EntCLIAdapter,
     ]


### PR DESCRIPTION
## Summary
- add CLI adapter implementing InputAdapterPlugin and OutputAdapterPlugin
- expose CLI entry point via `entity.cli`
- include CLI in the zero-config default workflow

## Testing
- `poetry run black src tests`
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_68807a0e67ac832294c245eb1b441c06