### PR TITLE
Add logging and metrics resources

### DIFF
--- a/src/entity/plugins/context.py
+++ b/src/entity/plugins/context.py
@@ -43,6 +43,8 @@ class PluginContext(WorkflowContext):
         self._conversation: List[str] = []
         self._tools: Dict[str, Any] = resources.get("tools", {})
         self._tool_queue: List[tuple[str, Dict[str, Any]]] = []
+        self.logger = resources.get("logging")
+        self.metrics_collector = resources.get("metrics_collector")
 
     async def remember(self, key: str, value: Any) -> None:
         """Persist value namespaced by ``user_id``."""

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -9,6 +9,8 @@ from .exceptions import ResourceInitializationError
 from .memory import Memory
 from .llm_wrapper import LLM
 from .storage_wrapper import Storage
+from .logging import LoggingResource
+from .metrics import MetricsCollectorResource
 
 __all__ = [
     "DatabaseResource",
@@ -20,4 +22,6 @@ __all__ = [
     "Memory",
     "LLM",
     "Storage",
+    "LoggingResource",
+    "MetricsCollectorResource",
 ]

--- a/src/entity/resources/logging.py
+++ b/src/entity/resources/logging.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class LoggingResource:
+    """Collect log entries for later inspection."""
+
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+
+    async def log(self, level: str, message: str, **fields: Any) -> None:
+        """Store a log entry with arbitrary metadata."""
+        entry = {"level": level, "message": message, **fields}
+        self.records.append(entry)

--- a/src/entity/resources/metrics.py
+++ b/src/entity/resources/metrics.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class MetricsCollectorResource:
+    """Simple in-memory metrics collector."""
+
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+
+    async def record_plugin_execution(
+        self,
+        plugin_name: str,
+        stage: str,
+        duration_ms: float,
+        success: bool,
+    ) -> None:
+        self.records.append(
+            {
+                "plugin_name": plugin_name,
+                "stage": stage,
+                "duration_ms": duration_ms,
+                "success": success,
+            }
+        )

--- a/tests/test_logging_metrics.py
+++ b/tests/test_logging_metrics.py
@@ -1,0 +1,70 @@
+import pytest
+
+from entity.workflow import Workflow, WorkflowExecutor
+from entity.plugins.base import Plugin
+from entity.plugins.context import PluginContext
+
+
+class LogPlugin(Plugin):
+    stage = WorkflowExecutor.THINK
+
+    async def _execute_impl(self, context: PluginContext) -> str:
+        await context.logger.log(
+            "info",
+            "running",
+            stage=context.current_stage,
+            plugin_name=self.__class__.__name__,
+        )
+        await context.metrics_collector.record_plugin_execution(
+            plugin_name=self.__class__.__name__,
+            stage=context.current_stage,
+            duration_ms=0.0,
+            success=True,
+        )
+        return context.message or ""
+
+
+class OutputPlugin(Plugin):
+    stage = WorkflowExecutor.OUTPUT
+
+    async def _execute_impl(self, context: PluginContext) -> str:
+        await context.logger.log(
+            "info",
+            "output",
+            stage=context.current_stage,
+            plugin_name=self.__class__.__name__,
+        )
+        await context.metrics_collector.record_plugin_execution(
+            plugin_name=self.__class__.__name__,
+            stage=context.current_stage,
+            duration_ms=0.0,
+            success=True,
+        )
+        context.say("done")
+        return "done"
+
+
+@pytest.mark.asyncio
+async def test_logging_and_metrics_per_stage():
+    wf = Workflow(
+        steps={
+            WorkflowExecutor.THINK: [LogPlugin],
+            WorkflowExecutor.OUTPUT: [OutputPlugin],
+        }
+    )
+    executor = WorkflowExecutor({}, wf.steps)
+    result = await executor.run("hi")
+
+    assert result == "done"
+
+    logs = executor.resources["logging"].records
+    metrics = executor.resources["metrics_collector"].records
+
+    assert [r["stage"] for r in logs] == [
+        WorkflowExecutor.THINK,
+        WorkflowExecutor.OUTPUT,
+    ]
+    assert [m["stage"] for m in metrics] == [
+        WorkflowExecutor.THINK,
+        WorkflowExecutor.OUTPUT,
+    ]


### PR DESCRIPTION
## Summary
- implement `LoggingResource` and `MetricsCollectorResource`
- expose both new resources to plugins via `PluginContext`
- automatically create them in `WorkflowExecutor`
- add a test covering log and metrics capture

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6880d7beecf08322ab91a2b630fa4b33