### PR TITLE
Implement namespaced chat workflow

### DIFF
--- a/src/entity/plugins/examples/input_reader.py
+++ b/src/entity/plugins/examples/input_reader.py
@@ -9,5 +9,8 @@ class InputReader(InputAdapterPlugin):
     async def _execute_impl(self, context) -> str:  # noqa: D401
         """Store and return the incoming message."""
         message = context.message or ""
+        history = await context.recall("history", [])
+        history.append(message)
+        await context.remember("history", history)
         await context.remember("input", message)
         return message

--- a/src/entity/workflow/executor.py
+++ b/src/entity/workflow/executor.py
@@ -34,10 +34,15 @@ class WorkflowExecutor:
             stage: list(plugins) for stage, plugins in (workflow or {}).items()
         }
 
-    async def run(self, message: str, user_id: str = "default") -> str:
+    async def run(
+        self,
+        message: str,
+        user_id: str = "default",
+        memory: dict[str, Any] | None = None,
+    ) -> str:
         """Execute configured plugins in order until an OUTPUT plugin calls ``say``."""
 
-        context = PluginContext(self.resources, user_id)
+        context = PluginContext(self.resources, user_id, memory=memory)
         result = message
         for stage in self._ORDER:
             for plugin_cls in self.workflow.get(stage, []):

--- a/tests/test_examples_workflow.py
+++ b/tests/test_examples_workflow.py
@@ -18,3 +18,17 @@ async def test_basic_example_workflow():
 
     result = await executor.run("2 + 2", user_id="test")
     assert result == "Result: 4"
+
+
+@pytest.mark.asyncio
+async def test_example_workflow_multiple_users():
+    wf = Workflow.from_yaml("examples/basic_workflow.yaml")
+    resources = {"llm": DummyLLM()}
+    executor = WorkflowExecutor(resources, wf.steps)
+    memory: dict[str, str] = {}
+
+    await executor.run("1 + 1", user_id="a", memory=memory)
+    await executor.run("2 + 2", user_id="b", memory=memory)
+
+    assert memory["a:history"] == ["1 + 1"]
+    assert memory["b:history"] == ["2 + 2"]


### PR DESCRIPTION
## Summary
- route `Agent.chat()` through `WorkflowExecutor`
- namespace plugin memory with `user_id`
- keep per-user history in `InputReader`
- allow `WorkflowExecutor.run()` to share memory
- add test covering independent conversations

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6880dc3931f88322acdf543041a139e5