### PR TITLE
Ensure resources use absolute imports and injection

### DIFF
--- a/src/entity/infrastructure/duckdb_infra.py
+++ b/src/entity/infrastructure/duckdb_infra.py
@@ -2,6 +2,8 @@ class DuckDBInfrastructure:
     """Layer 1 infrastructure for managing a DuckDB database file."""
 
     def __init__(self, file_path: str) -> None:
+        """Create the infrastructure for a given database file."""
+
         self.file_path = file_path
         self._connection = None
 

--- a/src/entity/infrastructure/local_storage_infra.py
+++ b/src/entity/infrastructure/local_storage_infra.py
@@ -5,8 +5,12 @@ class LocalStorageInfrastructure:
     """Layer 1 infrastructure for storing files on the local filesystem."""
 
     def __init__(self, base_path: str) -> None:
+        """Create the infrastructure rooted at ``base_path``."""
+
         self.base_path = Path(base_path)
         self.base_path.mkdir(parents=True, exist_ok=True)
 
     def resolve_path(self, key: str) -> Path:
+        """Return the absolute path for the given storage key."""
+
         return self.base_path / key

--- a/src/entity/infrastructure/ollama_infra.py
+++ b/src/entity/infrastructure/ollama_infra.py
@@ -5,6 +5,8 @@ class OllamaInfrastructure:
     """Layer 1 infrastructure for communicating with an Ollama server."""
 
     def __init__(self, base_url: str, model: str) -> None:
+        """Configure the client base URL and model."""
+
         self.base_url = base_url.rstrip("/")
         self.model = model
 

--- a/src/entity/infrastructure/s3_infra.py
+++ b/src/entity/infrastructure/s3_infra.py
@@ -5,13 +5,19 @@ class S3Infrastructure:
     """Layer 1 infrastructure for interacting with an S3 bucket."""
 
     def __init__(self, bucket: str) -> None:
+        """Configure the target bucket."""
+
         self.bucket = bucket
         self._session: aioboto3.Session | None = None
 
     def session(self) -> aioboto3.Session:
+        """Return an aioboto3 session, creating one if needed."""
+
         if self._session is None:
             self._session = aioboto3.Session()
         return self._session
 
     def client(self):
+        """Create an S3 client from the session."""
+
         return self.session().client("s3")

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -1,16 +1,16 @@
 """Public resource interfaces and canonical wrappers."""
 
-from .database import DatabaseResource
-from .vector_store import VectorStoreResource
-from .llm import LLMResource
-from .storage import StorageResource
-from .local_storage import LocalStorageResource
-from .exceptions import ResourceInitializationError
-from .memory import Memory
-from .llm_wrapper import LLM
-from .storage_wrapper import Storage
-from .logging import LoggingResource
-from .metrics import MetricsCollectorResource
+from entity.resources.database import DatabaseResource
+from entity.resources.vector_store import VectorStoreResource
+from entity.resources.llm import LLMResource
+from entity.resources.storage import StorageResource
+from entity.resources.local_storage import LocalStorageResource
+from entity.resources.exceptions import ResourceInitializationError
+from entity.resources.memory import Memory
+from entity.resources.llm_wrapper import LLM
+from entity.resources.storage_wrapper import Storage
+from entity.resources.logging import LoggingResource
+from entity.resources.metrics import MetricsCollectorResource
 
 __all__ = [
     "DatabaseResource",

--- a/src/entity/resources/database.py
+++ b/src/entity/resources/database.py
@@ -1,12 +1,18 @@
-from ..infrastructure.duckdb_infra import DuckDBInfrastructure
+"""Database resource that executes queries using a DuckDB backend."""
+
+from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
 
 
 class DatabaseResource:
     """Layer 2 resource providing database access."""
 
     def __init__(self, infrastructure: DuckDBInfrastructure) -> None:
+        """Initialize with an injected DuckDB infrastructure."""
+
         self.infrastructure = infrastructure
 
-    def execute(self, query: str, *params):
+    def execute(self, query: str, *params: object) -> object:
+        """Execute a SQL query and return the result cursor."""
+
         conn = self.infrastructure.connect()
         return conn.execute(query, params)

--- a/src/entity/resources/exceptions.py
+++ b/src/entity/resources/exceptions.py
@@ -1,2 +1,13 @@
-class ResourceInitializationError(Exception):
+"""Custom exceptions used across resources and infrastructure."""
+
+
+class ResourceError(Exception):
+    """Base class for errors raised by resource implementations."""
+
+
+class InfrastructureError(ResourceError):
+    """Raised when infrastructure operations fail."""
+
+
+class ResourceInitializationError(ResourceError):
     """Raised when a canonical resource is missing required dependencies."""

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -1,11 +1,17 @@
-from ..infrastructure.ollama_infra import OllamaInfrastructure
+"""Resource wrapper around an Ollama LLM deployment."""
+
+from entity.infrastructure.ollama_infra import OllamaInfrastructure
 
 
 class LLMResource:
     """Layer 2 resource that wraps an Ollama LLM."""
 
     def __init__(self, infrastructure: OllamaInfrastructure) -> None:
+        """Initialize with the Ollama infrastructure instance."""
+
         self.infrastructure = infrastructure
 
     async def generate(self, prompt: str) -> str:
+        """Return the model output for a given prompt."""
+
         return await self.infrastructure.generate(prompt)

--- a/src/entity/resources/llm_wrapper.py
+++ b/src/entity/resources/llm_wrapper.py
@@ -1,14 +1,18 @@
-from .llm import LLMResource
-from .exceptions import ResourceInitializationError
+from entity.resources.llm import LLMResource
+from entity.resources.exceptions import ResourceInitializationError
 
 
 class LLM:
     """Layer 3 wrapper around an LLM resource."""
 
     def __init__(self, resource: LLMResource | None) -> None:
+        """Wrap the provided :class:`LLMResource`."""
+
         if resource is None:
             raise ResourceInitializationError("LLMResource is required")
         self.resource = resource
 
     async def generate(self, prompt: str) -> str:
+        """Generate a completion using the underlying resource."""
+
         return await self.resource.generate(prompt)

--- a/src/entity/resources/local_storage.py
+++ b/src/entity/resources/local_storage.py
@@ -3,16 +3,20 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from ..infrastructure.local_storage_infra import LocalStorageInfrastructure
+from entity.infrastructure.local_storage_infra import LocalStorageInfrastructure
 
 
 class LocalStorageResource:
     """Layer 2 resource for local file storage."""
 
     def __init__(self, infrastructure: LocalStorageInfrastructure) -> None:
+        """Create the resource with a local storage backend."""
+
         self.infrastructure = infrastructure
 
     async def upload_text(self, key: str, data: str) -> None:
+        """Persist text to the local filesystem."""
+
         path = self.infrastructure.resolve_path(key)
         path.parent.mkdir(parents=True, exist_ok=True)
         await asyncio.to_thread(path.write_text, data)

--- a/src/entity/resources/logging.py
+++ b/src/entity/resources/logging.py
@@ -7,6 +7,8 @@ class LoggingResource:
     """Collect log entries for later inspection."""
 
     def __init__(self) -> None:
+        """Initialize an empty list of log records."""
+
         self.records: List[Dict[str, Any]] = []
 
     async def log(self, level: str, message: str, **fields: Any) -> None:

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -1,6 +1,6 @@
-from .database import DatabaseResource
-from .vector_store import VectorStoreResource
-from .exceptions import ResourceInitializationError
+from entity.resources.database import DatabaseResource
+from entity.resources.vector_store import VectorStoreResource
+from entity.resources.exceptions import ResourceInitializationError
 
 
 class Memory:
@@ -11,6 +11,8 @@ class Memory:
         database: DatabaseResource | None,
         vector_store: VectorStoreResource | None,
     ) -> None:
+        """Create the memory wrapper with required resources."""
+
         if database is None or vector_store is None:
             raise ResourceInitializationError(
                 "DatabaseResource and VectorStoreResource are required"
@@ -18,11 +20,17 @@ class Memory:
         self.database = database
         self.vector_store = vector_store
 
-    def execute(self, query: str, *params):
+    def execute(self, query: str, *params: object) -> object:
+        """Execute a database query."""
+
         return self.database.execute(query, *params)
 
-    def add_vector(self, table: str, vector):
+    def add_vector(self, table: str, vector: object) -> None:
+        """Store a vector via the underlying vector resource."""
+
         self.vector_store.add_vector(table, vector)
 
-    def query(self, query: str):
+    def query(self, query: str) -> object:
+        """Execute a vector store query."""
+
         return self.vector_store.query(query)

--- a/src/entity/resources/metrics.py
+++ b/src/entity/resources/metrics.py
@@ -7,6 +7,8 @@ class MetricsCollectorResource:
     """Simple in-memory metrics collector."""
 
     def __init__(self) -> None:
+        """Start with an empty list of metric records."""
+
         self.records: List[Dict[str, Any]] = []
 
     async def record_plugin_execution(
@@ -16,6 +18,8 @@ class MetricsCollectorResource:
         duration_ms: float,
         success: bool,
     ) -> None:
+        """Record execution metrics for a plugin call."""
+
         self.records.append(
             {
                 "plugin_name": plugin_name,

--- a/src/entity/resources/storage.py
+++ b/src/entity/resources/storage.py
@@ -1,13 +1,19 @@
-from ..infrastructure.s3_infra import S3Infrastructure
+"""Resource for storing text to an S3 bucket."""
+
+from entity.infrastructure.s3_infra import S3Infrastructure
 
 
 class StorageResource:
     """Layer 2 resource for S3-based file storage."""
 
     def __init__(self, infrastructure: S3Infrastructure) -> None:
+        """Initialize the resource with an S3 infrastructure instance."""
+
         self.infrastructure = infrastructure
 
     async def upload_text(self, key: str, data: str) -> None:
+        """Upload plain text to the configured bucket under the given key."""
+
         async with self.infrastructure.client() as client:
             await client.put_object(
                 Bucket=self.infrastructure.bucket, Key=key, Body=data

--- a/src/entity/resources/storage_wrapper.py
+++ b/src/entity/resources/storage_wrapper.py
@@ -1,15 +1,19 @@
-from .storage import StorageResource
-from .local_storage import LocalStorageResource
-from .exceptions import ResourceInitializationError
+from entity.resources.storage import StorageResource
+from entity.resources.local_storage import LocalStorageResource
+from entity.resources.exceptions import ResourceInitializationError
 
 
 class Storage:
     """Layer 3 wrapper around a storage resource."""
 
     def __init__(self, resource: StorageResource | LocalStorageResource | None) -> None:
+        """Wrap a local or S3 storage resource."""
+
         if resource is None:
             raise ResourceInitializationError("StorageResource is required")
         self.resource = resource
 
     async def upload_text(self, key: str, data: str) -> None:
+        """Proxy text upload to the underlying resource."""
+
         await self.resource.upload_text(key, data)

--- a/src/entity/resources/vector_store.py
+++ b/src/entity/resources/vector_store.py
@@ -1,16 +1,24 @@
-from ..infrastructure.duckdb_infra import DuckDBInfrastructure
+"""Vector store resource backed by DuckDB."""
+
+from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
 
 
 class VectorStoreResource:
     """Layer 2 resource for storing and searching vectors."""
 
     def __init__(self, infrastructure: DuckDBInfrastructure) -> None:
+        """Create the resource with a DuckDB backend."""
+
         self.infrastructure = infrastructure
 
-    def add_vector(self, table: str, vector):
+    def add_vector(self, table: str, vector: object) -> None:
+        """Insert a vector into the given table."""
+
         conn = self.infrastructure.connect()
         conn.execute(f"INSERT INTO {table} VALUES (?)", (vector,))
 
-    def query(self, query: str):
+    def query(self, query: str) -> object:
+        """Run a vector search query."""
+
         conn = self.infrastructure.connect()
         return conn.execute(query)

--- a/tests/test_layer_separation.py
+++ b/tests/test_layer_separation.py
@@ -1,0 +1,42 @@
+import pytest
+
+from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
+from entity.infrastructure.ollama_infra import OllamaInfrastructure
+from entity.infrastructure.s3_infra import S3Infrastructure
+from entity.infrastructure.local_storage_infra import LocalStorageInfrastructure
+
+from entity.resources.database import DatabaseResource
+from entity.resources.vector_store import VectorStoreResource
+from entity.resources.llm import LLMResource
+from entity.resources.storage import StorageResource
+from entity.resources.local_storage import LocalStorageResource
+from entity.resources.memory import Memory
+from entity.resources.llm_wrapper import LLM
+from entity.resources.storage_wrapper import Storage
+from entity.resources.exceptions import ResourceInitializationError
+
+
+class DummyInfra:
+    pass
+
+
+def test_resources_store_injected_infrastructure(tmp_path):
+    db_infra = DuckDBInfrastructure(str(tmp_path / "db.duckdb"))
+    s3_infra = S3Infrastructure("bucket")
+    ollama_infra = OllamaInfrastructure("http://localhost", "model")
+    local_infra = LocalStorageInfrastructure(tmp_path)
+
+    assert DatabaseResource(db_infra).infrastructure is db_infra
+    assert VectorStoreResource(db_infra).infrastructure is db_infra
+    assert LLMResource(ollama_infra).infrastructure is ollama_infra
+    assert StorageResource(s3_infra).infrastructure is s3_infra
+    assert LocalStorageResource(local_infra).infrastructure is local_infra
+
+
+def test_wrappers_require_resources():
+    with pytest.raises(ResourceInitializationError):
+        Memory(None, None)
+    with pytest.raises(ResourceInitializationError):
+        LLM(None)
+    with pytest.raises(ResourceInitializationError):
+        Storage(None)


### PR DESCRIPTION
## Summary
- document layering in README
- use absolute imports in resources
- add docstrings and type hints throughout resources and infrastructure
- add custom exceptions for infrastructure failures
- test that resources store injected dependencies
- remove expanded README text as requested

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: `scripts/test_with_docker.sh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68815de59f7c8322a20d52f5152e0e48