### PR TITLE
Add output looping test

### DIFF
--- a/tests/test_output_loop.py
+++ b/tests/test_output_loop.py
@@ -1,0 +1,27 @@
+import pytest
+
+from entity.plugins.base import Plugin
+from entity.workflow.executor import WorkflowExecutor
+from entity.plugins.context import PluginContext
+
+
+@pytest.mark.asyncio
+async def test_output_plugin_sets_response_on_second_iteration():
+    calls: list[int] = []
+
+    class TwoPassOutputPlugin(Plugin):
+        stage = WorkflowExecutor.OUTPUT
+
+        async def _execute_impl(self, context: PluginContext) -> str:
+            calls.append(context.loop_count)
+            if context.loop_count >= 1:
+                context.say("final")
+            return "ignored"
+
+    wf = {WorkflowExecutor.OUTPUT: [TwoPassOutputPlugin]}
+    executor = WorkflowExecutor({}, wf)
+
+    result = await executor.run("hello")
+
+    assert result == "final"
+    assert calls == [0, 1]


### PR DESCRIPTION
## Summary
- ensure WorkflowExecutor loops when output plugin sets `context.response`
- add test verifying second pass triggers `context.say`

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6881755ad56483228bdc339154aa0fff