### PR TITLE
Remove examples extra references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Entity Framework
 Python agent framework
+
+## Examples
+Run `python -m entity.examples` to see sample workflows. The old `[examples]` extra has been removed.


### PR DESCRIPTION
## Summary
- clarify in the README that the `[examples]` extra is gone

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68818037f0b883228e873222d043f86c