### PR TITLE
Remove unused Poe tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,7 @@ _publish = { cmd = "poetry publish --build" }
 release = ["docs", "patch", "_publish"]
 
 # Development helpers
-build-react = { cmd = "npm ci --prefix webapp && npm run build --prefix webapp" }
 start-db = { cmd = "docker compose up -d postgres" }
-open-app = { cmd = "python -m entity.utils.browser" }
-dev = ["build-react", "start-db", "open-app"]
 
 # ALL test tasks need the env variable
 test = { cmd = "pytest", env = { PYTHONPATH = "src" } }
@@ -80,10 +77,6 @@ unit = { cmd = "pytest tests/unit", env = { PYTHONPATH = "src" } }
 integration = { cmd = "pytest tests/integration", env = { PYTHONPATH = "src" } }
 e2e = { cmd = "pytest tests/e2e", env = { PYTHONPATH = "src" } }
 
-start-test-services = { cmd = "docker compose up -d" }
-stop-test-services = { cmd = "docker compose down -v" }
-test-with-docker = { cmd = "bash scripts/test_with_docker.sh" }
-test-layer-boundaries = { cmd = "bash scripts/test_with_docker.sh tests/architecture/test_layer_boundaries.py" }
 
 setup-dev = { cmd = "poetry install --with dev" }
 


### PR DESCRIPTION
## Summary
- delete obsolete Poe tasks from `pyproject.toml`
- keep only `start-db` and test-related tasks

## Testing
- `poetry run poe --help`
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_688181708c6c8322bd4bb25821b041ab