### PR TITLE
Remove poe envfile and set explicit env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poe]
-envfile = ".env"
-
-# Remove the envfile line and use explicit env vars on each task
+# envfile removed; tasks now declare necessary variables explicitly
 [tool.poe.tasks]
 patch = { cmd = "poetry version patch" }
 _publish = { cmd = "poetry publish --build" }
@@ -98,7 +96,7 @@ sequence = [
     { cmd = "poetry run mypy src" },
     { cmd = "bandit -r src" },
     { ref = "validate" },
-    { cmd = "pytest" },
+    { cmd = "pytest", env = { PYTHONPATH = "src" } },
 ]
 
 


### PR DESCRIPTION
## Summary
- drop `.env` from `poe` config
- make the `check` task set `PYTHONPATH`

## Testing
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_68818608eea48322ba8103ddd1777db6