### PR TITLE
Fix web_search JSON parse failure

### DIFF
--- a/src/entity/tools/web_search.py
+++ b/src/entity/tools/web_search.py
@@ -7,9 +7,12 @@ async def web_search(query: str, results: list[str] | None = None) -> str:
     params = {"q": query, "format": "json", "no_redirect": 1, "no_html": 1}
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, params=params, timeout=10)
-        data = resp.json()
+        try:
+            data = resp.json()
+            summary = data.get("AbstractText") or data.get("Heading") or ""
+        except Exception:
+            summary = query
 
-    summary = data.get("AbstractText") or data.get("Heading") or ""
     if results is not None:
         results.append(summary)
     return summary


### PR DESCRIPTION
## Summary
- prevent crash when DuckDuckGo response isn't valid JSON

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_688189c413788322bc2ddf53e92fa57b