### PR TITLE
Add startup plugin validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ Run `python -m entity.examples` to see sample workflows. The old `[examples]` ex
 ## Persistent Memory
 
 Entity uses a DuckDB database to store all remembered values. Each key is automatically namespaced by the user ID to keep data isolated between users. The memory API is fully asynchronous and guarded by an internal lock so concurrent workflows remain thread safe.
+
+## Plugin Lifecycle
+
+Plugins are validated before any workflow executes:
+
+1. **Configuration validation** &mdash; each plugin defines a `ConfigModel` and
+   the classmethod `validate_config` uses Pydantic to parse user supplied
+   options.
+2. **Workflow validation** &mdash; `validate_workflow` ensures the plugin is
+   placed in a supported stage during workflow construction.
+3. **Execution** &mdash; once instantiated with resources, plugins run without
+   additional checks.

--- a/src/entity/config/validation.py
+++ b/src/entity/config/validation.py
@@ -37,13 +37,4 @@ def validate_workflow(workflow: Workflow) -> None:
         if stage not in WorkflowExecutor._STAGES:
             raise WorkflowConfigError(f"Unknown stage: {stage}")
         for plugin_cls in plugins:
-            supported = getattr(plugin_cls, "supported_stages", None)
-            explicit = getattr(plugin_cls, "stage", None)
-            if supported and stage not in supported:
-                raise WorkflowConfigError(
-                    f"{plugin_cls.__name__} does not support stage '{stage}'"
-                )
-            if explicit and explicit != stage:
-                raise WorkflowConfigError(
-                    f"{plugin_cls.__name__} expects stage '{explicit}', not '{stage}'"
-                )
+            plugin_cls.validate_workflow(stage)

--- a/src/entity/plugins/base.py
+++ b/src/entity/plugins/base.py
@@ -1,23 +1,62 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Dict, Type
+
+from pydantic import BaseModel, ValidationError
 
 
 class Plugin(ABC):
     """Base class for all plugins."""
 
+    class ConfigModel(BaseModel):
+        """Default empty configuration."""
+
+        class Config:  # pragma: no cover - simple pydantic setup
+            extra = "forbid"
+
     stage: str | None = None
     supported_stages: list[str] = []
     dependencies: list[str] = []
 
-    def __init__(self, resources: dict[str, Any]):
+    def __init__(self, resources: dict[str, Any], config: Dict[str, Any] | None = None):
         self.resources = resources
+        self.config = self.validate_config(config or {})
+        self._validate_dependencies()
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def validate_config(cls, config: Dict[str, Any]) -> ConfigModel:
+        """Return validated configuration for ``cls``."""
+        try:
+            return cls.ConfigModel(**config)
+        except ValidationError as exc:  # pragma: no cover - simple conversion
+            raise ValueError(
+                f"Invalid configuration for {cls.__name__}: {exc}"
+            ) from exc
+
+    @classmethod
+    def validate_workflow(cls, stage: str) -> None:
+        """Ensure ``cls`` can run at ``stage``."""
+        from ..workflow.workflow import WorkflowConfigError
+
+        if cls.supported_stages and stage not in cls.supported_stages:
+            allowed = ", ".join(cls.supported_stages)
+            raise WorkflowConfigError(
+                f"{cls.__name__} does not support stage '{stage}'. "
+                f"Supported stages: {allowed}"
+            )
+        if cls.stage and cls.stage != stage:
+            raise WorkflowConfigError(
+                f"{cls.__name__} is fixed to stage '{cls.stage}', not '{stage}'"
+            )
 
     async def execute(self, context: Any) -> Any:
         """Validate and run the plugin implementation."""
         self._enforce_stage(context)
-        self._validate_dependencies()
         try:
             return await self._execute_impl(context)
         except Exception as exc:  # pragma: no cover - simple example
@@ -30,18 +69,22 @@ class Plugin(ABC):
         expected = self.stage
         if expected and current != expected:
             raise RuntimeError(
-                f"{self.__class__.__name__} cannot run in stage '{current}'"
+                f"{self.__class__.__name__} expected stage '{expected}' but "
+                f"was scheduled for '{current}'"
             )
         if self.supported_stages and current not in self.supported_stages:
+            allowed = ", ".join(self.supported_stages)
             raise RuntimeError(
-                f"{self.__class__.__name__} cannot run in stage '{current}'"
+                f"{self.__class__.__name__} does not support stage '{current}'. "
+                f"Supported stages: {allowed}"
             )
 
     def _validate_dependencies(self) -> None:
         missing = [dep for dep in self.dependencies if dep not in self.resources]
         if missing:
+            needed = ", ".join(missing)
             raise RuntimeError(
-                f"Missing dependencies for {self.__class__.__name__}: {', '.join(missing)}"
+                f"{self.__class__.__name__} requires resources: {needed}"
             )
 
     @abstractmethod

--- a/src/entity/workflow/workflow.py
+++ b/src/entity/workflow/workflow.py
@@ -52,7 +52,10 @@ class Workflow:
                 plugin_cls = (
                     _import_string(plugin) if isinstance(plugin, str) else plugin
                 )
-                _validate_plugin_stage(plugin_cls, stage)
+                if hasattr(plugin_cls, "validate_workflow"):
+                    plugin_cls.validate_workflow(stage)
+                else:
+                    _legacy_validate_plugin_stage(plugin_cls, stage)
                 steps[stage].append(plugin_cls)
         return cls(steps)
 
@@ -67,9 +70,8 @@ class Workflow:
         return cls.from_dict(data)
 
 
-def _validate_plugin_stage(plugin_cls: Type[Plugin], stage: str) -> None:
-    """Ensure ``plugin_cls`` supports ``stage``."""
-
+def _legacy_validate_plugin_stage(plugin_cls: Type[Plugin], stage: str) -> None:
+    """Fallback validation for plugins without ``validate_workflow``."""
     supported = getattr(plugin_cls, "supported_stages", None)
     explicit = getattr(plugin_cls, "stage", None)
 

--- a/tests/plugin_test_base.py
+++ b/tests/plugin_test_base.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from entity.plugins import Plugin
+from entity.workflow.executor import WorkflowExecutor
+from entity.workflow.workflow import WorkflowConfigError
+
+
+class PluginValidationTests:
+    """Mixin with basic validation checks for plugins."""
+
+    Plugin: type[Plugin]
+    stage: str = WorkflowExecutor.THINK
+    config: dict = {}
+
+    def test_validate_config(self):
+        self.Plugin.validate_config(self.config)
+
+    def test_validate_workflow(self):
+        self.Plugin.validate_workflow(self.stage)
+
+    def test_invalid_stage(self):
+        with pytest.raises(WorkflowConfigError):
+            self.Plugin.validate_workflow("invalid")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,17 +2,21 @@ import pytest
 
 from entity.config.validation import validate_config, validate_workflow
 from entity.workflow.workflow import Workflow, WorkflowConfigError
+from entity.plugins import Plugin
 from entity.workflow.executor import WorkflowExecutor
 
 
-class DummyPlugin:
+class DummyPlugin(Plugin):
     stage = WorkflowExecutor.THINK
+
+    class ConfigModel(Plugin.ConfigModel):
+        value: int = 0
 
     async def _execute_impl(self, context):
         return "ok"
 
 
-class MultiStagePlugin:
+class MultiStagePlugin(Plugin):
     supported_stages = [WorkflowExecutor.PARSE]
 
     async def _execute_impl(self, context):
@@ -48,3 +52,17 @@ def test_validate_workflow_fail_plugin():
     wf = Workflow(steps={"think": [MultiStagePlugin]})
     with pytest.raises(WorkflowConfigError):
         validate_workflow(wf)
+
+
+def test_plugin_config_validation():
+    class TestPlugin(Plugin):
+        stage = WorkflowExecutor.THINK
+
+        class ConfigModel(Plugin.ConfigModel):
+            value: int
+
+        async def _execute_impl(self, context):
+            return "ok"
+
+    with pytest.raises(ValueError):
+        TestPlugin({}, config={"value": "bad"})


### PR DESCRIPTION
## Summary
- validate plugins with Pydantic config models
- check workflow compatibility when building workflows
- document plugin lifecycle
- add base test class for plugin validation

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68818d6d33948322931477d41be35973