### PR TITLE
Improve memory docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,10 @@ Run `python -m entity.examples` to see sample workflows. The old `[examples]` ex
 
 ## Persistent Memory
 
-Entity uses a DuckDB database to store all remembered values. Each key is automatically namespaced by the user ID to keep data isolated between users. The memory API is fully asynchronous and guarded by an internal lock so concurrent workflows remain thread safe.
+Entity stores all remembered values inside a DuckDB database. Keys are automatically prefixed with the user ID so data never leaks across users. The `Memory` API exposes asynchronous `store` and `load` helpers which run queries in a background thread while holding an internal `asyncio.Lock`. This design keeps concurrent workflows safe even when multiple users interact with the same agent.
+
+```python
+infra = DuckDBInfrastructure("agent.db")
+memory = Memory(DatabaseResource(infra), VectorStoreResource(infra))
+await memory.store("bob:greeting", "hello")
+```

--- a/tests/test_memory_isolation.py
+++ b/tests/test_memory_isolation.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from entity.plugins.context import PluginContext
@@ -19,3 +20,21 @@ async def test_remember_isolated_by_user_id():
 
     assert await ctx_a.recall("val") == 1
     assert await ctx_b.recall("val") == 2
+
+
+@pytest.mark.asyncio
+async def test_memory_thread_safety_with_concurrent_users():
+    infra = DuckDBInfrastructure(":memory:")
+    memory = Memory(DatabaseResource(infra), VectorStoreResource(infra))
+    ctx_a = PluginContext({}, user_id="a", memory=memory)
+    ctx_b = PluginContext({}, user_id="b", memory=memory)
+
+    await asyncio.gather(
+        ctx_a.remember("count", 1),
+        ctx_b.remember("count", 2),
+    )
+    results = await asyncio.gather(
+        ctx_a.recall("count"),
+        ctx_b.recall("count"),
+    )
+    assert results == [1, 2]


### PR DESCRIPTION
## Summary
- document persistent memory model in README
- add a concurrency test for async memory

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68818ee877a48322a96949ad9d11b9ab