### PR TITLE
Improve plugin validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,29 @@ Run `python -m entity.examples` to see sample workflows. The old `[examples]` ex
 
 ## Persistent Memory
 
-<<<<<<< HEAD
-Entity uses a DuckDB database to store all remembered values. Each key is automatically namespaced by the user ID to keep data isolated between users. The memory API is fully asynchronous and guarded by an internal lock so concurrent workflows remain thread safe.
+Entity uses a DuckDB database to store all remembered values. Keys are
+namespaced by user ID to keep data isolated between users. The `Memory` API is
+asynchronous and protected by an internal lock so concurrent workflows remain
+thread safe.
 
 ## Plugin Lifecycle
 
 Plugins are validated before any workflow executes:
 
-1. **Configuration validation** &mdash; each plugin defines a `ConfigModel` and
-   the classmethod `validate_config` uses Pydantic to parse user supplied
-   options.
-2. **Workflow validation** &mdash; `validate_workflow` ensures the plugin is
-   placed in a supported stage during workflow construction.
-3. **Execution** &mdash; once instantiated with resources, plugins run without
-   additional checks.
-=======
-Entity stores all remembered values inside a DuckDB database. Keys are automatically prefixed with the user ID so data never leaks across users. The `Memory` API exposes asynchronous `store` and `load` helpers which run queries in a background thread while holding an internal `asyncio.Lock`. This design keeps concurrent workflows safe even when multiple users interact with the same agent.
+1. **Configuration validation** – each plugin defines a `ConfigModel` and the
+   `validate_config` classmethod parses user options with Pydantic.
+2. **Workflow validation** – `validate_workflow` is called when workflows are
+   built to ensure a plugin supports its assigned stage.
+3. **Execution** – once instantiated with resources, validated plugins run
+   without further checks.
+
+Entity stores all remembered values inside a DuckDB database. Keys are
+automatically prefixed with the user ID so data never leaks across users. The
+`Memory` API exposes asynchronous helpers that run queries in a background
+thread while holding an internal `asyncio.Lock`.
 
 ```python
 infra = DuckDBInfrastructure("agent.db")
 memory = Memory(DatabaseResource(infra), VectorStoreResource(infra))
 await memory.store("bob:greeting", "hello")
 ```
->>>>>>> pr-1889

--- a/tests/plugin_test_base.py
+++ b/tests/plugin_test_base.py
@@ -23,3 +23,18 @@ class PluginValidationTests:
     def test_invalid_stage(self):
         with pytest.raises(WorkflowConfigError):
             self.Plugin.validate_workflow("invalid")
+
+
+class PluginDependencyTests:
+    """Mixin verifying dependency checks during initialization."""
+
+    Plugin: type[Plugin]
+    resources: dict = {}
+    config: dict = {}
+
+    def test_missing_dependency_error(self):
+        if not self.Plugin.dependencies:
+            pytest.skip("plugin has no dependencies")
+        partial = {d: object() for d in self.Plugin.dependencies[:-1]}
+        with pytest.raises(RuntimeError):
+            self.Plugin(partial, config=self.config)

--- a/tests/test_plugin_base_validation.py
+++ b/tests/test_plugin_base_validation.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from entity.plugins import Plugin
+from entity.workflow.executor import WorkflowExecutor
+
+from plugin_test_base import PluginValidationTests, PluginDependencyTests
+
+
+class ExamplePlugin(Plugin):
+    stage = WorkflowExecutor.THINK
+    dependencies = ["memory"]
+
+    class ConfigModel(Plugin.ConfigModel):
+        value: int
+
+    async def _execute_impl(self, context):  # pragma: no cover - not executed
+        return "ok"
+
+
+class TestExamplePlugin(PluginValidationTests, PluginDependencyTests):
+    Plugin = ExamplePlugin
+    stage = WorkflowExecutor.THINK
+    config = {"value": 1}
+    resources = {}


### PR DESCRIPTION
## Summary
- clarify plugin lifecycle in docs
- tighten Plugin.validate_workflow and dependency errors
- run config checks when plugins are created
- add reusable plugin test mixins
- test validation behavior with a sample plugin

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_688190e9117c83228ec0d6290e1dfd9a