### PR TITLE
Implement config variable substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,17 @@ ENTITY_OLLAMA_URL=http://ollama:11434 \
 ENTITY_STORAGE_PATH=/data/files \
 python -m entity.examples
 ```
+
+### Environment Variable Substitution
+
+Configuration files support `${VAR}` references. Values are resolved using the
+current environment and variables defined in a local `.env` file if present.
+Nested references are expanded recursively and circular references raise a
+`ValueError`.
+
+```yaml
+resources:
+  database:
+    host: ${DB_HOST}
+    password: ${DB_PASS}
+```

--- a/src/entity/config/__init__.py
+++ b/src/entity/config/__init__.py
@@ -1,5 +1,70 @@
-"""Configuration utilities."""
+"""Configuration utilities.
+
+This module provides helpers for loading and validating configuration files. It
+also offers `${VAR}` style environment variable substitution with cycle
+detection and optional ``.env`` loading.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
 
 from .validation import validate_config, validate_workflow
 
-__all__ = ["validate_config", "validate_workflow"]
+
+class VariableResolver:
+    """Resolve ``${VAR}`` patterns recursively with cycle detection."""
+
+    _pattern = re.compile(r"\$\{([^}]+)\}")
+
+    def __init__(self, env_file: str | None = None) -> None:
+        self.env: dict[str, str] = dict(os.environ)
+
+        env_path = Path(env_file or ".env")
+        if env_path.exists():
+            for line in env_path.read_text().splitlines():
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                self.env.setdefault(key.strip(), val.strip())
+
+    def substitute(self, obj: Any) -> Any:
+        """Recursively substitute environment variables in ``obj``."""
+
+        if isinstance(obj, dict):
+            return {k: self.substitute(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [self.substitute(v) for v in obj]
+        if isinstance(obj, str):
+            return self._resolve_value(obj, [])
+        return obj
+
+    def _resolve_value(self, value: str, stack: list[str]) -> str:
+        def replace(match: re.Match[str]) -> str:
+            var = match.group(1)
+            if var in stack:
+                cycle = " -> ".join(stack + [var])
+                raise ValueError(f"Circular reference detected: {cycle}")
+            if var not in self.env:
+                raise ValueError(f"Environment variable '{var}' not found")
+            return self._resolve_value(self.env[var], stack + [var])
+
+        return self._pattern.sub(replace, value)
+
+
+def substitute_variables(obj: Any, env_file: str | None = None) -> Any:
+    """Public helper to substitute environment variables in ``obj``."""
+
+    resolver = VariableResolver(env_file)
+    return resolver.substitute(obj)
+
+
+__all__ = [
+    "validate_config",
+    "validate_workflow",
+    "VariableResolver",
+    "substitute_variables",
+]

--- a/tests/test_config_substitution.py
+++ b/tests/test_config_substitution.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+from entity.config import substitute_variables, VariableResolver
+
+
+def test_env_file_substitution(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("BASE=http://example.com\nURL=${BASE}/api\n")
+    resolver = VariableResolver(str(env_file))
+    result = resolver.substitute({"endpoint": "${URL}"})
+    assert result["endpoint"] == "http://example.com/api"
+
+
+def test_missing_variable():
+    resolver = VariableResolver()
+    with pytest.raises(ValueError, match="not found"):
+        resolver.substitute({"a": "${UNKNOWN}"})
+
+
+def test_cycle_detection(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("A=${B}\nB=${A}\n")
+    resolver = VariableResolver(str(env_file))
+    with pytest.raises(ValueError, match="Circular reference"):
+        resolver.substitute("${A}")
+
+
+def test_auto_env_loading(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("VAR=value")
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        result = substitute_variables("${VAR}")
+        assert result == "value"
+    finally:
+        os.chdir(cwd)
+
+
+def test_nested_env_and_os(tmp_path, monkeypatch):
+    monkeypatch.setenv("BAR", "world")
+    env_file = tmp_path / ".env"
+    env_file.write_text("FOO=hello ${BAR}")
+    resolver = VariableResolver(str(env_file))
+    assert resolver.substitute("${FOO}") == "hello world"


### PR DESCRIPTION
## Summary
- add VariableResolver class for `${VAR}` substitution
- auto-load `.env` files
- detect missing variables and circular references
- document substitution usage in README
- test variable substitution logic

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: Unrecognised task)*

------
https://chatgpt.com/codex/tasks/task_e_6881980f9d848322b9c5c5413473c1b1