### PR TITLE
Add docker substitution test and error class

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,11 @@ resources:
     host: ${DB_HOST}
     password: ${DB_PASS}
 ```
+
+You can resolve placeholders in Python using `substitute_variables`:
+
+```python
+from entity.config import substitute_variables
+
+config = substitute_variables({"endpoint": "${DB_HOST}/api"})
+```

--- a/src/entity/config/__init__.py
+++ b/src/entity/config/__init__.py
@@ -3,6 +3,7 @@
 This module provides helpers for loading and validating configuration files. It
 also offers `${VAR}` style environment variable substitution with cycle
 detection and optional ``.env`` loading.
+Errors raised during substitution use :class:`SubstitutionError` for clarity.
 """
 
 from __future__ import annotations
@@ -13,6 +14,12 @@ from pathlib import Path
 from typing import Any
 
 from .validation import validate_config, validate_workflow
+
+
+class SubstitutionError(ValueError):
+    """Raised when environment variable substitution fails."""
+
+    pass
 
 
 class VariableResolver:
@@ -47,9 +54,9 @@ class VariableResolver:
             var = match.group(1)
             if var in stack:
                 cycle = " -> ".join(stack + [var])
-                raise ValueError(f"Circular reference detected: {cycle}")
+                raise SubstitutionError(f"Circular reference detected: {cycle}")
             if var not in self.env:
-                raise ValueError(f"Environment variable '{var}' not found")
+                raise SubstitutionError(f"Environment variable '{var}' not found")
             return self._resolve_value(self.env[var], stack + [var])
 
         return self._pattern.sub(replace, value)
@@ -65,6 +72,7 @@ def substitute_variables(obj: Any, env_file: str | None = None) -> Any:
 __all__ = [
     "validate_config",
     "validate_workflow",
+    "SubstitutionError",
     "VariableResolver",
     "substitute_variables",
 ]

--- a/tests/test_config_substitution_docker.py
+++ b/tests/test_config_substitution_docker.py
@@ -1,0 +1,40 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(shutil.which("docker") is None, reason="docker not installed")
+def test_nested_substitution_in_docker(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("BASE=http://service\nURL=${BASE}/api\n")
+
+    script = (
+        "import sys, json;"
+        "sys.path.insert(0, '/src');"
+        "from entity.config import VariableResolver;"
+        "resolver = VariableResolver('/data/.env');"
+        "print(json.dumps(resolver.substitute({'endpoint': '${URL}'})))"
+    )
+
+    result = subprocess.check_output(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{Path.cwd()}:/src",
+            "-v",
+            f"{tmp_path}:/data",
+            "python:3.11-slim",
+            "python",
+            "-c",
+            script,
+        ],
+        text=True,
+    ).strip()
+
+    assert json.loads(result)["endpoint"] == "http://service/api"


### PR DESCRIPTION
## Summary
- implement custom `SubstitutionError`
- document `substitute_variables` usage in README
- add Docker-based test for env substitution (skipped if Docker missing)

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68819a6747348322832c6ca592567f62