### PR TITLE
Improve logging and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,33 @@ from entity.config import substitute_variables
 config = substitute_variables({"endpoint": "${DB_HOST}/api"})
 ```
 
+## Observability
+
+Logs are captured using `LoggingResource` which stores structured entries as
+JSON dictionaries. Each entry contains a UTC timestamp, log level and any
+additional fields supplied by the caller:
+
+```python
+{
+    "level": "info",
+    "message": "plugin_start",
+    "timestamp": "2024-05-01T12:00:00Z",
+    "fields": {"stage": "think", "plugin_name": "MyPlugin"}
+}
+```
+
+Execution metrics are aggregated by `MetricsCollectorResource`. The collector
+stores individual records and keeps running totals per plugin and stage:
+
+```python
+{
+    "plugin_name": "MyPlugin",
+    "stage": "think",
+    "duration_ms": 12.4,
+    "success": True
+}
+```
+
 ## Tool Security
 
 Registered tools run inside a small sandbox that limits CPU time and memory.

--- a/src/entity/plugins/context.py
+++ b/src/entity/plugins/context.py
@@ -46,13 +46,6 @@ class PluginContext(WorkflowContext):
         self._memory = memory if memory is not None else resources.get("memory")
         if self._memory is None:
             raise RuntimeError("Memory resource required")
-<<<<<<< HEAD
-        self._tools: Dict[str, Any] = resources.get("tools", {})
-        self._tool_queue: List[tuple[str, Dict[str, Any]]] = []
-        self.logger = resources.get("logging")
-        self.metrics_collector = resources.get("metrics_collector")
-        self._conversation: List[str] = []
-=======
         self._conversation: List[str] = []
         tools_src = resources.get("tools", {})
         self._tools: Dict[str, ToolInfo] = {}
@@ -65,7 +58,6 @@ class PluginContext(WorkflowContext):
         self.logger = resources.get("logging")
         self.metrics_collector = resources.get("metrics_collector")
         self.sandbox = resources.get("sandbox", SandboxedToolRunner())
->>>>>>> pr-1897
 
     async def remember(self, key: str, value: Any) -> None:
         """Persist value namespaced by ``user_id``."""

--- a/src/entity/resources/logging.py
+++ b/src/entity/resources/logging.py
@@ -1,17 +1,39 @@
 from __future__ import annotations
 
+import asyncio
+from dataclasses import dataclass, asdict
+from datetime import datetime
 from typing import Any, Dict, List
 
 
+@dataclass
+class LogRecord:
+    level: str
+    message: str
+    timestamp: str
+    fields: Dict[str, Any]
+
+
 class LoggingResource:
-    """Collect log entries for later inspection."""
+    """Collect structured log entries with level filtering."""
 
-    def __init__(self) -> None:
-        """Initialize an empty list of log records."""
+    LEVELS = {"debug": 10, "info": 20, "warning": 30, "error": 40}
 
+    def __init__(self, level: str = "info") -> None:
+        self.level = level
         self.records: List[Dict[str, Any]] = []
+        self._lock = asyncio.Lock()
 
     async def log(self, level: str, message: str, **fields: Any) -> None:
-        """Store a log entry with arbitrary metadata."""
-        entry = {"level": level, "message": message, **fields}
-        self.records.append(entry)
+        """Store a log entry if ``level`` is above the configured threshold."""
+
+        if self.LEVELS.get(level, 0) < self.LEVELS.get(self.level, 0):
+            return
+        record = LogRecord(
+            level=level,
+            message=message,
+            timestamp=datetime.utcnow().isoformat(),
+            fields=fields,
+        )
+        async with self._lock:
+            self.records.append(asdict(record))

--- a/src/entity/resources/metrics.py
+++ b/src/entity/resources/metrics.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import asyncio
+import random
 from typing import Any, Dict, List
 
 
 class MetricsCollectorResource:
-    """Simple in-memory metrics collector."""
+    """Collect and aggregate plugin execution metrics."""
 
-    def __init__(self) -> None:
-        """Start with an empty list of metric records."""
-
+    def __init__(self, sample_rate: float = 1.0) -> None:
+        self.sample_rate = sample_rate
         self.records: List[Dict[str, Any]] = []
+        self.aggregates: Dict[str, Dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
 
     async def record_plugin_execution(
         self,
@@ -20,11 +23,22 @@ class MetricsCollectorResource:
     ) -> None:
         """Record execution metrics for a plugin call."""
 
-        self.records.append(
-            {
-                "plugin_name": plugin_name,
-                "stage": stage,
-                "duration_ms": duration_ms,
-                "success": success,
-            }
-        )
+        if random.random() > self.sample_rate:
+            return
+
+        record = {
+            "plugin_name": plugin_name,
+            "stage": stage,
+            "duration_ms": duration_ms,
+            "success": success,
+        }
+        async with self._lock:
+            self.records.append(record)
+            key = f"{plugin_name}:{stage}"
+            agg = self.aggregates.setdefault(
+                key, {"count": 0, "success": 0, "duration_ms": 0.0}
+            )
+            agg["count"] += 1
+            if success:
+                agg["success"] += 1
+            agg["duration_ms"] += duration_ms


### PR DESCRIPTION
## Summary
- extend LoggingResource for structured async logging with levels
- add MetricsCollectorResource aggregation and sampling
- auto log and record metrics in Plugin.execute
- document logging format and metrics schema
- test logging and metrics including Docker interaction

## Testing
- `poetry run pytest -q`
- `poetry run poe test-with-docker` *(fails: task not found)*

------
https://chatgpt.com/codex/tasks/task_e_68819d47eb288322b50899eace1373a0