### PR TITLE
Fix docker integration tests

### DIFF
--- a/tests/test_config_substitution_docker.py
+++ b/tests/test_config_substitution_docker.py
@@ -12,12 +12,14 @@ def test_nested_substitution_in_docker(tmp_path):
     env_file = tmp_path / ".env"
     env_file.write_text("BASE=http://service\nURL=${BASE}/api\n")
 
-    script = (
-        "import sys, json;"
-        "sys.path.insert(0, '/src');"
-        "from entity.config import VariableResolver;"
-        "resolver = VariableResolver('/data/.env');"
-        "print(json.dumps(resolver.substitute({'endpoint': '${URL}'})))"
+    script = "\n".join(
+        [
+            "import sys, json",
+            "sys.path.insert(0, '/src/src')",
+            "from entity.config import VariableResolver",
+            "resolver = VariableResolver('/data/.env')",
+            "print(json.dumps(resolver.substitute({'endpoint': '${URL}'})))",
+        ]
     )
 
     result = subprocess.check_output(

--- a/tests/test_logging_metrics.py
+++ b/tests/test_logging_metrics.py
@@ -62,17 +62,22 @@ async def test_logging_and_metrics_per_stage():
 @pytest.mark.integration
 @pytest.mark.skipif(shutil.which("docker") is None, reason="docker not installed")
 def test_docker_logging_metrics(tmp_path):
-    script = (
-        "import json, asyncio;"
-        "from entity.resources.logging import LoggingResource;"
-        "from entity.resources.metrics import MetricsCollectorResource;"
-        "async def main():\n"
-        "    logger = LoggingResource();\n"
-        "    metrics = MetricsCollectorResource();\n"
-        "    await logger.log('info', 'hello', container='id');\n"
-        "    await metrics.record_plugin_execution('p','stage',0.1,True);\n"
-        "    print(json.dumps({'logs': logger.records, 'metrics': metrics.records}))\n"
-        "asyncio.run(main())"
+    script = "\n".join(
+        [
+            "import json, asyncio, sys",
+            "sys.path.insert(0, '/src/src')",
+            "from entity.resources.logging import LoggingResource",
+            "from entity.resources.metrics import MetricsCollectorResource",
+            "",
+            "async def main():",
+            "    logger = LoggingResource()",
+            "    metrics = MetricsCollectorResource()",
+            "    await logger.log('info', 'hello', container='id')",
+            "    await metrics.record_plugin_execution('p', 'stage', 0.1, True)",
+            "    print(json.dumps({'logs': logger.records, 'metrics': metrics.records}))",
+            "",
+            "asyncio.run(main())",
+        ]
     )
     result1 = subprocess.check_output(
         [


### PR DESCRIPTION
## Summary
- fix `test_docker_logging_metrics` script so it uses newlines and updates `sys.path`
- fix Docker config substitution test path

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68819fd038848322b4ca5db6cb76310a