### PR TITLE
Fix docker-based tests by lazy Agent import

### DIFF
--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -7,6 +7,12 @@ try:
 except Exception:  # pragma: no cover - package not installed
     __version__ = "0.0.0"
 
-from .core.agent import Agent
-
 __all__ = ["Agent", "__version__"]
+
+
+def __getattr__(name: str):
+    if name == "Agent":
+        from .core.agent import Agent  # Lazy import to avoid heavy deps at import time
+
+        return Agent
+    raise AttributeError(name)


### PR DESCRIPTION
## Summary
- avoid heavy dependencies on package import by lazily loading `Agent`

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: Unrecognised task)*

------
https://chatgpt.com/codex/tasks/task_e_6881a187f30c8322ba27362d9a9512e6