### PR TITLE
Refactor imports to absolute paths

### DIFF
--- a/src/entity/__init__.py
+++ b/src/entity/__init__.py
@@ -12,7 +12,9 @@ __all__ = ["Agent", "__version__"]
 
 def __getattr__(name: str):
     if name == "Agent":
-        from .core.agent import Agent  # Lazy import to avoid heavy deps at import time
+        from entity.core.agent import (
+            Agent,
+        )  # Lazy import to avoid heavy deps at import time
 
         return Agent
     raise AttributeError(name)

--- a/src/entity/cli/__main__.py
+++ b/src/entity/cli/__main__.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import asyncio
 
-from ..core.agent import Agent
-from ..plugins.defaults import (
+from entity.core.agent import Agent
+from entity.plugins.defaults import (
     ParsePlugin,
     ThinkPlugin,
     DoPlugin,
     ReviewPlugin,
 )
-from .ent_cli_adapter import EntCLIAdapter
+from entity.cli.ent_cli_adapter import EntCLIAdapter
 
 
 async def _run() -> None:

--- a/src/entity/cli/ent_cli_adapter.py
+++ b/src/entity/cli/ent_cli_adapter.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import sys
 from typing import Any
 
-from ..plugins.input_adapter import InputAdapterPlugin
-from ..plugins.output_adapter import OutputAdapterPlugin
-from ..workflow.executor import WorkflowExecutor
-from ..plugins.context import PluginContext
+from entity.plugins.input_adapter import InputAdapterPlugin
+from entity.plugins.output_adapter import OutputAdapterPlugin
+from entity.workflow.executor import WorkflowExecutor
+from entity.plugins.context import PluginContext
 
 
 class EntCLIAdapter(InputAdapterPlugin, OutputAdapterPlugin):

--- a/src/entity/config/__init__.py
+++ b/src/entity/config/__init__.py
@@ -13,7 +13,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from .validation import ConfigModel, validate_config, validate_workflow
+from entity.config.validation import ConfigModel, validate_config, validate_workflow
 
 
 class SubstitutionError(ValueError):

--- a/src/entity/config/validation.py
+++ b/src/entity/config/validation.py
@@ -10,8 +10,8 @@ from pydantic import BaseModel, ValidationError
 import yaml
 
 # TODO: Use absolute imports
-from ..workflow.workflow import Workflow, WorkflowConfigError
-from ..workflow.executor import WorkflowExecutor
+from entity.workflow.workflow import Workflow, WorkflowConfigError
+from entity.workflow.executor import WorkflowExecutor
 
 REQUIRED_KEYS = {"resources", "workflow"}
 

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -1,7 +1,7 @@
 # TODO: Use absolute imports
-from ..defaults import load_defaults
-from ..plugins.defaults import default_workflow
-from ..workflow import WorkflowExecutor
+from entity.defaults import load_defaults
+from entity.plugins.defaults import default_workflow
+from entity.workflow import WorkflowExecutor
 
 
 class Agent:

--- a/src/entity/defaults.py
+++ b/src/entity/defaults.py
@@ -5,10 +5,10 @@ import tempfile
 from dataclasses import dataclass
 
 # TODO: Do not use relative imports
-from .infrastructure.duckdb_infra import DuckDBInfrastructure
-from .infrastructure.ollama_infra import OllamaInfrastructure
-from .infrastructure.local_storage_infra import LocalStorageInfrastructure
-from .resources import (
+from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
+from entity.infrastructure.ollama_infra import OllamaInfrastructure
+from entity.infrastructure.local_storage_infra import LocalStorageInfrastructure
+from entity.resources import (
     DatabaseResource,
     VectorStoreResource,
     LLMResource,

--- a/src/entity/plugins/__init__.py
+++ b/src/entity/plugins/__init__.py
@@ -1,10 +1,10 @@
 """Public plugin interfaces and helpers."""
 
-from .base import Plugin
-from .prompt import PromptPlugin
-from .tool import ToolPlugin
-from .input_adapter import InputAdapterPlugin
-from .output_adapter import OutputAdapterPlugin
+from entity.plugins.base import Plugin
+from entity.plugins.prompt import PromptPlugin
+from entity.plugins.tool import ToolPlugin
+from entity.plugins.input_adapter import InputAdapterPlugin
+from entity.plugins.output_adapter import OutputAdapterPlugin
 
 __all__ = [
     "Plugin",

--- a/src/entity/plugins/base.py
+++ b/src/entity/plugins/base.py
@@ -45,7 +45,7 @@ class Plugin(ABC):
     @classmethod
     def validate_workflow(cls, stage: str) -> None:
         """Validate that ``cls`` can run in ``stage`` before workflow execution."""
-        from ..workflow.workflow import WorkflowConfigError
+        from entity.workflow.workflow import WorkflowConfigError
 
         if cls.supported_stages and stage not in cls.supported_stages:
             allowed = ", ".join(cls.supported_stages)

--- a/src/entity/plugins/context.py
+++ b/src/entity/plugins/context.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from ..tools.sandbox import SandboxedToolRunner
-from ..tools.registry import ToolInfo
+from entity.tools.sandbox import SandboxedToolRunner
+from entity.tools.registry import ToolInfo
 from pydantic import BaseModel, ValidationError
 
 
@@ -18,7 +18,7 @@ class WorkflowContext:
     def say(self, message: str) -> None:
         """Store the final response only during the OUTPUT stage."""
 
-        from ..workflow.executor import WorkflowExecutor
+        from entity.workflow.executor import WorkflowExecutor
 
         if self.current_stage != WorkflowExecutor.OUTPUT:
             raise RuntimeError("context.say() only allowed in OUTPUT stage")
@@ -130,6 +130,6 @@ class PluginContext(WorkflowContext):
 
     def discover_tools(self, **filters: Any):
         """Return registered tools filtered by ``filters``."""
-        from ..tools.registry import discover_tools
+        from entity.tools.registry import discover_tools
 
         return discover_tools(**filters)

--- a/src/entity/plugins/defaults/__init__.py
+++ b/src/entity/plugins/defaults/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from ..base import Plugin
-from ...cli.ent_cli_adapter import EntCLIAdapter
+from entity.plugins.base import Plugin
+from entity.cli.ent_cli_adapter import EntCLIAdapter
 
 
 class InputPlugin(Plugin):

--- a/src/entity/plugins/examples/calculator.py
+++ b/src/entity/plugins/examples/calculator.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import ast
 import operator
-from ..tool import ToolPlugin
-from ...workflow.executor import WorkflowExecutor
+from entity.plugins.tool import ToolPlugin
+from entity.workflow.executor import WorkflowExecutor
 
 
 _ALLOWED_OPS = {

--- a/src/entity/plugins/examples/input_reader.py
+++ b/src/entity/plugins/examples/input_reader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..input_adapter import InputAdapterPlugin
+from entity.plugins.input_adapter import InputAdapterPlugin
 
 
 class InputReader(InputAdapterPlugin):

--- a/src/entity/plugins/examples/keyword_extractor.py
+++ b/src/entity/plugins/examples/keyword_extractor.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import re
-from ..base import Plugin
-from ...workflow.executor import WorkflowExecutor
+from entity.plugins.base import Plugin
+from entity.workflow.executor import WorkflowExecutor
 
 
 class KeywordExtractor(Plugin):

--- a/src/entity/plugins/examples/output_formatter.py
+++ b/src/entity/plugins/examples/output_formatter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..output_adapter import OutputAdapterPlugin
+from entity.plugins.output_adapter import OutputAdapterPlugin
 
 
 class OutputFormatter(OutputAdapterPlugin):

--- a/src/entity/plugins/examples/reason_generator.py
+++ b/src/entity/plugins/examples/reason_generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from ..prompt import PromptPlugin
-from ...workflow.executor import WorkflowExecutor
+from entity.plugins.prompt import PromptPlugin
+from entity.workflow.executor import WorkflowExecutor
 
 
 class ReasonGenerator(PromptPlugin):

--- a/src/entity/plugins/examples/static_reviewer.py
+++ b/src/entity/plugins/examples/static_reviewer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from ..base import Plugin
-from ...workflow.executor import WorkflowExecutor
+from entity.plugins.base import Plugin
+from entity.workflow.executor import WorkflowExecutor
 
 
 class StaticReviewer(Plugin):

--- a/src/entity/plugins/input_adapter.py
+++ b/src/entity/plugins/input_adapter.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import Plugin
-from ..workflow.executor import WorkflowExecutor
+from entity.plugins.base import Plugin
+from entity.workflow.executor import WorkflowExecutor
 
 
 class InputAdapterPlugin(Plugin):

--- a/src/entity/plugins/output_adapter.py
+++ b/src/entity/plugins/output_adapter.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import Plugin
-from ..workflow.executor import WorkflowExecutor
+from entity.plugins.base import Plugin
+from entity.workflow.executor import WorkflowExecutor
 
 
 class OutputAdapterPlugin(Plugin):

--- a/src/entity/plugins/prompt.py
+++ b/src/entity/plugins/prompt.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import Plugin
-from ..workflow.executor import WorkflowExecutor
+from entity.plugins.base import Plugin
+from entity.workflow.executor import WorkflowExecutor
 
 
 class PromptPlugin(Plugin):

--- a/src/entity/plugins/smart_selector.py
+++ b/src/entity/plugins/smart_selector.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from .prompt import PromptPlugin
-from ..tools.registry import ToolInfo
-from ..workflow.executor import WorkflowExecutor
+from entity.plugins.prompt import PromptPlugin
+from entity.tools.registry import ToolInfo
+from entity.workflow.executor import WorkflowExecutor
 
 
 class SmartToolSelectorPlugin(PromptPlugin):

--- a/src/entity/plugins/tool.py
+++ b/src/entity/plugins/tool.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import Plugin
-from ..workflow.executor import WorkflowExecutor
+from entity.plugins.base import Plugin
+from entity.workflow.executor import WorkflowExecutor
 
 
 class ToolPlugin(Plugin):

--- a/src/entity/tools/__init__.py
+++ b/src/entity/tools/__init__.py
@@ -1,10 +1,10 @@
-from .registry import (
+from entity.tools.registry import (
     discover_tools,
     register_tool,
     ToolInfo,
     clear_registry,
 )
-from .sandbox import SandboxedToolRunner
+from entity.tools.sandbox import SandboxedToolRunner
 
 __all__ = [
     "discover_tools",

--- a/src/entity/tools/workflow_viz.py
+++ b/src/entity/tools/workflow_viz.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import argparse
 from textwrap import indent
 
-from ..workflow.workflow import Workflow
-from ..workflow.executor import WorkflowExecutor
+from entity.workflow.workflow import Workflow
+from entity.workflow.executor import WorkflowExecutor
 
 
 def ascii_diagram(workflow: Workflow) -> str:

--- a/src/entity/workflow/executor.py
+++ b/src/entity/workflow/executor.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from typing import Any, Iterable
 from itertools import count
 
-from ..resources.logging import LoggingResource
-from ..resources.metrics import MetricsCollectorResource
+from entity.resources.logging import LoggingResource
+from entity.resources.metrics import MetricsCollectorResource
 
-from ..plugins.context import PluginContext
+from entity.plugins.context import PluginContext
 
 
 class WorkflowExecutor:

--- a/src/entity/workflow/templates/__init__.py
+++ b/src/entity/workflow/templates/__init__.py
@@ -1,3 +1,7 @@
-from .loader import load_template, list_templates, TemplateNotFoundError
+from entity.workflow.templates.loader import (
+    load_template,
+    list_templates,
+    TemplateNotFoundError,
+)
 
 __all__ = ["load_template", "list_templates", "TemplateNotFoundError"]

--- a/src/entity/workflow/templates/loader.py
+++ b/src/entity/workflow/templates/loader.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 import yaml
 
-from ..workflow import Workflow, WorkflowConfigError
+from entity.workflow.workflow import Workflow, WorkflowConfigError
 
 TEMPLATES_DIR = Path(__file__).parent
 

--- a/src/entity/workflow/workflow.py
+++ b/src/entity/workflow/workflow.py
@@ -6,8 +6,8 @@ from typing import Dict, Iterable, List, Type
 
 import yaml
 
-from ..plugins.base import Plugin
-from .executor import WorkflowExecutor
+from entity.plugins.base import Plugin
+from entity.workflow.executor import WorkflowExecutor
 
 
 class WorkflowConfigError(Exception):


### PR DESCRIPTION
## Summary
- refactor to use absolute imports inside src/entity
- keep behaviour by pointing to actual modules

## Testing
- `poetry run black src/entity`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68836f0496f08322b654a32c9dcb62de