### PR TITLE
Update README with Docker test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,18 @@ from entity.tools import generate_docs
 print(generate_docs())
 ```
 
+## Running Tests
+
+Install dependencies with Poetry and run the full suite:
+
+```bash
+poetry install --with dev
+poetry run poe test
+```
+
+For integration tests that require Docker, install Docker and then run:
+
+```bash
+poetry run poe test-with-docker
+```
+


### PR DESCRIPTION
## Summary
- document how to run the standard test suite
- add instructions for running integration tests in Docker

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688371a8e4088322999a378dadd30af8