### PR TITLE
Add agent factory helpers

### DIFF
--- a/examples/basic_config.yaml
+++ b/examples/basic_config.yaml
@@ -1,0 +1,8 @@
+resources: {}
+workflow:
+  parse:
+    - entity.plugins.defaults.ParsePlugin
+  think:
+    - entity.plugins.defaults.ThinkPlugin
+  output:
+    - entity.plugins.defaults.OutputPlugin

--- a/examples/factory_methods.py
+++ b/examples/factory_methods.py
@@ -1,0 +1,20 @@
+"""Demonstrate Agent factory helpers."""
+
+from entity.core.agent import Agent
+
+
+# Build from a workflow template
+agent_from_template = Agent.from_workflow("basic")
+
+# Build from a dictionary mapping stages to plugins
+agent_from_dict = Agent.from_workflow_dict(
+    {
+        "think": ["entity.plugins.defaults.ThinkPlugin"],
+        "output": ["entity.plugins.defaults.OutputPlugin"],
+    }
+)
+
+# Build from a configuration file
+agent_from_config = Agent.from_config("examples/basic_config.yaml")
+
+print(agent_from_template, agent_from_dict, agent_from_config)

--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -1,7 +1,12 @@
 # TODO: Use absolute imports
+from pathlib import Path
+
 from entity.defaults import load_defaults
 from entity.plugins.defaults import default_workflow
 from entity.workflow import WorkflowExecutor
+from entity.workflow.templates import load_template, TemplateNotFoundError
+from entity.workflow.workflow import Workflow
+from entity.config import load_config
 
 
 class Agent:
@@ -10,6 +15,73 @@ class Agent:
         self.resources = resources or load_defaults()
         self.workflow = workflow
         self.infrastructure = infrastructure
+
+    # ------------------------------------------------------------------
+    # Factory helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_workflow(
+        cls,
+        name: str,
+        *,
+        resources: dict | None = None,
+        infrastructure: object | None = None,
+    ) -> "Agent":
+        """Build an agent from a workflow template or YAML file."""
+
+        if name == "default":
+            workflow = default_workflow()
+        else:
+            path = Path(name)
+            if path.exists():
+                workflow = Workflow.from_yaml(str(path)).steps
+            else:
+                try:
+                    workflow = load_template(name).steps
+                except (TemplateNotFoundError, FileNotFoundError) as exc:
+                    raise ValueError(f"Unknown workflow '{name}'") from exc
+
+        return cls(
+            resources=resources if resources is not None else load_defaults(),
+            workflow=workflow,
+            infrastructure=infrastructure,
+        )
+
+    @classmethod
+    def from_workflow_dict(
+        cls,
+        config: dict,
+        *,
+        resources: dict | None = None,
+        infrastructure: object | None = None,
+    ) -> "Agent":
+        """Instantiate from a stage-to-plugins mapping."""
+
+        wf = Workflow.from_dict(config)
+        return cls(
+            resources=resources if resources is not None else load_defaults(),
+            workflow=wf.steps,
+            infrastructure=infrastructure,
+        )
+
+    @classmethod
+    def from_config(
+        cls,
+        path: str | Path,
+        *,
+        resources: dict | None = None,
+        infrastructure: object | None = None,
+    ) -> "Agent":
+        """Create an agent from a YAML configuration file."""
+
+        cfg = load_config(path)
+        wf = Workflow.from_dict(cfg.workflow)
+        return cls(
+            resources=resources if resources is not None else load_defaults(),
+            workflow=wf.steps,
+            infrastructure=infrastructure,
+        )
 
     async def chat(self, message: str, user_id: str = "default"):
         """Process ``message`` through the workflow for ``user_id``."""

--- a/tests/test_agent_factories.py
+++ b/tests/test_agent_factories.py
@@ -1,0 +1,69 @@
+import asyncio
+
+import pytest
+
+from entity.core.agent import Agent
+from entity.config import load_config, clear_config_cache
+from entity.resources.memory import Memory
+from entity.resources.database import DatabaseResource
+from entity.resources.vector_store import VectorStoreResource
+from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
+
+
+def _memory() -> Memory:
+    infra = DuckDBInfrastructure(":memory:")
+    return Memory(DatabaseResource(infra), VectorStoreResource(infra))
+
+
+@pytest.mark.asyncio
+async def test_from_workflow(tmp_path):
+    path = tmp_path / "wf.yaml"
+    path.write_text(
+        """\
+think:
+  - entity.plugins.defaults.ThinkPlugin
+"""
+    )
+    agent = Agent.from_workflow(str(path), resources={"memory": _memory()})
+    result = await agent.chat("hi")
+    assert result["response"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_from_workflow_dict():
+    agent = Agent.from_workflow_dict(
+        {
+            "think": ["entity.plugins.defaults.ThinkPlugin"],
+        },
+        resources={"memory": _memory()},
+    )
+    out = await agent.chat("hello")
+    assert out["response"] == "hello"
+
+
+def test_from_config(tmp_path):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        """\
+resources: {}
+workflow:
+  think:
+    - entity.plugins.defaults.ThinkPlugin
+"""
+    )
+    agent = Agent.from_config(str(cfg), resources={"memory": _memory()})
+    loop = asyncio.get_event_loop()
+    result = loop.run_until_complete(agent.chat("hey"))
+    assert result["response"] == "hey"
+
+
+def test_config_cache(tmp_path):
+    cfg = tmp_path / "conf.yml"
+    cfg.write_text("resources: {}\nworkflow: {}")
+    clear_config_cache()
+    first = load_config(str(cfg))
+    second = load_config(str(cfg))
+    assert first is second
+    clear_config_cache()
+    third = load_config(str(cfg))
+    assert first is not third


### PR DESCRIPTION
## Summary
- add `from_workflow`, `from_workflow_dict`, and `from_config` helpers on `Agent`
- implement cached config loading in `entity.config`
- document usage in `examples`
- test all factory methods and caching behaviour

## Testing
- `poetry run pytest -vv tests/test_agent_factories.py`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6883765daff483229062b3eb3b76784d