### PR TITLE
Add workflow validation phase and error recovery

### DIFF
--- a/src/entity/plugins/context.py
+++ b/src/entity/plugins/context.py
@@ -20,8 +20,11 @@ class WorkflowContext:
 
         from entity.workflow.executor import WorkflowExecutor
 
-        if self.current_stage != WorkflowExecutor.OUTPUT:
-            raise RuntimeError("context.say() only allowed in OUTPUT stage")
+        if self.current_stage not in {
+            WorkflowExecutor.OUTPUT,
+            WorkflowExecutor.ERROR,
+        }:
+            raise RuntimeError("context.say() only allowed in OUTPUT or ERROR stage")
 
         self._response = message
 


### PR DESCRIPTION
## Summary
- add second-phase workflow compatibility validation
- support error stage recovery in `WorkflowExecutor`
- allow `context.say` during ERROR stage
- test new validation and recovery behaviour

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68837daad648832280a41eab822e567f