### PR TITLE
Add resource checks and health validation

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,7 +4,7 @@ mypy_path = src
 exclude = ^src/entity/workflow/templates/
 strict = True
 ignore_errors = True
-files = src/entity/plugins/context.py
+files = src/entity/plugins/context.py, src/entity/resources
 follow_imports = skip
 
 [mypy-langchain_core.*]
@@ -33,4 +33,7 @@ ignore_missing_imports = True
 
 [mypy-cdktf_cdktf_provider_aws.*]
 ignore_missing_imports = True
+
+[mypy-src.entity.resources.*]
+ignore_errors = False
 

--- a/src/entity/infrastructure/s3_infra.py
+++ b/src/entity/infrastructure/s3_infra.py
@@ -21,3 +21,13 @@ class S3Infrastructure:
         """Create an S3 client from the session."""
 
         return self.session().client("s3")
+
+    def health_check(self) -> bool:
+        """Return ``True`` if the bucket is reachable."""
+
+        try:
+            client = self.client()
+            client.list_buckets()
+            return True
+        except Exception:
+            return False

--- a/src/entity/resources/database.py
+++ b/src/entity/resources/database.py
@@ -1,15 +1,23 @@
 """Database resource that executes queries using a DuckDB backend."""
 
 from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
+from entity.resources.exceptions import ResourceInitializationError
 
 
 class DatabaseResource:
     """Layer 2 resource providing database access."""
 
-    def __init__(self, infrastructure: DuckDBInfrastructure) -> None:
+    def __init__(self, infrastructure: DuckDBInfrastructure | None) -> None:
         """Initialize with an injected DuckDB infrastructure."""
 
+        if infrastructure is None:
+            raise ResourceInitializationError("DuckDBInfrastructure is required")
         self.infrastructure = infrastructure
+
+    def health_check(self) -> bool:
+        """Return ``True`` if the underlying infrastructure is healthy."""
+
+        return self.infrastructure.health_check()
 
     def execute(self, query: str, *params: object) -> object:
         """Execute a SQL query and return the result cursor."""

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -1,15 +1,23 @@
 """Resource wrapper around an Ollama LLM deployment."""
 
 from entity.infrastructure.ollama_infra import OllamaInfrastructure
+from entity.resources.exceptions import ResourceInitializationError
 
 
 class LLMResource:
     """Layer 2 resource that wraps an Ollama LLM."""
 
-    def __init__(self, infrastructure: OllamaInfrastructure) -> None:
+    def __init__(self, infrastructure: OllamaInfrastructure | None) -> None:
         """Initialize with the Ollama infrastructure instance."""
 
+        if infrastructure is None:
+            raise ResourceInitializationError("OllamaInfrastructure is required")
         self.infrastructure = infrastructure
+
+    def health_check(self) -> bool:
+        """Return ``True`` if the underlying infrastructure is healthy."""
+
+        return self.infrastructure.health_check()
 
     async def generate(self, prompt: str) -> str:
         """Return the model output for a given prompt."""

--- a/src/entity/resources/llm_wrapper.py
+++ b/src/entity/resources/llm_wrapper.py
@@ -12,6 +12,11 @@ class LLM:
             raise ResourceInitializationError("LLMResource is required")
         self.resource = resource
 
+    def health_check(self) -> bool:
+        """Return ``True`` if the underlying resource is healthy."""
+
+        return self.resource.health_check()
+
     async def generate(self, prompt: str) -> str:
         """Generate a completion using the underlying resource."""
 

--- a/src/entity/resources/local_storage.py
+++ b/src/entity/resources/local_storage.py
@@ -4,15 +4,23 @@ import asyncio
 from pathlib import Path
 
 from entity.infrastructure.local_storage_infra import LocalStorageInfrastructure
+from entity.resources.exceptions import ResourceInitializationError
 
 
 class LocalStorageResource:
     """Layer 2 resource for local file storage."""
 
-    def __init__(self, infrastructure: LocalStorageInfrastructure) -> None:
+    def __init__(self, infrastructure: LocalStorageInfrastructure | None) -> None:
         """Create the resource with a local storage backend."""
 
+        if infrastructure is None:
+            raise ResourceInitializationError("LocalStorageInfrastructure is required")
         self.infrastructure = infrastructure
+
+    def health_check(self) -> bool:
+        """Return ``True`` if the underlying infrastructure is healthy."""
+
+        return self.infrastructure.health_check()
 
     async def upload_text(self, key: str, data: str) -> None:
         """Persist text to the local filesystem."""

--- a/src/entity/resources/logging.py
+++ b/src/entity/resources/logging.py
@@ -24,6 +24,11 @@ class LoggingResource:
         self.records: List[Dict[str, Any]] = []
         self._lock = asyncio.Lock()
 
+    def health_check(self) -> bool:
+        """Always returns ``True`` as logging has no external deps."""
+
+        return True
+
     async def log(self, level: str, message: str, **fields: Any) -> None:
         """Store a log entry if ``level`` is above the configured threshold."""
 

--- a/src/entity/resources/memory.py
+++ b/src/entity/resources/memory.py
@@ -28,6 +28,11 @@ class Memory:
         self._lock = asyncio.Lock()
         self._ensure_table()
 
+    def health_check(self) -> bool:
+        """Return ``True`` if both underlying resources are healthy."""
+
+        return self.database.health_check() and self.vector_store.health_check()
+
     def execute(self, query: str, *params: object) -> object:
         """Execute a database query."""
 

--- a/src/entity/resources/metrics.py
+++ b/src/entity/resources/metrics.py
@@ -14,6 +14,11 @@ class MetricsCollectorResource:
         self.aggregates: Dict[str, Dict[str, Any]] = {}
         self._lock = asyncio.Lock()
 
+    def health_check(self) -> bool:
+        """Return ``True`` as metrics collection has no external deps."""
+
+        return True
+
     async def record_plugin_execution(
         self,
         plugin_name: str,

--- a/src/entity/resources/storage.py
+++ b/src/entity/resources/storage.py
@@ -1,15 +1,23 @@
 """Resource for storing text to an S3 bucket."""
 
 from entity.infrastructure.s3_infra import S3Infrastructure
+from entity.resources.exceptions import ResourceInitializationError
 
 
 class StorageResource:
     """Layer 2 resource for S3-based file storage."""
 
-    def __init__(self, infrastructure: S3Infrastructure) -> None:
+    def __init__(self, infrastructure: S3Infrastructure | None) -> None:
         """Initialize the resource with an S3 infrastructure instance."""
 
+        if infrastructure is None:
+            raise ResourceInitializationError("S3Infrastructure is required")
         self.infrastructure = infrastructure
+
+    def health_check(self) -> bool:
+        """Return ``True`` if the underlying infrastructure is healthy."""
+
+        return self.infrastructure.health_check()
 
     async def upload_text(self, key: str, data: str) -> None:
         """Upload plain text to the configured bucket under the given key."""

--- a/src/entity/resources/storage_wrapper.py
+++ b/src/entity/resources/storage_wrapper.py
@@ -13,6 +13,11 @@ class Storage:
             raise ResourceInitializationError("StorageResource is required")
         self.resource = resource
 
+    def health_check(self) -> bool:
+        """Return ``True`` if the underlying resource is healthy."""
+
+        return self.resource.health_check()
+
     async def upload_text(self, key: str, data: str) -> None:
         """Proxy text upload to the underlying resource."""
 

--- a/src/entity/resources/vector_store.py
+++ b/src/entity/resources/vector_store.py
@@ -1,15 +1,23 @@
 """Vector store resource backed by DuckDB."""
 
 from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
+from entity.resources.exceptions import ResourceInitializationError
 
 
 class VectorStoreResource:
     """Layer 2 resource for storing and searching vectors."""
 
-    def __init__(self, infrastructure: DuckDBInfrastructure) -> None:
+    def __init__(self, infrastructure: DuckDBInfrastructure | None) -> None:
         """Create the resource with a DuckDB backend."""
 
+        if infrastructure is None:
+            raise ResourceInitializationError("DuckDBInfrastructure is required")
         self.infrastructure = infrastructure
+
+    def health_check(self) -> bool:
+        """Return ``True`` if the underlying infrastructure is healthy."""
+
+        return self.infrastructure.health_check()
 
     def add_vector(self, table: str, vector: object) -> None:
         """Insert a vector into the given table."""

--- a/tests/resources/test_resource_initialization.py
+++ b/tests/resources/test_resource_initialization.py
@@ -1,0 +1,69 @@
+import pytest
+
+from entity.resources import (
+    DatabaseResource,
+    VectorStoreResource,
+    LLMResource,
+    LocalStorageResource,
+    StorageResource,
+    Memory,
+    LLM,
+    Storage,
+    ResourceInitializationError,
+)
+from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
+from entity.infrastructure.local_storage_infra import LocalStorageInfrastructure
+
+
+class HealthyInfra:
+    def health_check(self) -> bool:  # pragma: no cover - simple stub
+        return True
+
+    def __getattr__(self, name):  # pragma: no cover - stub
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
+
+
+class FailingInfra:
+    def health_check(self) -> bool:  # pragma: no cover - simple stub
+        return False
+
+
+def test_constructors_success(tmp_path):
+    duckdb = DuckDBInfrastructure(":memory:")
+    db_res = DatabaseResource(duckdb)
+    vector_res = VectorStoreResource(duckdb)
+    mem = Memory(db_res, vector_res)
+
+    llm_res = LLMResource(HealthyInfra())
+    llm = LLM(llm_res)
+
+    storage_infra = LocalStorageInfrastructure(tmp_path)
+    local_res = LocalStorageResource(storage_infra)
+    s3_res = StorageResource(HealthyInfra())
+    storage = Storage(local_res)
+
+    assert mem.health_check()
+    assert llm.health_check()
+    assert storage.health_check()
+
+
+def test_constructor_failure():
+    with pytest.raises(ResourceInitializationError):
+        DatabaseResource(None)
+    with pytest.raises(ResourceInitializationError):
+        VectorStoreResource(None)
+    with pytest.raises(ResourceInitializationError):
+        LLMResource(None)
+    with pytest.raises(ResourceInitializationError):
+        LocalStorageResource(None)
+    with pytest.raises(ResourceInitializationError):
+        StorageResource(None)
+    with pytest.raises(ResourceInitializationError):
+        Memory(DatabaseResource(FailingInfra()), None)
+    with pytest.raises(ResourceInitializationError):
+        LLM(None)
+    with pytest.raises(ResourceInitializationError):
+        Storage(None)


### PR DESCRIPTION
## Summary
- ensure all resource constructors verify dependencies
- expose `health_check` on resources and S3 infrastructure
- tighten mypy settings for resources
- add unit tests for resource initialization

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_688386c9ee9883229dc5da1589454c43