### PR TITLE
Add docker-compose test fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,12 @@ poetry install --with dev
 poetry run poe test
 ```
 
-For integration tests that require Docker, install Docker and then run:
+Integration tests rely on the services defined in `docker-compose.yml`.
+Run them with Docker installed:
 
 ```bash
 poetry run poe test-with-docker
 ```
+This task brings the containers up, runs all tests marked `integration` in
+parallel, and then tears the services down so no state is shared between runs.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ release = ["patch", "_publish"]
 
 # Development helpers
 start-db = { cmd = "docker compose up -d postgres" }
+start-test-services = { cmd = "docker compose up -d" }
+stop-test-services = { cmd = "docker compose down -v" }
 
 # ALL test tasks need the env variable
 test = { cmd = "pytest", env = { PYTHONPATH = "src" } }
@@ -75,8 +77,15 @@ unit = { cmd = "pytest tests/unit", env = { PYTHONPATH = "src" } }
 integration = { cmd = "pytest tests/integration", env = { PYTHONPATH = "src" } }
 e2e = { cmd = "pytest tests/e2e", env = { PYTHONPATH = "src" } }
 
+[tool.poe.tasks.test-with-docker]
+sequence = [
+    { ref = "start-test-services" },
+    { cmd = "pytest -m integration -n auto", env = { PYTHONPATH = "src" } },
+    { ref = "stop-test-services" },
+]
 
-setup-dev = { cmd = "poetry install --with dev" }
+[tool.poe.tasks.setup-dev]
+cmd = "poetry install --with dev"
 
 [tool.poe.tasks.lint]
 sequence = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+COMPOSE_FILE = Path(__file__).resolve().parents[1] / "docker-compose.yml"
+
+
+def _compose(*args: str) -> None:
+    subprocess.check_call(["docker", "compose", "-f", str(COMPOSE_FILE), *args])
+
+
+@pytest.fixture(scope="session")
+def compose_services():
+    """Start docker-compose services for integration tests."""
+    if shutil.which("docker") is None:
+        pytest.skip("docker not installed")
+    _compose("up", "-d")
+    try:
+        yield
+    finally:
+        _compose("down", "-v")
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        if "integration" in item.keywords:
+            item.fixturenames.append("compose_services")


### PR DESCRIPTION
## Summary
- spin up docker-compose services for integration tests
- provide poe task for running integration tests in parallel
- document new workflow for local testing

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: executable 'docker' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839072f7c083228932f13f19011313