### PR TITLE
Add new example scripts and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 Python agent framework
 
 ## Examples
-Run `python -m entity.examples` to see sample workflows. The old `[examples]` extra has been removed.
+Run `python examples/zero_config_agent.py` for a minimal CLI demo or
+`python examples/advanced_workflow.py` to see a multi-stage workflow in action.
+The old `[examples]` extra has been removed.
 
 ### Workflow Templates
 
@@ -165,4 +167,16 @@ poetry run poe test-with-docker
 ```
 This task brings the containers up, runs all tests marked `integration` in
 parallel, and then tears the services down so no state is shared between runs.
+
+## Docker Usage
+
+Spin up the local services defined in `docker-compose.yml`:
+
+```bash
+docker compose up -d
+# run agents or tests here
+docker compose down -v
+```
+
+See `install_docker.sh` for an automated install script on Ubuntu.
 

--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import asyncio
+
+from entity.core.agent import Agent
+from entity.defaults import load_defaults
+
+
+class DummyLLM:
+    async def generate(self, prompt: str) -> str:  # pragma: no cover - example
+        return "dummy"
+
+
+async def main() -> None:
+    resources = load_defaults()
+    resources["llm"] = DummyLLM()
+    agent = Agent.from_workflow("examples/advanced_workflow.yaml", resources=resources)
+    result = await agent.chat("2 + 2")
+    print(result["response"])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/advanced_workflow.yaml
+++ b/examples/advanced_workflow.yaml
@@ -1,0 +1,15 @@
+input:
+  - entity.plugins.examples.input_reader.InputReader
+parse:
+  - entity.plugins.examples.keyword_extractor.KeywordExtractor
+  - entity.plugins.defaults.ParsePlugin
+think:
+  - entity.plugins.examples.reason_generator.ReasonGenerator
+  - entity.plugins.defaults.ThinkPlugin
+do:
+  - entity.plugins.examples.calculator.Calculator
+review:
+  - entity.plugins.examples.static_reviewer.StaticReviewer
+  - entity.plugins.defaults.ReviewPlugin
+output:
+  - entity.plugins.examples.output_formatter.OutputFormatter

--- a/examples/zero_config_agent.py
+++ b/examples/zero_config_agent.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import asyncio
+
+from entity import Agent
+
+
+async def main() -> None:
+    agent = Agent()
+    await agent.chat("")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/tests/examples/test_advanced_workflow.py
+++ b/tests/examples/test_advanced_workflow.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.examples
+def test_advanced_workflow():
+    env = dict(os.environ, PYTHONPATH="src")
+    proc = subprocess.run(
+        [sys.executable, "examples/advanced_workflow.py"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        env=env,
+    )
+    assert proc.stdout.strip() == "Result: 4"

--- a/tests/examples/test_zero_config_agent.py
+++ b/tests/examples/test_zero_config_agent.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.examples
+def test_zero_config_agent():
+    env = dict(os.environ, PYTHONPATH="src")
+    proc = subprocess.run(
+        [sys.executable, "examples/zero_config_agent.py"],
+        input="ping\n",
+        text=True,
+        capture_output=True,
+        timeout=5,
+        env=env,
+    )
+    assert proc.stdout.strip() == "ping"


### PR DESCRIPTION
## Summary
- show zero-config and advanced workflow examples
- document usage and Docker details
- add tests for the new examples

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6883966781188322a341669d95ff6f1e