### PR TITLE
Add infrastructure base class with async lifecycle

### DIFF
--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -1,0 +1,13 @@
+from .base import BaseInfrastructure
+from .duckdb_infra import DuckDBInfrastructure
+from .local_storage_infra import LocalStorageInfrastructure
+from .ollama_infra import OllamaInfrastructure
+from .s3_infra import S3Infrastructure
+
+__all__ = [
+    "BaseInfrastructure",
+    "DuckDBInfrastructure",
+    "LocalStorageInfrastructure",
+    "OllamaInfrastructure",
+    "S3Infrastructure",
+]

--- a/src/entity/infrastructure/base.py
+++ b/src/entity/infrastructure/base.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+
+
+class BaseInfrastructure(ABC):
+    """Common functionality for infrastructure components."""
+
+    version = "0.1"
+
+    def __init__(self, version: str | None = None) -> None:
+        self.version = version or self.version
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    async def startup(self) -> None:  # pragma: no cover - thin wrapper
+        """Perform asynchronous initialization."""
+        self.logger.debug(
+            "Starting %s version %s", self.__class__.__name__, self.version
+        )
+
+    async def shutdown(self) -> None:  # pragma: no cover - thin wrapper
+        """Perform asynchronous cleanup."""
+        self.logger.debug("Shutting down %s", self.__class__.__name__)
+
+    @abstractmethod
+    def health_check(self) -> bool:
+        """Return ``True`` if the infrastructure is healthy."""
+        raise NotImplementedError

--- a/src/entity/infrastructure/local_storage_infra.py
+++ b/src/entity/infrastructure/local_storage_infra.py
@@ -1,12 +1,15 @@
 from pathlib import Path
 
+from .base import BaseInfrastructure
 
-class LocalStorageInfrastructure:
+
+class LocalStorageInfrastructure(BaseInfrastructure):
     """Layer 1 infrastructure for storing files on the local filesystem."""
 
-    def __init__(self, base_path: str) -> None:
+    def __init__(self, base_path: str, version: str | None = None) -> None:
         """Create the infrastructure rooted at ``base_path``."""
 
+        super().__init__(version)
         self.base_path = Path(base_path)
         self.base_path.mkdir(parents=True, exist_ok=True)
 
@@ -24,3 +27,10 @@ class LocalStorageInfrastructure:
             return True
         except Exception:
             return False
+
+    async def startup(self) -> None:  # pragma: no cover - thin wrapper
+        await super().startup()
+        self.logger.info("Storage path %s ready", self.base_path)
+
+    async def shutdown(self) -> None:  # pragma: no cover - thin wrapper
+        await super().shutdown()

--- a/src/entity/infrastructure/ollama_infra.py
+++ b/src/entity/infrastructure/ollama_infra.py
@@ -1,12 +1,15 @@
 import httpx
 
+from .base import BaseInfrastructure
 
-class OllamaInfrastructure:
+
+class OllamaInfrastructure(BaseInfrastructure):
     """Layer 1 infrastructure for communicating with an Ollama server."""
 
-    def __init__(self, base_url: str, model: str) -> None:
+    def __init__(self, base_url: str, model: str, version: str | None = None) -> None:
         """Configure the client base URL and model."""
 
+        super().__init__(version)
         self.base_url = base_url.rstrip("/")
         self.model = model
 
@@ -20,6 +23,13 @@ class OllamaInfrastructure:
             response.raise_for_status()
             data = response.json()
             return data.get("response", "")
+
+    async def startup(self) -> None:  # pragma: no cover - thin wrapper
+        await super().startup()
+        self.logger.info("Ollama endpoint %s", self.base_url)
+
+    async def shutdown(self) -> None:  # pragma: no cover - thin wrapper
+        await super().shutdown()
 
     def health_check(self) -> bool:
         """Return ``True`` if the Ollama server responds."""

--- a/src/entity/infrastructure/s3_infra.py
+++ b/src/entity/infrastructure/s3_infra.py
@@ -1,12 +1,15 @@
 import aioboto3
 
+from .base import BaseInfrastructure
 
-class S3Infrastructure:
+
+class S3Infrastructure(BaseInfrastructure):
     """Layer 1 infrastructure for interacting with an S3 bucket."""
 
-    def __init__(self, bucket: str) -> None:
+    def __init__(self, bucket: str, version: str | None = None) -> None:
         """Configure the target bucket."""
 
+        super().__init__(version)
         self.bucket = bucket
         self._session: aioboto3.Session | None = None
 
@@ -21,6 +24,14 @@ class S3Infrastructure:
         """Create an S3 client from the session."""
 
         return self.session().client("s3")
+
+    async def startup(self) -> None:  # pragma: no cover - thin wrapper
+        await super().startup()
+        self._session = aioboto3.Session()
+        self.logger.info("Using bucket %s", self.bucket)
+
+    async def shutdown(self) -> None:  # pragma: no cover - thin wrapper
+        await super().shutdown()
 
     def health_check(self) -> bool:
         """Return ``True`` if the bucket is reachable."""

--- a/tests/test_infrastructure_docker.py
+++ b/tests/test_infrastructure_docker.py
@@ -1,0 +1,38 @@
+import shutil
+import pytest
+
+from entity.infrastructure import (
+    DuckDBInfrastructure,
+    LocalStorageInfrastructure,
+    OllamaInfrastructure,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_duckdb_startup_shutdown(tmp_path):
+    infra = DuckDBInfrastructure(str(tmp_path / "db.duckdb"))
+    await infra.startup()
+    assert infra.health_check()
+    await infra.shutdown()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_local_storage_startup_shutdown(tmp_path):
+    infra = LocalStorageInfrastructure(tmp_path)
+    await infra.startup()
+    assert infra.health_check()
+    await infra.shutdown()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(shutil.which("docker") is None, reason="docker not installed")
+@pytest.mark.asyncio
+async def test_ollama_health(compose_services):
+    infra = OllamaInfrastructure("http://localhost:11434", "test")
+    await infra.startup()
+    try:
+        assert infra.health_check()
+    finally:
+        await infra.shutdown()


### PR DESCRIPTION
## Summary
- create `BaseInfrastructure` with async startup/shutdown
- extend infrastructure modules from the new base class
- expose infrastructure classes from package init
- add docker-based integration tests

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: `docker` executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839890d4d083228b6dfc0ac7890636