### PR TITLE
Update examples to run with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ollama/ollama:latest
+
+ENV OLLAMA_MODEL=llama3:8b-instruct-q6_K \
+    OLLAMA_HOST=0.0.0.0
+
+EXPOSE 11434
+
+ENTRYPOINT ["bash", "-c", "ollama serve & sleep 3 && ollama pull ${OLLAMA_MODEL} || true && wait"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 Python agent framework
 
 ## Examples
-Run `python examples/zero_config_agent.py` for a minimal CLI demo or
+First start the local services:
+
+```bash
+docker compose up -d
+```
+
+Then run `python examples/zero_config_agent.py` for a minimal CLI demo or
 `python examples/advanced_workflow.py` to see a multi-stage workflow in action.
 The old `[examples]` extra has been removed.
 
@@ -170,9 +176,11 @@ parallel, and then tears the services down so no state is shared between runs.
 
 ## Docker Usage
 
-Spin up the local services defined in `docker-compose.yml`:
+Spin up the local services defined in `docker-compose.yml`.
+The `ollama` service is built from the provided Dockerfile:
 
 ```bash
+docker compose build ollama
 docker compose up -d
 # run agents or tests here
 docker compose down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,24 +20,15 @@ services:
       retries: 5
 
   ollama:
-    image: ollama/ollama
+    build: .
+    image: entity-ollama
     privileged: true
     env_file:
       - .env
     ports:
-      - "11434"
+      - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
-    environment:
-      - OLLAMA_HOST=0.0.0.0
-    entrypoint: >
-      bash -c '
-        set -e
-        ollama serve &
-        sleep 3
-        ollama pull ${OLLAMA_MODEL:-llama3:8b-instruct-q6_K} || true
-        wait
-      '
 
 volumes:
   postgres_data:

--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+"""Demonstrate a multi-stage agent with Docker services.
+
+Run the supporting containers first:
+
+```
+docker compose up -d
+```
+"""
+
 import asyncio
 
 from entity.core.agent import Agent

--- a/examples/factory_methods.py
+++ b/examples/factory_methods.py
@@ -1,4 +1,11 @@
-"""Demonstrate Agent factory helpers."""
+"""Demonstrate Agent factory helpers.
+
+Start the service stack before running:
+
+```
+docker compose up -d
+```
+"""
 
 from entity.core.agent import Agent
 

--- a/examples/zero_config_agent.py
+++ b/examples/zero_config_agent.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+"""Run a minimal agent with Docker services.
+
+Start the dependencies before running this script:
+
+```
+docker compose up -d
+```
+"""
+
 import asyncio
 
 from entity import Agent


### PR DESCRIPTION
## Summary
- add Dockerfile to build an Ollama container
- build ollama service with docker-compose
- mention docker-compose in example scripts and docs

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68839aca4e288322a31951a2851fa8db