### PR TITLE
Fix CLI hang

### DIFF
--- a/src/entity/cli/ent_cli_adapter.py
+++ b/src/entity/cli/ent_cli_adapter.py
@@ -69,6 +69,9 @@ class EntCLIAdapter(InputAdapterPlugin, OutputAdapterPlugin):
             print(output)
         except BrokenPipeError:
             self._stop.set()
+        else:
+            # ensure CLI exits after successfully writing output
+            self._stop.set()
         context.say(output)
         return output
 


### PR DESCRIPTION
## Summary
- ensure CLI adapter stops after writing output

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883bc3a6a2c8322ad0b3aaf2d752a04