### PR TITLE
Improve Agent factory typing and caching

### DIFF
--- a/src/entity/core/agent.py
+++ b/src/entity/core/agent.py
@@ -1,20 +1,43 @@
 # TODO: Use absolute imports
 from pathlib import Path
+from typing import Any, Iterable
 
+from entity.config import load_config
 from entity.defaults import load_defaults
 from entity.plugins.defaults import default_workflow
 from entity.workflow import WorkflowExecutor
-from entity.workflow.templates import load_template, TemplateNotFoundError
+from entity.workflow.templates import TemplateNotFoundError, load_template
 from entity.workflow.workflow import Workflow
-from entity.config import load_config
 
 
 class Agent:
-    # TODO: Arguments should have typehints
-    def __init__(self, resources=None, workflow=None, infrastructure=None):
-        self.resources = resources or load_defaults()
+    """Core object composed of resources, workflow, and infrastructure."""
+
+    _config_cache: dict[str, "Agent"] = {}
+
+    def __init__(
+        self,
+        resources: dict[str, Any] | None = None,
+        workflow: dict[str, Iterable[type]] | list[type] | None = None,
+        infrastructure: object | None = None,
+    ) -> None:
+        if resources is None:
+            resources = load_defaults()
+        if not isinstance(resources, dict):
+            raise TypeError("resources must be a mapping")
+
+        if workflow is not None and not isinstance(workflow, (dict, list)):
+            raise TypeError("workflow must be a list or mapping")
+
+        self.resources = resources
         self.workflow = workflow
         self.infrastructure = infrastructure
+
+    @classmethod
+    def clear_from_config_cache(cls) -> None:
+        """Reset the ``from_config`` cache."""
+
+        cls._config_cache.clear()
 
     # ------------------------------------------------------------------
     # Factory helpers
@@ -25,7 +48,7 @@ class Agent:
         cls,
         name: str,
         *,
-        resources: dict | None = None,
+        resources: dict[str, Any] | None = None,
         infrastructure: object | None = None,
     ) -> "Agent":
         """Build an agent from a workflow template or YAML file."""
@@ -51,9 +74,9 @@ class Agent:
     @classmethod
     def from_workflow_dict(
         cls,
-        config: dict,
+        config: dict[str, Iterable[str | type]],
         *,
-        resources: dict | None = None,
+        resources: dict[str, Any] | None = None,
         infrastructure: object | None = None,
     ) -> "Agent":
         """Instantiate from a stage-to-plugins mapping."""
@@ -70,18 +93,27 @@ class Agent:
         cls,
         path: str | Path,
         *,
-        resources: dict | None = None,
+        resources: dict[str, Any] | None = None,
         infrastructure: object | None = None,
     ) -> "Agent":
         """Create an agent from a YAML configuration file."""
 
-        cfg = load_config(path)
+        resolved = str(Path(path).resolve())
+        if resources is None and infrastructure is None:
+            cached = cls._config_cache.get(resolved)
+            if cached is not None:
+                return cached
+
+        cfg = load_config(resolved)
         wf = Workflow.from_dict(cfg.workflow)
-        return cls(
+        agent = cls(
             resources=resources if resources is not None else load_defaults(),
             workflow=wf.steps,
             infrastructure=infrastructure,
         )
+        if resources is None and infrastructure is None:
+            cls._config_cache[resolved] = agent
+        return agent
 
     async def chat(self, message: str, user_id: str = "default"):
         """Process ``message`` through the workflow for ``user_id``."""

--- a/tests/test_agent_factories.py
+++ b/tests/test_agent_factories.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 
 from entity.core.agent import Agent
-from entity.config import load_config, clear_config_cache
+from entity.config import clear_config_cache, load_config
 from entity.resources.memory import Memory
 from entity.resources.database import DatabaseResource
 from entity.resources.vector_store import VectorStoreResource
@@ -67,3 +67,27 @@ def test_config_cache(tmp_path):
     clear_config_cache()
     third = load_config(str(cfg))
     assert first is not third
+
+
+def test_from_config_caching(tmp_path):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        """
+resources: {}
+workflow:
+  think:
+    - entity.plugins.defaults.ThinkPlugin
+"""
+    )
+    Agent.clear_from_config_cache()
+    a1 = Agent.from_config(cfg)
+    a2 = Agent.from_config(cfg)
+    assert a1 is a2
+    Agent.clear_from_config_cache()
+    a3 = Agent.from_config(cfg)
+    assert a1 is not a3
+
+
+def test_invalid_workflow_dict():
+    with pytest.raises(Exception):
+        Agent.from_workflow_dict({"bad_stage": ["entity.plugins.defaults.ThinkPlugin"]})


### PR DESCRIPTION
## Summary
- type all Agent factory methods
- validate Agent inputs and cache `from_config`
- add tests for `from_config` caching and failure cases

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6883be05bdec83228f753be674ab975d