### PR TITLE
Fix CLI default workflow invocation

### DIFF
--- a/src/entity/cli/__main__.py
+++ b/src/entity/cli/__main__.py
@@ -20,7 +20,12 @@ def _load_workflow(name: str) -> list[type] | dict[str, list[type]]:
     """Return workflow steps from ``name`` or exit with a helpful error."""
 
     if name == "default":
-        return default_workflow()
+        steps = list(default_workflow())
+        if steps and steps[0] is EntCLIAdapter:
+            steps = steps[1:]
+        if steps and steps[-1] is EntCLIAdapter:
+            steps = steps[:-1]
+        return steps
 
     path = Path(name)
     if path.exists():


### PR DESCRIPTION
## Summary
- ensure CLI doesn't wait for extra input by stripping EntCLIAdapter
- update default workflow loader

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6883f4553c008322aa47ac847849bc4e