### PR TITLE
Fix CLI workflow termination

### DIFF
--- a/src/entity/plugins/defaults/__init__.py
+++ b/src/entity/plugins/defaults/__init__.py
@@ -36,8 +36,11 @@ class ReviewPlugin(Plugin):
 
 class OutputPlugin(Plugin):
     async def _execute_impl(self, context) -> str:  # noqa: D401
-        """Return final response."""
-        return context.message or ""
+        """Return final response and terminate the workflow."""
+
+        message = context.message or ""
+        context.say(message)
+        return message
 
 
 def default_workflow() -> list[type[Plugin]]:


### PR DESCRIPTION
## Summary
- ensure the default OutputPlugin ends the workflow

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6883f755d1f08322a0fae2e1d042804d