### PR TITLE
Fix docker substitution test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ bandit = "^1.8.5"
 poethepoet = "^0.36.0"
 vulture = "^2.14"
 httpx = "0.27.*"
+build = "^1.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- avoid network access when running config substitution test in Docker
- include `build` in dev dependencies for wheel creation

## Testing
- `poetry run poe test`
- `poetry run pytest tests/test_config_substitution_docker.py::test_nested_substitution_in_docker -vv`

------
https://chatgpt.com/codex/tasks/task_e_6883fc79e8b88322bb1f2447f8fbeceb