### PR TITLE
Fix CLI timeout hang

### DIFF
--- a/src/entity/cli/__main__.py
+++ b/src/entity/cli/__main__.py
@@ -97,6 +97,7 @@ async def _run(args: argparse.Namespace) -> None:
         pass
     except asyncio.TimeoutError:
         print("Execution timed out", file=sys.stderr)
+        adapter.stop()
         return
     finally:
         await adapter.wait_closed()

--- a/src/entity/cli/ent_cli_adapter.py
+++ b/src/entity/cli/ent_cli_adapter.py
@@ -23,6 +23,10 @@ class EntCLIAdapter(InputAdapterPlugin, OutputAdapterPlugin):
         super().__init__(resources, config)
         self._stop = asyncio.Event()
 
+    def stop(self) -> None:
+        """Signal any waiting ``wait_closed`` calls to exit."""
+        self._stop.set()
+
     def _install_signals(self) -> None:
         loop = asyncio.get_running_loop()
         for sig in (signal.SIGINT, signal.SIGTERM):


### PR DESCRIPTION
## Summary
- ensure CLI exits when workflows exceed timeout
- expose `EntCLIAdapter.stop()` for safe shutdowns

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6884071a4f90832289df65d783078702