### PR TITLE
Improve default infrastructure detection

### DIFF
--- a/src/entity/defaults.py
+++ b/src/entity/defaults.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import os
 import tempfile
+import logging
 from dataclasses import dataclass
 
 # TODO: Do not use relative imports
 from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
 from entity.infrastructure.ollama_infra import OllamaInfrastructure
 from entity.infrastructure.local_storage_infra import LocalStorageInfrastructure
+from entity.infrastructure.ollama_installer import OllamaInstaller
 from entity.resources import (
     DatabaseResource,
     VectorStoreResource,
@@ -57,18 +59,30 @@ def load_defaults(config: DefaultConfig | None = None) -> dict[str, object]:
     """Build canonical resources using ``config`` or environment overrides."""
 
     cfg = config or DefaultConfig.from_env()
+    logger = logging.getLogger("defaults")
 
     duckdb = DuckDBInfrastructure(cfg.duckdb_path)
     if not duckdb.health_check():
+        logger.debug("Falling back to in-memory DuckDB")
         duckdb = DuckDBInfrastructure(":memory:")
 
     ollama = OllamaInfrastructure(cfg.ollama_url, cfg.ollama_model)
+    logger.debug("Checking local Ollama at %s", cfg.ollama_url)
     if not ollama.health_check():
-        ollama = _NullLLMInfrastructure()
+        logger.debug("Ollama not reachable; attempting installation")
+        OllamaInstaller.ensure_installed()
+        if not ollama.health_check():
+            logger.warning("Using stub LLM implementation")
+            ollama = _NullLLMInfrastructure()
 
     storage_infra = LocalStorageInfrastructure(cfg.storage_path)
     if not storage_infra.health_check():
         fallback = os.path.join(tempfile.gettempdir(), "entity_files")
+        logger.warning(
+            "Storage path %s unavailable; falling back to %s",
+            cfg.storage_path,
+            fallback,
+        )
         storage_infra = LocalStorageInfrastructure(fallback)
 
     db_resource = DatabaseResource(duckdb)

--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -2,6 +2,7 @@ from .base import BaseInfrastructure
 from .duckdb_infra import DuckDBInfrastructure
 from .local_storage_infra import LocalStorageInfrastructure
 from .ollama_infra import OllamaInfrastructure
+from .ollama_installer import OllamaInstaller
 from .s3_infra import S3Infrastructure
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "DuckDBInfrastructure",
     "LocalStorageInfrastructure",
     "OllamaInfrastructure",
+    "OllamaInstaller",
     "S3Infrastructure",
 ]

--- a/src/entity/infrastructure/duckdb_infra.py
+++ b/src/entity/infrastructure/duckdb_infra.py
@@ -65,6 +65,8 @@ class DuckDBInfrastructure(BaseInfrastructure):
         try:
             with self.connect() as conn:
                 conn.execute("SELECT 1")
+            self.logger.debug("Health check succeeded for %s", self.file_path)
             return True
-        except Exception:
+        except Exception as exc:
+            self.logger.warning("Health check failed for %s: %s", self.file_path, exc)
             return False

--- a/src/entity/infrastructure/local_storage_infra.py
+++ b/src/entity/infrastructure/local_storage_infra.py
@@ -11,7 +11,7 @@ class LocalStorageInfrastructure(BaseInfrastructure):
 
         super().__init__(version)
         self.base_path = Path(base_path)
-        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.base_path.mkdir(parents=True, exist_ok=True, mode=0o755)
 
     def resolve_path(self, key: str) -> Path:
         """Return the absolute path for the given storage key."""
@@ -24,8 +24,10 @@ class LocalStorageInfrastructure(BaseInfrastructure):
             test_file = self.base_path / ".health_check"
             test_file.write_text("ok")
             test_file.unlink()
+            self.logger.debug("Health check succeeded for %s", self.base_path)
             return True
-        except Exception:
+        except Exception as exc:
+            self.logger.warning("Health check failed for %s: %s", self.base_path, exc)
             return False
 
     async def startup(self) -> None:  # pragma: no cover - thin wrapper

--- a/src/entity/infrastructure/ollama_infra.py
+++ b/src/entity/infrastructure/ollama_infra.py
@@ -36,6 +36,8 @@ class OllamaInfrastructure(BaseInfrastructure):
         try:
             response = httpx.get(f"{self.base_url}/api/tags", timeout=2)
             response.raise_for_status()
+            self.logger.debug("Health check succeeded for %s", self.base_url)
             return True
-        except Exception:
+        except Exception as exc:
+            self.logger.warning("Health check failed for %s: %s", self.base_url, exc)
             return False

--- a/src/entity/infrastructure/ollama_installer.py
+++ b/src/entity/infrastructure/ollama_installer.py
@@ -1,0 +1,34 @@
+import logging
+import subprocess
+
+
+class OllamaInstaller:
+    """Attempt to install the Ollama server locally."""
+
+    @classmethod
+    def ensure_installed(cls) -> None:
+        logger = logging.getLogger(cls.__name__)
+        try:
+            subprocess.run(
+                ["ollama", "--version"],
+                check=True,
+                capture_output=True,
+                timeout=5,
+            )
+            logger.debug("Ollama already installed")
+            return
+        except Exception as exc:
+            logger.debug("Ollama not found: %s", exc)
+
+        logger.info("Attempting automatic Ollama installation")
+        try:
+            subprocess.run(
+                "curl -fsSL https://ollama.com/install.sh | sh",
+                shell=True,
+                check=True,
+                timeout=5,
+                capture_output=True,
+            )
+            logger.info("Ollama installation complete")
+        except Exception as exc:
+            logger.warning("Automatic installation failed: %s", exc)


### PR DESCRIPTION
## Summary
- attempt to auto-install Ollama before falling back to stub
- add more detailed health check logging
- ensure directories have proper permissions
- update `load_defaults` with debug logs and improved fallbacks

## Testing
- `poetry run black src tests`
- `poetry run poe test`


------
https://chatgpt.com/codex/tasks/task_e_68841270a9208322ac48f208ab48836c