### PR TITLE
Update examples for automatic defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,10 @@
 Python agent framework
 
 ## Examples
-First start the local services:
-
-```bash
-docker compose up -d
-```
-
-Then run `python examples/zero_config_agent.py` for a minimal CLI demo or
+Run `python examples/zero_config_agent.py` for a minimal CLI demo or
 `python examples/advanced_workflow.py` to see a multi-stage workflow in action.
+Resources are prepared automatically using ``load_defaults()`` so Docker is no
+longer required for these examples.
 The old `[examples]` extra has been removed.
 
 ### Workflow Templates

--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-"""Demonstrate a multi-stage agent with Docker services.
+"""Demonstrate a multi-stage agent.
 
-Run the supporting containers first:
-
-```
-docker compose up -d
-```
+All resources are prepared automatically. Any initialization errors are
+reported to the console.
 """
 
 import asyncio
@@ -21,7 +18,12 @@ class DummyLLM:
 
 
 async def main() -> None:
-    resources = load_defaults()
+    try:
+        resources = load_defaults()
+    except Exception as exc:  # pragma: no cover - example runtime guard
+        print(f"Failed to initialize resources: {exc}")
+        return
+
     resources["llm"] = DummyLLM()
     agent = Agent.from_workflow("examples/advanced_workflow.yaml", resources=resources)
     result = await agent.chat("2 + 2")

--- a/examples/factory_methods.py
+++ b/examples/factory_methods.py
@@ -1,27 +1,34 @@
 """Demonstrate Agent factory helpers.
 
-Start the service stack before running:
-
-```
-docker compose up -d
-```
+Resources are created with :func:`load_defaults`. Any initialization
+errors are printed and the example exits cleanly.
 """
 
 from entity.core.agent import Agent
+from entity.defaults import load_defaults
 
+
+try:
+    default_resources = load_defaults()
+except Exception as exc:  # pragma: no cover - example runtime guard
+    print(f"Failed to initialize resources: {exc}")
+    raise SystemExit(1)
 
 # Build from a workflow template
-agent_from_template = Agent.from_workflow("basic")
+agent_from_template = Agent.from_workflow("basic", resources=default_resources)
 
 # Build from a dictionary mapping stages to plugins
 agent_from_dict = Agent.from_workflow_dict(
     {
         "think": ["entity.plugins.defaults.ThinkPlugin"],
         "output": ["entity.plugins.defaults.OutputPlugin"],
-    }
+    },
+    resources=default_resources,
 )
 
 # Build from a configuration file
-agent_from_config = Agent.from_config("examples/basic_config.yaml")
+agent_from_config = Agent.from_config(
+    "examples/basic_config.yaml", resources=default_resources
+)
 
 print(agent_from_template, agent_from_dict, agent_from_config)

--- a/examples/zero_config_agent.py
+++ b/examples/zero_config_agent.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
 
-"""Run a minimal agent with Docker services.
+"""Run a minimal agent using automatic defaults.
 
-Start the dependencies before running this script:
-
-```
-docker compose up -d
-```
+All required resources are prepared on first run. If initialization fails,
+an error message is printed and the program exits.
 """
 
 import asyncio
 
 from entity import Agent
+from entity.defaults import load_defaults
 
 
 async def main() -> None:
-    agent = Agent()
+    try:
+        resources = load_defaults()
+    except Exception as exc:  # pragma: no cover - example runtime guard
+        print(f"Failed to initialize resources: {exc}")
+        return
+
+    agent = Agent(resources=resources)
     await agent.chat("")
 
 


### PR DESCRIPTION
## Summary
- update example scripts to remove docker instructions
- show how to call `load_defaults()`
- catch initialization errors in examples
- clarify README examples section

## Testing
- `poetry run black examples/advanced_workflow.py examples/factory_methods.py examples/zero_config_agent.py` *(success)*
- `poetry run black README.md` *(fails: Cannot parse for target version Python 3.11)*
- `poetry run black examples README.md` *(fails: README not reformatted)*
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68841275e7cc832287f5018bb8dfb588