### PR TITLE
Improve local-first docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
 # Entity Framework
-Python agent framework
+Entity is a Python framework for building AI agents. It runs locally by default and sets up resources automatically.
 
 ## Examples
-First start the local services:
 
-```bash
-docker compose up -d
-```
-
-Then run `python examples/zero_config_agent.py` for a minimal CLI demo or
+Run `python examples/zero_config_agent.py` for a minimal CLI demo or
 `python examples/advanced_workflow.py` to see a multi-stage workflow in action.
 The old `[examples]` extra has been removed.
 
@@ -174,10 +169,9 @@ poetry run poe test-with-docker
 This task brings the containers up, runs all tests marked `integration` in
 parallel, and then tears the services down so no state is shared between runs.
 
-## Docker Usage
+## Advanced Setup
 
-Spin up the local services defined in `docker-compose.yml`.
-The `ollama` service is built from the provided Dockerfile:
+Optional services are provided in `docker-compose.yml`. Use them when you need Postgres or Ollama:
 
 ```bash
 docker compose build ollama
@@ -185,6 +179,4 @@ docker compose up -d
 # run agents or tests here
 docker compose down -v
 ```
-
-See `install_docker.sh` for an automated install script on Ubuntu.
-
+See `install_docker.sh` for an automated install script on Ubuntu. Detailed deployment steps live in `docs/production_deployment.md`. For help migrating away from Docker, check `docs/migration_from_docker.md`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
+# Optional stack for integration tests or production.
+# The framework runs locally without these services.
 version: '3.8'
 
 services:
+  # Optional Postgres database for tests
   postgres:
     image: pgvector/pgvector:pg16
     env_file:
@@ -18,7 +21,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
-
+  # Optional LLM service for development
   ollama:
     build: .
     image: entity-ollama

--- a/docs/migration_from_docker.md
+++ b/docs/migration_from_docker.md
@@ -1,0 +1,8 @@
+# Migrating from Docker
+
+Earlier versions recommended running `docker compose up` before using the framework.
+Local execution no longer requires these containers.
+
+1. Stop any running compose stack with `docker compose down -v`.
+2. Run your agent scripts directly. `load_defaults()` will create a DuckDB database and local storage automatically.
+3. Only start `docker compose` again when you need Postgres or Ollama for production or integration tests.

--- a/docs/production_deployment.md
+++ b/docs/production_deployment.md
@@ -1,0 +1,25 @@
+# Production Deployment
+
+This project can run entirely on your machine, but you can containerize the services for a reproducible environment.
+
+1. Build the `ollama` image provided in the repository:
+
+```bash
+docker compose build ollama
+```
+
+2. Start the stack in the background:
+
+```bash
+docker compose up -d
+```
+
+3. Run agents or tests as needed while the services are running.
+
+4. When finished, shut everything down and remove volumes:
+
+```bash
+docker compose down -v
+```
+
+See `install_docker.sh` for a quick installation script on Ubuntu.

--- a/src/entity/cli/__main__.py
+++ b/src/entity/cli/__main__.py
@@ -41,7 +41,9 @@ def _load_workflow(name: str) -> list[type] | dict[str, list[type]]:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run an Entity workflow")
+    parser = argparse.ArgumentParser(
+        description="Run an Entity workflow locally with automatic resource setup"
+    )
     parser.add_argument(
         "--workflow",
         default="default",


### PR DESCRIPTION
## Summary
- clarify local-first setup in the README
- move docker usage docs into a new advanced section
- add production deployment instructions
- document how to migrate away from docker
- mention local-first behavior in CLI help
- note docker compose file is optional

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68841278332c83228d93aa821d978f89