### PR TITLE
Improve local testing setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ python_functions = ["test_*"]
 
 # Make sure src is in the Python path for pytest
 pythonpath = ["src"]
+env = { ENTITY_TEST_MODE = "local" }
 
 addopts = [
     "-v",
@@ -144,6 +145,7 @@ markers = [
     "cli: Tests related to CLI interface",
     "benchmark: Performance benchmarking tests",
     "examples: Tests that run example scripts",
+    "docker: Tests that require Docker",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,19 @@
+import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent))
+from fixtures.local_resources import (
+    local_duckdb_path,
+    local_storage_dir,
+    mock_ollama_server,
+)
+
+ENTITY_TEST_MODE = os.getenv("ENTITY_TEST_MODE", "local")
 
 COMPOSE_FILE = Path(__file__).resolve().parents[1] / "docker-compose.yml"
 
@@ -25,5 +36,7 @@ def compose_services():
 
 def pytest_collection_modifyitems(config, items):
     for item in items:
-        if "integration" in item.keywords:
+        if "docker" in item.keywords:
+            item.fixturenames.append("compose_services")
+        elif ENTITY_TEST_MODE == "docker" and "integration" in item.keywords:
             item.fixturenames.append("compose_services")

--- a/tests/fixtures/local_resources.py
+++ b/tests/fixtures/local_resources.py
@@ -1,0 +1,62 @@
+import json
+import http.server
+import socketserver
+import threading
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def local_duckdb_path(tmp_path: Path) -> Path:
+    path = tmp_path / "db.duckdb"
+    yield path
+    if path.exists():
+        path.unlink()
+
+
+@pytest.fixture()
+def local_storage_dir(tmp_path: Path) -> Path:
+    path = tmp_path / "storage"
+    path.mkdir()
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+class _OllamaHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # pragma: no cover - simple mock
+        if self.path == "/api/tags":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"{}")
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:  # pragma: no cover - simple mock
+        if self.path == "/api/generate":
+            length = int(self.headers.get("content-length", 0))
+            data = json.loads(self.rfile.read(length)) if length else {}
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            resp = json.dumps({"response": data.get("prompt", "")})
+            self.wfile.write(resp.encode())
+        else:
+            self.send_error(404)
+
+    def log_message(self, *args) -> None:  # pragma: no cover - silence log
+        return
+
+
+@pytest.fixture()
+def mock_ollama_server() -> str:
+    with socketserver.TCPServer(("localhost", 0), _OllamaHandler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        url = f"http://localhost:{server.server_address[1]}"
+        try:
+            yield url
+        finally:
+            server.shutdown()
+            thread.join()

--- a/tests/test_config_substitution_docker.py
+++ b/tests/test_config_substitution_docker.py
@@ -8,6 +8,7 @@ import pytest
 
 
 @pytest.mark.integration
+@pytest.mark.docker
 @pytest.mark.skipif(shutil.which("docker") is None, reason="docker not installed")
 def test_nested_substitution_in_docker(tmp_path):
     env_file = tmp_path / ".env"

--- a/tests/test_infrastructure_docker.py
+++ b/tests/test_infrastructure_docker.py
@@ -27,6 +27,7 @@ async def test_local_storage_startup_shutdown(tmp_path):
 
 
 @pytest.mark.integration
+@pytest.mark.docker
 @pytest.mark.skipif(shutil.which("docker") is None, reason="docker not installed")
 @pytest.mark.asyncio
 async def test_ollama_health(compose_services):

--- a/tests/test_logging_metrics.py
+++ b/tests/test_logging_metrics.py
@@ -60,6 +60,7 @@ async def test_logging_and_metrics_per_stage():
 
 
 @pytest.mark.integration
+@pytest.mark.docker
 @pytest.mark.skipif(shutil.which("docker") is None, reason="docker not installed")
 def test_docker_logging_metrics(tmp_path):
     script = "\n".join(

--- a/tests/test_template_loader_docker.py
+++ b/tests/test_template_loader_docker.py
@@ -6,6 +6,7 @@ import pytest
 
 
 @pytest.mark.integration
+@pytest.mark.docker
 @pytest.mark.skipif(shutil.which("docker") is None, reason="docker not installed")
 def test_template_loading_in_docker(tmp_path):
     script = "\n".join(


### PR DESCRIPTION
## Summary
- add fixtures for local DuckDB, local storage, and mock Ollama
- control docker startup via `ENTITY_TEST_MODE`
- mark docker-only tests with `@pytest.mark.docker`
- set default `ENTITY_TEST_MODE` in pytest config

## Testing
- `poetry run poe test` *(fails: subprocess.TimeoutExpired)*
- `ENTITY_TEST_MODE=docker poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6884127402cc8322a82aac48cb6d482d