### PR TITLE
Remove outdated CLI timeout test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,22 +69,4 @@ def test_cli_unknown_workflow():
     assert "not found" in proc.stderr.lower()
 
 
-@pytest.mark.integration
-def test_cli_timeout_flag():
-    workflow_file = Path("tests/data/slow_workflow.yaml")
-    proc = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "entity.cli",
-            "--workflow",
-            str(workflow_file),
-            "--timeout",
-            "10",
-        ],
-        input="sleep\n",
-        capture_output=True,
-        text=True,
-        timeout=15,
-    )
-    assert "timed out" in proc.stderr.lower()
+# TODO: Timeout functionality removed - not part of MVP scope


### PR DESCRIPTION
## Summary
- delete CLI timeout test that referenced removed `--timeout` argument
- tidy CLI tests

## Testing
- `poetry run black src tests`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6884225ff06c8322bff181f3ed021586