### PR TITLE
Fix examples to skip Ollama install

### DIFF
--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -9,7 +9,7 @@ reported to the console.
 import asyncio
 
 from entity.core.agent import Agent
-from entity.defaults import load_defaults
+from entity.defaults import DefaultConfig, load_defaults
 
 
 class DummyLLM:
@@ -19,7 +19,7 @@ class DummyLLM:
 
 async def main() -> None:
     try:
-        resources = load_defaults()
+        resources = load_defaults(DefaultConfig(auto_install_ollama=False))
     except Exception as exc:  # pragma: no cover - example runtime guard
         print(f"Failed to initialize resources: {exc}")
         return

--- a/examples/zero_config_agent.py
+++ b/examples/zero_config_agent.py
@@ -9,12 +9,12 @@ an error message is printed and the program exits.
 import asyncio
 
 from entity import Agent
-from entity.defaults import load_defaults
+from entity.defaults import DefaultConfig, load_defaults
 
 
 async def main() -> None:
     try:
-        resources = load_defaults()
+        resources = load_defaults(DefaultConfig(auto_install_ollama=False))
     except Exception as exc:  # pragma: no cover - example runtime guard
         print(f"Failed to initialize resources: {exc}")
         return


### PR DESCRIPTION
## Summary
- stop Ollama install in `advanced_workflow.py`
- stop Ollama install in `zero_config_agent.py`

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: executable 'docker' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68842ae82aac8322845edee909382ae4