### PR TITLE
Remove outdated timeout comment

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,3 @@ def test_cli_unknown_workflow():
     )
     assert proc.returncode != 0
     assert "not found" in proc.stderr.lower()
-
-
-# TODO: Timeout functionality removed - not part of MVP scope


### PR DESCRIPTION
## Summary
- fully delete leftover TODO around CLI timeout flag

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: executable 'docker' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68842c347354832281f33e0555f0af9d