### PR TITLE
Update advanced workflow example

### DIFF
--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -9,22 +9,16 @@ reported to the console.
 import asyncio
 
 from entity.core.agent import Agent
-from entity.defaults import DefaultConfig, load_defaults
-
-
-class DummyLLM:
-    async def generate(self, prompt: str) -> str:  # pragma: no cover - example
-        return "dummy"
+from entity.defaults import load_defaults
 
 
 async def main() -> None:
     try:
-        resources = load_defaults(DefaultConfig(auto_install_ollama=False))
+        resources = load_defaults()
     except Exception as exc:  # pragma: no cover - example runtime guard
         print(f"Failed to initialize resources: {exc}")
         return
 
-    resources["llm"] = DummyLLM()
     agent = Agent.from_workflow("examples/advanced_workflow.yaml", resources=resources)
     result = await agent.chat("2 + 2")
     print(result["response"])

--- a/src/entity/defaults.py
+++ b/src/entity/defaults.py
@@ -53,7 +53,7 @@ class DefaultConfig:
 class _NullLLMInfrastructure:
     """Fallback LLM implementation used when Ollama is unavailable."""
 
-    def generate(self, prompt: str) -> str:  # pragma: no cover - simple stub
+    async def generate(self, prompt: str) -> str:  # pragma: no cover - simple stub
         return "LLM service unavailable"
 
     def health_check(self) -> bool:  # pragma: no cover - constant result

--- a/tests/examples/test_advanced_workflow.py
+++ b/tests/examples/test_advanced_workflow.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.mark.examples
 def test_advanced_workflow():
-    env = dict(os.environ, PYTHONPATH="src")
+    env = dict(os.environ, PYTHONPATH="src", ENTITY_AUTO_INSTALL_OLLAMA="false")
     proc = subprocess.run(
         [sys.executable, "examples/advanced_workflow.py"],
         capture_output=True,


### PR DESCRIPTION
## Summary
- simplify advanced workflow example to rely on standard defaults
- avoid auto-installing Ollama in the example test
- make `_NullLLMInfrastructure.generate` async so examples run without a real LLM

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_68844d47e8588322b9d00ed80b4cebdb