### PR TITLE
Add automatic Ollama setup

### DIFF
--- a/src/entity/defaults.py
+++ b/src/entity/defaults.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
 from entity.infrastructure.ollama_infra import OllamaInfrastructure
 from entity.infrastructure.local_storage_infra import LocalStorageInfrastructure
-from entity.installers.ollama import OllamaInstaller
+from entity.setup.ollama_installer import OllamaInstaller
 from entity.resources import (
     DatabaseResource,
     VectorStoreResource,
@@ -68,9 +68,7 @@ def load_defaults(config: DefaultConfig | None = None) -> dict[str, object]:
     logger = logging.getLogger("defaults")
 
     if cfg.auto_install_ollama:
-        from entity.installers.ollama import OllamaInstaller
-
-        OllamaInstaller.ensure_installed()
+        OllamaInstaller.ensure_ollama_available(cfg.ollama_model)
 
     duckdb = DuckDBInfrastructure(cfg.duckdb_path)
     if not duckdb.health_check():
@@ -85,16 +83,12 @@ def load_defaults(config: DefaultConfig | None = None) -> dict[str, object]:
     logger.debug("Checking local Ollama at %s", cfg.ollama_url)
     if ollama.health_check():
         if cfg.auto_install_ollama:
-            from entity.installers.ollama import OllamaInstaller
-
-            OllamaInstaller.pull_default_model(cfg.ollama_model)
+            OllamaInstaller.ensure_ollama_available(cfg.ollama_model)
     else:
         logger.debug("Ollama not reachable; attempting installation")
         if cfg.auto_install_ollama:
-            OllamaInstaller.ensure_installed()
-            if ollama.health_check():
-                OllamaInstaller.pull_default_model(cfg.ollama_model)
-            else:
+            OllamaInstaller.ensure_ollama_available(cfg.ollama_model)
+            if not ollama.health_check():
                 logger.warning("Using stub LLM implementation")
                 ollama = _NullLLMInfrastructure()
         else:

--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -2,7 +2,6 @@ from .base import BaseInfrastructure
 from .duckdb_infra import DuckDBInfrastructure
 from .local_storage_infra import LocalStorageInfrastructure
 from .ollama_infra import OllamaInfrastructure
-from .ollama_installer import OllamaInstaller
 from .s3_infra import S3Infrastructure
 
 __all__ = [
@@ -10,6 +9,5 @@ __all__ = [
     "DuckDBInfrastructure",
     "LocalStorageInfrastructure",
     "OllamaInfrastructure",
-    "OllamaInstaller",
     "S3Infrastructure",
 ]

--- a/src/entity/setup/__init__.py
+++ b/src/entity/setup/__init__.py
@@ -1,0 +1,5 @@
+"""Setup utilities for initializing Entity's local environment."""
+
+from .ollama_installer import OllamaInstaller
+
+__all__ = ["OllamaInstaller"]

--- a/src/entity/setup/ollama_installer.py
+++ b/src/entity/setup/ollama_installer.py
@@ -1,0 +1,111 @@
+"""Utilities for automatically setting up the Ollama service."""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import time
+from typing import Final
+
+import httpx
+
+# TODO: Expose installation paths and URLs via configuration
+
+
+class OllamaInstaller:
+    """Handle installation and startup of the local Ollama service."""
+
+    DEFAULT_MODEL: Final[str] = "llama3.2:3b"
+    DEFAULT_URL: Final[str] = "http://localhost:11434"
+
+    logger = logging.getLogger(__name__)
+
+    @classmethod
+    def ensure_ollama_available(cls, model: str | None = None) -> None:
+        """Install and start Ollama if required."""
+
+        model = model or cls.DEFAULT_MODEL
+        auto_install_env = os.getenv("ENTITY_AUTO_INSTALL_OLLAMA", "true").lower()
+        auto_install = auto_install_env in {"1", "true", "yes"}
+
+        if not auto_install:
+            cls.logger.debug("Auto install disabled via environment")
+            return
+
+        if not shutil.which("ollama"):
+            cls.logger.info("Ollama binary not found; attempting install")
+            cls._install_ollama()
+        else:
+            cls.logger.debug("Ollama binary already present")
+
+        if not cls._service_healthy():
+            cls.logger.info("Starting local Ollama service")
+            cls._start_service()
+            if not cls._wait_for_service():
+                cls.logger.warning("Ollama service failed to start")
+                return
+
+        cls._pull_model(model)
+
+    # Installation helpers -------------------------------------------------
+    @classmethod
+    def _install_ollama(cls) -> None:
+        system = platform.system()
+        try:
+            if system == "Darwin":
+                subprocess.run(["brew", "install", "ollama"], check=True)
+            elif system == "Linux":
+                subprocess.run(
+                    ["bash", "-c", "curl -fsSL https://ollama.com/install.sh | sh"],
+                    check=True,
+                )
+            elif system == "Windows":
+                subprocess.run(
+                    ["winget", "install", "-e", "--id", "Ollama.Ollama"],
+                    check=True,
+                )
+            else:
+                cls.logger.warning("Unsupported platform: %s", system)
+        except subprocess.CalledProcessError as exc:
+            cls.logger.error("Failed to install Ollama: %s", exc)
+
+    # Service management ---------------------------------------------------
+    @classmethod
+    def _start_service(cls) -> None:
+        try:
+            subprocess.Popen(
+                ["ollama", "serve"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            time.sleep(0.5)  # Give subprocess a moment
+            # TODO: Consider platform specific service managers
+        except Exception as exc:  # pragma: no cover - rare
+            cls.logger.error("Unable to start Ollama service: %s", exc)
+
+    @classmethod
+    def _service_healthy(cls) -> bool:
+        try:
+            httpx.get(f"{cls.DEFAULT_URL}/api/tags", timeout=1).raise_for_status()
+            return True
+        except Exception:
+            return False
+
+    @classmethod
+    def _wait_for_service(cls, retries: int = 5, delay: float = 1.0) -> bool:
+        for _ in range(retries):
+            if cls._service_healthy():
+                return True
+            time.sleep(delay)
+        return False
+
+    # Model helpers --------------------------------------------------------
+    @classmethod
+    def _pull_model(cls, model: str) -> None:
+        try:
+            subprocess.run(["ollama", "pull", model], check=True)
+        except subprocess.CalledProcessError as exc:
+            cls.logger.error("Failed to pull model %s: %s", model, exc)


### PR DESCRIPTION
## Summary
- add new setup package for Ollama installation and startup
- retry Ollama health checks and call installer from defaults
- remove old installer exports

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688456852b008322a00507c76b7f329f