### PR TITLE
Enhance advanced workflow example

### DIFF
--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -10,14 +10,29 @@ import asyncio
 
 from entity.core.agent import Agent
 from entity.defaults import load_defaults
+from entity.setup.ollama_installer import OllamaInstaller
 
 
 async def main() -> None:
     try:
         resources = load_defaults()
     except Exception as exc:  # pragma: no cover - example runtime guard
-        print(f"Failed to initialize resources: {exc}")
+        print(
+            "Failed to initialize resources. "
+            "Automatic Ollama installation may have failed.\n"
+            "Try installing manually with:\n"
+            "  curl -fsSL https://ollama.com/install.sh | sh\n"
+            "or set ENTITY_AUTO_INSTALL_OLLAMA=false to skip.\n"
+            f"Details: {exc}"
+        )
         return
+
+    if not resources["llm"].health_check():
+        print(
+            "Warning: Ollama service is unreachable. "
+            "Ensure it is running on http://localhost:11434 "
+            "if results seem incorrect."
+        )
 
     agent = Agent.from_workflow("examples/advanced_workflow.yaml", resources=resources)
     result = await agent.chat("2 + 2")

--- a/tests/examples/test_advanced_workflow.py
+++ b/tests/examples/test_advanced_workflow.py
@@ -1,18 +1,26 @@
+import asyncio
 import os
-import subprocess
 import sys
 
 import pytest
 
 
 @pytest.mark.examples
-def test_advanced_workflow():
-    env = dict(os.environ, PYTHONPATH="src", ENTITY_AUTO_INSTALL_OLLAMA="false")
-    proc = subprocess.run(
-        [sys.executable, "examples/advanced_workflow.py"],
-        capture_output=True,
-        text=True,
-        timeout=5,
-        env=env,
+@pytest.mark.asyncio
+async def test_advanced_workflow(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "entity.setup.ollama_installer.OllamaInstaller.ensure_ollama_available",
+        lambda model=None: None,
     )
-    assert proc.stdout.strip() == "Result: 4"
+    monkeypatch.setattr(
+        "entity.infrastructure.ollama_infra.OllamaInfrastructure.health_check",
+        lambda self: False,
+    )
+    sys.path.insert(0, "src")
+    sys.path.insert(0, ".")
+    import importlib
+
+    mod = importlib.import_module("examples.advanced_workflow")
+    await mod.main()
+    captured = capsys.readouterr()
+    assert captured.out.strip().endswith("Result: 4")


### PR DESCRIPTION
## Summary
- tweak the advanced workflow example to print helpful installation errors
- run the example test asynchronously and without extra env vars

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6884587153888322aee1d186f810b890