### PR TITLE
Add LLM infrastructure protocol

### DIFF
--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -3,6 +3,7 @@ from .duckdb_infra import DuckDBInfrastructure
 from .local_storage_infra import LocalStorageInfrastructure
 from .ollama_infra import OllamaInfrastructure
 from .s3_infra import S3Infrastructure
+from .vllm_infra import VLLMInfrastructure
 
 __all__ = [
     "BaseInfrastructure",
@@ -10,4 +11,5 @@ __all__ = [
     "LocalStorageInfrastructure",
     "OllamaInfrastructure",
     "S3Infrastructure",
+    "VLLMInfrastructure",
 ]

--- a/src/entity/infrastructure/vllm_infra.py
+++ b/src/entity/infrastructure/vllm_infra.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import httpx
+
+from .base import BaseInfrastructure
+
+
+class VLLMInfrastructure(BaseInfrastructure):
+    """Layer 1 infrastructure for a vLLM server."""
+
+    def __init__(self, base_url: str, model: str, version: str | None = None) -> None:
+        super().__init__(version)
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    async def generate(self, prompt: str) -> str:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/generate",
+                json={"model": self.model, "prompt": prompt},
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("response", data.get("text", ""))
+
+    def health_check(self) -> bool:
+        try:
+            response = httpx.get(f"{self.base_url}/health", timeout=2)
+            response.raise_for_status()
+            return True
+        except Exception:
+            return False

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -3,6 +3,7 @@
 from entity.resources.database import DatabaseResource
 from entity.resources.vector_store import VectorStoreResource
 from entity.resources.llm import LLMResource
+from entity.resources.llm_protocol import LLMInfrastructure
 from entity.resources.storage import StorageResource
 from entity.resources.local_storage import LocalStorageResource
 from entity.resources.exceptions import ResourceInitializationError
@@ -16,6 +17,7 @@ __all__ = [
     "DatabaseResource",
     "VectorStoreResource",
     "LLMResource",
+    "LLMInfrastructure",
     "StorageResource",
     "LocalStorageResource",
     "ResourceInitializationError",

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -1,17 +1,17 @@
-"""Resource wrapper around an Ollama LLM deployment."""
+"""Resource wrapper around an LLM infrastructure."""
 
-from entity.infrastructure.ollama_infra import OllamaInfrastructure
 from entity.resources.exceptions import ResourceInitializationError
+from .llm_protocol import LLMInfrastructure
 
 
 class LLMResource:
-    """Layer 2 resource that wraps an Ollama LLM."""
+    """Layer 2 resource that wraps an LLM infrastructure."""
 
-    def __init__(self, infrastructure: OllamaInfrastructure | None) -> None:
-        """Initialize with the Ollama infrastructure instance."""
+    def __init__(self, infrastructure: LLMInfrastructure | None) -> None:
+        """Initialize with the infrastructure instance."""
 
         if infrastructure is None:
-            raise ResourceInitializationError("OllamaInfrastructure is required")
+            raise ResourceInitializationError("LLM infrastructure is required")
         self.infrastructure = infrastructure
 
     def health_check(self) -> bool:

--- a/src/entity/resources/llm_protocol.py
+++ b/src/entity/resources/llm_protocol.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LLMInfrastructure(Protocol):
+    """Protocol for infrastructures used by :class:`LLMResource`."""
+
+    async def generate(self, prompt: str) -> str:
+        """Generate a completion for ``prompt``."""
+
+    def health_check(self) -> bool:
+        """Return ``True`` if the infrastructure is healthy."""

--- a/tests/resources/test_resource_initialization.py
+++ b/tests/resources/test_resource_initialization.py
@@ -13,6 +13,9 @@ from entity.resources import (
 )
 from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
 from entity.infrastructure.local_storage_infra import LocalStorageInfrastructure
+from entity.infrastructure.ollama_infra import OllamaInfrastructure
+from entity.infrastructure.vllm_infra import VLLMInfrastructure
+from entity.resources.llm_protocol import LLMInfrastructure
 
 
 class HealthyInfra:
@@ -66,3 +69,22 @@ def test_constructor_failure():
         LLM(None)
     with pytest.raises(ResourceInitializationError):
         Storage(None)
+
+
+def test_infrastructures_satisfy_protocol():
+    ollama = OllamaInfrastructure("http://localhost", "model", auto_install=False)
+    vllm = VLLMInfrastructure("http://localhost:8000", "model")
+
+    assert isinstance(ollama, LLMInfrastructure)
+    assert isinstance(vllm, LLMInfrastructure)
+
+
+def test_llm_resource_accepts_real_infrastructures():
+    ollama = OllamaInfrastructure("http://localhost", "model", auto_install=False)
+    vllm = VLLMInfrastructure("http://localhost:8000", "model")
+
+    res_ollama = LLMResource(ollama)
+    res_vllm = LLMResource(vllm)
+
+    assert res_ollama.infrastructure is ollama
+    assert res_vllm.infrastructure is vllm


### PR DESCRIPTION
## Summary
- introduce `LLMInfrastructure` protocol for `LLMResource`
- implement `VLLMInfrastructure`
- export new infrastructure and protocol
- update `LLMResource` to use protocol
- test protocol compliance of Ollama and vLLM infrastructures

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6884c7186e6c83228350d0131a445412