### PR TITLE
Add structured logging to plugins

### DIFF
--- a/src/entity/resources/logging.py
+++ b/src/entity/resources/logging.py
@@ -3,7 +3,42 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, asdict
 from datetime import datetime
-from typing import Any, Dict, List
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class LogLevel(Enum):
+    """Supported log levels."""
+
+    DEBUG = "debug"
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class LogCategory(Enum):
+    """High level categories for structured log events."""
+
+    PLUGIN_LIFECYCLE = "plugin_lifecycle"
+    USER_ACTION = "user_action"
+    RESOURCE_ACCESS = "resource_access"
+    TOOL_USAGE = "tool_usage"
+    MEMORY_OPERATION = "memory_operation"
+    WORKFLOW_EXECUTION = "workflow_execution"
+    PERFORMANCE = "performance"
+    ERROR = "error"
+
+
+@dataclass
+class LogContext:
+    """Contextual fields automatically injected into each log entry."""
+
+    user_id: str
+    workflow_id: Optional[str] = None
+    stage: Optional[str] = None
+    plugin_name: Optional[str] = None
+    execution_id: Optional[str] = None
 
 
 @dataclass
@@ -29,13 +64,27 @@ class LoggingResource:
 
         return True
 
-    async def log(self, level: str, message: str, **fields: Any) -> None:
+    async def log(
+        self,
+        level: LogLevel,
+        category: LogCategory,
+        message: str,
+        context: LogContext | None = None,
+        **extra_fields: Any,
+    ) -> None:
         """Store a log entry if ``level`` is above the configured threshold."""
 
-        if self.LEVELS.get(level, 0) < self.LEVELS.get(self.level, 0):
+        level_str = level.value
+        if self.LEVELS.get(level_str, 0) < self.LEVELS.get(self.level, 0):
             return
+
+        fields: Dict[str, Any] = {"category": category.value}
+        if context is not None:
+            fields.update({k: v for k, v in asdict(context).items() if v is not None})
+        fields.update(extra_fields)
+
         record = LogRecord(
-            level=level,
+            level=level_str,
             message=message,
             timestamp=datetime.utcnow().isoformat(),
             fields=fields,

--- a/tests/test_context_logging.py
+++ b/tests/test_context_logging.py
@@ -1,0 +1,21 @@
+import pytest
+from entity.plugins.context import PluginContext
+from entity.resources.logging import LogLevel, LogCategory, LoggingResource
+from entity.resources.memory import Memory
+from entity.resources.database import DatabaseResource
+from entity.resources.vector_store import VectorStoreResource
+from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
+
+
+@pytest.mark.asyncio
+async def test_context_log_injects_ids():
+    infra = DuckDBInfrastructure(":memory:")
+    memory = Memory(DatabaseResource(infra), VectorStoreResource(infra))
+    ctx = PluginContext({"memory": memory, "logging": LoggingResource()}, user_id="u")
+    await ctx.log(LogLevel.INFO, LogCategory.USER_ACTION, "hello")
+    record = ctx.get_resource("logging").records[0]
+    fields = record["fields"]
+    assert fields["user_id"] == "u"
+    assert fields.get("workflow_id")
+    assert fields.get("execution_id")
+    assert fields["category"] == LogCategory.USER_ACTION.value

--- a/tests/test_logging_metrics.py
+++ b/tests/test_logging_metrics.py
@@ -3,6 +3,7 @@ import pytest
 from entity.workflow import Workflow, WorkflowExecutor
 from entity.plugins.base import Plugin
 from entity.plugins.context import PluginContext
+from entity.resources.logging import LogCategory
 from entity.resources.memory import Memory
 from entity.resources.database import DatabaseResource
 from entity.resources.vector_store import VectorStoreResource
@@ -42,9 +43,15 @@ async def test_logging_and_metrics_per_stage():
     logs = executor.resources["logging"].records
     metrics = executor.resources["metrics_collector"].records
 
-    assert [r["fields"]["stage"] for r in logs] == [
+    assert [r["fields"]["category"] for r in logs[:2]] == [
+        LogCategory.PLUGIN_LIFECYCLE.value,
+        LogCategory.PLUGIN_LIFECYCLE.value,
+    ]
+    assert [r["fields"]["stage"] for r in logs[:2]] == [
         WorkflowExecutor.THINK,
         WorkflowExecutor.THINK,
+    ]
+    assert [r["fields"]["stage"] for r in logs[2:]] == [
         WorkflowExecutor.OUTPUT,
         WorkflowExecutor.OUTPUT,
     ]


### PR DESCRIPTION
## Summary
- extend PluginContext with automatic LogContext generation and log helper
- augment LoggingResource with LogLevel, LogCategory, and LogContext support
- update Plugin to capture detailed lifecycle events and resource access
- add tests for new logging features

## Testing
- `poetry run poe test` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6884c71a4c108322872322fceaf1e825