### PR TITLE
Add vLLM infra and logging tests

### DIFF
--- a/src/entity/defaults.py
+++ b/src/entity/defaults.py
@@ -8,8 +8,10 @@ from dataclasses import dataclass
 # TODO: Do not use relative imports
 from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
 from entity.infrastructure.ollama_infra import OllamaInfrastructure
+from entity.infrastructure.vllm_infra import VLLMInfrastructure
 from entity.infrastructure.local_storage_infra import LocalStorageInfrastructure
 from entity.setup.ollama_installer import OllamaInstaller
+from entity.setup.vllm_installer import VLLMInstaller
 from entity.resources import (
     DatabaseResource,
     VectorStoreResource,
@@ -32,6 +34,7 @@ class DefaultConfig:
     ollama_model: str = "llama3.2:3b"
     storage_path: str = "./agent_files"
     auto_install_ollama: bool = True
+    auto_install_vllm: bool = True
 
     @classmethod
     def from_env(cls) -> "DefaultConfig":
@@ -45,6 +48,11 @@ class DefaultConfig:
             auto_install_ollama=os.getenv(
                 "ENTITY_AUTO_INSTALL_OLLAMA",
                 str(cls.auto_install_ollama),
+            ).lower()
+            in {"1", "true", "yes"},
+            auto_install_vllm=os.getenv(
+                "ENTITY_AUTO_INSTALL_VLLM",
+                str(cls.auto_install_vllm),
             ).lower()
             in {"1", "true", "yes"},
         )
@@ -67,33 +75,50 @@ def load_defaults(config: DefaultConfig | None = None) -> dict[str, object]:
     cfg = config or DefaultConfig.from_env()
     logger = logging.getLogger("defaults")
 
-    if cfg.auto_install_ollama:
-        OllamaInstaller.ensure_ollama_available(cfg.ollama_model)
+    llm_impl: object | None = None
+
+    if cfg.auto_install_vllm:
+        try:
+            VLLMInstaller.ensure_vllm_available()
+            vllm = VLLMInfrastructure()
+            if vllm.health_check():
+                llm_impl = vllm
+                logger.info("Using vLLM as default LLM")
+        except Exception as exc:  # pragma: no cover - setup issues
+            logger.warning("vLLM setup failed: %s", exc)
+
+    if llm_impl is None:
+        if cfg.auto_install_ollama:
+            OllamaInstaller.ensure_ollama_available(cfg.ollama_model)
 
     duckdb = DuckDBInfrastructure(cfg.duckdb_path)
     if not duckdb.health_check():
         logger.debug("Falling back to in-memory DuckDB")
         duckdb = DuckDBInfrastructure(":memory:")
 
-    ollama = OllamaInfrastructure(
-        cfg.ollama_url,
-        cfg.ollama_model,
-        auto_install=cfg.auto_install_ollama,
-    )
-    logger.debug("Checking local Ollama at %s", cfg.ollama_url)
-    if ollama.health_check():
-        if cfg.auto_install_ollama:
-            OllamaInstaller.ensure_ollama_available(cfg.ollama_model)
-    else:
-        logger.debug("Ollama not reachable; attempting installation")
-        if cfg.auto_install_ollama:
-            OllamaInstaller.ensure_ollama_available(cfg.ollama_model)
-            if not ollama.health_check():
-                logger.warning("Using stub LLM implementation")
-                ollama = _NullLLMInfrastructure()
+    if llm_impl is None:
+        ollama = OllamaInfrastructure(
+            cfg.ollama_url,
+            cfg.ollama_model,
+            auto_install=cfg.auto_install_ollama,
+        )
+        logger.debug("Checking local Ollama at %s", cfg.ollama_url)
+        if ollama.health_check():
+            if cfg.auto_install_ollama:
+                OllamaInstaller.ensure_ollama_available(cfg.ollama_model)
+            llm_impl = ollama
         else:
-            logger.warning("Using stub LLM implementation")
-            ollama = _NullLLMInfrastructure()
+            logger.debug("Ollama not reachable; attempting installation")
+            if cfg.auto_install_ollama:
+                OllamaInstaller.ensure_ollama_available(cfg.ollama_model)
+                if not ollama.health_check():
+                    logger.warning("Using stub LLM implementation")
+                    llm_impl = _NullLLMInfrastructure()
+                else:
+                    llm_impl = ollama
+            else:
+                logger.warning("Using stub LLM implementation")
+                llm_impl = _NullLLMInfrastructure()
 
     storage_infra = LocalStorageInfrastructure(cfg.storage_path)
     if not storage_infra.health_check():
@@ -107,7 +132,7 @@ def load_defaults(config: DefaultConfig | None = None) -> dict[str, object]:
 
     db_resource = DatabaseResource(duckdb)
     vector_resource = VectorStoreResource(duckdb)
-    llm_resource = LLMResource(ollama)
+    llm_resource = LLMResource(llm_impl)
     storage_resource = LocalStorageResource(storage_infra)
 
     return {

--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -2,6 +2,7 @@ from .base import BaseInfrastructure
 from .duckdb_infra import DuckDBInfrastructure
 from .local_storage_infra import LocalStorageInfrastructure
 from .ollama_infra import OllamaInfrastructure
+from .vllm_infra import VLLMInfrastructure
 from .s3_infra import S3Infrastructure
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "DuckDBInfrastructure",
     "LocalStorageInfrastructure",
     "OllamaInfrastructure",
+    "VLLMInfrastructure",
     "S3Infrastructure",
 ]

--- a/src/entity/infrastructure/vllm_infra.py
+++ b/src/entity/infrastructure/vllm_infra.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import httpx
+
+from .base import BaseInfrastructure
+
+
+class VLLMInfrastructure(BaseInfrastructure):
+    """Simple infrastructure wrapper for a vLLM server."""
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8000",
+        model: str | None = None,
+        version: str | None = None,
+    ) -> None:
+        super().__init__(version)
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    async def generate(self, prompt: str) -> str:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/generate",
+                json={"prompt": prompt, "model": self.model},
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("response", "")
+
+    def health_check(self) -> bool:
+        try:
+            httpx.get(f"{self.base_url}/health", timeout=1).raise_for_status()
+            return True
+        except Exception as exc:  # pragma: no cover - network errors
+            self.logger.debug("vLLM health check failed: %s", exc)
+            return False

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -9,7 +9,11 @@ from entity.resources.exceptions import ResourceInitializationError
 from entity.resources.memory import Memory
 from entity.resources.llm_wrapper import LLM
 from entity.resources.storage_wrapper import Storage
-from entity.resources.logging import LoggingResource
+from entity.resources.logging import (
+    LoggingResource,
+    ConsoleLoggingResource,
+    JSONLoggingResource,
+)
 from entity.resources.metrics import MetricsCollectorResource
 
 __all__ = [
@@ -23,5 +27,7 @@ __all__ = [
     "LLM",
     "Storage",
     "LoggingResource",
+    "ConsoleLoggingResource",
+    "JSONLoggingResource",
     "MetricsCollectorResource",
 ]

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -1,17 +1,17 @@
 """Resource wrapper around an Ollama LLM deployment."""
 
-from entity.infrastructure.ollama_infra import OllamaInfrastructure
+from entity.infrastructure.base import BaseInfrastructure
 from entity.resources.exceptions import ResourceInitializationError
 
 
 class LLMResource:
-    """Layer 2 resource that wraps an Ollama LLM."""
+    """Layer 2 resource that wraps an LLM infrastructure."""
 
-    def __init__(self, infrastructure: OllamaInfrastructure | None) -> None:
-        """Initialize with the Ollama infrastructure instance."""
+    def __init__(self, infrastructure: BaseInfrastructure | None) -> None:
+        """Initialize with the infrastructure instance."""
 
         if infrastructure is None:
-            raise ResourceInitializationError("OllamaInfrastructure is required")
+            raise ResourceInitializationError("LLM infrastructure is required")
         self.infrastructure = infrastructure
 
     def health_check(self) -> bool:

--- a/src/entity/setup/__init__.py
+++ b/src/entity/setup/__init__.py
@@ -1,5 +1,6 @@
 """Setup utilities for initializing Entity's local environment."""
 
 from .ollama_installer import OllamaInstaller
+from .vllm_installer import VLLMInstaller
 
-__all__ = ["OllamaInstaller"]
+__all__ = ["OllamaInstaller", "VLLMInstaller"]

--- a/src/entity/setup/vllm_installer.py
+++ b/src/entity/setup/vllm_installer.py
@@ -1,0 +1,20 @@
+"""Utilities for validating local vLLM availability."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+
+
+class VLLMInstaller:
+    """Ensure the vLLM package is installed."""
+
+    logger = logging.getLogger(__name__)
+
+    @classmethod
+    def ensure_vllm_available(cls) -> None:
+        try:
+            importlib.import_module("vllm")
+            cls.logger.debug("vLLM package available")
+        except ModuleNotFoundError:
+            cls.logger.warning("vLLM package not installed")

--- a/tests/test_defaults_vllm.py
+++ b/tests/test_defaults_vllm.py
@@ -1,0 +1,29 @@
+import types
+
+from entity.defaults import load_defaults
+from entity.setup.vllm_installer import VLLMInstaller
+from entity.infrastructure.vllm_infra import VLLMInfrastructure
+from entity.infrastructure.ollama_infra import OllamaInfrastructure
+
+
+def test_load_defaults_prefers_vllm(monkeypatch):
+    monkeypatch.setenv("ENTITY_AUTO_INSTALL_VLLM", "1")
+    monkeypatch.setenv("ENTITY_AUTO_INSTALL_OLLAMA", "0")
+
+    monkeypatch.setattr(VLLMInstaller, "ensure_vllm_available", lambda: None)
+    monkeypatch.setattr(VLLMInfrastructure, "health_check", lambda self: True)
+
+    resources = load_defaults()
+    assert isinstance(resources["llm"].resource.infrastructure, VLLMInfrastructure)
+
+
+def test_load_defaults_fallbacks_to_ollama(monkeypatch):
+    monkeypatch.setenv("ENTITY_AUTO_INSTALL_VLLM", "1")
+    monkeypatch.setenv("ENTITY_AUTO_INSTALL_OLLAMA", "1")
+
+    monkeypatch.setattr(VLLMInstaller, "ensure_vllm_available", lambda: None)
+    monkeypatch.setattr(VLLMInfrastructure, "health_check", lambda self: False)
+    monkeypatch.setattr(OllamaInfrastructure, "health_check", lambda self: True)
+
+    resources = load_defaults()
+    assert isinstance(resources["llm"].resource.infrastructure, OllamaInfrastructure)

--- a/tests/test_logging_output.py
+++ b/tests/test_logging_output.py
@@ -1,0 +1,23 @@
+import json
+import pytest
+
+from entity.resources.logging import ConsoleLoggingResource, JSONLoggingResource
+
+
+@pytest.mark.asyncio
+async def test_console_logging_output(capsys):
+    logger = ConsoleLoggingResource(level="debug")
+    await logger.log("info", "hello", foo="bar")
+    captured = capsys.readouterr()
+    assert "hello" in captured.out
+    assert "foo" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_json_logging_output(capsys):
+    logger = JSONLoggingResource(level="debug")
+    await logger.log("warning", "oops", code=123)
+    captured = capsys.readouterr()
+    data = json.loads(captured.out.strip())
+    assert data["message"] == "oops"
+    assert data["fields"]["code"] == 123

--- a/tests/test_vllm_infra.py
+++ b/tests/test_vllm_infra.py
@@ -1,0 +1,15 @@
+import pytest
+
+from entity.infrastructure.vllm_infra import VLLMInfrastructure
+
+
+def test_vllm_health_check(mock_vllm_server):
+    infra = VLLMInfrastructure(base_url=mock_vllm_server)
+    assert infra.health_check()
+
+
+@pytest.mark.asyncio
+async def test_vllm_generate(mock_vllm_server):
+    infra = VLLMInfrastructure(base_url=mock_vllm_server)
+    out = await infra.generate("ping")
+    assert out == "ping"

--- a/tests/test_vllm_installer.py
+++ b/tests/test_vllm_installer.py
@@ -1,0 +1,20 @@
+import importlib
+
+import pytest
+
+from entity.setup.vllm_installer import VLLMInstaller
+
+
+def test_vllm_installed(monkeypatch):
+    monkeypatch.setattr(importlib, "import_module", lambda name: object())
+    VLLMInstaller.ensure_vllm_available()
+
+
+def test_vllm_missing(monkeypatch, caplog):
+    def _raise(name):
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(importlib, "import_module", _raise)
+    caplog.set_level("WARNING")
+    VLLMInstaller.ensure_vllm_available()
+    assert "not installed" in caplog.text


### PR DESCRIPTION
## Summary
- implement `VLLMInfrastructure` and `VLLMInstaller`
- prefer vLLM in `load_defaults`
- extend logging resource with console and JSON variants
- provide fixtures and tests for new infrastructure and logging
- verify defaults choose vLLM over Ollama when available

## Testing
- `poetry run poe test`
- `poetry run poe test-with-docker` *(fails: executable 'docker' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6884c71cc908832283b80d60dc0d87db