### PR TITLE
Add VLLM infrastructure

### DIFF
--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -2,6 +2,7 @@ from .base import BaseInfrastructure
 from .duckdb_infra import DuckDBInfrastructure
 from .local_storage_infra import LocalStorageInfrastructure
 from .ollama_infra import OllamaInfrastructure
+from .vllm_infra import VLLMInfrastructure
 from .s3_infra import S3Infrastructure
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "DuckDBInfrastructure",
     "LocalStorageInfrastructure",
     "OllamaInfrastructure",
+    "VLLMInfrastructure",
     "S3Infrastructure",
 ]

--- a/src/entity/infrastructure/vllm_infra.py
+++ b/src/entity/infrastructure/vllm_infra.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+import subprocess
+import time
+from typing import Any
+
+import httpx
+
+from .base import BaseInfrastructure
+
+
+class VLLMInfrastructure(BaseInfrastructure):
+    """Layer 1 infrastructure for vLLM serving with automatic resource detection."""
+
+    MODEL_SELECTION_MATRIX = {
+        "high_gpu": {
+            "models": [
+                "meta-llama/Llama-3.1-8b-instruct",
+                "Qwen/Qwen2.5-7B-Instruct",
+            ],
+            "priority": "performance",
+        },
+        "medium_gpu": {
+            "models": ["Qwen/Qwen2.5-3B-Instruct", "microsoft/DialoGPT-medium"],
+            "priority": "balanced",
+        },
+        "low_gpu": {
+            "models": ["Qwen/Qwen2.5-1.5B-Instruct", "Qwen/Qwen2.5-0.5B-Instruct"],
+            "priority": "efficiency",
+        },
+        "cpu_only": {
+            "models": ["Qwen/Qwen2.5-0.5B-Instruct"],
+            "priority": "compatibility",
+        },
+    }
+
+    def __init__(
+        self,
+        model: str | None = None,
+        auto_detect_model: bool = True,
+        gpu_memory_utilization: float = 0.9,
+        port: int | None = None,
+        version: str | None = None,
+    ) -> None:
+        super().__init__(version)
+        self.model = model or (
+            self._detect_optimal_model()
+            if auto_detect_model
+            else "Qwen/Qwen2.5-0.5B-Instruct"
+        )
+        self.gpu_memory_utilization = gpu_memory_utilization
+        self.port = port or self._find_available_port()
+        self._server_process: subprocess.Popen | None = None
+
+    def _find_available_port(self) -> int:
+        with socket.socket() as s:
+            s.bind(("localhost", 0))
+            return s.getsockname()[1]
+
+    def _detect_hardware_tier(self) -> str:
+        try:
+            import torch  # type: ignore
+
+            if torch.cuda.is_available():
+                mem_gb = torch.cuda.get_device_properties(0).total_memory / 1024**3
+                if mem_gb > 16:
+                    return "high_gpu"
+                if mem_gb >= 4:
+                    return "medium_gpu"
+                return "low_gpu"
+        except Exception as exc:  # pragma: no cover - optional dependency
+            self.logger.debug("GPU detection failed: %s", exc)
+        return "cpu_only"
+
+    def _detect_optimal_model(self) -> str:
+        hardware_tier = self._detect_hardware_tier()
+        return self.MODEL_SELECTION_MATRIX[hardware_tier]["models"][0]
+
+    async def startup(self) -> None:
+        await super().startup()
+        if not self._server_process:
+            await self._start_vllm_server()
+
+    async def shutdown(self) -> None:
+        await super().shutdown()
+        if self._server_process and self._server_process.poll() is None:
+            self._server_process.terminate()
+            try:
+                self._server_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:  # pragma: no cover - unlikely
+                self._server_process.kill()
+        self._server_process = None
+
+    def health_check(self) -> bool:
+        if self._server_process and self._server_process.poll() is not None:
+            return False
+        try:
+            response = httpx.get(f"http://localhost:{self.port}/health", timeout=2)
+            return response.status_code == 200
+        except Exception as exc:  # pragma: no cover - network errors
+            self.logger.debug("Health check failed: %s", exc)
+            return False
+
+    async def _start_vllm_server(self) -> None:
+        cmd = [
+            "python",
+            "-m",
+            "vllm.entrypoints.openai.api_server",
+            "--model",
+            self.model,
+            "--port",
+            str(self.port),
+            "--gpu-memory-utilization",
+            str(self.gpu_memory_utilization),
+        ]
+        self.logger.debug("Starting vLLM server: %s", " ".join(cmd))
+        self._server_process = subprocess.Popen(cmd)
+        await asyncio.sleep(1)

--- a/tests/infrastructure/test_vllm_infra.py
+++ b/tests/infrastructure/test_vllm_infra.py
@@ -1,0 +1,66 @@
+import pytest
+
+from entity.infrastructure.vllm_infra import VLLMInfrastructure
+
+
+class DummyProcess:
+    def __init__(self) -> None:
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):  # pragma: no cover - simple stub
+        return None
+
+    def terminate(self):  # pragma: no cover - simple stub
+        self.terminated = True
+
+    def wait(self, timeout: float | None = None):  # pragma: no cover - simple stub
+        return 0
+
+    def kill(self):  # pragma: no cover - simple stub
+        self.killed = True
+
+
+@pytest.mark.asyncio
+async def test_startup_starts_server(monkeypatch):
+    proc = DummyProcess()
+
+    async def fake_start(self):
+        self._server_process = proc
+
+    monkeypatch.setattr(VLLMInfrastructure, "_start_vllm_server", fake_start)
+    infra = VLLMInfrastructure(model="m", auto_detect_model=False)
+
+    await infra.startup()
+
+    assert infra._server_process is proc
+
+
+def test_detect_optimal_model(monkeypatch):
+    infra = VLLMInfrastructure(model="m", auto_detect_model=False)
+    monkeypatch.setattr(infra, "_detect_hardware_tier", lambda: "cpu_only")
+    assert (
+        infra._detect_optimal_model()
+        == VLLMInfrastructure.MODEL_SELECTION_MATRIX["cpu_only"]["models"][0]
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_terminates(monkeypatch):
+    proc = DummyProcess()
+    infra = VLLMInfrastructure(model="m", auto_detect_model=False)
+    infra._server_process = proc
+    await infra.shutdown()
+    assert proc.terminated
+
+
+def test_health_check(monkeypatch):
+    class Resp:
+        status_code = 200
+
+    infra = VLLMInfrastructure(model="m", auto_detect_model=False)
+    monkeypatch.setattr(
+        "entity.infrastructure.vllm_infra.httpx.get", lambda *a, **k: Resp()
+    )
+    infra._server_process = DummyProcess()
+    assert infra.health_check()


### PR DESCRIPTION
## Summary
- implement `VLLMInfrastructure` class for serving vLLM models
- export the new infrastructure in package init
- add unit tests covering startup, shutdown and health check

## Testing
- `poetry run pytest -q tests/infrastructure/test_vllm_infra.py`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6884c6af03ac832295ee992e948a8b0b