### PR TITLE
Add docs for vLLM setup and logging templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,11 @@ See `install_docker.sh` for an automated install script on Ubuntu. Detailed depl
 
 `ollama pull` requires an authentication key at `~/.ollama/id_ed25519`. Run `ollama login` once to generate this file before using `entity-cli`.
 Automatic installation can be skipped by setting `ENTITY_AUTO_INSTALL_OLLAMA=false` when you prefer manual setup.
+
+### vLLM Setup
+
+The framework can start a vLLM server automatically. See [docs/vllm.md](docs/vllm.md) for configuration options and troubleshooting tips.
+
+### Logging Workflows
+
+Example workflow templates showing console and JSON logging live in [docs/logging_templates.md](docs/logging_templates.md).

--- a/docs/logging_templates.md
+++ b/docs/logging_templates.md
@@ -1,0 +1,21 @@
+# Logging Workflow Templates
+
+Choose how plugins send log entries. The console template writes readable text, while the JSON template saves structured logs.
+
+## Console Logging
+
+```yaml
+workflows:
+  console_logger:
+    output:
+      - entity.plugins.logging.ConsoleLogger
+```
+
+## JSON Logging
+
+```yaml
+workflows:
+  json_logger:
+    output:
+      - entity.plugins.logging.JsonLogger
+```

--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -1,0 +1,19 @@
+# vLLM Configuration
+
+The framework can start a vLLM server for you. Set `ENTITY_AUTO_INSTALL_VLLM=true` to download the package at runtime. Provide a specific model or let vLLM pick one based on GPU memory.
+
+## Example
+
+```python
+from entity.defaults import load_defaults
+
+resources = load_defaults()
+```
+
+The call checks for vLLM and installs it if missing. A local server is launched automatically and shut down when the process exits.
+
+## Troubleshooting
+
+* **No GPU detected** – vLLM falls back to CPU mode. Performance will be slow.
+* **Port in use** – set `ENTITY_VLLM_PORT` to an open port.
+* **Installation fails** – install vLLM manually with `pip install vllm` and rerun your script.


### PR DESCRIPTION
## Summary
- explain vLLM setup in README
- add vLLM configuration guide with troubleshooting
- document logging workflow templates

## Testing
- `poetry run black src tests`
- `poetry run poe test` *(fails: subprocess.TimeoutExpired)*
- `poetry run poe test-with-docker` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884c71bf0c88322bc797a9b4ee67e4f