### PR TITLE
Add vLLM infrastructure defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ await memory.store("bob:greeting", "hello")
 | `ENTITY_OLLAMA_URL` | `http://localhost:11434` |
 | `ENTITY_OLLAMA_MODEL` | `llama3.2:3b` |
 | `ENTITY_STORAGE_PATH` | `./agent_files` |
+| `ENTITY_AUTO_INSTALL_VLLM` | `true` |
+| `ENTITY_VLLM_MODEL` | *(auto)* |
 
 Services are checked for availability when defaults are built. If a component is
 unreachable, an in-memory or stub implementation is used so the framework still

--- a/src/entity/infrastructure/__init__.py
+++ b/src/entity/infrastructure/__init__.py
@@ -2,6 +2,7 @@ from .base import BaseInfrastructure
 from .duckdb_infra import DuckDBInfrastructure
 from .local_storage_infra import LocalStorageInfrastructure
 from .ollama_infra import OllamaInfrastructure
+from .vllm_infra import VLLMInfrastructure
 from .s3_infra import S3Infrastructure
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "DuckDBInfrastructure",
     "LocalStorageInfrastructure",
     "OllamaInfrastructure",
+    "VLLMInfrastructure",
     "S3Infrastructure",
 ]

--- a/src/entity/infrastructure/vllm_infra.py
+++ b/src/entity/infrastructure/vllm_infra.py
@@ -1,0 +1,57 @@
+import time
+import httpx
+
+from .base import BaseInfrastructure
+from entity.setup.vllm_installer import VLLMInstaller
+
+
+class VLLMInfrastructure(BaseInfrastructure):
+    """Layer 1 infrastructure for a local vLLM service."""
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8000",
+        model: str | None = None,
+        version: str | None = None,
+        auto_install: bool = True,
+    ) -> None:
+        super().__init__(version)
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.auto_install = auto_install
+
+    async def generate(self, prompt: str) -> str:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/generate",
+                json={"prompt": prompt, "model": self.model},
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("text", "")
+
+    def health_check(self) -> bool:
+        for attempt in range(3):
+            try:
+                resp = httpx.get(f"{self.base_url}/health", timeout=2)
+                resp.raise_for_status()
+                self.logger.debug(
+                    "Health check succeeded for %s on attempt %s",
+                    self.base_url,
+                    attempt + 1,
+                )
+                return True
+            except Exception as exc:
+                self.logger.debug(
+                    "Health check attempt %s failed for %s: %s",
+                    attempt + 1,
+                    self.base_url,
+                    exc,
+                )
+                time.sleep(1)
+
+        self.logger.warning("Health check failed for %s", self.base_url)
+        if self.auto_install:
+            self.logger.debug("Attempting automatic vLLM install")
+            VLLMInstaller.ensure_vllm_available(self.model)
+        return False

--- a/src/entity/resources/llm.py
+++ b/src/entity/resources/llm.py
@@ -1,17 +1,24 @@
-"""Resource wrapper around an Ollama LLM deployment."""
+"""Resource wrapper around an LLM infrastructure."""
 
-from entity.infrastructure.ollama_infra import OllamaInfrastructure
+from typing import Protocol
+
 from entity.resources.exceptions import ResourceInitializationError
 
 
-class LLMResource:
-    """Layer 2 resource that wraps an Ollama LLM."""
+class LLMInfrastructure(Protocol):
+    async def generate(self, prompt: str) -> str: ...
 
-    def __init__(self, infrastructure: OllamaInfrastructure | None) -> None:
-        """Initialize with the Ollama infrastructure instance."""
+    def health_check(self) -> bool: ...
+
+
+class LLMResource:
+    """Layer 2 resource that wraps an LLM implementation."""
+
+    def __init__(self, infrastructure: LLMInfrastructure | None) -> None:
+        """Initialize with the infrastructure instance."""
 
         if infrastructure is None:
-            raise ResourceInitializationError("OllamaInfrastructure is required")
+            raise ResourceInitializationError("LLMInfrastructure is required")
         self.infrastructure = infrastructure
 
     def health_check(self) -> bool:

--- a/src/entity/setup/__init__.py
+++ b/src/entity/setup/__init__.py
@@ -1,5 +1,6 @@
 """Setup utilities for initializing Entity's local environment."""
 
 from .ollama_installer import OllamaInstaller
+from .vllm_installer import VLLMInstaller
 
-__all__ = ["OllamaInstaller"]
+__all__ = ["OllamaInstaller", "VLLMInstaller"]

--- a/src/entity/setup/vllm_installer.py
+++ b/src/entity/setup/vllm_installer.py
@@ -1,0 +1,28 @@
+import logging
+import importlib.util
+import os
+import subprocess
+import sys
+
+
+class VLLMInstaller:
+    """Install the vLLM package when not already present."""
+
+    logger = logging.getLogger(__name__)
+
+    @classmethod
+    def ensure_vllm_available(cls, model: str | None = None) -> None:
+        """Install vLLM via pip if ``ENTITY_AUTO_INSTALL_VLLM`` is truthy."""
+
+        auto_env = os.getenv("ENTITY_AUTO_INSTALL_VLLM", "true").lower()
+        if auto_env not in {"1", "true", "yes"}:
+            cls.logger.debug("Auto install disabled via environment")
+            return
+
+        if importlib.util.find_spec("vllm") is None:
+            cls.logger.info("Installing vLLM package")
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", "vllm"], check=False
+            )
+        else:
+            cls.logger.debug("vLLM package already available")

--- a/tests/test_vllm_defaults.py
+++ b/tests/test_vllm_defaults.py
@@ -1,0 +1,59 @@
+from entity import defaults
+from entity.defaults import load_defaults
+
+
+class DummyVLLM:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def generate(self, prompt: str) -> str:
+        return "vllm"
+
+    def health_check(self) -> bool:
+        return True
+
+
+class FailingVLLM(DummyVLLM):
+    def health_check(self) -> bool:
+        return False
+
+
+class DummyOllama:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def generate(self, prompt: str) -> str:
+        return "ollama"
+
+    def health_check(self) -> bool:
+        return True
+
+
+def test_vllm_preferred(monkeypatch):
+    monkeypatch.setenv("ENTITY_AUTO_INSTALL_VLLM", "true")
+    monkeypatch.setattr(defaults, "VLLMInfrastructure", lambda *a, **k: DummyVLLM())
+    monkeypatch.setattr(defaults, "OllamaInfrastructure", lambda *a, **k: DummyOllama())
+    monkeypatch.setattr(
+        defaults.VLLMInstaller, "ensure_vllm_available", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        defaults.OllamaInstaller, "ensure_ollama_available", lambda *a, **k: None
+    )
+
+    resources = load_defaults()
+    assert isinstance(resources["llm"].resource.infrastructure, DummyVLLM)
+
+
+def test_vllm_fallback(monkeypatch):
+    monkeypatch.setenv("ENTITY_AUTO_INSTALL_VLLM", "true")
+    monkeypatch.setattr(defaults, "VLLMInfrastructure", lambda *a, **k: FailingVLLM())
+    monkeypatch.setattr(defaults, "OllamaInfrastructure", lambda *a, **k: DummyOllama())
+    monkeypatch.setattr(
+        defaults.VLLMInstaller, "ensure_vllm_available", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        defaults.OllamaInstaller, "ensure_ollama_available", lambda *a, **k: None
+    )
+
+    resources = load_defaults()
+    assert isinstance(resources["llm"].resource.infrastructure, DummyOllama)


### PR DESCRIPTION
## Summary
- include auto-install vLLM settings in `DefaultConfig`
- prefer vLLM infrastructure in `load_defaults`
- expose new `VLLMInfrastructure` and `VLLMInstaller`
- document `ENTITY_AUTO_INSTALL_VLLM` and `ENTITY_VLLM_MODEL`
- test that defaults choose vLLM and fall back to Ollama

## Testing
- `poetry run poe test` *(fails: tests/examples/test_zero_config_agent.py::test_zero_config_agent FAILED, tests/test_cli.py::test_cli_default_workflow FAILED, tests/test_cli.py::test_cli_verbose_flag FAILED, tests/test_cli.py::test_cli_custom_workflow FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6884c718318883228bd59514633223cb