### PR TITLE
Rename Storage wrapper to FileStorage

### DIFF
--- a/src/entity/defaults.py
+++ b/src/entity/defaults.py
@@ -16,7 +16,7 @@ from entity.resources import (
     Memory,
     LLM,
     LocalStorageResource,
-    Storage,
+    FileStorage,
     ConsoleLoggingResource,
     JSONLoggingResource,
 )
@@ -145,6 +145,6 @@ def load_defaults(config: DefaultConfig | None = None) -> dict[str, object]:
     return {
         "memory": Memory(db_resource, vector_resource),
         "llm": LLM(llm_resource),
-        "storage": Storage(storage_resource),
+        "file_storage": FileStorage(storage_resource),
         "logging": logging_resource,
     }

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -8,7 +8,7 @@ from entity.resources.local_storage import LocalStorageResource
 from entity.resources.exceptions import ResourceInitializationError
 from entity.resources.memory import Memory
 from entity.resources.llm_wrapper import LLM
-from entity.resources.storage_wrapper import Storage
+from entity.resources.file_storage_wrapper import FileStorage
 from entity.resources.logging import (
     ConsoleLoggingResource,
     EnhancedLoggingResource,
@@ -25,7 +25,7 @@ __all__ = [
     "ResourceInitializationError",
     "Memory",
     "LLM",
-    "Storage",
+    "FileStorage",
     "EnhancedLoggingResource",
     "ConsoleLoggingResource",
     "JSONLoggingResource",

--- a/src/entity/resources/file_storage_wrapper.py
+++ b/src/entity/resources/file_storage_wrapper.py
@@ -3,7 +3,7 @@ from entity.resources.local_storage import LocalStorageResource
 from entity.resources.exceptions import ResourceInitializationError
 
 
-class Storage:
+class FileStorage:
     """Layer 3 wrapper around a storage resource."""
 
     def __init__(self, resource: StorageResource | LocalStorageResource | None) -> None:

--- a/tests/resources/test_resource_initialization.py
+++ b/tests/resources/test_resource_initialization.py
@@ -8,7 +8,7 @@ from entity.resources import (
     StorageResource,
     Memory,
     LLM,
-    Storage,
+    FileStorage,
     ResourceInitializationError,
 )
 from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
@@ -45,7 +45,7 @@ def test_constructors_success(tmp_path):
 
     storage_infra = LocalStorageInfrastructure(tmp_path)
     local_res = LocalStorageResource(storage_infra)
-    storage = Storage(local_res)
+    storage = FileStorage(local_res)
 
     assert mem.health_check()
     assert llm.health_check()
@@ -68,7 +68,7 @@ def test_constructor_failure():
     with pytest.raises(ResourceInitializationError):
         LLM(None)
     with pytest.raises(ResourceInitializationError):
-        Storage(None)
+        FileStorage(None)
 
 
 def test_infrastructures_satisfy_protocol():

--- a/tests/test_layer_separation.py
+++ b/tests/test_layer_separation.py
@@ -12,7 +12,7 @@ from entity.resources.storage import StorageResource
 from entity.resources.local_storage import LocalStorageResource
 from entity.resources.memory import Memory
 from entity.resources.llm_wrapper import LLM
-from entity.resources.storage_wrapper import Storage
+from entity.resources.file_storage_wrapper import FileStorage
 from entity.resources.exceptions import ResourceInitializationError
 
 
@@ -39,4 +39,4 @@ def test_wrappers_require_resources():
     with pytest.raises(ResourceInitializationError):
         LLM(None)
     with pytest.raises(ResourceInitializationError):
-        Storage(None)
+        FileStorage(None)


### PR DESCRIPTION
## Summary
- rename `storage_wrapper` to `file_storage_wrapper`
- rename wrapper class to `FileStorage`
- update imports and defaults for the new canonical `file_storage` key
- adjust unit tests to use `FileStorage`

## Testing
- `poetry run poe test` *(fails: vLLM installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6884d6b9d398832286f77bfadbead632