### PR TITLE
Implement rich logging resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ websockets = "^15.0"
 grpcio = "^1.62.2"
 grpcio-tools = "^1.62.2"
 huggingface_hub = "^0.23"
+rich = "^13.7"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/entity/cli/__main__.py
+++ b/src/entity/cli/__main__.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from entity.core.agent import Agent
 from entity.plugins.defaults import default_workflow
 from entity.cli.ent_cli_adapter import EntCLIAdapter
-from entity.resources.logging import ConsoleLoggingResource, LogLevel
+from entity.resources.logging import RichConsoleLoggingResource, LogLevel
 from entity.defaults import load_defaults
 from entity.workflow.templates.loader import load_template, TemplateNotFoundError
 from entity.workflow.workflow import Workflow
@@ -73,7 +73,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 async def _run(args: argparse.Namespace) -> None:
     level = "debug" if args.verbose else "error" if args.quiet else "info"
     resources = load_defaults()
-    resources["logging"] = ConsoleLoggingResource(LogLevel(level))
+    resources["logging"] = RichConsoleLoggingResource(LogLevel(level))
     workflow = _load_workflow(args.workflow)
     agent = Agent(resources=resources, workflow=workflow)
 

--- a/src/entity/defaults.py
+++ b/src/entity/defaults.py
@@ -17,8 +17,8 @@ from entity.resources import (
     LLM,
     LocalStorageResource,
     Storage,
-    ConsoleLoggingResource,
-    JSONLoggingResource,
+    RichConsoleLoggingResource,
+    RichJSONLoggingResource,
 )
 
 
@@ -77,9 +77,9 @@ def load_defaults(config: DefaultConfig | None = None) -> dict[str, object]:
     json_logs = os.getenv("ENTITY_JSON_LOGS", "0").lower() in {"1", "true", "yes"}
     log_file = os.getenv("ENTITY_LOG_FILE", "./agent.log")
     logging_resource = (
-        JSONLoggingResource(log_file, log_level)
+        RichJSONLoggingResource(log_file, log_level)
         if json_logs
-        else ConsoleLoggingResource(log_level)
+        else RichConsoleLoggingResource(log_level)
     )
 
     llm_infra = None

--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -10,9 +10,9 @@ from entity.resources.memory import Memory
 from entity.resources.llm_wrapper import LLM
 from entity.resources.storage_wrapper import Storage
 from entity.resources.logging import (
-    ConsoleLoggingResource,
     EnhancedLoggingResource,
-    JSONLoggingResource,
+    RichConsoleLoggingResource,
+    RichJSONLoggingResource,
 )
 from entity.resources.metrics import MetricsCollectorResource
 
@@ -27,7 +27,7 @@ __all__ = [
     "LLM",
     "Storage",
     "EnhancedLoggingResource",
-    "ConsoleLoggingResource",
-    "JSONLoggingResource",
+    "RichConsoleLoggingResource",
+    "RichJSONLoggingResource",
     "MetricsCollectorResource",
 ]

--- a/src/entity/workflow/executor.py
+++ b/src/entity/workflow/executor.py
@@ -4,7 +4,7 @@ from typing import Any, Iterable
 from itertools import count
 import warnings
 
-from entity.resources.logging import ConsoleLoggingResource
+from entity.resources.logging import RichConsoleLoggingResource
 from entity.resources.metrics import MetricsCollectorResource
 
 from entity.plugins.context import PluginContext
@@ -30,7 +30,7 @@ class WorkflowExecutor:
         workflow: dict[str, Iterable[type]] | None = None,
     ) -> None:
         self.resources = dict(resources)
-        self.resources.setdefault("logging", ConsoleLoggingResource())
+        self.resources.setdefault("logging", RichConsoleLoggingResource())
         self.resources.setdefault("metrics_collector", MetricsCollectorResource())
         self.workflow = {
             stage: list(plugins) for stage, plugins in (workflow or {}).items()

--- a/tests/test_context_logging.py
+++ b/tests/test_context_logging.py
@@ -1,6 +1,10 @@
 import pytest
 from entity.plugins.context import PluginContext
-from entity.resources.logging import LogLevel, LogCategory, LoggingResource
+from entity.resources.logging import (
+    LogLevel,
+    LogCategory,
+    RichConsoleLoggingResource,
+)
 from entity.resources.memory import Memory
 from entity.resources.database import DatabaseResource
 from entity.resources.vector_store import VectorStoreResource
@@ -11,7 +15,9 @@ from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
 async def test_context_log_injects_ids():
     infra = DuckDBInfrastructure(":memory:")
     memory = Memory(DatabaseResource(infra), VectorStoreResource(infra))
-    ctx = PluginContext({"memory": memory, "logging": LoggingResource()}, user_id="u")
+    ctx = PluginContext(
+        {"memory": memory, "logging": RichConsoleLoggingResource()}, user_id="u"
+    )
     await ctx.log(LogLevel.INFO, LogCategory.USER_ACTION, "hello")
     record = ctx.get_resource("logging").records[0]
     fields = record["fields"]

--- a/tests/test_logging_output.py
+++ b/tests/test_logging_output.py
@@ -1,12 +1,15 @@
 import json
 import pytest
 
-from entity.resources.logging import ConsoleLoggingResource, JSONLoggingResource
+from entity.resources.logging import (
+    RichConsoleLoggingResource,
+    RichJSONLoggingResource,
+)
 
 
 @pytest.mark.asyncio
 async def test_console_logging_output(capsys):
-    logger = ConsoleLoggingResource(level="debug")
+    logger = RichConsoleLoggingResource(level="debug")
     await logger.log("info", "hello", foo="bar")
     captured = capsys.readouterr()
     assert "hello" in captured.out
@@ -15,7 +18,7 @@ async def test_console_logging_output(capsys):
 
 @pytest.mark.asyncio
 async def test_json_logging_output(capsys):
-    logger = JSONLoggingResource(level="debug")
+    logger = RichJSONLoggingResource(level="debug")
     await logger.log("warning", "oops", code=123)
     captured = capsys.readouterr()
     data = json.loads(captured.out.strip())

--- a/tests/test_logging_resource.py
+++ b/tests/test_logging_resource.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import pytest
 
 from entity.resources.logging import (
-    ConsoleLoggingResource,
-    JSONLoggingResource,
+    RichConsoleLoggingResource,
+    RichJSONLoggingResource,
     LogCategory,
     LogContext,
     LogLevel,
@@ -14,7 +14,7 @@ from entity.resources.logging import (
 
 @pytest.mark.asyncio
 async def test_console_logging(capsys):
-    logger = ConsoleLoggingResource(level=LogLevel.DEBUG)
+    logger = RichConsoleLoggingResource(level=LogLevel.DEBUG)
     ctx = LogContext(user_id="u1")
     await logger.log(LogLevel.INFO, LogCategory.USER_ACTION, "hello", ctx)
     captured = capsys.readouterr().out
@@ -25,7 +25,7 @@ async def test_console_logging(capsys):
 @pytest.mark.asyncio
 async def test_json_logging(tmp_path: Path):
     log_file = tmp_path / "log.json"
-    logger = JSONLoggingResource(level=LogLevel.INFO, output_file=str(log_file))
+    logger = RichJSONLoggingResource(level=LogLevel.INFO, output_file=str(log_file))
     ctx = LogContext(user_id="u2")
     await logger.log(LogLevel.INFO, LogCategory.USER_ACTION, "hi", ctx)
     data = json.loads(log_file.read_text())
@@ -36,7 +36,7 @@ async def test_json_logging(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_json_log_rotation(tmp_path: Path):
     log_file = tmp_path / "log.json"
-    logger = JSONLoggingResource(
+    logger = RichJSONLoggingResource(
         level=LogLevel.INFO,
         output_file=str(log_file),
         max_bytes=10,


### PR DESCRIPTION
## Summary
- add `rich` dependency
- introduce `RichConsoleLoggingResource` and `RichJSONLoggingResource`
- remove old logging resource and monkey-patch logging
- update resource exports and default configuration
- adjust plugin execution flow
- update CLI and executor to use new resources
- update tests for new logging API

## Testing
- `poetry run poe test` *(fails: ConnectError, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6884d6b8e4408322bc13b8e1feec4ee0