### PR TITLE
Implement vLLM-first defaults and Rich logging

### DIFF
--- a/src/entity/resources/__init__.py
+++ b/src/entity/resources/__init__.py
@@ -13,6 +13,8 @@ from entity.resources.logging import (
     EnhancedLoggingResource,
     RichConsoleLoggingResource,
     RichJSONLoggingResource,
+    RichLoggingResource,
+    LogLevel,
 )
 from entity.resources.metrics import MetricsCollectorResource
 
@@ -29,5 +31,7 @@ __all__ = [
     "EnhancedLoggingResource",
     "RichConsoleLoggingResource",
     "RichJSONLoggingResource",
+    "RichLoggingResource",
+    "LogLevel",
     "MetricsCollectorResource",
 ]

--- a/tests/test_context_logging.py
+++ b/tests/test_context_logging.py
@@ -1,16 +1,6 @@
 import pytest
 from entity.plugins.context import PluginContext
-<<<<<<< HEAD
-from entity.resources.logging import (
-    LogLevel,
-    LogCategory,
-    RichConsoleLoggingResource,
-)
-=======
-from entity.resources.logging import LogLevel, LogCategory, LoggingResource
-
-pytest.skip("Context logging integration unstable", allow_module_level=True)
->>>>>>> pr-1959
+from entity.resources.logging import RichLoggingResource, LogLevel, LogCategory
 from entity.resources.memory import Memory
 from entity.resources.database import DatabaseResource
 from entity.resources.vector_store import VectorStoreResource
@@ -22,12 +12,12 @@ async def test_context_log_injects_ids():
     infra = DuckDBInfrastructure(":memory:")
     memory = Memory(DatabaseResource(infra), VectorStoreResource(infra))
     ctx = PluginContext(
-        {"memory": memory, "logging": RichConsoleLoggingResource()}, user_id="u"
+        {"memory": memory, "logging": RichLoggingResource()}, user_id="u"
     )
     await ctx.log(LogLevel.INFO, LogCategory.USER_ACTION, "hello")
     record = ctx.get_resource("logging").records[0]
-    fields = record["fields"]
-    assert fields["user_id"] == "u"
-    assert fields.get("workflow_id")
-    assert fields.get("execution_id")
-    assert fields["category"] == LogCategory.USER_ACTION.value
+    context = record["context"]
+    assert context["user_id"] == "u"
+    assert context.get("stage") == ctx.current_stage
+    assert context.get("plugin_name") is None
+    assert record["category"] == LogCategory.USER_ACTION.value

--- a/tests/test_defaults_env.py
+++ b/tests/test_defaults_env.py
@@ -13,7 +13,7 @@ def test_env_overrides(monkeypatch, tmp_path):
 
     memory = defaults["memory"]
     llm = defaults["llm"]
-    storage = defaults["storage"]
+    storage = defaults["file_storage"]
 
     assert memory.database.infrastructure.file_path.endswith("custom.db")
     llm_infra = llm.resource.infrastructure

--- a/tests/test_logging_output.py
+++ b/tests/test_logging_output.py
@@ -1,42 +1,25 @@
 import json
 import pytest
 
-from entity.resources.logging import (
-<<<<<<< HEAD
-    RichConsoleLoggingResource,
-    RichJSONLoggingResource,
-=======
-    ConsoleLoggingResource,
-    JSONLoggingResource,
-    LogLevel,
-    LogCategory,
->>>>>>> pr-1959
-)
+from entity.resources.logging import RichLoggingResource, LogLevel, LogCategory
 
 
 @pytest.mark.asyncio
 async def test_console_logging_output(capsys):
-<<<<<<< HEAD
-    logger = RichConsoleLoggingResource(level="debug")
-    await logger.log("info", "hello", foo="bar")
-=======
-    logger = ConsoleLoggingResource(level=LogLevel.DEBUG)
+    logger = RichLoggingResource(level=LogLevel.DEBUG)
     await logger.log(LogLevel.INFO, LogCategory.USER_ACTION, "hello", foo="bar")
->>>>>>> pr-1959
     captured = capsys.readouterr()
     assert "hello" in captured.out
     assert "foo" in captured.out
 
 
 @pytest.mark.asyncio
-async def test_json_logging_output(capsys):
-<<<<<<< HEAD
-    logger = RichJSONLoggingResource(level="debug")
-    await logger.log("warning", "oops", code=123)
-    captured = capsys.readouterr()
-    data = json.loads(captured.out.strip())
+async def test_json_logging_output(tmp_path):
+    log_file = tmp_path / "log.json"
+    logger = RichLoggingResource(
+        level=LogLevel.DEBUG, json=True, log_file=str(log_file)
+    )
+    await logger.log(LogLevel.WARNING, LogCategory.ERROR, "oops", code=123)
+    data = json.loads(log_file.read_text().splitlines()[0])
     assert data["message"] == "oops"
     assert data["fields"]["code"] == 123
-=======
-    pytest.skip("JSON logging requires file system access", allow_module_level=False)
->>>>>>> pr-1959


### PR DESCRIPTION
## Summary
- add `RichLoggingResource` wrapper
- export `LogLevel` and `RichLoggingResource`
- update default resource loading for vLLM-first logic
- switch tests to renamed `file_storage` resource
- clean up logging tests

## Testing
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_6884df95e02c83228d2058a88d282dae