### PR TITLE
Enforce OUTPUT stage for say()

### DIFF
--- a/src/entity/plugins/context.py
+++ b/src/entity/plugins/context.py
@@ -16,14 +16,12 @@ class WorkflowContext:
         self.message: str | None = None
 
     def say(self, message: str) -> None:
-        """Store the final response only during the OUTPUT stage."""
+        """Store the final response only during the OUTPUT or ERROR stage."""
 
         from entity.workflow.executor import WorkflowExecutor
 
-        if self.current_stage not in {
-            WorkflowExecutor.OUTPUT,
-            WorkflowExecutor.ERROR,
-        }:
+        allowed_stages = {WorkflowExecutor.OUTPUT, WorkflowExecutor.ERROR}
+        if self.current_stage not in allowed_stages:
             raise RuntimeError("context.say() only allowed in OUTPUT or ERROR stage")
 
         self._response = message

--- a/src/entity/plugins/defaults/__init__.py
+++ b/src/entity/plugins/defaults/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from entity.plugins.base import Plugin
 from entity.cli.ent_cli_adapter import EntCLIAdapter
+from entity.workflow.executor import WorkflowExecutor
 
 
 class InputPlugin(Plugin):
@@ -35,6 +36,8 @@ class ReviewPlugin(Plugin):
 
 
 class OutputPlugin(Plugin):
+    stage = WorkflowExecutor.OUTPUT
+
     async def _execute_impl(self, context) -> str:  # noqa: D401
         """Return final response and terminate the workflow."""
 

--- a/tests/test_context_say.py
+++ b/tests/test_context_say.py
@@ -1,0 +1,34 @@
+import pytest
+
+from entity.plugins.context import WorkflowContext, PluginContext
+from entity.plugins.base import Plugin
+from entity.workflow.executor import WorkflowExecutor
+from entity.resources.memory import Memory
+from entity.resources.database import DatabaseResource
+from entity.resources.vector_store import VectorStoreResource
+from entity.infrastructure.duckdb_infra import DuckDBInfrastructure
+
+
+def test_say_rejects_invalid_stage() -> None:
+    ctx = WorkflowContext()
+    ctx.current_stage = WorkflowExecutor.THINK
+    with pytest.raises(RuntimeError):
+        ctx.say("nope")
+
+
+@pytest.mark.asyncio
+async def test_plugin_say_invalid_stage() -> None:
+    class BadPlugin(Plugin):
+        stage = WorkflowExecutor.THINK
+
+        async def _execute_impl(self, context: PluginContext) -> str:
+            context.say("oops")
+            return "ignored"
+
+    wf = {WorkflowExecutor.THINK: [BadPlugin]}
+    infra = DuckDBInfrastructure(":memory:")
+    memory = Memory(DatabaseResource(infra), VectorStoreResource(infra))
+    executor = WorkflowExecutor({"memory": memory}, wf)
+
+    with pytest.raises(RuntimeError):
+        await executor.execute("hi")


### PR DESCRIPTION
## Summary
- restrict `WorkflowContext.say` to OUTPUT or ERROR stages
- guard Default `OutputPlugin` to OUTPUT stage
- verify `say()` misuse raises runtime error

## Testing
- `poetry run poe test` *(fails: KeyboardInterrupt during vllm installation)*

------
https://chatgpt.com/codex/tasks/task_e_6884ebb531dc8322a48a720f268a0259